### PR TITLE
Fix startTask not to change todo task status to in_progress

### DIFF
--- a/src/__tests__/startTask.test.ts
+++ b/src/__tests__/startTask.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect, vi } from 'vitest';
+import { createTask, getTaskByNumber } from '../taskMetadata';
+
+// Mock child_process so execAsync resolves without real git commands
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+  exec: vi.fn((_cmd: string, _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+    cb(null, { stdout: 'main\n', stderr: '' });
+  }),
+}));
+
+// Mock fs/promises — keep real readFile/writeFile for taskMetadata, stub mkdir/access/cp for worktree
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    mkdir: vi.fn(async () => undefined),
+    access: vi.fn(async () => { throw new Error('ENOENT'); }),
+    cp: vi.fn(async () => undefined),
+  };
+});
+
+// Mock koffi (native FFI, not needed in tests)
+vi.mock('koffi', () => ({
+  default: { load: vi.fn() },
+}));
+
+import { startTask } from '../worktree';
+
+describe('startTask', () => {
+  test('does not change a todo task status to in_progress', async () => {
+    const project = '/test/start-keeps-todo';
+    await createTask(project, 1, 'My todo task', { status: 'todo' });
+
+    const result = await startTask(project, 1);
+    expect(result.success).toBe(true);
+
+    const task = await getTaskByNumber(project, 1);
+    expect(task).not.toBeNull();
+    expect(task!.status).toBe('todo');
+  });
+
+  test('sets branch and worktreePath on the task', async () => {
+    const project = '/test/start-sets-fields';
+    await createTask(project, 1, 'Branch task', { status: 'todo' });
+
+    const result = await startTask(project, 1, 'custom-branch-1');
+    expect(result.success).toBe(true);
+    expect(result.task).toBeDefined();
+    expect(result.task!.branch).toBe('custom-branch-1');
+    expect(result.worktreePath).toBeTruthy();
+  });
+
+  test('rejects starting a non-todo task', async () => {
+    const project = '/test/start-reject-nontodo';
+    await createTask(project, 1, 'In progress task'); // defaults to in_progress
+
+    const result = await startTask(project, 1);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Task is already started');
+  });
+
+  test('returns error for non-existent task', async () => {
+    const result = await startTask('/test/start-missing', 99);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Task not found');
+  });
+});

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -9,7 +9,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import koffi from 'koffi';
-import { getNextTaskNumber, createTask, getTaskByNumber, deleteTaskByNumber, setTaskStatus, setTaskBranch, setTaskWorktreePath, setTaskMergeTarget, type TaskMetadata, type TaskStatus } from './taskMetadata';
+import { getNextTaskNumber, createTask, getTaskByNumber, deleteTaskByNumber, setTaskBranch, setTaskWorktreePath, setTaskMergeTarget, type TaskMetadata, type TaskStatus } from './taskMetadata';
 
 const execAsync = promisify(exec);
 
@@ -300,7 +300,6 @@ export async function startTask(
     ]);
 
     await Promise.all([
-      setTaskStatus(projectPath, taskNumber, 'in_progress'),
       setTaskBranch(projectPath, taskNumber, branch),
       setTaskWorktreePath(projectPath, taskNumber, worktreePath),
     ]);


### PR DESCRIPTION
Opening a terminal for a todo task should only provision the worktree without changing the task's status. Users can move tasks to in_progress explicitly via the kanban board.