### PR TITLE
Rename theatre to project-centric naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Do NOT run `npm run start` or other dev server commands.
 - `src/preload.ts` - Preload script (IPC bridge)
 - `src/renderer.ts` - Renderer entry point
 - `src/components/` - UI components
-- `src/components/theatre/` - Theatre mode (terminal/task runner UI)
+- `src/components/project/` - Project mode (terminal/task runner UI)
 - `src/utils/` - Shared utilities
 - `src/ouijit/` - Core app logic (import/export, dependencies)
 - `src/lima/` - Lima VM sandbox integration
@@ -36,23 +36,23 @@ Do NOT run `npm run start` or other dev server commands.
 
 ## Code Rules
 
-- **No dynamic imports** — never use `import()` for lazy loading or code splitting. Always use static `import` at the top of the file. Vite handles circular dependencies fine for functions called inside handlers (not at module evaluation time). Use the `theatreRegistry` pattern only when true circular top-level access is needed.
+- **No dynamic imports** — never use `import()` for lazy loading or code splitting. Always use static `import` at the top of the file. Vite handles circular dependencies fine for functions called inside handlers (not at module evaluation time). Use the `projectRegistry` pattern only when true circular top-level access is needed.
 - Don't replace `innerHTML` on elements with event listeners (destroys handlers)
 - Use targeted DOM updates instead of full rebuilds
 - Clear intervals/timeouts on cleanup
 - Use `-webkit-app-region: no-drag;` for any UI elements (dropdowns, menus) originating in the titlebar area
 
-### Theatre Mode Hotkeys
+### Project Mode Hotkeys
 
-To add a new hotkey in theatre mode:
+To add a new hotkey in project mode:
 
-1. Add the handler function signature to `TheatreRegistry` interface in `helpers.ts`
-2. Add initial `null` value in the `theatreRegistry` object
+1. Add the handler function signature to `ProjectRegistry` interface in `helpers.ts`
+2. Add initial `null` value in the `projectRegistry` object
 3. Implement the handler in the appropriate module (e.g., `terminalCards.ts`, `diffPanel.ts`)
-4. Register it: `theatreRegistry.myHandler = myHandler;` at module load time
-5. In `theatreMode.ts`:
-   - Register hotkey in both `enterTheatreMode` and `restoreTheatreMode`
-   - Unregister in `exitTheatreMode`
-   - Call via registry with optional chaining: `theatreRegistry.myHandler?.()`
+4. Register it: `projectRegistry.myHandler = myHandler;` at module load time
+5. In `projectMode.ts`:
+   - Register hotkey in both `enterProjectMode` and `restoreProjectMode`
+   - Unregister in `exitProjectMode`
+   - Call via registry with optional chaining: `projectRegistry.myHandler?.()`
 
-This registry pattern avoids circular dependencies between theatre modules.
+This registry pattern avoids circular dependencies between project modules.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ouijit
 
-![Ouijit Theatre Mode](screenshot.png)
+![Ouijit Project Mode](screenshot.png)
 
 ## Features
 
@@ -87,7 +87,7 @@ src/main.ts          # Electron main process
 src/preload.ts       # Preload script (IPC bridge)
 src/renderer.ts      # Renderer entry point
 src/components/      # UI components
-src/components/theatre/  # Theatre mode (terminal/task runner UI)
+src/components/project/  # Project mode (terminal/task runner UI)
 src/utils/           # Shared utilities
 src/ouijit/          # Core app logic (import/export, dependencies)
 src/lima/            # Lima VM sandbox integration

--- a/src/__tests__/resolveTerminalLabel.test.ts
+++ b/src/__tests__/resolveTerminalLabel.test.ts
@@ -17,7 +17,7 @@ vi.mock('lucide', () => ({ createIcons: () => {}, icons: {} }));
 vi.mock('../components/importDialog', () => ({ showToast: () => {} }));
 vi.mock('../components/hookConfigDialog', () => ({ showHookConfigDialog: () => {} }));
 
