### PR TITLE
Add inline editing of task title and description on kanban board

### DIFF
--- a/src/__tests__/taskMetadata.test.ts
+++ b/src/__tests__/taskMetadata.test.ts
@@ -8,6 +8,8 @@ import {
   setTaskStatus,
   setTaskMergeTarget,
   setTaskSandboxed,
+  setTaskName,
+  setTaskDescription,
   deleteTaskByNumber,
 } from '../taskMetadata';
 
@@ -158,6 +160,47 @@ describe('taskMetadata', () => {
 
     expect(tasksB).toHaveLength(1);
     expect(tasksB[0].name).toBe('Task B');
+  });
+
+  test('setTaskName updates the task name', async () => {
+    const project = '/test/set-name';
+    await createTask(project, 1, 'Original name', { branch: 'feat/name' });
+
+    const result = await setTaskName(project, 1, 'Updated name');
+    expect(result.success).toBe(true);
+
+    const task = await getTaskByNumber(project, 1);
+    expect(task!.name).toBe('Updated name');
+  });
+
+  test('setTaskName returns error for missing task', async () => {
+    const project = '/test/set-name-missing';
+    await createTask(project, 1, 'Exists');
+    const result = await setTaskName(project, 99, 'No task');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Task not found');
+  });
+
+  test('setTaskDescription sets a description', async () => {
+    const project = '/test/set-description';
+    await createTask(project, 1, 'Desc task', { branch: 'feat/desc' });
+
+    const result = await setTaskDescription(project, 1, 'New description');
+    expect(result.success).toBe(true);
+
+    const task = await getTaskByNumber(project, 1);
+    expect(task!.prompt).toBe('New description');
+  });
+
+  test('setTaskDescription with empty string clears the description', async () => {
+    const project = '/test/set-description-clear';
+    await createTask(project, 1, 'Clear desc task', { branch: 'feat/clear', prompt: 'Has a description' });
+
+    const result = await setTaskDescription(project, 1, '');
+    expect(result.success).toBe(true);
+
+    const task = await getTaskByNumber(project, 1);
+    expect(task!.prompt).toBeUndefined();
   });
 
   test('createTask with todo status (no branch)', async () => {

--- a/src/components/theatre/kanbanBoard.ts
+++ b/src/components/theatre/kanbanBoard.ts
@@ -166,6 +166,57 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
   const name = document.createElement('span');
   name.className = 'kanban-card-name';
   name.textContent = task.name;
+
+  // Double-click to edit title inline
+  name.addEventListener('dblclick', (e) => {
+    e.stopPropagation();
+    clearTimeout(clickTimer);
+
+    const input = document.createElement('textarea');
+    input.className = 'kanban-card-name-input';
+    input.value = task.name;
+    input.rows = 1;
+    input.setAttribute('style', '-webkit-app-region: no-drag;');
+
+    const autoResize = () => {
+      input.style.height = 'auto';
+      input.style.height = input.scrollHeight + 'px';
+    };
+
+    let cancelled = false;
+
+    const restoreName = () => {
+      name.textContent = task.name;
+      header.replaceChild(name, input);
+    };
+
+    const commit = async () => {
+      if (cancelled) return;
+      const newName = input.value.trim();
+      if (newName && newName !== task.name) {
+        const result = await window.api.task.setName(path, task.taskNumber, newName);
+        if (result.success) {
+          task.name = newName;
+          invalidateTaskList();
+        }
+      }
+      restoreName();
+    };
+
+    input.addEventListener('input', autoResize);
+    input.addEventListener('blur', () => commit());
+    input.addEventListener('keydown', (ke) => {
+      ke.stopPropagation();
+      if (ke.key === 'Enter') { ke.preventDefault(); input.blur(); }
+      if (ke.key === 'Escape') { ke.preventDefault(); cancelled = true; restoreName(); }
+    });
+
+    header.replaceChild(input, name);
+    input.focus();
+    input.select();
+    autoResize();
+  });
+
   header.appendChild(name);
 
   const expandBtn = document.createElement('button');
@@ -187,12 +238,75 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
     detail.appendChild(branchRow);
   }
 
-  if (task.prompt) {
-    const promptRow = document.createElement('div');
-    promptRow.className = 'kanban-card-detail-row';
-    promptRow.innerHTML = `<span class="kanban-card-detail-label">Description</span><span class="kanban-card-detail-value kanban-card-detail-value--clamp">${escapeHtml(task.prompt)}</span>`;
-    detail.appendChild(promptRow);
-  }
+  // Description row — always visible, with placeholder when empty
+  const promptRow = document.createElement('div');
+  promptRow.className = 'kanban-card-detail-row';
+
+  const promptLabel = document.createElement('span');
+  promptLabel.className = 'kanban-card-detail-label';
+  promptLabel.textContent = 'Description';
+  promptRow.appendChild(promptLabel);
+
+  const promptValue = document.createElement('span');
+  promptValue.className = 'kanban-card-detail-value' + (task.prompt ? ' kanban-card-detail-value--clamp' : ' kanban-card-detail-value--placeholder');
+  promptValue.textContent = task.prompt || 'Add description...';
+  promptRow.appendChild(promptValue);
+
+  // Enter description edit mode
+  const startDescriptionEdit = () => {
+    const textarea = document.createElement('textarea');
+    textarea.className = 'kanban-card-description-textarea';
+    textarea.value = task.prompt || '';
+    textarea.setAttribute('style', '-webkit-app-region: no-drag;');
+    let cancelled = false;
+
+    const restorePromptValue = () => {
+      promptValue.textContent = task.prompt || 'Add description...';
+      promptValue.className = 'kanban-card-detail-value' + (task.prompt ? ' kanban-card-detail-value--clamp' : ' kanban-card-detail-value--placeholder');
+      promptRow.replaceChild(promptValue, textarea);
+    };
+
+    const commitDesc = async () => {
+      if (cancelled) return;
+      const newDesc = textarea.value.trim();
+      if (newDesc !== (task.prompt || '')) {
+        const result = await window.api.task.setDescription(path, task.taskNumber, newDesc);
+        if (result.success) {
+          task.prompt = newDesc || undefined;
+          invalidateTaskList();
+        }
+      }
+      restorePromptValue();
+    };
+
+    textarea.addEventListener('blur', () => commitDesc());
+    textarea.addEventListener('keydown', (ke) => {
+      ke.stopPropagation();
+      if (ke.key === 'Enter' && !ke.shiftKey) { ke.preventDefault(); textarea.blur(); }
+      if (ke.key === 'Escape') { ke.preventDefault(); cancelled = true; restorePromptValue(); }
+    });
+
+    promptRow.replaceChild(textarea, promptValue);
+    textarea.focus();
+  };
+
+  // Double-click to edit existing description
+  promptValue.addEventListener('dblclick', (e) => {
+    e.stopPropagation();
+    clearTimeout(clickTimer);
+    startDescriptionEdit();
+  });
+
+  // Single click on placeholder to start editing
+  promptValue.addEventListener('click', (e) => {
+    if (!task.prompt) {
+      e.stopPropagation();
+      clearTimeout(clickTimer);
+      startDescriptionEdit();
+    }
+  });
+
+  detail.appendChild(promptRow);
 
   const dateRow = document.createElement('div');
   dateRow.className = 'kanban-card-detail-row';
@@ -243,6 +357,8 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
   card.appendChild(detail);
 
   // Click anywhere on card toggles expand/collapse
+  let clickTimer: ReturnType<typeof setTimeout>;
+
   const toggleExpand = () => {
     const isExpanded = detail.classList.toggle('kanban-card-detail--visible');
     expandBtn.classList.toggle('kanban-card-expand--open', isExpanded);
@@ -255,11 +371,21 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
   });
 
   card.addEventListener('click', () => {
-    toggleExpand();
+    clearTimeout(clickTimer);
+    clickTimer = setTimeout(() => toggleExpand(), 200);
+  });
+
+  card.addEventListener('dblclick', () => {
+    clearTimeout(clickTimer);
   });
 
   // Drag handlers
   card.addEventListener('dragstart', (e) => {
+    // Prevent drag when editing inline
+    if (card.querySelector('.kanban-card-name-input, .kanban-card-description-textarea')) {
+      e.preventDefault();
+      return;
+    }
     card.classList.add('kanban-card--dragging');
     e.dataTransfer?.setData('text/plain', String(task.taskNumber));
     if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move';

--- a/src/index.css
+++ b/src/index.css
@@ -2129,11 +2129,13 @@ body.kanban-open .theatre-stack {
 }
 
 .kanban-card-header {
-  @apply flex items-center gap-2;
+  @apply flex items-start gap-2;
 }
 
 .kanban-card-name {
-  @apply flex-1 font-mono text-xs font-medium text-text-primary truncate;
+  @apply flex-1 font-mono text-xs font-medium text-text-primary min-w-0;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .kanban-card-status-dots {
@@ -2220,6 +2222,31 @@ body.kanban-open .theatre-stack {
   -webkit-box-orient: vertical;
   overflow: hidden;
   white-space: normal;
+}
+
+.kanban-card-detail-value--placeholder {
+  @apply text-text-tertiary italic transition-colors duration-150 ease-out;
+}
+
+.kanban-card-detail-value--placeholder:hover {
+  @apply text-text-secondary;
+}
+
+.kanban-card-name-input {
+  @apply flex-1 font-mono text-xs font-medium text-text-primary bg-transparent border-0 border-b border-accent p-0 outline-none min-w-0 resize-none overflow-hidden;
+  -webkit-app-region: no-drag;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.kanban-card-description-textarea {
+  @apply w-full font-sans text-xs text-text-primary bg-transparent border border-white/10 rounded p-1 outline-none resize-none;
+  min-height: 3lh;
+  -webkit-app-region: no-drag;
+}
+
+.kanban-card-description-textarea:focus {
+  @apply border-accent;
 }
 
 .kanban-card-actions {

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -24,6 +24,8 @@ import {
   setTaskStatus,
   setTaskMergeTarget,
   setTaskSandboxed,
+  setTaskName,
+  setTaskDescription,
   deleteTaskByNumber,
   getTask,
   getTaskByNumber,
@@ -465,6 +467,14 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
 
   ipcMain.handle('task:set-sandboxed', async (_event, projectPath: string, taskNumber: number, sandboxed: boolean): Promise<{ success: boolean; error?: string }> => {
     return setTaskSandboxed(projectPath, taskNumber, sandboxed);
+  });
+
+  ipcMain.handle('task:set-name', async (_event, projectPath: string, taskNumber: number, name: string): Promise<{ success: boolean; error?: string }> => {
+    return setTaskName(projectPath, taskNumber, name);
+  });
+
+  ipcMain.handle('task:set-description', async (_event, projectPath: string, taskNumber: number, description: string): Promise<{ success: boolean; error?: string }> => {
+    return setTaskDescription(projectPath, taskNumber, description);
   });
 
   // Hook handlers

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -133,6 +133,12 @@ contextBridge.exposeInMainWorld('api', {
 
     setSandboxed: (projectPath: string, taskNumber: number, sandboxed: boolean): Promise<{ success: boolean; error?: string }> =>
       ipcRenderer.invoke('task:set-sandboxed', projectPath, taskNumber, sandboxed),
+
+    setName: (projectPath: string, taskNumber: number, name: string): Promise<{ success: boolean; error?: string }> =>
+      ipcRenderer.invoke('task:set-name', projectPath, taskNumber, name),
+
+    setDescription: (projectPath: string, taskNumber: number, description: string): Promise<{ success: boolean; error?: string }> =>
+      ipcRenderer.invoke('task:set-description', projectPath, taskNumber, description),
   },
 
   /**

--- a/src/taskMetadata.ts
+++ b/src/taskMetadata.ts
@@ -398,3 +398,61 @@ export async function setTaskBranch(
   }
 }
 
+export async function setTaskName(
+  projectPath: string,
+  taskNumber: number,
+  name: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const store = await loadStore();
+    const projectData = getProjectData(store, projectPath);
+
+    if (!projectData) {
+      return { success: false, error: 'Project not found' };
+    }
+
+    const task = projectData.tasks.find(t => t.taskNumber === taskNumber);
+    if (!task) {
+      return { success: false, error: 'Task not found' };
+    }
+
+    task.name = name;
+    await saveStore(store);
+    return { success: true };
+  } catch (error) {
+    console.error('Failed to set task name:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+}
+
+export async function setTaskDescription(
+  projectPath: string,
+  taskNumber: number,
+  description: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const store = await loadStore();
+    const projectData = getProjectData(store, projectPath);
+
+    if (!projectData) {
+      return { success: false, error: 'Project not found' };
+    }
+
+    const task = projectData.tasks.find(t => t.taskNumber === taskNumber);
+    if (!task) {
+      return { success: false, error: 'Task not found' };
+    }
+
+    if (description) {
+      task.prompt = description;
+    } else {
+      delete task.prompt;
+    }
+    await saveStore(store);
+    return { success: true };
+  } catch (error) {
+    console.error('Failed to set task description:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+}
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,6 +266,8 @@ export interface TaskAPI {
   delete(projectPath: string, taskNumber: number): Promise<{ success: boolean; error?: string }>;
   setMergeTarget(projectPath: string, taskNumber: number, mergeTarget: string): Promise<{ success: boolean; error?: string }>;
   setSandboxed(projectPath: string, taskNumber: number, sandboxed: boolean): Promise<{ success: boolean; error?: string }>;
+  setName(projectPath: string, taskNumber: number, name: string): Promise<{ success: boolean; error?: string }>;
+  setDescription(projectPath: string, taskNumber: number, description: string): Promise<{ success: boolean; error?: string }>;
 }
 
 /**


### PR DESCRIPTION
Double-click card title or description to edit inline. Empty descriptions show an "Add description..." placeholder that opens the editor on single click. Titles wrap instead of truncating. Escape cancels, Enter/blur saves.