### PR TITLE
Display current task name on terminal cards instead of stale cached copy

### DIFF
--- a/src/__tests__/resolveTerminalLabel.test.ts
+++ b/src/__tests__/resolveTerminalLabel.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect, vi } from 'vitest';
+
+// Provide browser globals that transitive imports reference at load time
+if (typeof globalThis.document === 'undefined') {
+  (globalThis as any).document = { addEventListener: () => {} };
+}
+if (typeof globalThis.navigator?.userAgent === 'undefined') {
+  (globalThis as any).navigator = { ...globalThis.navigator, userAgent: '', platform: 'MacIntel' };
+}
+
+// Mock browser-only modules that terminalCards.ts imports at load time
+vi.mock('@xterm/xterm', () => ({ Terminal: class {} }));
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: class {} }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: class {} }));
+vi.mock('hotkeys-js', () => ({ default: Object.assign(() => {}, { filter: true, setScope: () => {}, getScope: () => '', deleteScope: () => {}, unbind: () => {} }) }));
+vi.mock('lucide', () => ({ createIcons: () => {}, icons: {} }));
+vi.mock('../components/importDialog', () => ({ showToast: () => {} }));
+vi.mock('../components/hookConfigDialog', () => ({ showHookConfigDialog: () => {} }));
+
+import { resolveTerminalLabel } from '../components/theatre/terminalCards';
+
+describe('resolveTerminalLabel', () => {
+  test('priority: task name > branch > fallback > Shell', () => {
+    // Task name wins when present
+    expect(resolveTerminalLabel('My Task', 'my-task-1234567890', 'Build')).toBe('My Task');
+    // Falls back to formatted branch (strips timestamp suffix)
+    expect(resolveTerminalLabel(null, 'my-task-1234567890')).toBe('my task');
+    // Falls back to explicit fallback
+    expect(resolveTerminalLabel(null, undefined, 'Build')).toBe('Build');
+    // Defaults to Shell
+    expect(resolveTerminalLabel(null, undefined)).toBe('Shell');
+  });
+
+  test('falsy task names (empty string, undefined) fall through', () => {
+    expect(resolveTerminalLabel('', 'feat-1234567890')).toBe('feat');
+    expect(resolveTerminalLabel(undefined, 'feat-1234567890')).toBe('feat');
+  });
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -3,6 +3,11 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 
+// Provide navigator for modules that reference it at import time (e.g. hotkeys.ts)
+if (typeof globalThis.navigator === 'undefined') {
+  (globalThis as any).navigator = { platform: 'MacIntel' };
+}
+
 const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ouijit-test-'));
 
 vi.mock('electron', () => ({

--- a/src/__tests__/taskMetadata.test.ts
+++ b/src/__tests__/taskMetadata.test.ts
@@ -203,6 +203,16 @@ describe('taskMetadata', () => {
     expect(task!.prompt).toBeUndefined();
   });
 
+  test('setTaskName is visible via getProjectTasks', async () => {
+    const project = '/test/name-propagates';
+    await createTask(project, 1, 'Original', { branch: 'feat/orig' });
+
+    await setTaskName(project, 1, 'Renamed');
+
+    const tasks = await getProjectTasks(project);
+    expect(tasks[0].name).toBe('Renamed');
+  });
+
   test('createTask with todo status (no branch)', async () => {
     const project = '/test/todo-task';
     const task = await createTask(project, 1, 'Plan feature', { status: 'todo' });

--- a/src/components/theatre/effects.ts
+++ b/src/components/theatre/effects.ts
@@ -13,7 +13,7 @@ import {
   kanbanVisible,
 } from './signals';
 // Direct imports - these modules import from signals.ts, not effects.ts, so no circular dep
-import { updateCardStack, showStackEmptyState, hideStackEmptyState } from './terminalCards';
+import { updateCardStack, showStackEmptyState, hideStackEmptyState, updateTerminalCardLabel } from './terminalCards';
 import { syncDiffPanelToActiveTerminal } from './diffPanel';
 import { refreshKanbanBoard, syncKanbanStatusDots } from './kanbanBoard';
 
@@ -109,6 +109,33 @@ export function initializeEffects(): void {
         void _terminals.length;
         syncKanbanStatusDots();
       }
+    })
+  );
+
+  // Effect: Sync terminal card labels when taskVersion bumps (e.g. task renamed)
+  let lastTaskVersionForLabels = taskVersion.value;
+  cleanupFunctions.push(
+    effect(() => {
+      const ver = taskVersion.value;
+      const path = projectPath.value;
+      const currentTerminals = terminals.value;
+      if (ver !== lastTaskVersionForLabels && path) {
+        lastTaskVersionForLabels = ver;
+        const taskTerminals = currentTerminals.filter(t => t.taskId != null);
+        if (taskTerminals.length > 0) {
+          window.api.task.getAll(path).then(tasks => {
+            const taskMap = new Map(tasks.map(t => [t.taskNumber, t]));
+            for (const term of taskTerminals) {
+              const task = taskMap.get(term.taskId!);
+              if (task && task.name !== term.label) {
+                term.label = task.name;
+                updateTerminalCardLabel(term);
+              }
+            }
+          });
+        }
+      }
+      lastTaskVersionForLabels = ver;
     })
   );
 

--- a/src/components/theatre/kanbanBoard.ts
+++ b/src/components/theatre/kanbanBoard.ts
@@ -448,7 +448,6 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
           existingWorktree: {
             path: startResult.worktreePath,
             branch: startResult.task?.branch || '',
-            taskName: task.name,
             prompt: task.prompt,
             createdAt: task.createdAt,
             sandboxed: task.sandboxed,
@@ -476,7 +475,6 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
         const worktreeOpts = {
           path: task.worktreePath!,
           branch: task.branch || '',
-          taskName: task.name,
           prompt: task.prompt,
           createdAt: task.createdAt,
           sandboxed: task.sandboxed,
@@ -501,7 +499,6 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
           existingWorktree: {
             path: startResult.worktreePath,
             branch: startResult.task?.branch || '',
-            taskName: task.name,
             prompt: task.prompt,
             createdAt: task.createdAt,
             sandboxed: task.sandboxed,
@@ -515,7 +512,6 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
           existingWorktree: {
             path: task.worktreePath,
             branch: task.branch || '',
-            taskName: task.name,
             prompt: task.prompt,
             createdAt: task.createdAt,
             sandboxed: task.sandboxed,
@@ -647,7 +643,6 @@ function setupColumnDropTargets(): void {
             existingWorktree: {
               path: worktreePath,
               branch,
-              taskName: task.name,
               prompt: task.prompt,
               createdAt: task.createdAt,
               sandboxed: task.sandboxed,

--- a/src/components/theatre/terminalCards.ts
+++ b/src/components/theatre/terminalCards.ts
@@ -81,7 +81,7 @@ export function debouncedResize(ptyId: PtyId, terminal: Terminal, fitAddon: FitA
 /**
  * Format a branch name for display (hyphens to spaces)
  */
-function formatBranchNameForDisplay(branch: string): string {
+export function formatBranchNameForDisplay(branch: string): string {
   // Check if it's an old-style agent-timestamp branch
   const agentMatch = branch.match(/^agent-(\d+)$/);
   if (agentMatch) {
@@ -98,6 +98,18 @@ function formatBranchNameForDisplay(branch: string): string {
 
   // Fallback: just replace hyphens with spaces
   return branch.replace(/-/g, ' ');
+}
+
+/** Resolve the display label for a terminal card.
+ *  Priority: task name > formatted branch name > fallback */
+export function resolveTerminalLabel(
+  taskName: string | null | undefined,
+  worktreeBranch: string | undefined,
+  fallback?: string,
+): string {
+  if (taskName) return taskName;
+  if (worktreeBranch) return formatBranchNameForDisplay(worktreeBranch);
+  return fallback || 'Shell';
 }
 
 // Track pending summary updates (debounced)
@@ -1070,7 +1082,6 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
     worktreeInfo = {
       path: result.worktreePath,
       branch: result.task.branch || '',
-      taskName: result.task.name,
       createdAt: result.task.createdAt,
     };
     taskPrompt = options.worktreePrompt;
@@ -1089,9 +1100,13 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
     terminalCwd = worktreeInfo.path;
   }
 
-  const label = worktreeInfo
-    ? (worktreeInfo.taskName || formatBranchNameForDisplay(worktreeInfo.branch))
-    : (runConfig?.name || 'Shell');
+  // Look up current task name from API (single source of truth)
+  let taskName: string | undefined;
+  if (options?.taskId != null) {
+    const task = await window.api.task.getByNumber(currentProjectPath, options.taskId);
+    taskName = task?.name;
+  }
+  const label = resolveTerminalLabel(taskName, worktreeInfo?.branch, runConfig?.name);
   const command = runConfig?.command;
   const index = currentTerminals.length;
 

--- a/src/components/theatre/theatreMode.ts
+++ b/src/components/theatre/theatreMode.ts
@@ -261,8 +261,16 @@ export async function enterTheatreMode(
         const mainSessions = orphaned.filter(s => !s.isRunner);
         const runnerSessions = orphaned.filter(s => s.isRunner);
 
+        // Override stale labels with current task names
+        const allTasks = await window.api.task.getAll(path);
+        const taskNameMap = new Map(allTasks.map(t => [t.taskNumber, t.name]));
+
         // First reconnect main terminals
         for (const session of mainSessions) {
+          if (session.taskId != null) {
+            const currentName = taskNameMap.get(session.taskId);
+            if (currentName) session.label = currentName;
+          }
           await reconnectTheatreTerminal(session);
         }
 
@@ -601,12 +609,18 @@ export async function restoreTheatreMode(
     const mainSessions = activeSessions.filter(s => !s.isRunner);
     const runnerSessions = activeSessions.filter(s => s.isRunner);
 
-    // Fetch task data for branch lookup during restoration
+    // Fetch task data for branch lookup and label override during restoration
     const allTasks = await window.api.task.getAll(path);
     const taskBranchMap = new Map(allTasks.filter(t => t.branch).map(t => [t.taskNumber, t.branch!]));
+    const taskNameMap = new Map(allTasks.map(t => [t.taskNumber, t.name]));
 
     // First reconnect main terminals
     for (const session of mainSessions) {
+      // Override stale label with current task name
+      if (session.taskId != null) {
+        const currentName = taskNameMap.get(session.taskId);
+        if (currentName) session.label = currentName;
+      }
       const worktreeBranch = session.taskId != null ? taskBranchMap.get(session.taskId) : undefined;
       await reconnectTheatreTerminal(session, worktreeBranch);
     }

--- a/src/components/theatre/worktreeDropdown.ts
+++ b/src/components/theatre/worktreeDropdown.ts
@@ -112,7 +112,6 @@ export async function reopenTask(path: string, task: TaskWithWorkspace): Promise
       existingWorktree: {
         path: taskPath,
         branch: task.branch || '',
-        taskName: task.name,
         createdAt: task.createdAt,
         prompt: task.prompt,
         sandboxed: task.sandboxed,

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,7 +213,6 @@ export interface TaskMetadata {
 export interface WorktreeInfo {
   path: string;
   branch: string;
-  taskName?: string;
   createdAt: string;
 }
 

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -37,7 +37,6 @@ try {
 export interface WorktreeInfo {
   path: string;
   branch: string;
-  taskName?: string;
   createdAt: string;
 }
 


### PR DESCRIPTION
Remove taskName from WorktreeInfo and resolve terminal labels from the task API (single source of truth). Labels auto-update when tasks are renamed via a taskVersion effect, and stale labels are overridden on session reconnect.