-import { resolveTerminalLabel } from '../components/theatre/terminalCards';
+import { resolveTerminalLabel } from '../components/project/terminalCards';
 
 describe('resolveTerminalLabel', () => {
   test('priority: task name > branch > fallback > Shell', () => {

--- a/src/components/project/diffPanel.ts
+++ b/src/components/project/diffPanel.ts
@@ -1,11 +1,11 @@
 /**
- * Compare panel for viewing diffs in theatre mode
+ * Compare panel for viewing diffs in project mode
  * Supports two modes: uncommitted changes and worktree branch vs main
  */
 
 import type { ChangedFile, FileDiff } from '../../types';
-import { TheatreTerminal } from './state';
-import { getTerminalGitPath, hideRunnerPanel, theatreRegistry } from './helpers';
+import { ProjectTerminal } from './state';
+import { getTerminalGitPath, hideRunnerPanel, projectRegistry } from './helpers';
 import {
   projectPath,
   terminals,
@@ -375,7 +375,7 @@ function wireDiffPanel(
  * Unified function that handles both uncommitted and worktree modes
  * @param targetBranch - For worktree mode, the branch to compare against (defaults to task merge target or main)
  */
-export async function showTerminalComparePanel(term: TheatreTerminal, mode: 'uncommitted' | 'worktree', targetBranch?: string): Promise<void> {
+export async function showTerminalComparePanel(term: ProjectTerminal, mode: 'uncommitted' | 'worktree', targetBranch?: string): Promise<void> {
   if (term.diffPanelOpen) return;
 
   // Worktree mode requires a worktree branch
@@ -435,7 +435,7 @@ export async function showTerminalComparePanel(term: TheatreTerminal, mode: 'unc
   }
 
   // Find the card body to insert the diff panel
-  const cardBody = term.container.querySelector('.theatre-card-body');
+  const cardBody = term.container.querySelector('.project-card-body');
   if (!cardBody) return;
 
   // Hide the terminal viewport
@@ -458,7 +458,7 @@ export async function showTerminalComparePanel(term: TheatreTerminal, mode: 'unc
   term.container.classList.add('diff-panel-open');
 
   // Mark stats button as active
-  const statsEl = term.container.querySelector('.theatre-card-git-stats--clickable');
+  const statsEl = term.container.querySelector('.project-card-git-stats--clickable');
   if (statsEl) statsEl.classList.add('card-tab--active');
 
   // Wire up panel interactions
@@ -526,7 +526,7 @@ export async function showTerminalComparePanel(term: TheatreTerminal, mode: 'unc
  * Show target branch dropdown for switching the comparison target
  */
 async function showTargetBranchDropdown(
-  term: TheatreTerminal,
+  term: ProjectTerminal,
   panel: HTMLElement,
   targetContainer: HTMLElement,
   currentTarget: string
@@ -604,7 +604,7 @@ async function showTargetBranchDropdown(
 /**
  * Swap the compare target branch in-place without tearing down the panel
  */
-async function swapCompareTarget(term: TheatreTerminal, panel: HTMLElement, newTarget: string): Promise<void> {
+async function swapCompareTarget(term: ProjectTerminal, panel: HTMLElement, newTarget: string): Promise<void> {
   const basePath = projectPath.value;
   if (!basePath || !term.worktreeBranch) return;
 
@@ -674,21 +674,21 @@ async function swapCompareTarget(term: TheatreTerminal, panel: HTMLElement, newT
 /**
  * Show the diff panel for a specific terminal (uncommitted changes)
  */
-export async function showTerminalDiffPanel(term: TheatreTerminal): Promise<void> {
+export async function showTerminalDiffPanel(term: ProjectTerminal): Promise<void> {
   return showTerminalComparePanel(term, 'uncommitted');
 }
 
 /**
  * Show the worktree diff panel for a specific terminal (branch vs main comparison)
  */
-export async function showTerminalWorktreeDiffPanel(term: TheatreTerminal): Promise<void> {
+export async function showTerminalWorktreeDiffPanel(term: ProjectTerminal): Promise<void> {
   return showTerminalComparePanel(term, 'worktree');
 }
 
 /**
  * Hide the diff panel for a specific terminal
  */
-export function hideTerminalDiffPanel(term: TheatreTerminal): void {
+export function hideTerminalDiffPanel(term: ProjectTerminal): void {
   if (!term.diffPanelOpen) return;
 
   // Find the panel inside the card
@@ -700,7 +700,7 @@ export function hideTerminalDiffPanel(term: TheatreTerminal): void {
       panel.remove();
 
       // Show the terminal viewport again
-      const cardBody = term.container.querySelector('.theatre-card-body');
+      const cardBody = term.container.querySelector('.project-card-body');
       const viewport = cardBody?.querySelector('.terminal-viewport') as HTMLElement;
       if (viewport) {
         viewport.style.display = '';
@@ -719,7 +719,7 @@ export function hideTerminalDiffPanel(term: TheatreTerminal): void {
   term.container.classList.remove('diff-panel-open');
 
   // Remove active state from stats button
-  const statsEl = term.container.querySelector('.theatre-card-git-stats--clickable');
+  const statsEl = term.container.querySelector('.project-card-git-stats--clickable');
   if (statsEl) statsEl.classList.remove('card-tab--active');
 
   // Update terminal state
@@ -739,7 +739,7 @@ export function hideTerminalDiffPanel(term: TheatreTerminal): void {
 /**
  * Toggle the diff panel for a specific terminal
  */
-export async function toggleTerminalDiffPanel(term: TheatreTerminal): Promise<void> {
+export async function toggleTerminalDiffPanel(term: ProjectTerminal): Promise<void> {
   if (term.diffPanelOpen) {
     hideTerminalDiffPanel(term);
   } else {
@@ -750,7 +750,7 @@ export async function toggleTerminalDiffPanel(term: TheatreTerminal): Promise<vo
 /**
  * Toggle the worktree diff panel for a specific terminal
  */
-export async function toggleTerminalWorktreeDiffPanel(term: TheatreTerminal): Promise<void> {
+export async function toggleTerminalWorktreeDiffPanel(term: ProjectTerminal): Promise<void> {
   if (term.diffPanelOpen) {
     hideTerminalDiffPanel(term);
   } else {
@@ -788,8 +788,8 @@ export async function showDiffPanel(): Promise<void> {
   // Wire up panel interactions
   wireDiffPanel(panel, () => hideDiffPanel());
 
-  // Add class to theatre stack to shrink it
-  const stack = document.querySelector('.theatre-stack');
+  // Add class to project stack to shrink it
+  const stack = document.querySelector('.project-stack');
   if (stack) {
     stack.classList.add('diff-panel-open');
   }
@@ -799,7 +799,7 @@ export async function showDiffPanel(): Promise<void> {
     panel.classList.add('diff-panel--visible');
   });
 
-  // Refit active theatre terminal after animation
+  // Refit active project terminal after animation
   setTimeout(() => refitActiveTerminal(), 250);
 
   // Load all diffs
@@ -821,13 +821,13 @@ export function hideDiffPanel(): void {
     setTimeout(() => panel.remove(), 250);
   }
 
-  // Remove class from theatre stack
-  const stack = document.querySelector('.theatre-stack');
+  // Remove class from project stack
+  const stack = document.querySelector('.project-stack');
   if (stack) {
     stack.classList.remove('diff-panel-open');
   }
 
-  // Refit active theatre terminal after animation
+  // Refit active project terminal after animation
   setTimeout(() => refitActiveTerminal(), 250);
 
   diffPanelVisible.value = false;
@@ -886,8 +886,8 @@ export async function showWorktreeDiffPanel(worktreeBranch: string): Promise<voi
     headerInfo.textContent = 'vs main';
   }
 
-  // Add class to theatre stack to shrink it
-  const stack = document.querySelector('.theatre-stack');
+  // Add class to project stack to shrink it
+  const stack = document.querySelector('.project-stack');
   if (stack) {
     stack.classList.add('diff-panel-open');
   }
@@ -897,7 +897,7 @@ export async function showWorktreeDiffPanel(worktreeBranch: string): Promise<voi
     panel.classList.add('diff-panel--visible');
   });
 
-  // Refit active theatre terminal after animation
+  // Refit active project terminal after animation
   setTimeout(() => refitActiveTerminal(), 250);
 
   // Load all diffs
@@ -956,5 +956,5 @@ async function toggleActiveDiffPanel(): Promise<void> {
   await toggleTerminalDiffPanel(activeTerm);
 }
 
-// Register in theatre registry for cross-module access
-theatreRegistry.toggleActiveDiffPanel = toggleActiveDiffPanel;
+// Register in project registry for cross-module access
+projectRegistry.toggleActiveDiffPanel = toggleActiveDiffPanel;

--- a/src/components/project/effects.ts
+++ b/src/components/project/effects.ts
@@ -1,5 +1,5 @@
 /**
- * Reactive effects for theatre mode
+ * Reactive effects for project mode
  * Automatically respond to signal changes without manual update calls
  */
 
@@ -24,8 +24,8 @@ let effectsInitialized = false;
 const cleanupFunctions: (() => void)[] = [];
 
 /**
- * Initialize all theatre mode effects
- * Should be called once when theatre mode is first entered
+ * Initialize all project mode effects
+ * Should be called once when project mode is first entered
  */
 export function initializeEffects(): void {
   if (effectsInitialized) return;
@@ -38,7 +38,7 @@ export function initializeEffects(): void {
       const _activeIndex = activeIndex.value;
       const _projectPath = projectPath.value;
 
-      // Only update if we're in theatre mode
+      // Only update if we're in project mode
       if (_projectPath) {
         if (_terminals.length > 0) {
           // Has terminals - hide empty state, update stack
@@ -74,7 +74,7 @@ export function initializeEffects(): void {
       const currentActiveIndex = activeIndex.value;
       const _projectPath = projectPath.value;
 
-      // Only sync if we're in theatre mode and the index actually changed
+      // Only sync if we're in project mode and the index actually changed
       if (_projectPath && _terminals.length > 0 && currentActiveIndex !== previousActiveIndex) {
         previousActiveIndex = currentActiveIndex;
         // Sync after a brief delay to allow terminal switch animation
@@ -144,7 +144,7 @@ export function initializeEffects(): void {
 
 /**
  * Clean up all effects
- * Should be called when completely shutting down theatre mode
+ * Should be called when completely shutting down project mode
  */
 export function cleanupEffects(): void {
   for (const cleanup of cleanupFunctions) {

--- a/src/components/project/gitStatus.ts
+++ b/src/components/project/gitStatus.ts
@@ -1,21 +1,21 @@
 /**
- * Git status display for theatre mode - per-terminal git status on card labels
+ * Git status display for project mode - per-terminal git status on card labels
  */
 
 import type { CompactGitStatus } from '../../types';
-import { theatreState, GIT_STATUS_IDLE_DELAY, TheatreTerminal } from './state';
+import { projectState, GIT_STATUS_IDLE_DELAY, ProjectTerminal } from './state';
 import { getTerminalGitPath } from './helpers';
 import { projectPath, terminals, gitDropdownVisible } from './signals';
 
 /**
- * Hide the git dropdown (cleanup for exitTheatreMode)
+ * Hide the git dropdown (cleanup for exitProjectMode)
  */
 export function hideGitDropdown(): void {
   if (!gitDropdownVisible.value) return;
 
-  if (theatreState.gitDropdownCleanup) {
-    theatreState.gitDropdownCleanup();
-    theatreState.gitDropdownCleanup = null;
+  if (projectState.gitDropdownCleanup) {
+    projectState.gitDropdownCleanup();
+    projectState.gitDropdownCleanup = null;
   }
 
   gitDropdownVisible.value = false;
@@ -34,15 +34,15 @@ export async function refreshGitStatus(): Promise<void> {
  */
 export function scheduleGitStatusRefresh(): void {
   // Clear any existing timeout
-  if (theatreState.gitStatusIdleTimeout) {
-    clearTimeout(theatreState.gitStatusIdleTimeout);
+  if (projectState.gitStatusIdleTimeout) {
+    clearTimeout(projectState.gitStatusIdleTimeout);
   }
 
   // Update last output time
-  theatreState.lastTerminalOutputTime = Date.now();
+  projectState.lastTerminalOutputTime = Date.now();
 
   // Schedule refresh after idle period
-  theatreState.gitStatusIdleTimeout = setTimeout(() => {
+  projectState.gitStatusIdleTimeout = setTimeout(() => {
     refreshGitStatus();
   }, GIT_STATUS_IDLE_DELAY);
 }
@@ -57,8 +57,8 @@ const pendingTerminalGitRefreshes = new Map<string, ReturnType<typeof setTimeout
  * @param onComplete - Optional callback to run after refresh (e.g., to update UI)
  */
 export function scheduleTerminalGitStatusRefresh(
-  term: TheatreTerminal,
-  onComplete?: (term: TheatreTerminal) => void
+  term: ProjectTerminal,
+  onComplete?: (term: ProjectTerminal) => void
 ): void {
   const key = term.ptyId;
   const existing = pendingTerminalGitRefreshes.get(key);
@@ -74,7 +74,7 @@ export function scheduleTerminalGitStatusRefresh(
 /**
  * Refresh git status for a specific terminal
  */
-export async function refreshTerminalGitStatus(term: TheatreTerminal): Promise<void> {
+export async function refreshTerminalGitStatus(term: ProjectTerminal): Promise<void> {
   const gitPath = getTerminalGitPath(term);
   const compactStatus = await window.api.getCompactGitStatus(gitPath);
   term.gitStatus = compactStatus;
@@ -89,7 +89,7 @@ export async function refreshAllTerminalGitStatus(): Promise<void> {
   if (currentTerminals.length === 0) return;
 
   // Group terminals by git path to avoid duplicate IPC calls
-  const pathToTerminals = new Map<string, TheatreTerminal[]>();
+  const pathToTerminals = new Map<string, ProjectTerminal[]>();
   for (const term of currentTerminals) {
     const gitPath = getTerminalGitPath(term);
     const group = pathToTerminals.get(gitPath);
@@ -120,9 +120,9 @@ export function buildCardGitBranchHtml(compactStatus: CompactGitStatus | null): 
 
   const { branch } = compactStatus;
   return `
-    <span class="theatre-card-git-branch" title="${branch}">
-      <i data-lucide="git-branch" class="theatre-card-git-icon"></i>
-      <span class="theatre-card-git-branch-name">${branch}</span>
+    <span class="project-card-git-branch" title="${branch}">
+      <i data-lucide="git-branch" class="project-card-git-icon"></i>
+      <span class="project-card-git-branch-name">${branch}</span>
     </span>
   `;
 }
@@ -135,15 +135,15 @@ export function buildCardGitStatsHtml(compactStatus: CompactGitStatus | null, is
 
   if (hasChanges) {
     const fileLabel = dirtyFileCount === 1 ? 'file' : 'files';
-    const parts: string[] = [`<span class="theatre-card-git-count">${dirtyFileCount} ${fileLabel}</span>`];
-    if (insertions > 0) parts.push(`<span class="theatre-card-git-add">+${insertions}</span>`);
-    if (deletions > 0) parts.push(`<span class="theatre-card-git-del">-${deletions}</span>`);
-    return `<span class="card-tab theatre-card-git-stats theatre-card-git-stats--clickable" title="View uncommitted changes">${parts.join(' ')}</span>`;
+    const parts: string[] = [`<span class="project-card-git-count">${dirtyFileCount} ${fileLabel}</span>`];
+    if (insertions > 0) parts.push(`<span class="project-card-git-add">+${insertions}</span>`);
+    if (deletions > 0) parts.push(`<span class="project-card-git-del">-${deletions}</span>`);
+    return `<span class="card-tab project-card-git-stats project-card-git-stats--clickable" title="View uncommitted changes">${parts.join(' ')}</span>`;
   }
 
   // No uncommitted changes — show "Compare" for worktree terminals only if branch has changes vs main
   if (isWorktree && compactStatus.branchDiffFileCount > 0) {
-    return `<span class="card-tab theatre-card-git-stats theatre-card-git-stats--clickable theatre-card-git-stats--compare" title="Compare branch changes">Compare</span>`;
+    return `<span class="card-tab project-card-git-stats project-card-git-stats--clickable project-card-git-stats--compare" title="Compare branch changes">Compare</span>`;
   }
 
   return '';

--- a/src/components/project/helpers.ts
+++ b/src/components/project/helpers.ts
@@ -1,10 +1,10 @@
 /**
- * Theatre mode helper functions
+ * Project mode helper functions
  * Separated from state.ts to maintain clean dependency hierarchy:
  *   state.ts (types/state) <- helpers.ts (utilities) <- other modules
  */
 
-import type { TheatreTerminal } from './state';
+import type { ProjectTerminal } from './state';
 import { createIcons, icons } from 'lucide';
 
 /**
@@ -12,12 +12,12 @@ import { createIcons, icons } from 'lucide';
  * Used to break circular dependencies - modules register their functions here,
  * allowing other modules to call them without direct imports
  */
-interface TheatreRegistry {
+interface ProjectRegistry {
   // From kanbanBoard
   showKanbanAndFocusInput: (() => Promise<void>) | null;
   // From terminalCards
-  addTheatreTerminal: ((runConfig?: unknown, options?: unknown) => Promise<boolean>) | null;
-  closeTheatreTerminal: ((index: number) => void) | null;
+  addProjectTerminal: ((runConfig?: unknown, options?: unknown) => Promise<boolean>) | null;
+  closeProjectTerminal: ((index: number) => void) | null;
   playOrToggleRunner: (() => Promise<void>) | null;
   // From kanbanBoard
   toggleKanbanBoard: (() => void) | null;
@@ -26,12 +26,12 @@ interface TheatreRegistry {
   toggleActiveDiffPanel: (() => Promise<void>) | null;
 }
 
-export const theatreRegistry: TheatreRegistry = {
+export const projectRegistry: ProjectRegistry = {
   showKanbanAndFocusInput: null,
   toggleKanbanBoard: null,
   syncKanbanStatusDots: null,
-  addTheatreTerminal: null,
-  closeTheatreTerminal: null,
+  addProjectTerminal: null,
+  closeProjectTerminal: null,
   playOrToggleRunner: null,
   toggleActiveDiffPanel: null,
 };
@@ -87,14 +87,14 @@ export function showTaskContextMenu(event: MouseEvent, onSandbox: () => void): v
 /**
  * Get the git path for a terminal (worktree path if it's a worktree, otherwise project path)
  */
-export function getTerminalGitPath(term: TheatreTerminal): string {
+export function getTerminalGitPath(term: ProjectTerminal): string {
   return term.worktreePath || term.projectPath;
 }
 
 /**
  * Hide the runner panel (does NOT kill the runner process)
  */
-export function hideRunnerPanel(term: TheatreTerminal): void {
+export function hideRunnerPanel(term: ProjectTerminal): void {
   if (!term.runnerPanelOpen) return;
 
   const panel = term.container.querySelector('.runner-panel') as HTMLElement;
@@ -109,7 +109,7 @@ export function hideRunnerPanel(term: TheatreTerminal): void {
       // Full-width: skip slide animation, close instantly
       panel.style.transition = 'none';
       panel.style.flexBasis = '0';
-      const cardBody = term.container.querySelector('.theatre-card-body');
+      const cardBody = term.container.querySelector('.project-card-body');
       if (cardBody) cardBody.classList.remove('runner-split', 'runner-full');
       // Restore transition and fit after layout
       requestAnimationFrame(() => {
@@ -121,7 +121,7 @@ export function hideRunnerPanel(term: TheatreTerminal): void {
       // Split mode: animate closed via flex-basis transition
       panel.style.flexBasis = '0';
       setTimeout(() => {
-        const cardBody = term.container.querySelector('.theatre-card-body');
+        const cardBody = term.container.querySelector('.project-card-body');
         if (cardBody) cardBody.classList.remove('runner-split', 'runner-full');
         term.fitAddon.fit();
         window.api.pty.resize(term.ptyId, term.terminal.cols, term.terminal.rows);

--- a/src/components/project/index.ts
+++ b/src/components/project/index.ts
@@ -1,11 +1,11 @@
 /**
- * Theatre mode barrel exports
- * Re-exports all theatre module functionality for external use
+ * Project mode barrel exports
+ * Re-exports all project module functionality for external use
  */
 
 // State (non-reactive)
 export {
-  theatreState,
+  projectState,
   projectSessions,
   orphanedSessions,
   ensureHiddenSessionsContainer,
@@ -13,8 +13,8 @@ export {
   HIDDEN_SESSIONS_CONTAINER_ID,
   GIT_STATUS_IDLE_DELAY,
   GIT_STATUS_PERIODIC_INTERVAL,
-  type TheatreTerminal,
-  type StoredTheatreSession,
+  type ProjectTerminal,
+  type StoredProjectSession,
   type SummaryType,
 } from './state';
 
@@ -22,7 +22,7 @@ export {
 export {
   getTerminalGitPath,
   hideRunnerPanel,
-  theatreRegistry,
+  projectRegistry,
 } from './helpers';
 
 // Signals (reactive state)
@@ -34,7 +34,7 @@ export {
   activeTerminal,
   activeStackPage,
   totalStackPages,
-  isInTheatreMode as isInTheatreModeSignal,
+  isInProjectMode as isInProjectModeSignal,
   diffPanelVisible,
   diffPanelFiles,
   diffPanelSelectedFile,
@@ -79,11 +79,11 @@ export {
 export {
   getTerminalTheme,
   updateTerminalCardLabel,
-  createTheatreCard,
+  createProjectCard,
   updateCardStack,
-  switchToTheatreTerminal,
-  addTheatreTerminal,
-  closeTheatreTerminal,
+  switchToProjectTerminal,
+  addProjectTerminal,
+  closeProjectTerminal,
   navigateStackPage,
   buildEmptyStateHtml,
   showStackEmptyState,
@@ -95,23 +95,23 @@ export {
 
 // Launch dropdown
 export {
-  buildTheatreHeader,
+  buildProjectHeader,
   buildLaunchDropdownContent,
   showLaunchDropdown,
   hideLaunchDropdown,
   toggleLaunchDropdown,
 } from './launchDropdown';
 
-// Theatre mode orchestration
+// Project mode orchestration
 export {
-  enterTheatreMode,
-  exitTheatreMode,
-  restoreTheatreMode,
-  destroyTheatreSessions,
+  enterProjectMode,
+  exitProjectMode,
+  restoreProjectMode,
+  destroyProjectSessions,
   getPreservedSessionPaths,
   hasPreservedSession,
-  isInTheatreMode,
-} from './theatreMode';
+  isInProjectMode,
+} from './projectMode';
 
 // Worktree/task operations
 export {

--- a/src/components/project/kanbanBoard.ts
+++ b/src/components/project/kanbanBoard.ts
@@ -3,12 +3,12 @@
  */
 
 import type { TaskWithWorkspace, TaskStatus, RunConfig } from '../../types';
-import type { TheatreTerminal } from './state';
-import { theatreState } from './state';
+import type { ProjectTerminal } from './state';
+import { projectState } from './state';
 import { projectPath, kanbanVisible, terminals, activeIndex, invalidateTaskList } from './signals';
-import { theatreRegistry } from './helpers';
+import { projectRegistry } from './helpers';
 import { reopenTask, deleteTask, closeTask } from './worktreeDropdown';
-import { switchToTheatreTerminal } from './terminalCards';
+import { switchToProjectTerminal } from './terminalCards';
 import { escapeHtml } from '../../utils/html';
 import { registerHotkey, unregisterHotkey, pushScope, popScope, Scopes, platformHotkey } from '../../utils/hotkeys';
 import { createIcons, icons } from 'lucide';
@@ -18,11 +18,11 @@ import Sortable from 'sortablejs';
  * Sync the view toggle buttons' active state with kanban visibility
  */
 export function syncViewToggle(): void {
-  const btns = document.querySelectorAll('.theatre-view-toggle-btn');
+  const btns = document.querySelectorAll('.project-view-toggle-btn');
   btns.forEach(btn => {
     const view = (btn as HTMLElement).dataset.view;
     const isBoard = view === 'board';
-    btn.classList.toggle('theatre-view-toggle-btn--active', isBoard === kanbanVisible.value);
+    btn.classList.toggle('project-view-toggle-btn--active', isBoard === kanbanVisible.value);
   });
 }
 
@@ -34,7 +34,7 @@ function showKanbanCardContextMenu(
   onOpenTerminal: () => void,
   onSandbox: (() => void) | null,
   onOpenInEditor: (() => void) | null,
-  connectedTerminals: { terminal: TheatreTerminal; index: number }[],
+  connectedTerminals: { terminal: ProjectTerminal; index: number }[],
   onSwitchTerminal: (index: number) => void,
   onCloseOrReopen: () => void,
   closeOrReopenLabel: string,
@@ -399,7 +399,7 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
         await window.api.task.setStatus(path, task.taskNumber, 'in_progress');
         invalidateTaskList();
         hideKanbanBoard();
-        await theatreRegistry.addTheatreTerminal?.(undefined, {
+        await projectRegistry.addProjectTerminal?.(undefined, {
           existingWorktree: {
             path: startResult.worktreePath,
             branch: startResult.task?.branch || '',
@@ -413,7 +413,7 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
         return;
       }
       hideKanbanBoard();
-      await theatreRegistry.addTheatreTerminal?.(undefined, {
+      await projectRegistry.addProjectTerminal?.(undefined, {
         existingWorktree: {
           path: task.worktreePath,
           branch: task.branch || '',
@@ -438,7 +438,7 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
         if (result.success) {
           invalidateTaskList();
           hideKanbanBoard();
-          await theatreRegistry.addTheatreTerminal?.(undefined, {
+          await projectRegistry.addProjectTerminal?.(undefined, {
             existingWorktree: worktreeOpts,
             taskId: task.taskNumber,
             sandboxed: true,
@@ -450,7 +450,7 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
         await window.api.task.setStatus(path, task.taskNumber, 'in_progress');
         invalidateTaskList();
         hideKanbanBoard();
-        await theatreRegistry.addTheatreTerminal?.(undefined, {
+        await projectRegistry.addProjectTerminal?.(undefined, {
           existingWorktree: {
             path: startResult.worktreePath,
             branch: startResult.task?.branch || '',
@@ -463,7 +463,7 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
         });
       } else {
         hideKanbanBoard();
-        await theatreRegistry.addTheatreTerminal?.(undefined, {
+        await projectRegistry.addProjectTerminal?.(undefined, {
           existingWorktree: {
             path: task.worktreePath,
             branch: task.branch || '',
@@ -480,7 +480,7 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
     const onSwitchTerminal = (idx: number) => {
       hideKanbanBoard();
       if (idx !== activeIndex.value) {
-        switchToTheatreTerminal(idx);
+        switchToProjectTerminal(idx);
       }
     };
 
@@ -594,7 +594,7 @@ async function handleSortableEnd(evt: Sortable.SortableEvent): Promise<void> {
         };
       }
 
-      await theatreRegistry.addTheatreTerminal?.(runConfig, {
+      await projectRegistry.addProjectTerminal?.(runConfig, {
         existingWorktree: {
           path: worktreePath,
           branch,
@@ -615,7 +615,7 @@ async function handleSortableEnd(evt: Sortable.SortableEvent): Promise<void> {
     const currentTerminals = terminals.value;
     for (let i = currentTerminals.length - 1; i >= 0; i--) {
       if (currentTerminals[i].taskId === taskNumber) {
-        theatreRegistry.closeTheatreTerminal?.(i);
+        projectRegistry.closeProjectTerminal?.(i);
       }
     }
     // Reorder handles status change, closedAt, and position in one write;
@@ -1014,10 +1014,10 @@ export async function showKanbanBoard(): Promise<void> {
 
   registerHotkey(platformHotkey('mod+i'), Scopes.KANBAN, () => {
     hideKanbanBoard();
-    theatreRegistry.addTheatreTerminal?.();
+    projectRegistry.addProjectTerminal?.();
   });
 
-  theatreState.kanbanCleanup = () => {
+  projectState.kanbanCleanup = () => {
     resizeObserver.disconnect();
     unregisterHotkey('escape', Scopes.KANBAN);
     unregisterHotkey(platformHotkey('mod+b'), Scopes.KANBAN);
@@ -1044,9 +1044,9 @@ export function hideKanbanBoard(): void {
 
   document.body.classList.remove('kanban-open');
 
-  if (theatreState.kanbanCleanup) {
-    theatreState.kanbanCleanup();
-    theatreState.kanbanCleanup = null;
+  if (projectState.kanbanCleanup) {
+    projectState.kanbanCleanup();
+    projectState.kanbanCleanup = null;
   }
 
   kanbanVisible.value = false;
@@ -1084,7 +1084,7 @@ export async function showKanbanAndFocusInput(): Promise<void> {
   if (input) input.focus();
 }
 
-// Register in the theatre registry for cross-module access
-theatreRegistry.showKanbanAndFocusInput = showKanbanAndFocusInput;
-theatreRegistry.toggleKanbanBoard = toggleKanbanBoard;
-theatreRegistry.syncKanbanStatusDots = syncKanbanStatusDots;
+// Register in the project registry for cross-module access
+projectRegistry.showKanbanAndFocusInput = showKanbanAndFocusInput;
+projectRegistry.toggleKanbanBoard = toggleKanbanBoard;
+projectRegistry.syncKanbanStatusDots = syncKanbanStatusDots;

--- a/src/components/project/launchDropdown.ts
+++ b/src/components/project/launchDropdown.ts
@@ -1,9 +1,9 @@
 /**
- * Launch dropdown for theatre mode - hooks configuration and project actions
+ * Launch dropdown for project mode - hooks configuration and project actions
  */
 
 import type { ScriptHook, HookType } from '../../types';
-import { theatreState } from './state';
+import { projectState } from './state';
 import { projectPath, projectData, launchDropdownVisible } from './signals';
 import { stringToColor, getInitials } from '../../utils/projectIcon';
 import { showToast } from '../importDialog';
@@ -18,51 +18,51 @@ const HOOK_HINTS: Record<string, string> = {
 };
 
 /**
- * Build the theatre mode header content
+ * Build the project mode header content
  * Note: Git status is now displayed per-terminal on card labels, not in the header
  */
-export function buildTheatreHeader(): string {
+export function buildProjectHeader(): string {
   const project = projectData.value;
   if (!project) return '';
 
   const icon = project.iconDataUrl
-    ? `<img src="${project.iconDataUrl}" alt="" class="theatre-project-icon" />`
-    : `<div class="theatre-project-icon theatre-project-icon--placeholder" style="background-color: ${stringToColor(project.name)}">${getInitials(project.name)}</div>`;
+    ? `<img src="${project.iconDataUrl}" alt="" class="project-header-icon" />`
+    : `<div class="project-header-icon project-header-icon--placeholder" style="background-color: ${stringToColor(project.name)}">${getInitials(project.name)}</div>`;
 
   return `
-    <div class="theatre-header-content">
-      <button class="theatre-exit-btn" title="Exit theatre mode">
+    <div class="project-header-content">
+      <button class="project-exit-btn" title="Exit project mode">
         <i data-lucide="arrow-left"></i>
       </button>
       ${icon}
-      <div class="theatre-project-info">
-        <span class="theatre-project-name">${project.name}</span>
-        <span class="theatre-project-path">${project.path}</span>
+      <div class="project-header-info">
+        <span class="project-header-name">${project.name}</span>
+        <span class="project-header-path">${project.path}</span>
       </div>
-      <div class="theatre-view-toggle">
-        <button class="theatre-view-toggle-btn theatre-view-toggle-btn--active" data-view="board" title="Board view">
+      <div class="project-view-toggle">
+        <button class="project-view-toggle-btn project-view-toggle-btn--active" data-view="board" title="Board view">
           <i data-lucide="columns-3"></i>
         </button>
-        <button class="theatre-view-toggle-btn" data-view="stack" title="Terminal stack">
+        <button class="project-view-toggle-btn" data-view="stack" title="Terminal stack">
           <i data-lucide="layers"></i>
         </button>
       </div>
-      <div class="theatre-launch-wrapper">
-        <button class="theatre-scripts-btn" title="Configure scripts">
+      <div class="project-launch-wrapper">
+        <button class="project-scripts-btn" title="Configure scripts">
           <i data-lucide="code"></i>
-          <i data-lucide="chevron-down" class="theatre-scripts-caret"></i>
+          <i data-lucide="chevron-down" class="project-scripts-caret"></i>
         </button>
       </div>
-      <div class="theatre-sandbox-wrapper" style="display: none;">
-        <button class="theatre-sandbox-btn" title="Sandbox">
+      <div class="project-sandbox-wrapper" style="display: none;">
+        <button class="project-sandbox-btn" title="Sandbox">
           <i data-lucide="box"></i>
-          <i data-lucide="chevron-down" class="theatre-sandbox-caret"></i>
+          <i data-lucide="chevron-down" class="project-sandbox-caret"></i>
         </button>
       </div>
-      <button class="theatre-terminal-btn" title="New terminal">
+      <button class="project-terminal-btn" title="New terminal">
         <i data-lucide="terminal"></i>
       </button>
-      <button class="theatre-newtask-btn" title="New task">
+      <button class="project-newtask-btn" title="New task">
         <i data-lucide="plus"></i>
       </button>
     </div>
@@ -184,14 +184,14 @@ export async function buildLaunchDropdownContent(dropdown: HTMLElement): Promise
 export async function showLaunchDropdown(): Promise<void> {
   if (launchDropdownVisible.value) return;
 
-  const wrapper = document.querySelector('.theatre-launch-wrapper');
+  const wrapper = document.querySelector('.project-launch-wrapper');
   if (!wrapper) return;
 
   // Create dropdown if it doesn't exist
-  let dropdown = wrapper.querySelector('.theatre-launch-dropdown') as HTMLElement;
+  let dropdown = wrapper.querySelector('.project-launch-dropdown') as HTMLElement;
   if (!dropdown) {
     dropdown = document.createElement('div');
-    dropdown.className = 'theatre-launch-dropdown';
+    dropdown.className = 'project-launch-dropdown';
     wrapper.appendChild(dropdown);
   }
 
@@ -206,7 +206,7 @@ export async function showLaunchDropdown(): Promise<void> {
   // Click outside handler
   const handleClickOutside = (e: MouseEvent) => {
     const target = e.target as HTMLElement;
-    if (!target.closest('.theatre-launch-wrapper')) {
+    if (!target.closest('.project-launch-wrapper')) {
       hideLaunchDropdown();
     }
   };
@@ -215,7 +215,7 @@ export async function showLaunchDropdown(): Promise<void> {
     document.addEventListener('click', handleClickOutside);
   }, 0);
 
-  theatreState.launchDropdownCleanup = () => {
+  projectState.launchDropdownCleanup = () => {
     document.removeEventListener('click', handleClickOutside);
   };
 }
@@ -226,15 +226,15 @@ export async function showLaunchDropdown(): Promise<void> {
 export function hideLaunchDropdown(): void {
   if (!launchDropdownVisible.value) return;
 
-  const dropdown = document.querySelector('.theatre-launch-dropdown');
+  const dropdown = document.querySelector('.project-launch-dropdown');
   if (dropdown) {
     dropdown.classList.remove('visible');
     setTimeout(() => dropdown.remove(), 150);
   }
 
-  if (theatreState.launchDropdownCleanup) {
-    theatreState.launchDropdownCleanup();
-    theatreState.launchDropdownCleanup = null;
+  if (projectState.launchDropdownCleanup) {
+    projectState.launchDropdownCleanup();
+    projectState.launchDropdownCleanup = null;
   }
 
   launchDropdownVisible.value = false;

--- a/src/components/project/projectMode.ts
+++ b/src/components/project/projectMode.ts
@@ -1,5 +1,5 @@
 /**
- * Theatre mode orchestration - enter/exit, session management
+ * Project mode orchestration - enter/exit, session management
  */
 
 import { Terminal } from '@xterm/xterm';
@@ -8,12 +8,12 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { createIcons, icons } from 'lucide';
 import type { Project, ActiveSession } from '../../types';
 import {
-  theatreState,
+  projectState,
   projectSessions,
   orphanedSessions,
   ensureHiddenSessionsContainer,
   GIT_STATUS_PERIODIC_INTERVAL,
-  TheatreTerminal,
+  ProjectTerminal,
 } from './state';
 import {
   projectPath,
@@ -40,17 +40,17 @@ import {
   loadAllDiffs,
 } from './diffPanel';
 import {
-  addTheatreTerminal,
+  addProjectTerminal,
   updateCardStack,
   showStackEmptyState,
-  switchToTheatreTerminal,
+  switchToProjectTerminal,
   selectByStackPosition,
   setupCardActions,
   setupTerminalAppHotkeys,
   debouncedResize,
-  closeTheatreTerminal,
+  closeProjectTerminal,
   getTerminalTheme,
-  createTheatreCard,
+  createProjectCard,
   updateTerminalCardLabel,
   updateRunnerPill,
   navigateStackPage,
@@ -59,26 +59,26 @@ import {
   resetIdleTimer,
 } from './terminalCards';
 import {
-  buildTheatreHeader,
+  buildProjectHeader,
   toggleLaunchDropdown,
   hideLaunchDropdown,
 } from './launchDropdown';
 import { hideKanbanBoard, showKanbanBoard, showKanbanAndFocusInput, syncViewToggle } from './kanbanBoard';
-import { theatreRegistry } from './helpers';
+import { projectRegistry } from './helpers';
 import { registerHotkey, unregisterHotkey, pushScope, popScope, Scopes, platformHotkey } from '../../utils/hotkeys';
 import { showNewProjectDialog } from '../newProjectDialog';
 import { showToast } from '../importDialog';
 import { showHookConfigDialog } from '../hookConfigDialog';
 
 /**
- * Enter theatre mode for the specified project
+ * Enter project mode for the specified project
  * If a preserved session exists, it will be restored instead of creating a new one
  */
-export async function enterTheatreMode(
+export async function enterProjectMode(
   path: string,
   project: Project
 ): Promise<void> {
-  if (projectPath.value) return; // Already in theatre mode
+  if (projectPath.value) return; // Already in project mode
 
   // Check for preserved session
   const existingSession = projectSessions.get(path);
@@ -94,23 +94,23 @@ export async function enterTheatreMode(
   registerHookStatusListener();
 
   // 1. Add class to body - CSS handles the rest
-  document.body.classList.add('theatre-mode');
+  document.body.classList.add('project-mode');
 
   // 2. Update header content
   // Note: Git status is now displayed per-terminal on card labels, not in the header
   const headerContent = document.querySelector('.header-content');
   if (headerContent) {
-    theatreState.originalHeaderContent = headerContent.innerHTML;
-    headerContent.innerHTML = buildTheatreHeader();
+    projectState.originalHeaderContent = headerContent.innerHTML;
+    headerContent.innerHTML = buildProjectHeader();
 
     // Wire up exit button
-    const exitBtn = headerContent.querySelector('.theatre-exit-btn');
+    const exitBtn = headerContent.querySelector('.project-exit-btn');
     if (exitBtn) {
-      exitBtn.addEventListener('click', () => exitTheatreMode());
+      exitBtn.addEventListener('click', () => exitProjectMode());
     }
 
     // Wire up scripts button (opens dropdown)
-    const scriptsBtn = headerContent.querySelector('.theatre-scripts-btn');
+    const scriptsBtn = headerContent.querySelector('.project-scripts-btn');
     if (scriptsBtn) {
       scriptsBtn.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -119,7 +119,7 @@ export async function enterTheatreMode(
     }
 
     // Wire up new task button (opens task overlay)
-    const newTaskBtn = headerContent.querySelector('.theatre-newtask-btn');
+    const newTaskBtn = headerContent.querySelector('.project-newtask-btn');
     if (newTaskBtn) {
       newTaskBtn.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -128,17 +128,17 @@ export async function enterTheatreMode(
     }
 
     // Wire up terminal button (opens new shell)
-    const terminalBtn = headerContent.querySelector('.theatre-terminal-btn');
+    const terminalBtn = headerContent.querySelector('.project-terminal-btn');
     if (terminalBtn) {
       terminalBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
         if (kanbanVisible.value) hideKanbanBoard();
-        await addTheatreTerminal();
+        await addProjectTerminal();
       });
     }
 
     // Wire up sandbox button (dropdown)
-    const sandboxWrapper = headerContent.querySelector('.theatre-sandbox-wrapper') as HTMLElement;
+    const sandboxWrapper = headerContent.querySelector('.project-sandbox-wrapper') as HTMLElement;
     if (sandboxWrapper) {
       wireSandboxButton(sandboxWrapper, path);
     }
@@ -196,7 +196,7 @@ export async function enterTheatreMode(
       for (const term of currentTerminals) {
         if (term.diffPanelOpen && term.diffPanelFiles.length > 0) {
           // Re-create the diff panel inside this terminal's card
-          const cardBody = term.container.querySelector('.theatre-card-body');
+          const cardBody = term.container.querySelector('.project-card-body');
           if (cardBody) {
             const panelHtml = buildDiffPanelHtml(term.diffPanelFiles);
             cardBody.insertAdjacentHTML('beforeend', panelHtml);
@@ -252,14 +252,14 @@ export async function enterTheatreMode(
       activeIndex.value = 0;
 
       const stack = document.createElement('div');
-      stack.className = 'theatre-stack';
+      stack.className = 'project-stack';
       mainContent.appendChild(stack);
 
       // Check for orphaned PTY sessions that survived an app refresh
       const orphaned = orphanedSessions.get(path);
       if (orphaned && orphaned.length > 0) {
         // Reconnect to orphaned sessions
-        console.log('[Theatre] Found orphaned PTY sessions, reconnecting:', orphaned);
+        console.log('[Project] Found orphaned PTY sessions, reconnecting:', orphaned);
         orphanedSessions.delete(path); // Consume them
         window.api.pty.setWindow();
 
@@ -277,7 +277,7 @@ export async function enterTheatreMode(
             const currentName = taskNameMap.get(session.taskId);
             if (currentName) session.label = currentName;
           }
-          await reconnectTheatreTerminal(session);
+          await reconnectProjectTerminal(session);
         }
 
         // Then reconnect runners to their parent terminals
@@ -287,7 +287,7 @@ export async function enterTheatreMode(
           if (parentTerminal) {
             await reconnectRunnerToParent(runnerSession, parentTerminal);
           } else {
-            console.warn('[Theatre] Could not find parent terminal for runner:', runnerSession.ptyId, 'parent:', runnerSession.parentPtyId);
+            console.warn('[Project] Could not find parent terminal for runner:', runnerSession.ptyId, 'parent:', runnerSession.parentPtyId);
           }
         }
 
@@ -303,38 +303,38 @@ export async function enterTheatreMode(
     }
   }
 
-  // 4. Set up keyboard shortcuts for theatre mode
+  // 4. Set up keyboard shortcuts for project mode
   // Use platformHotkey() to convert 'mod+' to 'command+' on Mac or 'ctrl+' on Linux/Windows
-  pushScope(Scopes.THEATRE);
-  registerHotkey(platformHotkey('mod+n'), Scopes.THEATRE, () => showKanbanAndFocusInput());
-  registerHotkey(platformHotkey('mod+b'), Scopes.THEATRE, () => theatreRegistry.toggleKanbanBoard?.());
-  registerHotkey(platformHotkey('mod+t'), Scopes.THEATRE, () => theatreRegistry.toggleKanbanBoard?.());
-  registerHotkey(platformHotkey('mod+i'), Scopes.THEATRE, () => addTheatreTerminal());
-  registerHotkey(platformHotkey('mod+p'), Scopes.THEATRE, () => theatreRegistry.playOrToggleRunner?.());
-  registerHotkey(platformHotkey('mod+d'), Scopes.THEATRE, () => theatreRegistry.toggleActiveDiffPanel?.());
-  registerHotkey(platformHotkey('mod+w'), Scopes.THEATRE, () => {
+  pushScope(Scopes.PROJECT);
+  registerHotkey(platformHotkey('mod+n'), Scopes.PROJECT, () => showKanbanAndFocusInput());
+  registerHotkey(platformHotkey('mod+b'), Scopes.PROJECT, () => projectRegistry.toggleKanbanBoard?.());
+  registerHotkey(platformHotkey('mod+t'), Scopes.PROJECT, () => projectRegistry.toggleKanbanBoard?.());
+  registerHotkey(platformHotkey('mod+i'), Scopes.PROJECT, () => addProjectTerminal());
+  registerHotkey(platformHotkey('mod+p'), Scopes.PROJECT, () => projectRegistry.playOrToggleRunner?.());
+  registerHotkey(platformHotkey('mod+d'), Scopes.PROJECT, () => projectRegistry.toggleActiveDiffPanel?.());
+  registerHotkey(platformHotkey('mod+w'), Scopes.PROJECT, () => {
     if (terminals.value.length > 0) {
-      closeTheatreTerminal(activeIndex.value);
+      closeProjectTerminal(activeIndex.value);
     }
   });
 
   // Mod+1-9 to select by stack position (terminals or tasks in empty state)
   for (let i = 1; i <= 9; i++) {
-    registerHotkey(platformHotkey(`mod+${i}`), Scopes.THEATRE, () => {
+    registerHotkey(platformHotkey(`mod+${i}`), Scopes.PROJECT, () => {
       selectByStackPosition(i);
     });
   }
 
   // Mod+Shift+Left/Right to navigate stack pages
-  registerHotkey(platformHotkey('mod+shift+left'), Scopes.THEATRE, () => navigateStackPage(-1));
-  registerHotkey(platformHotkey('mod+shift+right'), Scopes.THEATRE, () => navigateStackPage(1));
+  registerHotkey(platformHotkey('mod+shift+left'), Scopes.PROJECT, () => navigateStackPage(-1));
+  registerHotkey(platformHotkey('mod+shift+right'), Scopes.PROJECT, () => navigateStackPage(1));
 
-  // 5. Show kanban board by default (after THEATRE scope so KANBAN scope stacks on top)
+  // 5. Show kanban board by default (after PROJECT scope so KANBAN scope stacks on top)
   await showKanbanBoard();
 
   // 6. Start periodic git status refresh (for long-running commands)
   if (project.hasGit) {
-    theatreState.gitStatusPeriodicInterval = setInterval(() => {
+    projectState.gitStatusPeriodicInterval = setInterval(() => {
       refreshAllTerminalGitStatus().then(() => {
         for (const term of terminals.value) {
           updateTerminalCardLabel(term);
@@ -345,9 +345,9 @@ export async function enterTheatreMode(
 }
 
 /**
- * Exit theatre mode - preserves sessions for later restoration
+ * Exit project mode - preserves sessions for later restoration
  */
-export function exitTheatreMode(): void {
+export function exitProjectMode(): void {
   const currentProjectPath = projectPath.value;
   if (!currentProjectPath) return;
 
@@ -355,7 +355,7 @@ export function exitTheatreMode(): void {
   const currentProjectData = projectData.value;
 
   // 1. Handle session preservation or cleanup
-  const stack = document.querySelector('.theatre-stack') as HTMLElement;
+  const stack = document.querySelector('.project-stack') as HTMLElement;
   if (stack) {
     if (currentTerminals.length > 0 && currentProjectData) {
       // Store session for later restoration
@@ -387,12 +387,12 @@ export function exitTheatreMode(): void {
   }
 
   // 2. Remove class from body
-  document.body.classList.remove('theatre-mode');
+  document.body.classList.remove('project-mode');
 
   // 3. Restore header content
   const headerContent = document.querySelector('.header-content');
-  if (headerContent && theatreState.originalHeaderContent) {
-    headerContent.innerHTML = theatreState.originalHeaderContent;
+  if (headerContent && projectState.originalHeaderContent) {
+    headerContent.innerHTML = projectState.originalHeaderContent;
     // Re-attach refresh handler with full behavior
     const refreshBtn = headerContent.querySelector('#refresh-btn');
     if (refreshBtn) {
@@ -444,28 +444,28 @@ export function exitTheatreMode(): void {
   unregisterHookStatusListener();
 
   // 5. Remove keyboard shortcuts and pop scope
-  unregisterHotkey(platformHotkey('mod+n'), Scopes.THEATRE);
-  unregisterHotkey(platformHotkey('mod+b'), Scopes.THEATRE);
-  unregisterHotkey(platformHotkey('mod+t'), Scopes.THEATRE);
-  unregisterHotkey(platformHotkey('mod+i'), Scopes.THEATRE);
-  unregisterHotkey(platformHotkey('mod+p'), Scopes.THEATRE);
-  unregisterHotkey(platformHotkey('mod+d'), Scopes.THEATRE);
-  unregisterHotkey(platformHotkey('mod+w'), Scopes.THEATRE);
+  unregisterHotkey(platformHotkey('mod+n'), Scopes.PROJECT);
+  unregisterHotkey(platformHotkey('mod+b'), Scopes.PROJECT);
+  unregisterHotkey(platformHotkey('mod+t'), Scopes.PROJECT);
+  unregisterHotkey(platformHotkey('mod+i'), Scopes.PROJECT);
+  unregisterHotkey(platformHotkey('mod+p'), Scopes.PROJECT);
+  unregisterHotkey(platformHotkey('mod+d'), Scopes.PROJECT);
+  unregisterHotkey(platformHotkey('mod+w'), Scopes.PROJECT);
   for (let i = 1; i <= 9; i++) {
-    unregisterHotkey(platformHotkey(`mod+${i}`), Scopes.THEATRE);
+    unregisterHotkey(platformHotkey(`mod+${i}`), Scopes.PROJECT);
   }
-  unregisterHotkey(platformHotkey('mod+shift+left'), Scopes.THEATRE);
-  unregisterHotkey(platformHotkey('mod+shift+right'), Scopes.THEATRE);
+  unregisterHotkey(platformHotkey('mod+shift+left'), Scopes.PROJECT);
+  unregisterHotkey(platformHotkey('mod+shift+right'), Scopes.PROJECT);
   popScope();
 
   // 5. Clear git status timers
-  if (theatreState.gitStatusIdleTimeout) {
-    clearTimeout(theatreState.gitStatusIdleTimeout);
-    theatreState.gitStatusIdleTimeout = null;
+  if (projectState.gitStatusIdleTimeout) {
+    clearTimeout(projectState.gitStatusIdleTimeout);
+    projectState.gitStatusIdleTimeout = null;
   }
-  if (theatreState.gitStatusPeriodicInterval) {
-    clearInterval(theatreState.gitStatusPeriodicInterval);
-    theatreState.gitStatusPeriodicInterval = null;
+  if (projectState.gitStatusPeriodicInterval) {
+    clearInterval(projectState.gitStatusPeriodicInterval);
+    projectState.gitStatusPeriodicInterval = null;
   }
 
   // 6. Hide and cleanup git dropdown
@@ -481,23 +481,23 @@ export function exitTheatreMode(): void {
   hideDiffPanel();
 
   // 8.5. Remove pagination row
-  const paginationRow = document.querySelector('.theatre-stack-pagination');
+  const paginationRow = document.querySelector('.project-stack-pagination');
   if (paginationRow) paginationRow.remove();
 
   // 9. Hide kanban board
   hideKanbanBoard();
 
-  theatreState.originalHeaderContent = null;
+  projectState.originalHeaderContent = null;
 
   // Reset all signals to initial values
   resetSignals();
 }
 
 /**
- * Permanently destroy all theatre sessions for a project
+ * Permanently destroy all project sessions for a project
  * Call this when you want to truly close sessions, not just switch away
  */
-export function destroyTheatreSessions(projectPath: string): void {
+export function destroyProjectSessions(projectPath: string): void {
   const session = projectSessions.get(projectPath);
   if (!session) return;
 
@@ -519,38 +519,38 @@ export function destroyTheatreSessions(projectPath: string): void {
 }
 
 /**
- * Get list of projects with preserved theatre sessions
+ * Get list of projects with preserved project sessions
  */
 export function getPreservedSessionPaths(): string[] {
   return Array.from(projectSessions.keys());
 }
 
 /**
- * Check if a project has a preserved theatre session
+ * Check if a project has a preserved project session
  */
 export function hasPreservedSession(projectPath: string): boolean {
   return projectSessions.has(projectPath);
 }
 
 /**
- * Check if we're currently in theatre mode
+ * Check if we're currently in project mode
  */
-export function isInTheatreMode(): boolean {
+export function isInProjectMode(): boolean {
   return projectPath.value !== null;
 }
 
 /**
- * Restore theatre mode after renderer reload (e.g., after sleep/wake)
+ * Restore project mode after renderer reload (e.g., after sleep/wake)
  * Reconnects to existing PTY sessions in the main process
  */
-export async function restoreTheatreMode(
+export async function restoreProjectMode(
   path: string,
   project: Project,
   activeSessions: ActiveSession[]
 ): Promise<void> {
-  if (projectPath.value) return; // Already in theatre mode
+  if (projectPath.value) return; // Already in project mode
 
-  console.log('[Theatre] Restoring theatre mode for', path, 'with', activeSessions.length, 'sessions');
+  console.log('[Project] Restoring project mode for', path, 'with', activeSessions.length, 'sessions');
 
   // Update window reference in main process
   window.api.pty.setWindow();
@@ -566,22 +566,22 @@ export async function restoreTheatreMode(
   registerHookStatusListener();
 
   // 1. Add class to body
-  document.body.classList.add('theatre-mode');
+  document.body.classList.add('project-mode');
 
   // 2. Update header content
   const headerContent = document.querySelector('.header-content');
   if (headerContent) {
-    theatreState.originalHeaderContent = headerContent.innerHTML;
-    headerContent.innerHTML = buildTheatreHeader();
+    projectState.originalHeaderContent = headerContent.innerHTML;
+    headerContent.innerHTML = buildProjectHeader();
 
     // Wire up exit button
-    const exitBtn = headerContent.querySelector('.theatre-exit-btn');
+    const exitBtn = headerContent.querySelector('.project-exit-btn');
     if (exitBtn) {
-      exitBtn.addEventListener('click', () => exitTheatreMode());
+      exitBtn.addEventListener('click', () => exitProjectMode());
     }
 
     // Wire up scripts button (opens dropdown)
-    const scriptsBtn = headerContent.querySelector('.theatre-scripts-btn');
+    const scriptsBtn = headerContent.querySelector('.project-scripts-btn');
     if (scriptsBtn) {
       scriptsBtn.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -590,7 +590,7 @@ export async function restoreTheatreMode(
     }
 
     // Wire up new task button (opens kanban board)
-    const newTaskBtn = headerContent.querySelector('.theatre-newtask-btn');
+    const newTaskBtn = headerContent.querySelector('.project-newtask-btn');
     if (newTaskBtn) {
       newTaskBtn.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -599,17 +599,17 @@ export async function restoreTheatreMode(
     }
 
     // Wire up terminal button (opens new shell)
-    const terminalBtn = headerContent.querySelector('.theatre-terminal-btn');
+    const terminalBtn = headerContent.querySelector('.project-terminal-btn');
     if (terminalBtn) {
       terminalBtn.addEventListener('click', async (e) => {
         e.stopPropagation();
         if (kanbanVisible.value) hideKanbanBoard();
-        await addTheatreTerminal();
+        await addProjectTerminal();
       });
     }
 
     // Wire up sandbox button (dropdown)
-    const sandboxWrapper = headerContent.querySelector('.theatre-sandbox-wrapper') as HTMLElement;
+    const sandboxWrapper = headerContent.querySelector('.project-sandbox-wrapper') as HTMLElement;
     if (sandboxWrapper) {
       wireSandboxButton(sandboxWrapper, path);
     }
@@ -626,7 +626,7 @@ export async function restoreTheatreMode(
     activeIndex.value = 0;
 
     const stack = document.createElement('div');
-    stack.className = 'theatre-stack';
+    stack.className = 'project-stack';
     mainContent.appendChild(stack);
 
     // Separate main terminals from runners
@@ -646,7 +646,7 @@ export async function restoreTheatreMode(
         if (currentName) session.label = currentName;
       }
       const worktreeBranch = session.taskId != null ? taskBranchMap.get(session.taskId) : undefined;
-      await reconnectTheatreTerminal(session, worktreeBranch);
+      await reconnectProjectTerminal(session, worktreeBranch);
     }
 
     // Then reconnect runners to their parent terminals
@@ -655,7 +655,7 @@ export async function restoreTheatreMode(
       if (parentTerminal) {
         await reconnectRunnerToParent(runnerSession, parentTerminal);
       } else {
-        console.warn('[Theatre] Could not find parent terminal for runner:', runnerSession.ptyId, 'parent:', runnerSession.parentPtyId);
+        console.warn('[Project] Could not find parent terminal for runner:', runnerSession.ptyId, 'parent:', runnerSession.parentPtyId);
       }
     }
 
@@ -667,31 +667,31 @@ export async function restoreTheatreMode(
   }
 
   // 4. Set up keyboard shortcuts
-  pushScope(Scopes.THEATRE);
-  registerHotkey(platformHotkey('mod+n'), Scopes.THEATRE, () => showKanbanAndFocusInput());
-  registerHotkey(platformHotkey('mod+b'), Scopes.THEATRE, () => theatreRegistry.toggleKanbanBoard?.());
-  registerHotkey(platformHotkey('mod+t'), Scopes.THEATRE, () => theatreRegistry.toggleKanbanBoard?.());
-  registerHotkey(platformHotkey('mod+i'), Scopes.THEATRE, () => addTheatreTerminal());
-  registerHotkey(platformHotkey('mod+p'), Scopes.THEATRE, () => theatreRegistry.playOrToggleRunner?.());
-  registerHotkey(platformHotkey('mod+d'), Scopes.THEATRE, () => theatreRegistry.toggleActiveDiffPanel?.());
-  registerHotkey(platformHotkey('mod+w'), Scopes.THEATRE, () => {
+  pushScope(Scopes.PROJECT);
+  registerHotkey(platformHotkey('mod+n'), Scopes.PROJECT, () => showKanbanAndFocusInput());
+  registerHotkey(platformHotkey('mod+b'), Scopes.PROJECT, () => projectRegistry.toggleKanbanBoard?.());
+  registerHotkey(platformHotkey('mod+t'), Scopes.PROJECT, () => projectRegistry.toggleKanbanBoard?.());
+  registerHotkey(platformHotkey('mod+i'), Scopes.PROJECT, () => addProjectTerminal());
+  registerHotkey(platformHotkey('mod+p'), Scopes.PROJECT, () => projectRegistry.playOrToggleRunner?.());
+  registerHotkey(platformHotkey('mod+d'), Scopes.PROJECT, () => projectRegistry.toggleActiveDiffPanel?.());
+  registerHotkey(platformHotkey('mod+w'), Scopes.PROJECT, () => {
     if (terminals.value.length > 0) {
-      closeTheatreTerminal(activeIndex.value);
+      closeProjectTerminal(activeIndex.value);
     }
   });
 
   // Mod+1-9 to select by stack position (terminals or tasks in empty state)
   for (let i = 1; i <= 9; i++) {
-    registerHotkey(platformHotkey(`mod+${i}`), Scopes.THEATRE, () => {
+    registerHotkey(platformHotkey(`mod+${i}`), Scopes.PROJECT, () => {
       selectByStackPosition(i);
     });
   }
 
   // Mod+Shift+Left/Right to navigate stack pages
-  registerHotkey(platformHotkey('mod+shift+left'), Scopes.THEATRE, () => navigateStackPage(-1));
-  registerHotkey(platformHotkey('mod+shift+right'), Scopes.THEATRE, () => navigateStackPage(1));
+  registerHotkey(platformHotkey('mod+shift+left'), Scopes.PROJECT, () => navigateStackPage(-1));
+  registerHotkey(platformHotkey('mod+shift+right'), Scopes.PROJECT, () => navigateStackPage(1));
 
-  // 5. Show kanban board by default (after THEATRE scope so KANBAN scope stacks on top)
+  // 5. Show kanban board by default (after PROJECT scope so KANBAN scope stacks on top)
   await showKanbanBoard();
 
   // 6. Refresh git status immediately and start periodic refresh
@@ -704,7 +704,7 @@ export async function restoreTheatreMode(
     });
 
     // Periodic refresh for ongoing changes
-    theatreState.gitStatusPeriodicInterval = setInterval(() => {
+    projectState.gitStatusPeriodicInterval = setInterval(() => {
       refreshAllTerminalGitStatus().then(() => {
         for (const term of terminals.value) {
           updateTerminalCardLabel(term);
@@ -717,7 +717,7 @@ export async function restoreTheatreMode(
 /**
  * Reconnect to an existing PTY session and create a terminal card for it
  */
-async function reconnectTheatreTerminal(session: ActiveSession, worktreeBranch?: string): Promise<void> {
+async function reconnectProjectTerminal(session: ActiveSession, worktreeBranch?: string): Promise<void> {
 
   const terminal = new Terminal({
     cursorBlink: true,
@@ -738,10 +738,10 @@ async function reconnectTheatreTerminal(session: ActiveSession, worktreeBranch?:
 
   // Create the card UI
   const index = terminals.value.length;
-  const card = createTheatreCard(session.label, index);
+  const card = createProjectCard(session.label, index);
 
   // Add to DOM
-  const stack = document.querySelector('.theatre-stack');
+  const stack = document.querySelector('.project-stack');
   if (!stack) return;
   stack.appendChild(card);
 
@@ -793,7 +793,7 @@ async function reconnectTheatreTerminal(session: ActiveSession, worktreeBranch?:
   // Reconnect to existing PTY
   const result = await window.api.pty.reconnect(session.ptyId);
 
-  // Guard: theatre mode may have been exited during the async reconnect
+  // Guard: project mode may have been exited during the async reconnect
   if (!projectPath.value) {
     terminal.dispose();
     card.remove();
@@ -801,7 +801,7 @@ async function reconnectTheatreTerminal(session: ActiveSession, worktreeBranch?:
   }
 
   if (!result.success) {
-    console.error('[Theatre] Failed to reconnect to PTY:', session.ptyId, result.error);
+    console.error('[Project] Failed to reconnect to PTY:', session.ptyId, result.error);
     card.remove();
     terminal.dispose();
     return;
@@ -827,7 +827,7 @@ async function reconnectTheatreTerminal(session: ActiveSession, worktreeBranch?:
   }, 50);
 
   // Create terminal object
-  const theatreTerminal: TheatreTerminal = {
+  const projectTerminal: ProjectTerminal = {
     ptyId: session.ptyId,
     projectPath: session.projectPath,
     command: session.command,
@@ -867,22 +867,22 @@ async function reconnectTheatreTerminal(session: ActiveSession, worktreeBranch?:
   };
 
   // Set up close button handler
-  const closeBtn = card.querySelector('.theatre-card-close') as HTMLButtonElement;
+  const closeBtn = card.querySelector('.project-card-close') as HTMLButtonElement;
   if (closeBtn) {
     closeBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      const idx = terminals.value.indexOf(theatreTerminal);
+      const idx = terminals.value.indexOf(projectTerminal);
       if (idx !== -1) {
-        closeTheatreTerminal(idx);
+        closeProjectTerminal(idx);
       }
     });
   }
 
   // Card click handler (to bring to front)
   card.addEventListener('click', () => {
-    const idx = terminals.value.indexOf(theatreTerminal);
+    const idx = terminals.value.indexOf(projectTerminal);
     if (idx !== -1 && idx !== activeIndex.value) {
-      switchToTheatreTerminal(idx);
+      switchToProjectTerminal(idx);
     }
   });
 
@@ -891,17 +891,17 @@ async function reconnectTheatreTerminal(session: ActiveSession, worktreeBranch?:
     terminal.write(data);
     resetIdleTimer(session.ptyId);
   });
-  theatreTerminal.cleanupData = cleanupData;
+  projectTerminal.cleanupData = cleanupData;
 
   // Set up exit handler
   const cleanupExit = window.api.pty.onExit(session.ptyId, () => {
-    console.log('[Theatre] Terminal exited:', session.ptyId);
-    const idx = terminals.value.indexOf(theatreTerminal);
+    console.log('[Project] Terminal exited:', session.ptyId);
+    const idx = terminals.value.indexOf(projectTerminal);
     if (idx !== -1) {
-      closeTheatreTerminal(idx);
+      closeProjectTerminal(idx);
     }
   });
-  theatreTerminal.cleanupExit = cleanupExit;
+  projectTerminal.cleanupExit = cleanupExit;
 
   // Forward input to PTY
   terminal.onData((data) => {
@@ -909,19 +909,19 @@ async function reconnectTheatreTerminal(session: ActiveSession, worktreeBranch?:
   });
 
   // Add to terminals array
-  terminals.value = [...terminals.value, theatreTerminal];
+  terminals.value = [...terminals.value, projectTerminal];
 
   // Set up card action buttons (runner pill for all, close-task for worktrees)
-  setupCardActions(theatreTerminal);
+  setupCardActions(projectTerminal);
 
   // Mark sandboxed terminals with a ring on the status dot
-  if (theatreTerminal.sandboxed) {
-    const dot = card.querySelector('.theatre-card-status-dot');
-    if (dot) dot.classList.add('theatre-card-status-dot--sandboxed');
+  if (projectTerminal.sandboxed) {
+    const dot = card.querySelector('.project-card-status-dot');
+    if (dot) dot.classList.add('project-card-status-dot--sandboxed');
   }
 
   // Update card label
-  updateTerminalCardLabel(theatreTerminal);
+  updateTerminalCardLabel(projectTerminal);
 
   // Focus if this is the first terminal
   if (terminals.value.length === 1) {
@@ -934,7 +934,7 @@ async function reconnectTheatreTerminal(session: ActiveSession, worktreeBranch?:
  */
 async function reconnectRunnerToParent(
   session: ActiveSession,
-  parentTerminal: TheatreTerminal
+  parentTerminal: ProjectTerminal
 ): Promise<void> {
   // Create runner terminal (hidden until panel is opened)
   const runnerTerminal = new Terminal({
@@ -960,14 +960,14 @@ async function reconnectRunnerToParent(
   // Reconnect to existing PTY
   const result = await window.api.pty.reconnect(session.ptyId);
 
-  // Guard: theatre mode may have been exited or parent closed during async reconnect
+  // Guard: project mode may have been exited or parent closed during async reconnect
   if (!projectPath.value || !terminals.value.includes(parentTerminal)) {
     runnerTerminal.dispose();
     return;
   }
 
   if (!result.success) {
-    console.error('[Theatre] Failed to reconnect runner PTY:', session.ptyId, result.error);
+    console.error('[Project] Failed to reconnect runner PTY:', session.ptyId, result.error);
     runnerTerminal.dispose();
     return;
   }
@@ -1024,14 +1024,14 @@ async function reconnectRunnerToParent(
   // Update runner pill to show running state
   updateRunnerPill(parentTerminal);
 
-  console.log('[Theatre] Reconnected runner to parent terminal:', session.ptyId, '->', parentTerminal.ptyId);
+  console.log('[Project] Reconnected runner to parent terminal:', session.ptyId, '->', parentTerminal.ptyId);
 }
 
 /**
  * Wire up the view toggle buttons in the header
  */
 function wireViewToggle(headerContent: Element): void {
-  const toggleBtns = headerContent.querySelectorAll('.theatre-view-toggle-btn');
+  const toggleBtns = headerContent.querySelectorAll('.project-view-toggle-btn');
   toggleBtns.forEach(btn => {
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
@@ -1053,7 +1053,7 @@ function wireSandboxButton(wrapper: HTMLElement, path: string): void {
   if (wrapper.dataset.wired) return;
   wrapper.dataset.wired = '1';
 
-  const sandboxBtn = wrapper.querySelector('.theatre-sandbox-btn') as HTMLElement;
+  const sandboxBtn = wrapper.querySelector('.project-sandbox-btn') as HTMLElement;
   if (!sandboxBtn) return;
 
   // Remove native title — dropdown replaces it
@@ -1063,7 +1063,7 @@ function wireSandboxButton(wrapper: HTMLElement, path: string): void {
   window.api.lima.status(path).then((status) => {
     if (!status.available) return;
     wrapper.style.display = 'flex';
-    sandboxBtn.classList.toggle('theatre-sandbox-btn--active', status.vmStatus === 'Running');
+    sandboxBtn.classList.toggle('project-sandbox-btn--active', status.vmStatus === 'Running');
   });
 
   // Click handler opens/closes dropdown
@@ -1113,14 +1113,14 @@ async function showSandboxDropdown(wrapper: HTMLElement, path: string): Promise<
   const handleClickOutside = (e: MouseEvent) => {
     if (Date.now() - openedAt < 50) return; // Ignore the opening click
     const target = e.target as HTMLElement;
-    if (!target.closest('.theatre-sandbox-wrapper')) {
+    if (!target.closest('.project-sandbox-wrapper')) {
       hideSandboxDropdown();
     }
   };
 
   document.addEventListener('click', handleClickOutside);
 
-  theatreState.sandboxDropdownCleanup = () => {
+  projectState.sandboxDropdownCleanup = () => {
     document.removeEventListener('click', handleClickOutside);
   };
 }
@@ -1137,9 +1137,9 @@ export function hideSandboxDropdown(): void {
     setTimeout(() => dropdown.remove(), 150);
   }
 
-  if (theatreState.sandboxDropdownCleanup) {
-    theatreState.sandboxDropdownCleanup();
-    theatreState.sandboxDropdownCleanup = null;
+  if (projectState.sandboxDropdownCleanup) {
+    projectState.sandboxDropdownCleanup();
+    projectState.sandboxDropdownCleanup = null;
   }
 
   sandboxDropdownVisible.value = false;
@@ -1154,7 +1154,7 @@ let activeBorderAnim: SVGElement | null = null;
  * that traces around the border while the VM is starting up.
  */
 export function setSandboxButtonStarting(starting: boolean): void {
-  const btn = document.querySelector('.theatre-sandbox-btn') as HTMLElement | null;
+  const btn = document.querySelector('.project-sandbox-btn') as HTMLElement | null;
 
   if (!btn) return;
 
@@ -1164,7 +1164,7 @@ export function setSandboxButtonStarting(starting: boolean): void {
       activeBorderAnim.remove();
       activeBorderAnim = null;
     }
-    btn.classList.add('theatre-sandbox-btn--starting');
+    btn.classList.add('project-sandbox-btn--starting');
     const w = btn.offsetWidth + 4;
     const h = btn.offsetHeight + 4;
     const r = (parseFloat(getComputedStyle(btn).borderRadius) || 6) + 2;
@@ -1189,7 +1189,7 @@ export function setSandboxButtonStarting(starting: boolean): void {
     activeBorderAnim = svg;
 
   } else {
-    btn.classList.remove('theatre-sandbox-btn--starting');
+    btn.classList.remove('project-sandbox-btn--starting');
 
     if (activeBorderAnim) {
       activeBorderAnim.remove();
@@ -1212,9 +1212,9 @@ export async function refreshSandboxButton(path: string): Promise<void> {
   try {
     const status = await window.api.lima.status(path);
 
-    const btn = document.querySelector('.theatre-sandbox-btn');
+    const btn = document.querySelector('.project-sandbox-btn');
     if (btn) {
-      btn.classList.toggle('theatre-sandbox-btn--active', status.vmStatus === 'Running');
+      btn.classList.toggle('project-sandbox-btn--active', status.vmStatus === 'Running');
     }
   } catch (error) {
     console.warn('[Lima] refreshSandboxButton failed:', error instanceof Error ? error.message : error);
@@ -1237,7 +1237,7 @@ async function buildSandboxDropdownContent(
     window.api.lima.getConfig(path),
   ]);
 
-  const sandboxBtn = wrapper.querySelector('.theatre-sandbox-btn') as HTMLElement;
+  const sandboxBtn = wrapper.querySelector('.project-sandbox-btn') as HTMLElement;
   const setupHook = hooks['sandbox-setup'];
 
   // Header
@@ -1396,7 +1396,7 @@ async function buildSandboxDropdownContent(
     startBtn.addEventListener('click', async (e) => {
       e.stopPropagation();
       hideSandboxDropdown();
-      sandboxBtn.classList.remove('theatre-sandbox-btn--active');
+      sandboxBtn.classList.remove('project-sandbox-btn--active');
       setSandboxButtonStarting(true);
       window.api.lima.start(path).catch(() => {});
       // Poll until VM is running (timeout after 5 min)
@@ -1438,7 +1438,7 @@ async function buildSandboxDropdownContent(
   consoleBtn.addEventListener('click', async (e) => {
     e.stopPropagation();
     hideSandboxDropdown();
-    await theatreRegistry.addTheatreTerminal?.(
+    await projectRegistry.addProjectTerminal?.(
       { name: 'VM Console', command: '', source: 'custom', priority: 0 },
       { sandboxed: true },
     );
@@ -1455,7 +1455,7 @@ async function buildSandboxDropdownContent(
       recreateBtn.disabled = true;
       recreateBtn.textContent = 'Recreating...';
       hideSandboxDropdown();
-      sandboxBtn.classList.remove('theatre-sandbox-btn--active');
+      sandboxBtn.classList.remove('project-sandbox-btn--active');
       setSandboxButtonStarting(true);
       // Fire recreate — don't await, the IPC may never resolve
       window.api.lima.recreate(path).catch(() => {});

--- a/src/components/project/signals.ts
+++ b/src/components/project/signals.ts
@@ -1,17 +1,17 @@
 /**
- * Reactive state management for theatre mode using Preact Signals
+ * Reactive state management for project mode using Preact Signals
  * Replaces manual update choreography and callback patterns
  */
 
 import { signal, computed } from '@preact/signals-core';
 import type { Project, ChangedFile } from '../../types';
-import type { TheatreTerminal } from './state';
+import type { ProjectTerminal } from './state';
 import { STACK_PAGE_SIZE } from './state';
 
 // Core reactive state
 export const projectPath = signal<string | null>(null);
 export const projectData = signal<Project | null>(null);
-export const terminals = signal<TheatreTerminal[]>([]);
+export const terminals = signal<ProjectTerminal[]>([]);
 export const activeIndex = signal(0);
 
 // Derived state (auto-updates when dependencies change)
@@ -19,7 +19,7 @@ export const activeTerminal = computed(() =>
   terminals.value[activeIndex.value] ?? null
 );
 
-export const isInTheatreMode = computed(() =>
+export const isInProjectMode = computed(() =>
   projectPath.value !== null
 );
 
@@ -53,7 +53,7 @@ export function invalidateTaskList(): void {
 
 /**
  * Reset all signals to initial values
- * Call this when exiting theatre mode
+ * Call this when exiting project mode
  */
 export function resetSignals(): void {
   projectPath.value = null;

--- a/src/components/project/state.ts
+++ b/src/components/project/state.ts
@@ -1,6 +1,6 @@
 /**
- * Shared state for theatre mode components
- * Centralizes state that needs to be accessed across multiple theatre modules
+ * Shared state for project mode components
+ * Centralizes state that needs to be accessed across multiple project modules
  */
 
 import { Terminal } from '@xterm/xterm';
@@ -10,8 +10,8 @@ import type { PtyId, Project, ChangedFile, CompactGitStatus, ActiveSession } fro
 // Summary type for terminal status indication
 export type SummaryType = 'thinking' | 'ready';
 
-// Theatre terminal interface for multi-terminal support
-export interface TheatreTerminal {
+// Project terminal interface for multi-terminal support
+export interface ProjectTerminal {
   ptyId: PtyId;
   projectPath: string;
   command: string | undefined;  // undefined = interactive shell
@@ -55,9 +55,9 @@ export interface TheatreTerminal {
   runnerResizeCleanup: (() => void) | null;     // cleanup for drag listeners
 }
 
-// Per-project session storage for preserving theatre mode across project switches
-export interface StoredTheatreSession {
-  terminals: TheatreTerminal[];
+// Per-project session storage for preserving project mode across project switches
+export interface StoredProjectSession {
+  terminals: ProjectTerminal[];
   activeIndex: number;
   projectData: Project;
   stackElement: HTMLElement;
@@ -69,16 +69,16 @@ export interface StoredTheatreSession {
 
 // Constants
 export const STACK_PAGE_SIZE = 5;
-export const HIDDEN_SESSIONS_CONTAINER_ID = 'hidden-theatre-sessions';
+export const HIDDEN_SESSIONS_CONTAINER_ID = 'hidden-project-sessions';
 export const GIT_STATUS_IDLE_DELAY = 2000;
 export const GIT_STATUS_PERIODIC_INTERVAL = 15000;
 
 /**
- * Non-reactive theatre mode state
+ * Non-reactive project mode state
  * Items that don't need reactive updates (handlers, timers, cleanup functions)
  * Reactive state is now in signals.ts
  */
-export const theatreState = {
+export const projectState = {
   // Header content for restoration on exit
   originalHeaderContent: null as string | null,
 
@@ -101,14 +101,14 @@ export const theatreState = {
 };
 
 // Session storage for preserved sessions (in-memory, survives project switching)
-export const projectSessions = new Map<string, StoredTheatreSession>();
+export const projectSessions = new Map<string, StoredProjectSession>();
 
 // Orphaned sessions storage (PTY sessions that survived an app refresh)
-// Populated on startup from main process, consumed by enterTheatreMode
+// Populated on startup from main process, consumed by enterProjectMode
 export const orphanedSessions = new Map<string, ActiveSession[]>();
 
 /**
- * Ensures the hidden container for storing detached theatre sessions exists
+ * Ensures the hidden container for storing detached project sessions exists
  */
 export function ensureHiddenSessionsContainer(): HTMLElement {
   let container = document.getElementById(HIDDEN_SESSIONS_CONTAINER_ID);

--- a/src/components/project/terminalCards.ts
+++ b/src/components/project/terminalCards.ts
@@ -1,5 +1,5 @@
 /**
- * Theatre terminal card management - multi-terminal UI, output analysis, card stack
+ * Project terminal card management - multi-terminal UI, output analysis, card stack
  */
 
 import { Terminal } from '@xterm/xterm';
@@ -7,11 +7,11 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import type { PtyId, PtySpawnOptions, RunConfig, WorktreeInfo } from '../../types';
 import {
-  TheatreTerminal,
+  ProjectTerminal,
   STACK_PAGE_SIZE,
-  theatreState,
+  projectState,
 } from './state';
-import { getTerminalGitPath, hideRunnerPanel, theatreRegistry } from './helpers';
+import { getTerminalGitPath, hideRunnerPanel, projectRegistry } from './helpers';
 import {
   projectPath,
   projectData,
@@ -25,7 +25,7 @@ import { showToast } from '../importDialog';
 import { showHookConfigDialog } from '../hookConfigDialog';
 import { refreshTerminalGitStatus, buildCardGitBranchHtml, buildCardGitStatsHtml, scheduleTerminalGitStatusRefresh } from './gitStatus';
 import { toggleTerminalDiffPanel, toggleTerminalWorktreeDiffPanel, hideTerminalDiffPanel } from './diffPanel';
-import { setSandboxButtonStarting, refreshSandboxButton } from './theatreMode';
+import { setSandboxButtonStarting, refreshSandboxButton } from './projectMode';
 import { createIcons, icons } from 'lucide';
 
 // Platform detection for shortcuts display
@@ -151,16 +151,16 @@ export function getTerminalTheme(): Record<string, string> {
 /**
  * Update the terminal card label with current summary state
  */
-export function updateTerminalCardLabel(term: TheatreTerminal): void {
-  const labelEl = term.container.querySelector('.theatre-card-label');
+export function updateTerminalCardLabel(term: ProjectTerminal): void {
+  const labelEl = term.container.querySelector('.project-card-label');
   if (!labelEl) return;
 
   // Ensure status dot exists
-  let dot = labelEl.querySelector('.theatre-card-status-dot') as HTMLElement;
+  let dot = labelEl.querySelector('.project-card-status-dot') as HTMLElement;
   if (!dot) {
     dot = document.createElement('span');
-    dot.className = 'theatre-card-status-dot';
-    if (term.sandboxed) dot.classList.add('theatre-card-status-dot--sandboxed');
+    dot.className = 'project-card-status-dot';
+    if (term.sandboxed) dot.classList.add('project-card-status-dot--sandboxed');
     labelEl.insertBefore(dot, labelEl.firstChild);
   }
 
@@ -168,7 +168,7 @@ export function updateTerminalCardLabel(term: TheatreTerminal): void {
   dot.setAttribute('data-status', term.summaryType);
 
   // Update label text
-  const labelText = labelEl.querySelector('.theatre-card-label-text');
+  const labelText = labelEl.querySelector('.project-card-label-text');
   if (labelText) {
     let display = term.label;
     if (term.summary) {
@@ -178,13 +178,13 @@ export function updateTerminalCardLabel(term: TheatreTerminal): void {
   }
 
   // Update OSC title pill
-  const labelTop = labelEl.querySelector('.theatre-card-label-top');
+  const labelTop = labelEl.querySelector('.project-card-label-top');
   if (labelTop) {
-    let oscPill = labelTop.querySelector('.theatre-card-osc-title') as HTMLElement;
+    let oscPill = labelTop.querySelector('.project-card-osc-title') as HTMLElement;
     if (term.lastOscTitle) {
       if (!oscPill) {
         oscPill = document.createElement('span');
-        oscPill.className = 'theatre-card-osc-title';
+        oscPill.className = 'project-card-osc-title';
         labelTop.appendChild(oscPill);
       }
       oscPill.textContent = term.lastOscTitle;
@@ -195,7 +195,7 @@ export function updateTerminalCardLabel(term: TheatreTerminal): void {
   }
 
   // Update git branch display (second line under label)
-  const branchRow = labelEl.querySelector('.theatre-card-git-branch-row') as HTMLElement;
+  const branchRow = labelEl.querySelector('.project-card-git-branch-row') as HTMLElement;
   if (branchRow) {
     const branchHtml = buildCardGitBranchHtml(term.gitStatus);
     if (branchRow.dataset.lastHtml !== branchHtml) {
@@ -205,7 +205,7 @@ export function updateTerminalCardLabel(term: TheatreTerminal): void {
   }
 
   // Update git stats display (in label-right)
-  const statsWrapper = labelEl.querySelector('.theatre-card-git-stats-wrapper') as HTMLElement;
+  const statsWrapper = labelEl.querySelector('.project-card-git-stats-wrapper') as HTMLElement;
   if (statsWrapper) {
     const isWorktree = term.taskId != null && !!term.worktreeBranch;
     const statsHtml = buildCardGitStatsHtml(term.gitStatus, isWorktree);
@@ -213,14 +213,14 @@ export function updateTerminalCardLabel(term: TheatreTerminal): void {
       statsWrapper.dataset.lastHtml = statsHtml;
       statsWrapper.innerHTML = statsHtml;
 
-      const statsEl = statsWrapper.querySelector('.theatre-card-git-stats--clickable') as HTMLElement;
+      const statsEl = statsWrapper.querySelector('.project-card-git-stats--clickable') as HTMLElement;
       if (statsEl) {
         // Restore active state if diff panel is open
         if (term.diffPanelOpen) statsEl.classList.add('card-tab--active');
 
         // "Compare" button (no uncommitted changes) opens worktree mode;
         // stats pill (has uncommitted changes) opens uncommitted mode
-        const isCompareBtn = statsEl.classList.contains('theatre-card-git-stats--compare');
+        const isCompareBtn = statsEl.classList.contains('project-card-git-stats--compare');
         statsEl.addEventListener('click', (e) => {
           e.stopPropagation();
           if (isCompareBtn) {
@@ -234,41 +234,41 @@ export function updateTerminalCardLabel(term: TheatreTerminal): void {
   }
 
   // Sync kanban card status dot if the board is visible
-  theatreRegistry.syncKanbanStatusDots?.();
+  projectRegistry.syncKanbanStatusDots?.();
 }
 
 /**
- * Create a theatre terminal card element
+ * Create a project terminal card element
  */
-export function createTheatreCard(label: string, index: number): HTMLElement {
+export function createProjectCard(label: string, index: number): HTMLElement {
   const card = document.createElement('div');
-  card.className = 'theatre-card';
+  card.className = 'project-card';
   card.dataset.index = String(index);
 
   // Card label
   const labelEl = document.createElement('div');
-  labelEl.className = 'theatre-card-label';
+  labelEl.className = 'project-card-label';
 
   labelEl.innerHTML = `
-    <div class="theatre-card-label-left">
-      <div class="theatre-card-label-top">
-        <span class="theatre-card-status-dot" data-status="ready"></span>
-        <kbd class="theatre-card-shortcut" style="display: none;"></kbd>
-        <span class="theatre-card-label-text">${label}</span>
+    <div class="project-card-label-left">
+      <div class="project-card-label-top">
+        <span class="project-card-status-dot" data-status="ready"></span>
+        <kbd class="project-card-shortcut" style="display: none;"></kbd>
+        <span class="project-card-label-text">${label}</span>
       </div>
-      <div class="theatre-card-git-branch-row"></div>
+      <div class="project-card-git-branch-row"></div>
     </div>
-    <div class="theatre-card-label-right">
-      <div class="theatre-card-git-stats-wrapper"></div>
+    <div class="project-card-label-right">
+      <div class="project-card-git-stats-wrapper"></div>
       <button class="card-tab card-tab-run" data-action="run" style="display: none;">Run</button>
-      <button class="theatre-card-close" title="Close terminal"><i data-lucide="x"></i></button>
+      <button class="project-card-close" title="Close terminal"><i data-lucide="x"></i></button>
     </div>
   `;
   card.appendChild(labelEl);
 
   // Card body - flex container for terminal viewport and diff panel
   const cardBody = document.createElement('div');
-  cardBody.className = 'theatre-card-body';
+  cardBody.className = 'project-card-body';
 
   // Terminal viewport
   const viewport = document.createElement('div');
@@ -289,29 +289,29 @@ export function createTheatreCard(label: string, index: number): HTMLElement {
  */
 export function createLoadingCard(label: string): HTMLElement {
   const card = document.createElement('div');
-  card.className = 'theatre-card theatre-card--loading theatre-card--active';
+  card.className = 'project-card project-card--loading project-card--active';
 
   const labelEl = document.createElement('div');
-  labelEl.className = 'theatre-card-label';
+  labelEl.className = 'project-card-label';
 
   labelEl.innerHTML = `
-    <div class="theatre-card-label-left">
-      <div class="theatre-card-label-top">
-        <span class="theatre-card-status-dot theatre-card-status-dot--loading"></span>
-        <span class="theatre-card-label-text">${label || 'New task'}</span>
+    <div class="project-card-label-left">
+      <div class="project-card-label-top">
+        <span class="project-card-status-dot project-card-status-dot--loading"></span>
+        <span class="project-card-label-text">${label || 'New task'}</span>
       </div>
     </div>
-    <div class="theatre-card-label-right"></div>
+    <div class="project-card-label-right"></div>
   `;
   card.appendChild(labelEl);
 
   const cardBody = document.createElement('div');
-  cardBody.className = 'theatre-card-body';
+  cardBody.className = 'project-card-body';
 
   const loadingContent = document.createElement('div');
-  loadingContent.className = 'theatre-card-loading-content';
+  loadingContent.className = 'project-card-loading-content';
   loadingContent.innerHTML = `
-    <div class="theatre-card-loading-text">Setting up workspace...</div>
+    <div class="project-card-loading-text">Setting up workspace...</div>
   `;
 
   cardBody.appendChild(loadingContent);
@@ -324,8 +324,8 @@ export function createLoadingCard(label: string): HTMLElement {
  * Show a loading card and push existing terminals back in the stack
  */
 export function showLoadingCardInStack(label: string): HTMLElement {
-  const stack = document.querySelector('.theatre-stack') as HTMLElement;
-  if (!stack) throw new Error('Theatre stack not found');
+  const stack = document.querySelector('.project-stack') as HTMLElement;
+  if (!stack) throw new Error('Project stack not found');
 
   const currentTerminals = terminals.value;
   const currentActiveIndex = activeIndex.value;
@@ -335,13 +335,13 @@ export function showLoadingCardInStack(label: string): HTMLElement {
 
   // Push existing terminals on the current page back by one position
   currentTerminals.forEach((term, index) => {
-    term.container.classList.remove('theatre-card--active', 'theatre-card--back-1', 'theatre-card--back-2', 'theatre-card--back-3', 'theatre-card--back-4', 'theatre-card--hidden');
+    term.container.classList.remove('project-card--active', 'project-card--back-1', 'project-card--back-2', 'project-card--back-3', 'project-card--back-4', 'project-card--hidden');
 
     if (index < pageStart || index >= pageEnd) {
-      term.container.classList.add('theatre-card--hidden');
+      term.container.classList.add('project-card--hidden');
     } else if (index === currentActiveIndex) {
       // Active card becomes back-1
-      term.container.classList.add('theatre-card--back-1');
+      term.container.classList.add('project-card--back-1');
     } else {
       // Calculate current back position within page and increment it
       const diff = index < currentActiveIndex
@@ -349,7 +349,7 @@ export function showLoadingCardInStack(label: string): HTMLElement {
         : (pageEnd - pageStart) - (index - pageStart) + (currentActiveIndex - pageStart);
       // Add 1 to push it back further
       const newBackPosition = Math.min(diff + 1, 4);
-      term.container.classList.add(`theatre-card--back-${newBackPosition}`);
+      term.container.classList.add(`project-card--back-${newBackPosition}`);
     }
   });
 
@@ -378,8 +378,8 @@ export function removeLoadingCard(loadingCard: HTMLElement): void {
  * Set up card action buttons (runner pill for all terminals, close-task for worktrees)
  * Note: Runner pill visibility is controlled by updateCardStack (only shown on active card)
  */
-export function setupCardActions(term: TheatreTerminal): void {
-  const labelEl = term.container.querySelector('.theatre-card-label');
+export function setupCardActions(term: ProjectTerminal): void {
+  const labelEl = term.container.querySelector('.project-card-label');
   if (!labelEl) return;
 
   // Right-click context menu for task terminals
@@ -408,9 +408,9 @@ export function setupCardActions(term: TheatreTerminal): void {
 }
 
 /**
- * Show a right-click context menu on a theatre card header
+ * Show a right-click context menu on a project card header
  */
-async function showCardContextMenu(event: MouseEvent, term: TheatreTerminal): Promise<void> {
+async function showCardContextMenu(event: MouseEvent, term: ProjectTerminal): Promise<void> {
   // Remove any existing menu
   document.querySelector('.task-context-menu')?.remove();
 
@@ -427,7 +427,7 @@ async function showCardContextMenu(event: MouseEvent, term: TheatreTerminal): Pr
     terminalItem.addEventListener('click', (e) => {
       e.stopPropagation();
       menu.remove();
-      addTheatreTerminal(undefined, {
+      addProjectTerminal(undefined, {
         existingWorktree: {
           path: term.worktreePath!,
           branch: term.worktreeBranch!,
@@ -450,7 +450,7 @@ async function showCardContextMenu(event: MouseEvent, term: TheatreTerminal): Pr
       sandboxItem.addEventListener('click', (e) => {
         e.stopPropagation();
         menu.remove();
-        addTheatreTerminal(undefined, {
+        addProjectTerminal(undefined, {
           existingWorktree: {
             path: term.worktreePath!,
             branch: term.worktreeBranch!,
@@ -526,7 +526,7 @@ async function showCardContextMenu(event: MouseEvent, term: TheatreTerminal): Pr
 /**
  * Update the runner button appearance based on runner state
  */
-export function updateRunnerPill(term: TheatreTerminal): void {
+export function updateRunnerPill(term: ProjectTerminal): void {
   const btn = term.container.querySelector('.card-tab-run') as HTMLElement;
   if (!btn) return;
 
@@ -563,7 +563,7 @@ export function updateRunnerPill(term: TheatreTerminal): void {
 /**
  * Close a task from its terminal card
  */
-async function closeTaskFromTerminal(term: TheatreTerminal): Promise<void> {
+async function closeTaskFromTerminal(term: ProjectTerminal): Promise<void> {
   if (term.taskId == null) return;
 
   const path = projectPath.value;
@@ -574,7 +574,7 @@ async function closeTaskFromTerminal(term: TheatreTerminal): Promise<void> {
     // Close this terminal
     const idx = terminals.value.indexOf(term);
     if (idx !== -1) {
-      closeTheatreTerminal(idx);
+      closeProjectTerminal(idx);
     }
     // Show warning if cleanup hook failed
     if (result.hookWarning) {
@@ -614,8 +614,8 @@ function buildRunnerPanelHtml(label: string, fullWidth: boolean): string {
  * Set up drag interaction for the runner resize handle.
  * Returns a cleanup function to remove listeners.
  */
-function setupRunnerResizeHandle(term: TheatreTerminal, handle: HTMLElement, panel: HTMLElement): () => void {
-  const cardBody = term.container.querySelector('.theatre-card-body') as HTMLElement;
+function setupRunnerResizeHandle(term: ProjectTerminal, handle: HTMLElement, panel: HTMLElement): () => void {
+  const cardBody = term.container.querySelector('.project-card-body') as HTMLElement;
   if (!cardBody) return () => {};
 
   let dragging = false;
@@ -667,7 +667,7 @@ function setupRunnerResizeHandle(term: TheatreTerminal, handle: HTMLElement, pan
 /**
  * Show the runner panel for a terminal
  */
-export function showRunnerPanel(term: TheatreTerminal): void {
+export function showRunnerPanel(term: ProjectTerminal): void {
   if (term.runnerPanelOpen || !term.runnerPtyId) return;
 
   // Close diff panel if open (mutual exclusivity)
@@ -675,7 +675,7 @@ export function showRunnerPanel(term: TheatreTerminal): void {
     hideTerminalDiffPanel(term);
   }
 
-  const cardBody = term.container.querySelector('.theatre-card-body') as HTMLElement;
+  const cardBody = term.container.querySelector('.project-card-body') as HTMLElement;
   if (!cardBody) return;
 
   // Add runner-split class for min-width constraints
@@ -839,7 +839,7 @@ export function showRunnerPanel(term: TheatreTerminal): void {
 /**
  * Toggle the runner panel visibility
  */
-export function toggleRunnerPanel(term: TheatreTerminal): void {
+export function toggleRunnerPanel(term: ProjectTerminal): void {
   if (term.runnerPanelOpen) {
     hideRunnerPanel(term);
   } else {
@@ -850,7 +850,7 @@ export function toggleRunnerPanel(term: TheatreTerminal): void {
 /**
  * Toggle runner panel between full-width and split mode
  */
-function toggleRunnerFullWidth(term: TheatreTerminal): void {
+function toggleRunnerFullWidth(term: ProjectTerminal): void {
   term.runnerFullWidth = !term.runnerFullWidth;
 
   const panel = term.container.querySelector('.runner-panel') as HTMLElement;
@@ -860,7 +860,7 @@ function toggleRunnerFullWidth(term: TheatreTerminal): void {
   panel.style.transition = 'none';
 
   // Toggle full-width class on card body
-  const cardBody = term.container.querySelector('.theatre-card-body');
+  const cardBody = term.container.querySelector('.project-card-body');
   if (cardBody) cardBody.classList.toggle('runner-full', term.runnerFullWidth);
 
   // Update toggle button icon
@@ -904,7 +904,7 @@ function toggleRunnerFullWidth(term: TheatreTerminal): void {
 /**
  * Kill the runner process and clean up resources
  */
-export function killRunner(term: TheatreTerminal): void {
+export function killRunner(term: ProjectTerminal): void {
   if (!term.runnerPtyId) return;
 
   // Mark panel closed and remove active state (skip hideRunnerPanel to avoid stale timeout)
@@ -943,7 +943,7 @@ export function killRunner(term: TheatreTerminal): void {
   if (panel) panel.remove();
 
   // Remove runner-split class from card body
-  const cardBody = term.container.querySelector('.theatre-card-body');
+  const cardBody = term.container.querySelector('.project-card-body');
   if (cardBody) cardBody.classList.remove('runner-split', 'runner-full');
 
   // Reset state
@@ -964,7 +964,7 @@ export function killRunner(term: TheatreTerminal): void {
 /**
  * Restart the runner — kill current process and re-run the run script
  */
-async function restartRunner(term: TheatreTerminal): Promise<void> {
+async function restartRunner(term: ProjectTerminal): Promise<void> {
   const wasFullWidth = term.runnerFullWidth;
   killRunner(term);
   await runDefaultInCard(term);
@@ -990,7 +990,7 @@ export function killExistingCommandInstances(command: string): void {
   // Then, close any terminals running the same command (in reverse order to avoid index issues)
   for (let i = currentTerminals.length - 1; i >= 0; i--) {
     if (currentTerminals[i].command === command) {
-      closeTheatreTerminal(i);
+      closeProjectTerminal(i);
     }
   }
 }
@@ -999,7 +999,7 @@ export function killExistingCommandInstances(command: string): void {
 /**
  * Run the run hook as a hidden runner
  */
-export async function runDefaultInCard(term: TheatreTerminal): Promise<void> {
+export async function runDefaultInCard(term: ProjectTerminal): Promise<void> {
   const path = projectPath.value;
   if (!path) return;
 
@@ -1147,7 +1147,7 @@ export async function runDefaultInCard(term: TheatreTerminal): Promise<void> {
  * Update card stack visual positions (page-scoped)
  */
 export function updateCardStack(): void {
-  const stack = document.querySelector('.theatre-stack') as HTMLElement;
+  const stack = document.querySelector('.project-stack') as HTMLElement;
   if (!stack) return;
 
   const currentTerminals = terminals.value;
@@ -1167,17 +1167,17 @@ export function updateCardStack(): void {
   const backPositions: { index: number; diff: number }[] = [];
   currentTerminals.forEach((term, index) => {
     // Remove all position classes
-    term.container.classList.remove('theatre-card--active', 'theatre-card--back-1', 'theatre-card--back-2', 'theatre-card--back-3', 'theatre-card--back-4', 'theatre-card--hidden');
+    term.container.classList.remove('project-card--active', 'project-card--back-1', 'project-card--back-2', 'project-card--back-3', 'project-card--back-4', 'project-card--hidden');
 
     if (index < pageStart || index >= pageEnd) {
       // Card is on a different page — hide it
-      term.container.classList.add('theatre-card--hidden');
+      term.container.classList.add('project-card--hidden');
     } else if (index === currentActiveIndex) {
-      term.container.classList.add('theatre-card--active');
+      term.container.classList.add('project-card--active');
     } else {
       // Calculate back position relative to active within this page
       const diff = index < currentActiveIndex ? currentActiveIndex - index : pageSize - (index - pageStart) + (currentActiveIndex - pageStart);
-      const backClass = `theatre-card--back-${Math.min(diff, 4)}`;
+      const backClass = `project-card--back-${Math.min(diff, 4)}`;
       term.container.classList.add(backClass);
       backPositions.push({ index, diff });
     }
@@ -1188,7 +1188,7 @@ export function updateCardStack(): void {
 
   // Second pass: assign shortcuts and toggle runner button visibility
   currentTerminals.forEach((term, index) => {
-    const shortcutEl = term.container.querySelector('.theatre-card-shortcut') as HTMLElement;
+    const shortcutEl = term.container.querySelector('.project-card-shortcut') as HTMLElement;
     const runnerBtn = term.container.querySelector('.card-tab-run') as HTMLElement;
 
     if (index < pageStart || index >= pageEnd) {
@@ -1257,9 +1257,9 @@ export function getTerminalIndexByStackPosition(stackPosition: number): number {
 }
 
 /**
- * Switch to a specific theatre terminal
+ * Switch to a specific project terminal
  */
-export function switchToTheatreTerminal(index: number): void {
+export function switchToProjectTerminal(index: number): void {
   const currentTerminals = terminals.value;
   if (index < 0 || index >= currentTerminals.length || index === activeIndex.value) return;
 
@@ -1277,14 +1277,14 @@ export function selectByStackPosition(position: number): void {
 
   const targetIndex = getTerminalIndexByStackPosition(position);
   if (targetIndex !== -1) {
-    switchToTheatreTerminal(targetIndex);
+    switchToProjectTerminal(targetIndex);
   }
 }
 
 /**
- * Options for adding a theatre terminal
+ * Options for adding a project terminal
  */
-export interface AddTheatreTerminalOptions {
+export interface AddProjectTerminalOptions {
   useWorktree?: boolean;
   existingWorktree?: WorktreeInfo & { prompt?: string; sandboxed?: boolean };
   worktreeName?: string;
@@ -1295,9 +1295,9 @@ export interface AddTheatreTerminalOptions {
 }
 
 /**
- * Add a new theatre terminal
+ * Add a new project terminal
  */
-export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddTheatreTerminalOptions): Promise<boolean> {
+export async function addProjectTerminal(runConfig?: RunConfig, options?: AddProjectTerminalOptions): Promise<boolean> {
   const currentProjectPath = projectPath.value;
   const currentTerminals = terminals.value;
 
@@ -1305,7 +1305,7 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
     return false;
   }
 
-  const stack = document.querySelector('.theatre-stack');
+  const stack = document.querySelector('.project-stack');
   if (!stack) return false;
 
   let terminalCwd = currentProjectPath;
@@ -1318,9 +1318,9 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
     const loadingLabel = options.worktreeName || 'New task';
 
     // Hide empty state if visible
-    const emptyState = stack.querySelector('.theatre-stack-empty') as HTMLElement;
+    const emptyState = stack.querySelector('.project-stack-empty') as HTMLElement;
     if (emptyState) {
-      emptyState.classList.remove('theatre-stack-empty--visible');
+      emptyState.classList.remove('project-stack-empty--visible');
     }
 
     // Show loading card in the stack (pushes existing cards back)
@@ -1334,7 +1334,7 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
       updateCardStack();
       // Re-show empty state if no terminals
       if (terminals.value.length === 0 && emptyState) {
-        emptyState.classList.add('theatre-stack-empty--visible');
+        emptyState.classList.add('project-stack-empty--visible');
       }
       showToast(result.error || 'Failed to create task', 'error');
       return false;
@@ -1376,14 +1376,14 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
   }
 
   // Create card element
-  const card = createTheatreCard(label, index);
+  const card = createProjectCard(label, index);
   stack.appendChild(card);
 
   // Render lucide icons now that card is in the DOM
   createIcons({ icons, nameAttr: 'data-lucide', attrs: {}, nodes: [card] });
 
   const xtermContainer = card.querySelector('.terminal-xterm-container') as HTMLElement;
-  const closeBtn = card.querySelector('.theatre-card-close') as HTMLButtonElement;
+  const closeBtn = card.querySelector('.project-card-close') as HTMLButtonElement;
 
   // Initialize xterm
   const terminal = new Terminal({
@@ -1448,10 +1448,10 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
   // during the slow VM startup. The ptyId gets updated after spawn completes.
   const taskSandboxedEarly = options?.sandboxed ?? options?.existingWorktree?.sandboxed;
   const addedEarly = !loadingCard && taskSandboxedEarly;
-  let theatreTerminal: TheatreTerminal | null = null;
+  let projectTerminal: ProjectTerminal | null = null;
 
   if (addedEarly) {
-    theatreTerminal = {
+    projectTerminal = {
       ptyId: '' as PtyId,
       projectPath: currentProjectPath,
       command: undefined,
@@ -1493,21 +1493,21 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
     // Set up close button and card click handlers
     closeBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      const idx = terminals.value.indexOf(theatreTerminal!);
-      if (idx !== -1) closeTheatreTerminal(idx);
+      const idx = terminals.value.indexOf(projectTerminal!);
+      if (idx !== -1) closeProjectTerminal(idx);
     });
     card.addEventListener('click', () => {
-      const idx = terminals.value.indexOf(theatreTerminal!);
-      if (idx !== -1 && idx !== activeIndex.value) switchToTheatreTerminal(idx);
+      const idx = terminals.value.indexOf(projectTerminal!);
+      if (idx !== -1 && idx !== activeIndex.value) switchToProjectTerminal(idx);
     });
 
     // Set up card action buttons and sandbox dot
-    setupCardActions(theatreTerminal);
-    const dot = card.querySelector('.theatre-card-status-dot');
-    if (dot) dot.classList.add('theatre-card-status-dot--sandboxed');
+    setupCardActions(projectTerminal);
+    const dot = card.querySelector('.project-card-status-dot');
+    if (dot) dot.classList.add('project-card-status-dot--sandboxed');
 
     // Add to signals — effects handle updateCardStack, empty state, focus
-    terminals.value = [...terminals.value, theatreTerminal];
+    terminals.value = [...terminals.value, projectTerminal];
     activeIndex.value = terminals.value.length - 1;
     terminal.focus();
   }
@@ -1583,7 +1583,7 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
     }
 
     // If terminal was closed during loading (user clicked X), clean up and bail
-    if (addedEarly && !terminals.value.includes(theatreTerminal!)) {
+    if (addedEarly && !terminals.value.includes(projectTerminal!)) {
       if (result.success && result.ptyId) window.api.pty.kill(result.ptyId);
       return false;
     }
@@ -1591,11 +1591,11 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
     if (!result.success || !result.ptyId) {
       terminal.writeln(`\x1b[31mFailed to start terminal: ${result.error || 'Unknown error'}\x1b[0m`);
       terminal.writeln(`\x1b[90mThis card will close in 10 seconds.\x1b[0m`);
-      if (addedEarly && theatreTerminal) {
-        // Card is in signals — use closeTheatreTerminal for clean removal
+      if (addedEarly && projectTerminal) {
+        // Card is in signals — use closeProjectTerminal for clean removal
         setTimeout(() => {
-          const idx = terminals.value.indexOf(theatreTerminal!);
-          if (idx !== -1) closeTheatreTerminal(idx);
+          const idx = terminals.value.indexOf(projectTerminal!);
+          if (idx !== -1) closeProjectTerminal(idx);
         }, 10_000);
       } else {
         setTimeout(() => {
@@ -1606,44 +1606,44 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
       return false;
     }
 
-    // If added early, update the existing TheatreTerminal in-place
-    if (addedEarly && theatreTerminal) {
-      theatreTerminal.ptyId = result.ptyId;
-      theatreTerminal.command = startCommand;
+    // If added early, update the existing ProjectTerminal in-place
+    if (addedEarly && projectTerminal) {
+      projectTerminal.ptyId = result.ptyId;
+      projectTerminal.command = startCommand;
 
       // Set up resize observer
-      theatreTerminal.resizeObserver = new ResizeObserver(() => {
+      projectTerminal.resizeObserver = new ResizeObserver(() => {
         debouncedResize(result.ptyId!, terminal, fitAddon);
       });
-      theatreTerminal.resizeObserver.observe(xtermContainer);
+      projectTerminal.resizeObserver.observe(xtermContainer);
 
       // Set up data listener
-      theatreTerminal.cleanupData = window.api.pty.onData(result.ptyId, (data) => {
+      projectTerminal.cleanupData = window.api.pty.onData(result.ptyId, (data) => {
         terminal.write(data);
         resetIdleTimer(result.ptyId!);
 
         const oscMatches = data.matchAll(/\x1b\]0;([^\x07]*)\x07/g);
         for (const match of oscMatches) {
           const newTitle = match[1];
-          if (newTitle !== theatreTerminal!.lastOscTitle) {
-            theatreTerminal!.lastOscTitle = newTitle;
-            updateTerminalCardLabel(theatreTerminal!);
+          if (newTitle !== projectTerminal!.lastOscTitle) {
+            projectTerminal!.lastOscTitle = newTitle;
+            updateTerminalCardLabel(projectTerminal!);
           }
         }
 
         if (projectPath.value) {
-          scheduleTerminalGitStatusRefresh(theatreTerminal!, updateTerminalCardLabel);
+          scheduleTerminalGitStatusRefresh(projectTerminal!, updateTerminalCardLabel);
         }
       });
 
       // Set up exit listener
-      theatreTerminal.cleanupExit = window.api.pty.onExit(result.ptyId, (exitCode) => {
+      projectTerminal.cleanupExit = window.api.pty.onExit(result.ptyId, (exitCode) => {
         terminal.writeln('');
         const exitColor = exitCode === 0 ? '32' : '31';
         terminal.writeln(`\x1b[${exitColor}m● Process exited with code ${exitCode}\x1b[0m`);
-        theatreTerminal!.summary = exitCode === 0 ? 'Exited' : `Exit ${exitCode}`;
-        theatreTerminal!.summaryType = 'ready';
-        updateTerminalCardLabel(theatreTerminal!);
+        projectTerminal!.summary = exitCode === 0 ? 'Exited' : `Exit ${exitCode}`;
+        projectTerminal!.summaryType = 'ready';
+        updateTerminalCardLabel(projectTerminal!);
       });
 
       // Forward terminal input
@@ -1652,16 +1652,16 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
       });
 
       // Fetch initial git status
-      refreshTerminalGitStatus(theatreTerminal).then(() => {
-        updateTerminalCardLabel(theatreTerminal!);
+      refreshTerminalGitStatus(projectTerminal).then(() => {
+        updateTerminalCardLabel(projectTerminal!);
       });
 
       terminal.focus();
       return true;
     }
 
-    // Normal path: create TheatreTerminal after spawn
-    theatreTerminal = {
+    // Normal path: create ProjectTerminal after spawn
+    projectTerminal = {
       ptyId: result.ptyId,
       projectPath: currentProjectPath,
       command: startCommand,
@@ -1703,13 +1703,13 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
     };
 
     // Set up resize observer with debouncing to prevent zsh artifacts during animations
-    theatreTerminal.resizeObserver = new ResizeObserver(() => {
+    projectTerminal.resizeObserver = new ResizeObserver(() => {
       debouncedResize(result.ptyId!, terminal, fitAddon);
     });
-    theatreTerminal.resizeObserver.observe(xtermContainer);
+    projectTerminal.resizeObserver.observe(xtermContainer);
 
     // Set up data listener
-    theatreTerminal.cleanupData = window.api.pty.onData(result.ptyId, (data) => {
+    projectTerminal.cleanupData = window.api.pty.onData(result.ptyId, (data) => {
       terminal.write(data);
       resetIdleTimer(result.ptyId!);
 
@@ -1717,28 +1717,28 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
       const oscMatches = data.matchAll(/\x1b\]0;([^\x07]*)\x07/g);
       for (const match of oscMatches) {
         const newTitle = match[1];
-        if (newTitle !== theatreTerminal!.lastOscTitle) {
-          theatreTerminal!.lastOscTitle = newTitle;
-          updateTerminalCardLabel(theatreTerminal!);
+        if (newTitle !== projectTerminal!.lastOscTitle) {
+          projectTerminal!.lastOscTitle = newTitle;
+          updateTerminalCardLabel(projectTerminal!);
         }
       }
 
       if (projectPath.value) {
         // Only schedule a refresh of this terminal's git status (not all terminals)
-        scheduleTerminalGitStatusRefresh(theatreTerminal!, updateTerminalCardLabel);
+        scheduleTerminalGitStatusRefresh(projectTerminal!, updateTerminalCardLabel);
       }
     });
 
     // Set up exit listener
-    theatreTerminal.cleanupExit = window.api.pty.onExit(result.ptyId, (exitCode) => {
+    projectTerminal.cleanupExit = window.api.pty.onExit(result.ptyId, (exitCode) => {
       terminal.writeln('');
       const exitColor = exitCode === 0 ? '32' : '31';
       terminal.writeln(`\x1b[${exitColor}m● Process exited with code ${exitCode}\x1b[0m`);
 
       // Update summary to show exit status
-      theatreTerminal!.summary = exitCode === 0 ? 'Exited' : `Exit ${exitCode}`;
-      theatreTerminal!.summaryType = 'ready';
-      updateTerminalCardLabel(theatreTerminal!);
+      projectTerminal!.summary = exitCode === 0 ? 'Exited' : `Exit ${exitCode}`;
+      projectTerminal!.summaryType = 'ready';
+      updateTerminalCardLabel(projectTerminal!);
     });
 
     // Forward terminal input
@@ -1749,38 +1749,38 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
     // Close button handler
     closeBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      const idx = terminals.value.indexOf(theatreTerminal!);
+      const idx = terminals.value.indexOf(projectTerminal!);
       if (idx !== -1) {
-        closeTheatreTerminal(idx);
+        closeProjectTerminal(idx);
       }
     });
 
     // Card click handler (to bring to front)
     card.addEventListener('click', () => {
-      const idx = terminals.value.indexOf(theatreTerminal!);
+      const idx = terminals.value.indexOf(projectTerminal!);
       if (idx !== -1 && idx !== activeIndex.value) {
-        switchToTheatreTerminal(idx);
+        switchToProjectTerminal(idx);
       }
     });
 
     // Set up card action buttons (runner pill, close-task for worktrees)
-    setupCardActions(theatreTerminal);
+    setupCardActions(projectTerminal);
 
     // Mark sandboxed terminals with a ring on the status dot
     if (useSandbox) {
-      const dot = card.querySelector('.theatre-card-status-dot');
+      const dot = card.querySelector('.project-card-status-dot');
       if (dot) {
-        dot.classList.add('theatre-card-status-dot--sandboxed');
+        dot.classList.add('project-card-status-dot--sandboxed');
       }
     }
 
     // Fetch initial git status for this terminal
-    refreshTerminalGitStatus(theatreTerminal).then(() => {
-      updateTerminalCardLabel(theatreTerminal!);
+    refreshTerminalGitStatus(projectTerminal).then(() => {
+      updateTerminalCardLabel(projectTerminal!);
     });
 
     // Add terminal to list and set as active - effects will handle updateCardStack
-    terminals.value = [...terminals.value, theatreTerminal];
+    terminals.value = [...terminals.value, projectTerminal];
     activeIndex.value = terminals.value.length - 1;
 
     terminal.focus();
@@ -1790,10 +1790,10 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
       setSandboxButtonStarting(false);
     }
     terminal.writeln(`\x1b[31mError: ${error instanceof Error ? error.message : 'Unknown error'}\x1b[0m`);
-    if (addedEarly && theatreTerminal) {
-      // Card is in signals — remove via closeTheatreTerminal
-      const idx = terminals.value.indexOf(theatreTerminal);
-      if (idx !== -1) closeTheatreTerminal(idx);
+    if (addedEarly && projectTerminal) {
+      // Card is in signals — remove via closeProjectTerminal
+      const idx = terminals.value.indexOf(projectTerminal);
+      if (idx !== -1) closeProjectTerminal(idx);
     } else {
       card.remove();
       terminal.dispose();
@@ -1803,9 +1803,9 @@ export async function addTheatreTerminal(runConfig?: RunConfig, options?: AddThe
 }
 
 /**
- * Close a theatre terminal
+ * Close a project terminal
  */
-export function closeTheatreTerminal(index: number): void {
+export function closeProjectTerminal(index: number): void {
   const currentTerminals = terminals.value;
   if (index < 0 || index >= currentTerminals.length) return;
 
@@ -1858,50 +1858,50 @@ export function closeTheatreTerminal(index: number): void {
  */
 export function buildEmptyStateHtml(): string {
   return `
-    <div class="theatre-stack-empty">
-      <div class="theatre-stack-empty-message">No active terminals</div>
-      <div class="theatre-stack-empty-hints">
-        <span class="theatre-stack-empty-hint"><span class="theatre-stack-empty-hint-shortcut">${isMac ? '⌘' : 'Ctrl+'}<span class="shortcut-number">N</span></span>New Task</span>
-        <span class="theatre-stack-empty-hint"><span class="theatre-stack-empty-hint-shortcut">${isMac ? '⌘' : 'Ctrl+'}<span class="shortcut-number">B</span></span>Board</span>
+    <div class="project-stack-empty">
+      <div class="project-stack-empty-message">No active terminals</div>
+      <div class="project-stack-empty-hints">
+        <span class="project-stack-empty-hint"><span class="project-stack-empty-hint-shortcut">${isMac ? '⌘' : 'Ctrl+'}<span class="shortcut-number">N</span></span>New Task</span>
+        <span class="project-stack-empty-hint"><span class="project-stack-empty-hint-shortcut">${isMac ? '⌘' : 'Ctrl+'}<span class="shortcut-number">B</span></span>Board</span>
       </div>
     </div>
   `;
 }
 
 /**
- * Show the empty state in the theatre stack
+ * Show the empty state in the project stack
  */
 export function showStackEmptyState(): void {
-  const stack = document.querySelector('.theatre-stack');
+  const stack = document.querySelector('.project-stack');
   if (!stack) return;
 
   // Check if empty state already exists
-  let emptyState = stack.querySelector('.theatre-stack-empty') as HTMLElement;
+  let emptyState = stack.querySelector('.project-stack-empty') as HTMLElement;
   if (emptyState) {
     requestAnimationFrame(() => {
-      emptyState.classList.add('theatre-stack-empty--visible');
+      emptyState.classList.add('project-stack-empty--visible');
     });
     return;
   }
 
   // Create and insert empty state
   stack.insertAdjacentHTML('beforeend', buildEmptyStateHtml());
-  emptyState = stack.querySelector('.theatre-stack-empty') as HTMLElement;
+  emptyState = stack.querySelector('.project-stack-empty') as HTMLElement;
 
   // Animate in
   requestAnimationFrame(() => {
-    emptyState.classList.add('theatre-stack-empty--visible');
+    emptyState.classList.add('project-stack-empty--visible');
   });
 }
 
 /**
- * Hide the empty state from the theatre stack
+ * Hide the empty state from the project stack
  */
 export function hideStackEmptyState(): void {
-  const emptyState = document.querySelector('.theatre-stack-empty') as HTMLElement;
+  const emptyState = document.querySelector('.project-stack-empty') as HTMLElement;
   if (!emptyState) return;
 
-  emptyState.classList.remove('theatre-stack-empty--visible');
+  emptyState.classList.remove('project-stack-empty--visible');
 
   // Remove after animation
   setTimeout(() => {
@@ -1914,15 +1914,15 @@ export function hideStackEmptyState(): void {
  * Created once and reused; hidden/shown by updatePaginationArrows.
  */
 function ensurePaginationRow(): HTMLElement {
-  let row = document.querySelector('.theatre-stack-pagination') as HTMLElement;
+  let row = document.querySelector('.project-stack-pagination') as HTMLElement;
   if (row) return row;
 
   row = document.createElement('div');
-  row.className = 'theatre-stack-pagination';
+  row.className = 'project-stack-pagination';
   row.style.display = 'none';
 
   const leftBtn = document.createElement('button');
-  leftBtn.className = 'theatre-stack-page-arrow';
+  leftBtn.className = 'project-stack-page-arrow';
   leftBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>';
   leftBtn.addEventListener('click', (e) => {
     e.stopPropagation();
@@ -1930,10 +1930,10 @@ function ensurePaginationRow(): HTMLElement {
   });
 
   const indicator = document.createElement('span');
-  indicator.className = 'theatre-stack-page-indicator';
+  indicator.className = 'project-stack-page-indicator';
 
   const rightBtn = document.createElement('button');
-  rightBtn.className = 'theatre-stack-page-arrow';
+  rightBtn.className = 'project-stack-page-arrow';
   rightBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>';
   rightBtn.addEventListener('click', (e) => {
     e.stopPropagation();
@@ -1956,16 +1956,16 @@ function updatePaginationArrows(_stack: HTMLElement): void {
   const page = activeStackPage.value;
 
   if (pages <= 1) {
-    const row = document.querySelector('.theatre-stack-pagination') as HTMLElement;
+    const row = document.querySelector('.project-stack-pagination') as HTMLElement;
     if (row) row.style.display = 'none';
     return;
   }
 
   const row = ensurePaginationRow();
-  const buttons = row.querySelectorAll('.theatre-stack-page-arrow');
+  const buttons = row.querySelectorAll('.project-stack-page-arrow');
   const leftBtn = buttons[0] as HTMLElement;
   const rightBtn = buttons[1] as HTMLElement;
-  const indicator = row.querySelector('.theatre-stack-page-indicator') as HTMLElement;
+  const indicator = row.querySelector('.project-stack-page-indicator') as HTMLElement;
 
   row.style.display = '';
   if (leftBtn) leftBtn.style.visibility = page > 0 ? 'visible' : 'hidden';
@@ -2110,8 +2110,8 @@ let hookStatusCleanup: (() => void) | null = null;
 
 /**
  * Register a single global listener for Claude Code hook status events.
- * Maps ptyId → TheatreTerminal and updates summaryType + card label.
- * Call once when theatre mode initializes; clean up on exit.
+ * Maps ptyId → ProjectTerminal and updates summaryType + card label.
+ * Call once when project mode initializes; clean up on exit.
  *
  * When tools were used (count > 1), Stop/Notification hooks use a
  * two-phase transition: first a deferral timer (5s) to catch premature
@@ -2204,7 +2204,7 @@ export function unregisterHookStatusListener(): void {
   clearAllIdleTimers();
 }
 
-// Register functions in the theatre registry for cross-module access
-theatreRegistry.addTheatreTerminal = addTheatreTerminal;
-theatreRegistry.closeTheatreTerminal = closeTheatreTerminal;
-theatreRegistry.playOrToggleRunner = playOrToggleRunner;
+// Register functions in the project registry for cross-module access
+projectRegistry.addProjectTerminal = addProjectTerminal;
+projectRegistry.closeProjectTerminal = closeProjectTerminal;
+projectRegistry.playOrToggleRunner = playOrToggleRunner;

--- a/src/components/project/worktreeDropdown.ts
+++ b/src/components/project/worktreeDropdown.ts
@@ -1,11 +1,11 @@
 /**
- * Worktree/task operations for theatre mode
+ * Worktree/task operations for project mode
  */
 
 import type { TaskWithWorkspace } from '../../types';
 import { projectPath, terminals, invalidateTaskList } from './signals';
 import { showToast } from '../importDialog';
-import { theatreRegistry } from './helpers';
+import { projectRegistry } from './helpers';
 import { registerHotkey, unregisterHotkey, pushScope, popScope, Scopes } from '../../utils/hotkeys';
 
 /**
@@ -83,7 +83,7 @@ export async function closeTask(path: string, task: TaskWithWorkspace): Promise<
     for (let i = currentTerminals.length - 1; i >= 0; i--) {
       const term = currentTerminals[i];
       if (term.taskId === task.taskNumber) {
-        theatreRegistry.closeTheatreTerminal?.(i);
+        projectRegistry.closeProjectTerminal?.(i);
       }
     }
     invalidateTaskList();
@@ -108,7 +108,7 @@ export async function reopenTask(path: string, task: TaskWithWorkspace): Promise
     invalidateTaskList();
     // Open terminal for the task (without sandbox by default)
     const taskPath = task.worktreePath || '';
-    await theatreRegistry.addTheatreTerminal?.(undefined, {
+    await projectRegistry.addProjectTerminal?.(undefined, {
       existingWorktree: {
         path: taskPath,
         branch: task.branch || '',
@@ -137,7 +137,7 @@ export async function deleteTask(path: string, task: TaskWithWorkspace): Promise
   for (let i = currentTerminals.length - 1; i >= 0; i--) {
     const term = currentTerminals[i];
     if (term.taskId === task.taskNumber) {
-      theatreRegistry.closeTheatreTerminal?.(i);
+      projectRegistry.closeProjectTerminal?.(i);
     }
   }
 

--- a/src/components/projectRow.ts
+++ b/src/components/projectRow.ts
@@ -1,7 +1,7 @@
 import type { Project } from '../types';
 import { stringToColor, getInitials } from '../utils/projectIcon';
 import { formatRelativeTime } from '../utils/formatDate';
-import { enterTheatreMode } from './theatre';
+import { enterProjectMode } from './project';
 
 /**
  * Creates a project icon element (image or placeholder)
@@ -121,9 +121,9 @@ export function createProjectRow(project: Project): HTMLElement {
   lastModified.textContent = formatRelativeTime(date);
   row.appendChild(lastModified);
 
-  // Click row to enter theatre mode
+  // Click row to enter project mode
   row.addEventListener('click', async () => {
-    await enterTheatreMode(project.path, project);
+    await enterProjectMode(project.path, project);
   });
 
   return row;

--- a/src/index.css
+++ b/src/index.css
@@ -405,7 +405,7 @@ textarea,
   @apply scale-[0.98];
 }
 
-/* Launch Dropdown (used in theatre mode) */
+/* Launch Dropdown (used in project mode) */
 .launch-dropdown {
   @apply absolute top-full right-0 mt-1 min-w-[220px] max-w-[320px] bg-surface border border-border rounded-md shadow-lg z-[1000] opacity-0 invisible overflow-hidden transition-all duration-150 ease-out;
   transform: translateY(-8px);
@@ -530,7 +530,7 @@ textarea,
 }
 
 /* ===================================
-   Terminal Viewport Styles (shared with theatre mode)
+   Terminal Viewport Styles (shared with project mode)
    =================================== */
 
 .terminal-viewport {
@@ -687,25 +687,25 @@ textarea,
 }
 
 /* ===================================
-   Theatre Mode Styles
+   Project Mode Styles
    =================================== */
 
-/* Hide project rows in theatre mode - NOT main-content */
-body.theatre-mode .project-row {
+/* Hide project rows in project mode - NOT main-content */
+body.project-mode .project-row {
   display: none !important;
 }
 
-body.theatre-mode .main-content {
+body.project-mode .main-content {
   min-height: 0;
 }
 
-/* Remove max-width constraint from header in theatre mode */
-body.theatre-mode .header {
+/* Remove max-width constraint from header in project mode */
+body.project-mode .header {
   z-index: 10000;
   border-bottom: none;
 }
 
-body.theatre-mode .header-content {
+body.project-mode .header-content {
   max-width: none;
   padding-left: 0;
   padding-right: 0;
@@ -713,112 +713,112 @@ body.theatre-mode .header-content {
 }
 
 /* Hide search/refresh area in header */
-body.theatre-mode .search-container {
+body.project-mode .search-container {
   display: none !important;
 }
 
-body.theatre-mode #refresh-btn,
-body.theatre-mode #new-project-btn {
+body.project-mode #refresh-btn,
+body.project-mode #new-project-btn {
   display: none !important;
 }
 
 /* Hide project list header */
-body.theatre-mode .project-list-header {
+body.project-mode .project-list-header {
   display: none !important;
 }
 
-/* Theatre header content */
-.theatre-header-content {
+/* Project header content */
+.project-header-content {
   @apply flex items-center gap-3 flex-1 px-4;
 }
 
 /* Add extra padding for macOS traffic lights (except fullscreen) */
-body.platform-darwin:not(.is-fullscreen) .theatre-header-content {
+body.platform-darwin:not(.is-fullscreen) .project-header-content {
   @apply pl-24;
 }
 
-.theatre-project-icon {
+.project-header-icon {
   @apply w-8 h-8 rounded-md object-cover;
 }
 
-.theatre-project-icon--placeholder {
+.project-header-icon--placeholder {
   @apply flex items-center justify-center text-base font-bold text-white;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
-.theatre-project-info {
+.project-header-info {
   @apply flex flex-col gap-0.5 flex-1 min-w-0;
 }
 
-.theatre-project-name {
+.project-header-name {
   @apply text-base font-semibold text-text-primary leading-tight;
 }
 
-.theatre-project-path {
+.project-header-path {
   @apply text-xs text-text-tertiary leading-tight truncate;
 }
 
-.theatre-terminal-btn {
+.project-terminal-btn {
   @apply w-8 h-8 flex items-center justify-center bg-background-secondary border border-border rounded-md text-text-secondary transition-all duration-150 ease-out ml-3;
   -webkit-app-region: no-drag;
 }
 
-.theatre-terminal-btn:hover {
+.project-terminal-btn:hover {
   @apply bg-background-tertiary text-text-primary;
 }
 
-.theatre-terminal-btn svg {
+.project-terminal-btn svg {
   @apply w-4 h-4;
 }
 
-.theatre-newtask-btn {
+.project-newtask-btn {
   @apply w-8 h-8 flex items-center justify-center bg-background-secondary border border-border rounded-md text-text-secondary transition-all duration-150 ease-out ml-3;
   -webkit-app-region: no-drag;
 }
 
-.theatre-newtask-btn:hover {
+.project-newtask-btn:hover {
   @apply bg-background-tertiary text-text-primary;
 }
 
-.theatre-newtask-btn svg {
+.project-newtask-btn svg {
   @apply w-4 h-4;
 }
 
 /* Sandbox wrapper */
-.theatre-sandbox-wrapper {
+.project-sandbox-wrapper {
   @apply relative flex ml-3;
   -webkit-app-region: no-drag;
 }
 
-.theatre-sandbox-btn {
+.project-sandbox-btn {
   @apply relative h-8 flex items-center justify-center gap-1.5 px-2 bg-background-secondary border border-border rounded-md text-text-secondary ease-out;
   transition: background-color 150ms ease-out, border-color 150ms ease-out, color 150ms ease-out;
 }
 
-.theatre-sandbox-btn:hover {
+.project-sandbox-btn:hover {
   @apply bg-background-tertiary text-text-primary;
 }
 
-.theatre-sandbox-btn svg:not(.sandbox-border-anim) {
+.project-sandbox-btn svg:not(.sandbox-border-anim) {
   @apply w-4 h-4;
 }
 
-.theatre-sandbox-caret {
+.project-sandbox-caret {
   @apply !w-3 !h-3 opacity-50;
 }
 
-.theatre-sandbox-btn--active {
+.project-sandbox-btn--active {
   background: rgba(10, 132, 255, 0.15);
   border-color: rgba(10, 132, 255, 0.4);
   color: #409CFF;
 }
 
-.theatre-sandbox-btn--active:hover {
+.project-sandbox-btn--active:hover {
   background: rgba(10, 132, 255, 0.25);
   color: #6AB4FF;
 }
 
-.theatre-sandbox-btn--starting {
+.project-sandbox-btn--starting {
   border-color: transparent;
   color: #409CFF;
 }
@@ -1042,210 +1042,210 @@ body.platform-darwin:not(.is-fullscreen) .theatre-header-content {
   transform: translateX(14px);
 }
 
-.theatre-exit-btn {
+.project-exit-btn {
   @apply w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-text-secondary opacity-70 transition-all duration-150 ease-out mr-2;
   -webkit-app-region: no-drag;
 }
 
-.theatre-exit-btn:hover {
+.project-exit-btn:hover {
   @apply bg-white/[0.08] text-text-primary opacity-100;
 }
 
-.theatre-exit-btn svg {
+.project-exit-btn svg {
   @apply w-3.5 h-3.5;
 }
 
 /* ==========================================
-   Theatre Mode Card Stack
+   Project Mode Card Stack
    ========================================== */
 
-.theatre-stack {
+.project-stack {
   @apply fixed top-[82px] left-4 right-4 bottom-4 z-[100] overflow-visible;
   transition: left 0.25s ease, right 0.25s ease, top 0.2s ease;
 }
 
-.theatre-card {
+.project-card {
   @apply absolute inset-0 rounded-lg border border-white/10 overflow-hidden flex flex-col;
   background: var(--color-terminal-bg, #1a1a1a);
   transition: translate 0.2s ease, scale 0.2s ease;
 }
 
-.theatre-card--active {
+.project-card--active {
   @apply z-10;
   transform: none;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2);
 }
 
-.theatre-card--back-1 {
+.project-card--back-1 {
   @apply z-[9] -translate-y-6 scale-x-[0.98];
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.12);
   contain: layout style paint;
 }
 
-.theatre-card--back-2 {
+.project-card--back-2 {
   @apply z-[8] -translate-y-12 scale-x-[0.96];
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 1px 4px rgba(0, 0, 0, 0.08);
   contain: layout style paint;
 }
 
-.theatre-card--back-3 {
+.project-card--back-3 {
   @apply z-[7] -translate-y-[72px] scale-x-[0.94];
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08);
   contain: layout style paint;
 }
 
-.theatre-card--back-4 {
+.project-card--back-4 {
   @apply z-[6] -translate-y-24 scale-x-[0.92];
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.06);
   contain: layout style paint;
 }
 
 /* Back card label positioning */
-.theatre-card--back-1 .theatre-card-label,
-.theatre-card--back-2 .theatre-card-label,
-.theatre-card--back-3 .theatre-card-label,
-.theatre-card--back-4 .theatre-card-label {
+.project-card--back-1 .project-card-label,
+.project-card--back-2 .project-card-label,
+.project-card--back-3 .project-card-label,
+.project-card--back-4 .project-card-label {
   @apply pt-0.5;
 }
 
 /* Hide non-essential elements on back cards, but keep close button */
-.theatre-card:not(.theatre-card--active) .theatre-card-git-branch-row,
-.theatre-card:not(.theatre-card--active) .theatre-card-git-stats-wrapper,
-.theatre-card:not(.theatre-card--active) .card-tab-run {
+.project-card:not(.project-card--active) .project-card-git-branch-row,
+.project-card:not(.project-card--active) .project-card-git-stats-wrapper,
+.project-card:not(.project-card--active) .card-tab-run {
   @apply hidden;
 }
 
 
 /* Hover effect on back cards */
-.theatre-card:not(.theatre-card--active):hover {
+.project-card:not(.project-card--active):hover {
   @apply border-accent;
 }
 
-.theatre-card--back-1:hover {
+.project-card--back-1:hover {
   @apply -translate-y-7 scale-x-[0.98];
 }
 
-.theatre-card--back-2:hover {
+.project-card--back-2:hover {
   @apply -translate-y-[52px] scale-x-[0.96];
 }
 
-.theatre-card--back-3:hover {
+.project-card--back-3:hover {
   @apply -translate-y-[76px] scale-x-[0.94];
 }
 
-.theatre-card--back-4:hover {
+.project-card--back-4:hover {
   @apply -translate-y-[100px] scale-x-[0.92];
 }
 
 /* Card label */
-.theatre-card-label {
+.project-card-label {
   @apply flex items-center justify-between pl-3 pr-3 py-2 min-h-9;
 }
 
-.theatre-card-label-left {
+.project-card-label-left {
   @apply flex flex-col min-w-0 shrink;
 }
 
-.theatre-card-label-top {
+.project-card-label-top {
   @apply flex items-center gap-2 min-w-0;
 }
 
-.theatre-card-git-branch-row {
+.project-card-git-branch-row {
   @apply min-w-0 overflow-hidden;
 }
 
-.theatre-card-label-right {
+.project-card-label-right {
   @apply flex items-center gap-1 shrink-0 justify-end;
 }
 
-.theatre-card-label-text {
+.project-card-label-text {
   @apply font-mono text-xs font-medium text-white/70 shrink-0;
 }
 
-.theatre-card-osc-title {
+.project-card-osc-title {
   @apply font-mono text-[11px] text-white/40 bg-white/5 rounded-full px-2 py-px truncate;
 }
 
-.theatre-card--back-1 .theatre-card-osc-title,
-.theatre-card--back-2 .theatre-card-osc-title,
-.theatre-card--back-3 .theatre-card-osc-title,
-.theatre-card--back-4 .theatre-card-osc-title {
+.project-card--back-1 .project-card-osc-title,
+.project-card--back-2 .project-card-osc-title,
+.project-card--back-3 .project-card-osc-title,
+.project-card--back-4 .project-card-osc-title {
   @apply hidden;
 }
 
 /* Keyboard shortcut hint for tab switching */
-.theatre-card-shortcut {
+.project-card-shortcut {
   @apply inline-flex items-center font-mono text-base text-white/40 shrink-0;
 }
 
 /* Status dot indicator for terminal summary */
-.theatre-card-status-dot {
+.project-card-status-dot {
   @apply w-1.5 h-1.5 rounded-full shrink-0 bg-[#69db7c] transition-all duration-200 ease-out;
   box-shadow: 0 0 4px rgba(105, 219, 124, 0.5);
 }
 
-.theatre-card-status-dot[data-status="ready"] {
+.project-card-status-dot[data-status="ready"] {
   @apply bg-[#69db7c];
   box-shadow: 0 0 4px rgba(105, 219, 124, 0.5);
 }
 
-.theatre-card-status-dot[data-status="thinking"] {
+.project-card-status-dot[data-status="thinking"] {
   @apply bg-[#da77f2];
   box-shadow: 0 0 4px rgba(218, 119, 242, 0.5);
   animation: terminal-status-pulse 1s ease-in-out infinite;
 }
 
 /* Sandboxed terminal ring on status dot */
-.theatre-card-status-dot--sandboxed {
+.project-card-status-dot--sandboxed {
   outline: 1.5px solid rgba(116, 192, 252, 0.6);
   outline-offset: 2px;
 }
 
 /* Loading card styles */
-.theatre-card--loading {
+.project-card--loading {
   @apply pointer-events-none;
 }
 
-.theatre-card-status-dot--loading {
+.project-card-status-dot--loading {
   @apply w-2 h-2 rounded-full bg-transparent border-[1.5px] border-white/30 border-t-white/80;
   animation: loading-dot-spin 0.8s linear infinite;
 }
 
-.theatre-card-loading-content {
+.project-card-loading-content {
   @apply flex-1 flex items-center justify-center;
 }
 
-.theatre-card-loading-text {
+.project-card-loading-text {
   @apply font-mono text-sm text-white/40;
 }
 
-.theatre-card-close {
+.project-card-close {
   @apply w-7 h-7 flex items-center justify-center bg-transparent border-none text-white/40 transition-colors duration-150 ease-out;
 }
 
-.theatre-card-close:hover {
+.project-card-close:hover {
   @apply text-white/90;
 }
 
-.theatre-card-close svg {
+.project-card-close svg {
   @apply w-4 h-4;
 }
 
 
 /* Card Git Status Display */
-.theatre-card-git-stats-wrapper {
+.project-card-git-stats-wrapper {
   @apply mr-2;
 }
 
-.theatre-card-git-branch {
+.project-card-git-branch {
   @apply flex items-center gap-1 font-mono text-[13px] text-white/50 min-w-0 overflow-hidden;
 }
 
-.theatre-card-git-branch-name {
+.project-card-git-branch-name {
   @apply truncate min-w-0;
 }
 
-.theatre-card-git-icon {
+.project-card-git-icon {
   @apply w-3.5 h-3.5 shrink-0 text-white/40;
 }
 
@@ -1267,38 +1267,38 @@ body.platform-darwin:not(.is-fullscreen) .theatre-header-content {
   @apply bg-accent text-white;
 }
 
-.theatre-card-git-stats {
+.project-card-git-stats {
   @apply flex items-center gap-1 px-1.5 py-0.5 rounded-sm font-mono text-[12px] text-white/70 bg-white/5;
 }
 
 /* When clickable, override base stats styles to match card-tab */
-.theatre-card-git-stats--clickable {
+.project-card-git-stats--clickable {
   @apply px-2.5 py-1 text-[13px] font-medium text-white/60 bg-white/[0.06] rounded-full;
 }
 
-.theatre-card-git-stats--compare {
+.project-card-git-stats--compare {
   @apply font-sans;
 }
 
-.theatre-card-git-count {
+.project-card-git-count {
   @apply font-medium;
 }
 
-.theatre-card-git-add {
+.project-card-git-add {
   @apply text-[#69db7c];
 }
 
-.theatre-card-git-del {
+.project-card-git-del {
   @apply text-[#ff6b6b];
 }
 
 /* Card body - flex container for terminal and diff panel */
-.theatre-card-body {
+.project-card-body {
   @apply relative flex-1 flex flex-row min-h-0 overflow-hidden;
 }
 
 /* Card viewport */
-.theatre-card .terminal-viewport {
+.project-card .terminal-viewport {
   @apply flex-1 min-h-0 min-w-0 h-auto rounded-none border-none;
   transition: flex 0.25s ease;
 }
@@ -1468,37 +1468,37 @@ body.platform-darwin:not(.is-fullscreen) .theatre-header-content {
 }
 
 
-/* Theatre Launch Button & Dropdown */
-.theatre-launch-wrapper {
+/* Project Launch Button & Dropdown */
+.project-launch-wrapper {
   @apply relative flex ml-3;
   -webkit-app-region: no-drag;
 }
 
-.theatre-scripts-btn {
+.project-scripts-btn {
   @apply relative h-8 flex items-center justify-center gap-1.5 px-2 bg-background-secondary border border-border rounded-md text-text-secondary ease-out;
   transition: background-color 150ms ease-out, border-color 150ms ease-out, color 150ms ease-out;
 }
 
-.theatre-scripts-btn:hover {
+.project-scripts-btn:hover {
   @apply bg-background-tertiary text-text-primary;
 }
 
-.theatre-scripts-btn svg {
+.project-scripts-btn svg {
   @apply w-4 h-4;
 }
 
-.theatre-scripts-caret {
+.project-scripts-caret {
   @apply !w-3 !h-3 opacity-50;
 }
 
 /* Launch dropdown - reuses .launch-dropdown pattern */
-.theatre-launch-dropdown {
+.project-launch-dropdown {
   @apply absolute top-full right-0 mt-1 min-w-[240px] max-w-[296px] bg-surface border border-border rounded-md shadow-lg z-[1000] opacity-0 invisible overflow-hidden transition-all duration-150 ease-out;
   transform: translateY(-8px);
   -webkit-app-region: no-drag;
 }
 
-.theatre-launch-dropdown.visible {
+.project-launch-dropdown.visible {
   @apply opacity-100 visible;
   transform: translateY(0);
 }
@@ -1591,33 +1591,33 @@ body.platform-darwin:not(.is-fullscreen) .theatre-header-content {
 
 
 /* ==========================================
-   Theatre Stack Empty State
+   Project Stack Empty State
    ========================================== */
 
-.theatre-stack-empty {
+.project-stack-empty {
   @apply absolute inset-0 flex flex-col items-center justify-center text-center rounded-lg border border-dashed border-white/10 p-12 opacity-0;
   background: var(--color-terminal-bg);
 }
 
-.theatre-stack-empty--visible {
+.project-stack-empty--visible {
   @apply opacity-100;
 }
 
-.theatre-stack-empty-message {
+.project-stack-empty-message {
   @apply text-sm text-white/30;
 }
 
-.theatre-stack-empty-hints {
+.project-stack-empty-hints {
   @apply flex justify-center gap-6 mt-6;
 }
 
-.theatre-stack-empty-hint {
+.project-stack-empty-hint {
   @apply flex items-center gap-1.5;
   font-size: var(--font-size-xs);
   color: rgba(255, 255, 255, 0.35);
 }
 
-.theatre-stack-empty-hint-shortcut {
+.project-stack-empty-hint-shortcut {
   display: inline-flex;
   align-items: center;
   font-family: 'Iosevka Extended', 'SF Mono', Monaco, Menlo, monospace;
@@ -1631,8 +1631,8 @@ body.platform-darwin:not(.is-fullscreen) .theatre-header-content {
 }
 
 /* On non-Mac platforms, use smaller font for shortcut text since "Ctrl+" is longer than ⌘ */
-body.platform-other .theatre-stack-empty-hint-shortcut,
-body.platform-other .theatre-card-shortcut {
+body.platform-other .project-stack-empty-hint-shortcut,
+body.platform-other .project-card-shortcut {
   @apply text-[13px];
 }
 
@@ -1645,31 +1645,31 @@ body.platform-other .shortcut-number {
    ========================================== */
 
 /* Hidden cards on other pages */
-.theatre-card--hidden {
+.project-card--hidden {
   display: none !important;
 }
 
 /* Pagination row — fixed below header, centered, only visible in stack view */
-.theatre-stack-pagination {
+.project-stack-pagination {
   @apply fixed z-[150] flex items-center gap-1.5;
   top: 58px;
   left: 50%;
   transform: translateX(-50%);
 }
 
-body.kanban-open .theatre-stack-pagination {
+body.kanban-open .project-stack-pagination {
   display: none !important;
 }
 
-.theatre-stack-page-arrow {
+.project-stack-page-arrow {
   @apply w-6 h-6 flex items-center justify-center bg-transparent border-none rounded text-white/35 transition-colors duration-150 ease-out;
 }
 
-.theatre-stack-page-arrow:hover {
+.project-stack-page-arrow:hover {
   @apply text-white/70;
 }
 
-.theatre-stack-page-indicator {
+.project-stack-page-indicator {
   @apply text-xs font-mono text-white/35;
 }
 
@@ -1677,24 +1677,24 @@ body.kanban-open .theatre-stack-pagination {
    View Toggle (Stack / Board)
    ========================================== */
 
-.theatre-view-toggle {
+.project-view-toggle {
   @apply flex items-center ml-3 bg-background-secondary border border-border rounded-md overflow-hidden;
   -webkit-app-region: no-drag;
 }
 
-.theatre-view-toggle-btn {
+.project-view-toggle-btn {
   @apply w-[30px] h-[30px] flex items-center justify-center text-text-secondary transition-all duration-150 ease-out;
 }
 
-.theatre-view-toggle-btn:hover {
+.project-view-toggle-btn:hover {
   @apply text-text-primary bg-background-tertiary;
 }
 
-.theatre-view-toggle-btn--active {
+.project-view-toggle-btn--active {
   @apply text-text-primary bg-background-tertiary;
 }
 
-.theatre-view-toggle-btn svg {
+.project-view-toggle-btn svg {
   @apply w-3.5 h-3.5;
 }
 
@@ -1703,7 +1703,7 @@ body.kanban-open .theatre-stack-pagination {
    ========================================== */
 
 /* Hide terminal stack when kanban is open (terminals keep running) */
-body.kanban-open .theatre-stack {
+body.kanban-open .project-stack {
   display: none;
 }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -13,7 +13,7 @@ import { setupSearch } from './components/searchBar';
 import { showToast } from './components/importDialog';
 import { showNewProjectDialog } from './components/newProjectDialog';
 import { initHotkeys } from './utils/hotkeys';
-import { restoreTheatreMode, orphanedSessions } from './components/theatre';
+import { restoreProjectMode, orphanedSessions } from './components/project';
 
 // Declare the global window.api interface
 declare global {
@@ -68,7 +68,7 @@ async function refreshProjects(): Promise<void> {
   }
 }
 
-// Expose refreshProjects on window for theatre mode restoration
+// Expose refreshProjects on window for project mode restoration
 (window as any).refreshProjects = refreshProjects;
 
 /**
@@ -90,7 +90,7 @@ async function initialize(): Promise<void> {
       console.log('[Renderer] Found active PTY sessions:', activeSessions);
 
       // Group sessions by project path and store in orphanedSessions map
-      // This allows enterTheatreMode to restore them when opening any project
+      // This allows enterProjectMode to restore them when opening any project
       const sessionsByProject = new Map<string, ActiveSession[]>();
       for (const session of activeSessions) {
         const existing = sessionsByProject.get(session.projectPath) || [];
@@ -115,16 +115,16 @@ async function initialize(): Promise<void> {
         }
       }
 
-      // Get project data and restore theatre mode for the active project
+      // Get project data and restore project mode for the active project
       const projects = await window.api.getProjects();
       const project = projects.find(p => p.path === bestProjectPath);
 
       if (project) {
         // Remove from orphanedSessions since we're restoring it now
         orphanedSessions.delete(bestProjectPath);
-        await restoreTheatreMode(bestProjectPath, project, bestSessions);
-        // Continue to load projects in background - CSS hides them in theatre mode,
-        // but they'll be visible when user exits theatre mode
+        await restoreProjectMode(bestProjectPath, project, bestSessions);
+        // Continue to load projects in background - CSS hides them in project mode,
+        // but they'll be visible when user exits project mode
       }
     }
   } catch (error) {
@@ -218,7 +218,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   initialize();
 
-  // Listen for fullscreen state changes (for theatre mode layout)
+  // Listen for fullscreen state changes (for project mode layout)
   window.api.onFullscreenChange((isFullscreen) => {
     document.body.classList.toggle('is-fullscreen', isFullscreen);
   });

--- a/src/styles/compare.css
+++ b/src/styles/compare.css
@@ -266,17 +266,17 @@ body > .diff-panel--visible {
 }
 
 /* ==========================================
-   Diff Panel inside Theatre Card
+   Diff Panel inside Project Card
    ========================================== */
 
 /* Diff panel inside card - full width like ship panel */
-.theatre-card .diff-panel {
+.project-card .diff-panel {
   @apply absolute inset-0 rounded-none border-0 border-t border-solid border-white/10 shadow-none z-20 flex overflow-hidden opacity-0 pointer-events-none;
   background: var(--color-terminal-bg, #1a1a1a);
   transition: opacity 0.15s ease;
 }
 
-.theatre-card .diff-panel--visible {
+.project-card .diff-panel--visible {
   @apply opacity-100 pointer-events-auto;
 }
 

--- a/src/utils/hotkeys.ts
+++ b/src/utils/hotkeys.ts
@@ -24,7 +24,7 @@ export function platformHotkey(keys: string): string {
 export const Scopes = {
   APP: 'app',
   PROJECT_LIST: 'project-list',
-  THEATRE: 'theatre',
+  PROJECT: 'project',
   KANBAN: 'kanban',
   MODAL: 'modal',
   DROPDOWN: 'dropdown',
@@ -32,7 +32,7 @@ export const Scopes = {
 
 type Scope = (typeof Scopes)[keyof typeof Scopes];
 
-// Scope stack for nested contexts (modal on top of theatre, etc.)
+// Scope stack for nested contexts (modal on top of project, etc.)
 const scopeStack: Scope[] = [Scopes.APP];
 
 /**


### PR DESCRIPTION
## Summary

- Renames `src/components/theatre/` → `src/components/project/` and all associated identifiers, CSS classes, and docs to use project-centric naming
- Fixes `.theatre-project-*` → `.project-header-*` to avoid redundant `project-project-*` naming
- Pure rename — 640 lines in, 640 lines out, zero behavioral changes