### PR TITLE
Add runner panel split view with drag-to-resize support

### DIFF
--- a/src/components/theatre/helpers.ts
+++ b/src/components/theatre/helpers.ts
@@ -97,9 +97,19 @@ export function getTerminalGitPath(term: TheatreTerminal): string {
 export function hideRunnerPanel(term: TheatreTerminal): void {
   if (!term.runnerPanelOpen) return;
 
-  const panel = term.container.querySelector('.runner-panel');
+  const panel = term.container.querySelector('.runner-panel') as HTMLElement;
   if (panel) {
-    panel.classList.remove('runner-panel--visible');
+    panel.classList.remove('runner-panel--visible', 'runner-panel--full');
+    // Animate closed via flex-basis transition
+    panel.style.flexBasis = '0';
+    // After transition, remove runner-split class from card body
+    setTimeout(() => {
+      const cardBody = term.container.querySelector('.theatre-card-body');
+      if (cardBody) cardBody.classList.remove('runner-split', 'runner-full');
+      // Fit main terminal after it expands back to full width
+      term.fitAddon.fit();
+      window.api.pty.resize(term.ptyId, term.terminal.cols, term.terminal.rows);
+    }, 250);
   }
 
   // Remove active state from run button

--- a/src/components/theatre/state.ts
+++ b/src/components/theatre/state.ts
@@ -49,6 +49,11 @@ export interface TheatreTerminal {
   runnerStatus: 'running' | 'success' | 'error' | 'idle';
   runnerCleanupData: (() => void) | null;
   runnerCleanupExit: (() => void) | null;
+  // Runner split layout state
+  runnerFullWidth: boolean;                     // true = full width (default), false = split
+  runnerSplitRatio: number;                    // 0-1, default 0.5
+  runnerResizeObserver: ResizeObserver | null;  // for runner xterm container
+  runnerResizeCleanup: (() => void) | null;     // cleanup for drag listeners
 }
 
 // Per-project session storage for preserving theatre mode across project switches

--- a/src/components/theatre/terminalCards.ts
+++ b/src/components/theatre/terminalCards.ts
@@ -583,12 +583,16 @@ async function closeTaskFromTerminal(term: TheatreTerminal): Promise<void> {
 /**
  * Build HTML for the runner panel
  */
-function buildRunnerPanelHtml(label: string): string {
+function buildRunnerPanelHtml(label: string, fullWidth: boolean): string {
+  const icon = fullWidth ? 'maximize-2' : 'columns-2';
+  const title = fullWidth ? 'Split view' : 'Full width';
   return `
-    <div class="runner-panel">
+    <div class="runner-panel${fullWidth ? ' runner-panel--full' : ''}">
       <div class="runner-panel-header">
+        <button class="runner-panel-kill" title="Kill"><i data-lucide="circle-off"></i></button>
+        <button class="runner-panel-restart" title="Restart"><i data-lucide="rotate-ccw"></i></button>
         <span class="runner-panel-title">${label}</span>
-        <button class="runner-panel-kill" title="Kill runner">Kill</button>
+        <button class="runner-panel-split-toggle" title="${title}"><i data-lucide="${icon}"></i></button>
         <button class="runner-panel-collapse" title="Close panel"><i data-lucide="x"></i></button>
       </div>
       <div class="runner-panel-body">
@@ -596,6 +600,60 @@ function buildRunnerPanelHtml(label: string): string {
       </div>
     </div>
   `;
+}
+
+/**
+ * Set up drag interaction for the runner resize handle.
+ * Returns a cleanup function to remove listeners.
+ */
+function setupRunnerResizeHandle(term: TheatreTerminal, handle: HTMLElement, panel: HTMLElement): () => void {
+  const cardBody = term.container.querySelector('.theatre-card-body') as HTMLElement;
+  if (!cardBody) return () => {};
+
+  let dragging = false;
+
+  const onMouseDown = (e: MouseEvent) => {
+    e.preventDefault();
+    dragging = true;
+    // Disable CSS transition during drag for smooth tracking
+    panel.style.transition = 'none';
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  };
+
+  const onMouseMove = (e: MouseEvent) => {
+    if (!dragging) return;
+    const rect = cardBody.getBoundingClientRect();
+    const handleWidth = handle.offsetWidth;
+    // Mouse position relative to card body, accounting for handle
+    const totalWidth = rect.width - handleWidth;
+    const mouseX = e.clientX - rect.left;
+    // Runner is on the right, so runner ratio = 1 - (mouseX / totalWidth)
+    let ratio = 1 - (mouseX / totalWidth);
+    // Clamp to [0.15, 0.85]
+    ratio = Math.max(0.15, Math.min(0.85, ratio));
+    term.runnerSplitRatio = ratio;
+    panel.style.flexBasis = `${ratio * 100}%`;
+  };
+
+  const onMouseUp = () => {
+    if (!dragging) return;
+    dragging = false;
+    // Restore CSS transition
+    panel.style.transition = '';
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+  };
+
+  handle.addEventListener('mousedown', onMouseDown);
+  document.addEventListener('mousemove', onMouseMove);
+  document.addEventListener('mouseup', onMouseUp);
+
+  return () => {
+    handle.removeEventListener('mousedown', onMouseDown);
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+  };
 }
 
 /**
@@ -609,16 +667,34 @@ export function showRunnerPanel(term: TheatreTerminal): void {
     hideTerminalDiffPanel(term);
   }
 
-  const cardBody = term.container.querySelector('.theatre-card-body');
+  const cardBody = term.container.querySelector('.theatre-card-body') as HTMLElement;
   if (!cardBody) return;
+
+  // Add runner-split class for min-width constraints
+  cardBody.classList.add('runner-split');
+  // Toggle full-width class on card body
+  cardBody.classList.toggle('runner-full', term.runnerFullWidth);
 
   // Check if panel already exists
   let panel = cardBody.querySelector('.runner-panel') as HTMLElement;
   if (!panel) {
+    // Create resize handle
+    const handle = document.createElement('div');
+    handle.className = 'runner-resize-handle';
+
+    // Insert handle before the runner panel position (after viewport)
+    const viewport = cardBody.querySelector('.terminal-viewport');
+    if (viewport) {
+      viewport.after(handle);
+    }
+
     // Create panel (insert at end so it appears on the right)
-    cardBody.insertAdjacentHTML('beforeend', buildRunnerPanelHtml(term.runnerCommand || term.runnerLabel || 'Runner'));
+    cardBody.insertAdjacentHTML('beforeend', buildRunnerPanelHtml(term.runnerCommand || term.runnerLabel || 'Runner', term.runnerFullWidth));
     panel = cardBody.querySelector('.runner-panel') as HTMLElement;
     if (!panel) return;
+
+    // Render lucide icons in the panel header
+    createIcons({ icons, nameAttr: 'data-lucide', attrs: {}, nodes: [panel] });
 
     // Wire up collapse button (hides panel but keeps runner alive)
     const collapseBtn = panel.querySelector('.runner-panel-collapse');
@@ -635,6 +711,24 @@ export function showRunnerPanel(term: TheatreTerminal): void {
       killBtn.addEventListener('click', (e) => {
         e.stopPropagation();
         killRunner(term);
+      });
+    }
+
+    // Wire up restart button (re-runs the run script)
+    const restartBtn = panel.querySelector('.runner-panel-restart');
+    if (restartBtn) {
+      restartBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        restartRunner(term);
+      });
+    }
+
+    // Wire up split toggle button
+    const splitToggleBtn = panel.querySelector('.runner-panel-split-toggle');
+    if (splitToggleBtn) {
+      splitToggleBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        toggleRunnerFullWidth(term);
       });
     }
 
@@ -678,13 +772,18 @@ export function showRunnerPanel(term: TheatreTerminal): void {
           setupRunnerDragDrop(xtermContainer, term.runnerTerminal);
         }
 
-        if (term.runnerFitAddon) {
-          requestAnimationFrame(() => {
-            term.runnerFitAddon!.fit();
-          });
-        }
+        // Set up ResizeObserver on runner xterm container
+        term.runnerResizeObserver = new ResizeObserver(() => {
+          if (term.runnerPtyId && term.runnerTerminal && term.runnerFitAddon) {
+            debouncedResize(term.runnerPtyId, term.runnerTerminal, term.runnerFitAddon);
+          }
+        });
+        term.runnerResizeObserver.observe(xtermContainer);
       }
     }
+
+    // Set up resize handle drag interaction
+    term.runnerResizeCleanup = setupRunnerResizeHandle(term, handle, panel);
   }
 
   term.runnerPanelOpen = true;
@@ -693,19 +792,30 @@ export function showRunnerPanel(term: TheatreTerminal): void {
   const runBtn = term.container.querySelector('.card-tab-run');
   if (runBtn) runBtn.classList.add('card-tab--active');
 
-  // Show panel
+  // Animate open via flex-basis
   requestAnimationFrame(() => {
     panel.classList.add('runner-panel--visible');
+    if (term.runnerFullWidth) {
+      panel.style.flexBasis = '100%';
+    } else {
+      panel.style.flexBasis = `${term.runnerSplitRatio * 100}%`;
+    }
   });
 
-  // Fit runner terminal after animation and focus it
+  // Fit terminals after animation settles
   setTimeout(() => {
+    // Fit runner terminal
     if (term.runnerFitAddon && term.runnerPtyId) {
       term.runnerFitAddon.fit();
       window.api.pty.resize(term.runnerPtyId, term.runnerTerminal!.cols, term.runnerTerminal!.rows);
       term.runnerTerminal!.focus();
     }
-  }, 200);
+    // Fit main terminal only if in split mode (it shrank)
+    if (!term.runnerFullWidth) {
+      term.fitAddon.fit();
+      window.api.pty.resize(term.ptyId, term.terminal.cols, term.terminal.rows);
+    }
+  }, 250);
 }
 
 
@@ -721,13 +831,69 @@ export function toggleRunnerPanel(term: TheatreTerminal): void {
 }
 
 /**
+ * Toggle runner panel between full-width and split mode
+ */
+function toggleRunnerFullWidth(term: TheatreTerminal): void {
+  term.runnerFullWidth = !term.runnerFullWidth;
+
+  const panel = term.container.querySelector('.runner-panel') as HTMLElement;
+  if (!panel) return;
+
+  // Disable transition for instant swap
+  panel.style.transition = 'none';
+
+  // Toggle full-width class on card body
+  const cardBody = term.container.querySelector('.theatre-card-body');
+  if (cardBody) cardBody.classList.toggle('runner-full', term.runnerFullWidth);
+
+  // Update toggle button icon
+  const toggleBtn = panel.querySelector('.runner-panel-split-toggle') as HTMLElement;
+
+  if (term.runnerFullWidth) {
+    panel.classList.add('runner-panel--full');
+    panel.style.flexBasis = '100%';
+    if (toggleBtn) {
+      toggleBtn.innerHTML = '<i data-lucide="maximize-2"></i>';
+      toggleBtn.title = 'Split view';
+    }
+  } else {
+    panel.classList.remove('runner-panel--full');
+    panel.style.flexBasis = `${term.runnerSplitRatio * 100}%`;
+    if (toggleBtn) {
+      toggleBtn.innerHTML = '<i data-lucide="columns-2"></i>';
+      toggleBtn.title = 'Full width';
+    }
+  }
+
+  // Re-render lucide icons for the updated button
+  if (toggleBtn) {
+    createIcons({ icons, nameAttr: 'data-lucide', attrs: {}, nodes: [toggleBtn] });
+  }
+
+  // Force layout, then restore transition and fit terminals
+  requestAnimationFrame(() => {
+    panel.style.transition = '';
+    if (term.runnerFitAddon && term.runnerPtyId && term.runnerTerminal) {
+      term.runnerFitAddon.fit();
+      window.api.pty.resize(term.runnerPtyId, term.runnerTerminal.cols, term.runnerTerminal.rows);
+    }
+    if (!term.runnerFullWidth) {
+      term.fitAddon.fit();
+      window.api.pty.resize(term.ptyId, term.terminal.cols, term.terminal.rows);
+    }
+  });
+}
+
+/**
  * Kill the runner process and clean up resources
  */
 export function killRunner(term: TheatreTerminal): void {
   if (!term.runnerPtyId) return;
 
-  // Hide panel first
-  hideRunnerPanel(term);
+  // Mark panel closed and remove active state (skip hideRunnerPanel to avoid stale timeout)
+  term.runnerPanelOpen = false;
+  const runBtn = term.container.querySelector('.card-tab-run');
+  if (runBtn) runBtn.classList.remove('card-tab--active');
 
   // Kill PTY
   window.api.pty.kill(term.runnerPtyId);
@@ -736,16 +902,32 @@ export function killRunner(term: TheatreTerminal): void {
   if (term.runnerCleanupData) term.runnerCleanupData();
   if (term.runnerCleanupExit) term.runnerCleanupExit();
 
+  // Clean up resize observer and drag listeners
+  if (term.runnerResizeObserver) {
+    term.runnerResizeObserver.disconnect();
+    term.runnerResizeObserver = null;
+  }
+  if (term.runnerResizeCleanup) {
+    term.runnerResizeCleanup();
+    term.runnerResizeCleanup = null;
+  }
+
   // Dispose terminal
   if (term.runnerTerminal) {
     term.runnerTerminal.dispose();
   }
 
+  // Remove resize handle DOM
+  const handle = term.container.querySelector('.runner-resize-handle');
+  if (handle) handle.remove();
+
   // Remove panel DOM
   const panel = term.container.querySelector('.runner-panel');
-  if (panel) {
-    panel.remove();
-  }
+  if (panel) panel.remove();
+
+  // Remove runner-split class from card body
+  const cardBody = term.container.querySelector('.theatre-card-body');
+  if (cardBody) cardBody.classList.remove('runner-split', 'runner-full');
 
   // Reset state
   term.runnerPtyId = null;
@@ -756,9 +938,22 @@ export function killRunner(term: TheatreTerminal): void {
   term.runnerStatus = 'idle';
   term.runnerCleanupData = null;
   term.runnerCleanupExit = null;
+  term.runnerFullWidth = true;
 
   // Collapse the pill
   updateRunnerPill(term);
+}
+
+/**
+ * Restart the runner — kill current process and re-run the run script
+ */
+async function restartRunner(term: TheatreTerminal): Promise<void> {
+  const wasFullWidth = term.runnerFullWidth;
+  killRunner(term);
+  await runDefaultInCard(term);
+  // Restore full-width preference and show panel
+  term.runnerFullWidth = wasFullWidth;
+  showRunnerPanel(term);
 }
 
 /**
@@ -1257,6 +1452,10 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
       runnerStatus: 'idle',
       runnerCleanupData: null,
       runnerCleanupExit: null,
+      runnerFullWidth: true,
+      runnerSplitRatio: 0.5,
+      runnerResizeObserver: null,
+      runnerResizeCleanup: null,
     };
 
     // Set up close button and card click handlers
@@ -1467,6 +1666,10 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
       runnerStatus: 'idle',
       runnerCleanupData: null,
       runnerCleanupExit: null,
+      runnerFullWidth: true,
+      runnerSplitRatio: 0.5,
+      runnerResizeObserver: null,
+      runnerResizeCleanup: null,
     };
 
     // Set up resize observer with debouncing to prevent zsh artifacts during animations
@@ -1596,6 +1799,8 @@ export function closeTheatreTerminal(index: number): void {
     window.api.pty.kill(term.runnerPtyId);
     if (term.runnerCleanupData) term.runnerCleanupData();
     if (term.runnerCleanupExit) term.runnerCleanupExit();
+    if (term.runnerResizeObserver) term.runnerResizeObserver.disconnect();
+    if (term.runnerResizeCleanup) term.runnerResizeCleanup();
     if (term.runnerTerminal) term.runnerTerminal.dispose();
   }
 

--- a/src/components/theatre/theatreMode.ts
+++ b/src/components/theatre/theatreMode.ts
@@ -832,6 +832,10 @@ async function reconnectTheatreTerminal(session: ActiveSession, worktreeBranch?:
     runnerStatus: 'idle',
     runnerCleanupData: null,
     runnerCleanupExit: null,
+    runnerFullWidth: true,
+    runnerSplitRatio: 0.5,
+    runnerResizeObserver: null,
+    runnerResizeCleanup: null,
   };
 
   // Set up close button handler

--- a/src/index.css
+++ b/src/index.css
@@ -1343,15 +1343,67 @@ body.platform-darwin:not(.is-fullscreen) .theatre-header-content {
   @apply text-[#ff6b6b];
 }
 
-/* Runner Panel - Full-width overlay (like diff panel) */
+/* Runner Panel - Side-by-side split layout */
 .runner-panel {
-  @apply absolute inset-0 rounded-none border-0 border-t border-solid border-white/10 shadow-none z-20 flex flex-col overflow-hidden opacity-0 pointer-events-none;
+  @apply rounded-none border-0 border-l border-t border-solid border-white/10 shadow-none flex flex-col overflow-hidden;
+  flex-basis: 0;
   background: var(--color-terminal-bg, #1a1a1a);
-  transition: opacity 0.15s ease;
+  transition: flex-basis 0.25s ease;
 }
 
 .runner-panel--visible {
-  @apply opacity-100 pointer-events-auto;
+  /* flex-basis is set dynamically via JS */
+}
+
+/* Full-width runner mode - runner covers the entire card body */
+.runner-panel--full {
+  flex: 1 0 100% !important;
+  border-left: none !important;
+  border-top: none;
+}
+
+/* Hide main terminal viewport and resize handle when runner is full-width */
+.runner-split.runner-full > .terminal-viewport {
+  display: none !important;
+}
+
+.runner-split.runner-full > .runner-resize-handle {
+  display: none !important;
+}
+
+/* Remove min-width in full mode to prevent layout conflict */
+.runner-split > .runner-panel.runner-panel--full {
+  min-width: 0;
+}
+
+/* Resize handle between terminal and runner panel */
+.runner-resize-handle {
+  @apply shrink-0 relative;
+  width: 4px;
+  cursor: col-resize;
+  background: transparent;
+  transition: background 0.15s ease;
+}
+
+.runner-resize-handle:hover,
+.runner-resize-handle:active {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.runner-resize-handle::after {
+  content: '';
+  @apply absolute top-0 bottom-0;
+  left: -8px;
+  right: -8px;
+}
+
+/* Min-width constraints when runner split is active */
+.runner-split > .terminal-viewport {
+  min-width: 200px;
+}
+
+.runner-split > .runner-panel {
+  min-width: 200px;
 }
 
 .runner-panel-header {
@@ -1363,11 +1415,39 @@ body.platform-darwin:not(.is-fullscreen) .theatre-header-content {
 }
 
 .runner-panel-kill {
-  @apply px-2 py-0.5 bg-white/5 border-none rounded text-[10px] font-medium text-white/40 transition-all duration-150 ease-out;
+  @apply w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/40 shrink-0 transition-all duration-150 ease-out;
 }
 
 .runner-panel-kill:hover {
   @apply bg-red-500/20 text-[#ff6b6b];
+}
+
+.runner-panel-kill svg {
+  @apply w-3.5 h-3.5;
+}
+
+.runner-panel-restart {
+  @apply w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/40 shrink-0 transition-all duration-150 ease-out;
+}
+
+.runner-panel-restart:hover {
+  @apply bg-white/10 text-white/90;
+}
+
+.runner-panel-restart svg {
+  @apply w-3.5 h-3.5;
+}
+
+.runner-panel-split-toggle {
+  @apply w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/60 shrink-0 transition-all duration-150 ease-out;
+}
+
+.runner-panel-split-toggle:hover {
+  @apply bg-white/10 text-white/90;
+}
+
+.runner-panel-split-toggle svg {
+  @apply w-3.5 h-3.5;
 }
 
 .runner-panel-collapse {


### PR DESCRIPTION
Replace full-width overlay layout with side-by-side split view that supports drag-to-resize between terminal and runner. Add restart button, split/full toggle, and proper cleanup for resize observers and drag listeners.