### PR TITLE
Switch from kanban to terminal view when creating new terminal

### DIFF
--- a/src/components/theatre/kanbanBoard.ts
+++ b/src/components/theatre/kanbanBoard.ts
@@ -1026,12 +1026,18 @@ export async function showKanbanBoard(): Promise<void> {
     if (input) input.focus();
   });
 
+  registerHotkey(platformHotkey('mod+i'), Scopes.KANBAN, () => {
+    hideKanbanBoard();
+    theatreRegistry.addTheatreTerminal?.();
+  });
+
   theatreState.kanbanCleanup = () => {
     resizeObserver.disconnect();
     unregisterHotkey('escape', Scopes.KANBAN);
     unregisterHotkey(platformHotkey('mod+b'), Scopes.KANBAN);
     unregisterHotkey(platformHotkey('mod+t'), Scopes.KANBAN);
     unregisterHotkey(platformHotkey('mod+n'), Scopes.KANBAN);
+    unregisterHotkey(platformHotkey('mod+i'), Scopes.KANBAN);
     popScope();
   };
 

--- a/src/components/theatre/theatreMode.ts
+++ b/src/components/theatre/theatreMode.ts
@@ -125,6 +125,7 @@ export async function enterTheatreMode(
     if (terminalBtn) {
       terminalBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
+        if (kanbanVisible.value) hideKanbanBoard();
         await addTheatreTerminal();
       });
     }
@@ -579,6 +580,7 @@ export async function restoreTheatreMode(
     if (terminalBtn) {
       terminalBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
+        if (kanbanVisible.value) hideKanbanBoard();
         await addTheatreTerminal();
       });
     }


### PR DESCRIPTION
When adding a new terminal via the toolbar button or Cmd+I while the kanban board is visible, automatically hide the kanban board first.