### PR TITLE
Reduce terminal and rendering overhead for better performance

### DIFF
--- a/src/components/theatre/terminalCards.ts
+++ b/src/components/theatre/terminalCards.ts
@@ -1048,7 +1048,7 @@ export async function runDefaultInCard(term: TheatreTerminal): Promise<void> {
     cursorBlink: false,
     cursorStyle: 'bar',
     allowTransparency: false,
-    scrollback: 10000,
+    scrollback: 2000,
   });
 
   const runnerFitAddon = new FitAddon();
@@ -1394,7 +1394,7 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
     cursorBlink: true,
     cursorStyle: 'bar',
     allowTransparency: false,
-    scrollback: 10000,
+    scrollback: 2000,
   });
 
   const fitAddon = new FitAddon();

--- a/src/components/theatre/theatreMode.ts
+++ b/src/components/theatre/theatreMode.ts
@@ -726,8 +726,8 @@ async function reconnectTheatreTerminal(session: ActiveSession, worktreeBranch?:
     fontFamily: 'Iosevka Term Extended, "SF Mono", Menlo, Monaco, monospace',
     lineHeight: 1.2,
     theme: getTerminalTheme(),
-    allowTransparency: true,
-    scrollback: 10000,
+    allowTransparency: false,
+    scrollback: 2000,
   });
 
   const fitAddon = new FitAddon();
@@ -944,8 +944,8 @@ async function reconnectRunnerToParent(
     lineHeight: 1.2,
     cursorBlink: false,
     cursorStyle: 'bar',
-    allowTransparency: true,
-    scrollback: 10000,
+    allowTransparency: false,
+    scrollback: 2000,
   });
 
   const runnerFitAddon = new FitAddon();

--- a/src/index.css
+++ b/src/index.css
@@ -1078,22 +1078,26 @@ body.platform-darwin:not(.is-fullscreen) .theatre-header-content {
 
 .theatre-card--back-1 {
   @apply z-[9] -translate-y-6 scale-x-[0.98];
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 2px 8px rgba(0, 0, 0, 0.1), 0 12px 24px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.12);
+  contain: layout style paint;
 }
 
 .theatre-card--back-2 {
   @apply z-[8] -translate-y-12 scale-x-[0.96];
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 2px 6px rgba(0, 0, 0, 0.08), 0 8px 16px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 1px 4px rgba(0, 0, 0, 0.08);
+  contain: layout style paint;
 }
 
 .theatre-card--back-3 {
   @apply z-[7] -translate-y-[72px] scale-x-[0.94];
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 1px 4px rgba(0, 0, 0, 0.06), 0 4px 10px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08);
+  contain: layout style paint;
 }
 
 .theatre-card--back-4 {
   @apply z-[6] -translate-y-24 scale-x-[0.92];
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 1px 2px rgba(0, 0, 0, 0.04), 0 2px 6px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.06);
+  contain: layout style paint;
 }
 
 /* Back card label positioning */


### PR DESCRIPTION
## Summary
- Lower terminal scrollback buffer from 10k to 2k lines across all terminal instances
- Disable `allowTransparency` on reconnected terminals (was unnecessarily enabled)
- Simplify back-card box shadows and add CSS `contain: layout style paint` for faster compositing