### PR TITLE
Close terminals when task is dragged to Done column

### DIFF
--- a/src/components/theatre/kanbanBoard.ts
+++ b/src/components/theatre/kanbanBoard.ts
@@ -581,6 +581,16 @@ function setupColumnDropTargets(): void {
         }
       }
 
+      if (newStatus === 'done') {
+        const tasks = await window.api.task.getAll(path);
+        const task = tasks.find(t => t.taskNumber === taskNumber);
+        if (task) {
+          await closeTask(path, task);
+          await populateKanbanBoard();
+        }
+        return;
+      }
+
       const result = await window.api.task.setStatus(path, taskNumber, newStatus);
       if (result.success) {
         invalidateTaskList();


### PR DESCRIPTION
Route drag-to-done through closeTask() so open terminals are cleaned up, matching the existing archive button behavior.