### PR TITLE
Polish compare button UX: match run button font, add ellipsis gap, hide when no changes

### DIFF
--- a/src/components/theatre/gitStatus.ts
+++ b/src/components/theatre/gitStatus.ts
@@ -140,8 +140,8 @@ export function buildCardGitStatsHtml(compactStatus: CompactGitStatus | null, is
     return `<span class="card-tab theatre-card-git-stats theatre-card-git-stats--clickable" title="View uncommitted changes">${parts.join(' ')}</span>`;
   }
 
-  // No uncommitted changes — show "Compare" for worktree terminals
-  if (isWorktree) {
+  // No uncommitted changes — show "Compare" for worktree terminals only if branch has changes vs main
+  if (isWorktree && compactStatus.branchDiffFileCount > 0) {
     return `<span class="card-tab theatre-card-git-stats theatre-card-git-stats--clickable theatre-card-git-stats--compare" title="Compare branch changes">Compare</span>`;
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1223,7 +1223,7 @@ body.platform-darwin:not(.is-fullscreen) .theatre-header-content {
 
 /* More actions (ellipsis) button — hidden until worktree setup adds --visible */
 .theatre-card-more {
-  @apply w-7 h-7 hidden items-center justify-center bg-transparent border-none text-white/50 opacity-0 transition-colors duration-150 ease-out;
+  @apply w-7 h-7 ml-1 hidden items-center justify-center bg-transparent border-none text-white/50 opacity-0 transition-colors duration-150 ease-out;
 }
 
 .theatre-card-more--visible {
@@ -1285,6 +1285,10 @@ body.platform-darwin:not(.is-fullscreen) .theatre-header-content {
 /* When clickable, override base stats styles to match card-tab */
 .theatre-card-git-stats--clickable {
   @apply px-2.5 py-1 text-[11px] font-medium text-white/60 bg-white/[0.06] rounded-full;
+}
+
+.theatre-card-git-stats--compare {
+  @apply font-sans;
 }
 
 .theatre-card-git-count {


### PR DESCRIPTION
- Add font-sans to compare button so it matches the run button styling
- Add margin between run button and ellipsis menu
- Only show Compare button when branch actually has changes vs main