### PR TITLE
Detect and recover tasks with missing worktree directories

### DIFF
--- a/src/__tests__/integration/recoverTaskWorktree.test.ts
+++ b/src/__tests__/integration/recoverTaskWorktree.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Integration tests for checkTaskWorktree and recoverTaskWorktree.
+ * Uses a real temporary git repo — no mocked child_process, fs, or koffi.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { execSync } from 'node:child_process';
+import { checkTaskWorktree, recoverTaskWorktree } from '../../worktree';
+import { createTask, getTaskByNumber, _resetCacheForTesting } from '../../taskMetadata';
+
+let tmpDir: string;
+let repoDir: string;
+
+beforeEach(async () => {
+  _resetCacheForTesting();
+
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ouijit-recover-'));
+  repoDir = path.join(tmpDir, 'project');
+  await fs.mkdir(repoDir, { recursive: true });
+
+  execSync('git init', { cwd: repoDir });
+  execSync('git commit --allow-empty -m "Initial commit"', { cwd: repoDir });
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('checkTaskWorktree', () => {
+  test('returns exists: true when worktree directory is present', async () => {
+    const wtPath = path.join(tmpDir, 'wt-1');
+    execSync(`git worktree add -b feat-1 "${wtPath}"`, { cwd: repoDir });
+
+    await createTask(repoDir, 1, 'Has worktree', {
+      branch: 'feat-1',
+      worktreePath: wtPath,
+    });
+
+    const result = await checkTaskWorktree(repoDir, 1);
+    expect(result.exists).toBe(true);
+    expect(result.branchExists).toBe(true);
+  });
+
+  test('detects missing directory but surviving branch', async () => {
+    const wtPath = path.join(tmpDir, 'wt-2');
+    execSync(`git worktree add -b feat-2 "${wtPath}"`, { cwd: repoDir });
+    await fs.rm(wtPath, { recursive: true, force: true });
+
+    await createTask(repoDir, 1, 'Dir gone', {
+      branch: 'feat-2',
+      worktreePath: wtPath,
+    });
+
+    const result = await checkTaskWorktree(repoDir, 1);
+    expect(result.exists).toBe(false);
+    expect(result.branchExists).toBe(true);
+  });
+
+  test('detects both directory and branch missing', async () => {
+    const wtPath = path.join(tmpDir, 'wt-3');
+    execSync(`git worktree add -b feat-3 "${wtPath}"`, { cwd: repoDir });
+    await fs.rm(wtPath, { recursive: true, force: true });
+    execSync('git worktree prune', { cwd: repoDir });
+    execSync('git branch -D feat-3', { cwd: repoDir });
+
+    await createTask(repoDir, 1, 'Both gone', {
+      branch: 'feat-3',
+      worktreePath: wtPath,
+    });
+
+    const result = await checkTaskWorktree(repoDir, 1);
+    expect(result.exists).toBe(false);
+    expect(result.branchExists).toBe(false);
+  });
+
+  test('returns both false for non-existent task', async () => {
+    const result = await checkTaskWorktree(repoDir, 99);
+    expect(result).toEqual({ exists: false, branchExists: false });
+  });
+});
+
+describe('recoverTaskWorktree', () => {
+  test('recreates worktree and preserves committed work', async () => {
+    const wtPath = path.join(tmpDir, 'wt-recover');
+    execSync(`git worktree add -b feat-recover "${wtPath}"`, { cwd: repoDir });
+    await fs.writeFile(path.join(wtPath, 'work.txt'), 'important work');
+    execSync('git add work.txt && git commit -m "Add work"', { cwd: wtPath });
+    await fs.rm(wtPath, { recursive: true, force: true });
+
+    await createTask(repoDir, 1, 'Recoverable', {
+      branch: 'feat-recover',
+      worktreePath: wtPath,
+    });
+
+    const result = await recoverTaskWorktree(repoDir, 1);
+    expect(result.success).toBe(true);
+    expect(result.worktreePath).toBeTruthy();
+
+    // The recovered worktree should contain the committed file
+    const content = await fs.readFile(path.join(result.worktreePath!, 'work.txt'), 'utf-8');
+    expect(content).toBe('important work');
+
+    // Task metadata should point to the new path
+    const task = await getTaskByNumber(repoDir, 1);
+    expect(task!.worktreePath).toBe(result.worktreePath);
+  });
+
+  test('fails when branch has been deleted', async () => {
+    const wtPath = path.join(tmpDir, 'wt-no-branch');
+    execSync(`git worktree add -b feat-gone "${wtPath}"`, { cwd: repoDir });
+    await fs.rm(wtPath, { recursive: true, force: true });
+    execSync('git worktree prune', { cwd: repoDir });
+    execSync('git branch -D feat-gone', { cwd: repoDir });
+
+    await createTask(repoDir, 1, 'Branch gone', {
+      branch: 'feat-gone',
+      worktreePath: wtPath,
+    });
+
+    const result = await recoverTaskWorktree(repoDir, 1);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Branch not found');
+  });
+
+  test('fails when task has no branch', async () => {
+    await createTask(repoDir, 1, 'No branch', { status: 'todo' });
+
+    const result = await recoverTaskWorktree(repoDir, 1);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Task has no branch');
+  });
+
+  test('fails for non-existent task', async () => {
+    const result = await recoverTaskWorktree(repoDir, 99);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Task not found');
+  });
+});

--- a/src/__tests__/integration/setup.ts
+++ b/src/__tests__/integration/setup.ts
@@ -1,0 +1,22 @@
+import { vi } from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+
+// Provide navigator for modules that reference it at import time (e.g. hotkeys.ts)
+if (typeof globalThis.navigator === 'undefined') {
+  (globalThis as any).navigator = { platform: 'MacIntel' };
+}
+
+// Each integration test run gets its own temp directory for Electron userData
+// (taskMetadata stores JSON here). Tests manage their own git repos separately.
+const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ouijit-integration-'));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'userData') return testDataDir;
+      return testDataDir;
+    },
+  },
+}));

--- a/src/__tests__/ipcRefactor.test.ts
+++ b/src/__tests__/ipcRefactor.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import * as os from 'node:os';
-import { createTask } from '../taskMetadata';
+import { createTask, _resetCacheForTesting } from '../taskMetadata';
 
 // ── Mocks (superset needed by all describe blocks) ──────────────────
 
@@ -231,6 +231,11 @@ describe('createProject path traversal', () => {
 // ── getTasksWithWorkspaces (await propagation) ──────────────────────
 
 describe('getTasksWithWorkspaces', () => {
+  beforeEach(() => {
+    vi.mocked(exec).mockReset();
+    _resetCacheForTesting();
+  });
+
   test('resolves worktree path from live git data, not stale metadata', async () => {
     const project = '/projects/myproject';
     const livePath = `${baseDir}/T-1`;

--- a/src/components/project/kanbanBoard.ts
+++ b/src/components/project/kanbanBoard.ts
@@ -7,7 +7,8 @@ import type { ProjectTerminal } from './state';
 import { projectState } from './state';
 import { projectPath, kanbanVisible, terminals, activeIndex, invalidateTaskList } from './signals';
 import { projectRegistry } from './helpers';
-import { reopenTask, deleteTask, closeTask } from './worktreeDropdown';
+import { showToast } from '../importDialog';
+import { reopenTask, deleteTask, closeTask, showMissingWorktreeDialog } from './worktreeDropdown';
 import { switchToProjectTerminal } from './terminalCards';
 import { escapeHtml } from '../../utils/html';
 import { registerHotkey, unregisterHotkey, pushScope, popScope, Scopes, platformHotkey } from '../../utils/hotkeys';
@@ -217,9 +218,43 @@ function buildKanbanHtml(): string {
 }
 
 /**
+ * Check if a task's worktree exists, and if not, prompt the user to recover it.
+ * Returns the (possibly new) worktree path on success, or null if the user cancelled or recovery failed.
+ */
+async function ensureWorktreeExists(path: string, task: TaskWithWorkspace): Promise<string | null> {
+  if (!task.worktreePath) return null;
+  const check = await window.api.task.checkWorktree(path, task.taskNumber);
+  if (check.exists) return task.worktreePath;
+
+  console.warn(`[kanban] worktree missing for #${task.taskNumber} (branchExists=${check.branchExists})`);
+  const action = await showMissingWorktreeDialog(task, check.branchExists);
+  if (action !== 'recover') {
+    console.info(`[kanban] user cancelled worktree recovery for #${task.taskNumber}`);
+    return null;
+  }
+
+  const result = await window.api.task.recover(path, task.taskNumber);
+  if (!result.success || !result.worktreePath) {
+    console.error(`[kanban] worktree recovery failed for #${task.taskNumber}:`, result.error);
+    showToast(result.error || 'Failed to recover worktree', 'error');
+    return null;
+  }
+
+  console.info(`[kanban] worktree recovered for #${task.taskNumber} → ${result.worktreePath}`);
+  // Update the local task object with new data
+  task.worktreePath = result.worktreePath;
+  if (result.task?.branch) task.branch = result.task.branch;
+  invalidateTaskList();
+  return result.worktreePath;
+}
+
+/**
  * Build a kanban card DOM element for a task
  */
 function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: boolean, editorConfigured: boolean): HTMLElement {
+  if (task.taskNumber == null) {
+    console.error('[kanban] task with missing taskNumber:', JSON.stringify(task));
+  }
   const card = document.createElement('div');
   card.className = 'kanban-card' + (task.status === 'done' ? ' kanban-card--done' : '');
   card.dataset.taskNumber = String(task.taskNumber);
@@ -388,14 +423,22 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
       .filter(({ terminal: t }) => t.taskId === task.taskNumber);
 
     const onOpenTerminal = async () => {
+      console.info(`[kanban] openTerminal #${task.taskNumber} status=${task.status} hasWorktree=${!!task.worktreePath}`);
       if (task.status === 'done') {
+        if (task.worktreePath) {
+          const wtPath = await ensureWorktreeExists(path, task);
+          if (!wtPath) return;
+        }
         hideKanbanBoard();
         await reopenTask(path, task);
         return;
       }
       if (!task.worktreePath) {
         const startResult = await window.api.task.start(path, task.taskNumber);
-        if (!startResult.success || !startResult.worktreePath) return;
+        if (!startResult.success || !startResult.worktreePath) {
+          console.error(`[kanban] task.start failed for #${task.taskNumber}:`, startResult.error);
+          return;
+        }
         await window.api.task.setStatus(path, task.taskNumber, 'in_progress');
         invalidateTaskList();
         hideKanbanBoard();
@@ -412,10 +455,12 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
         });
         return;
       }
+      const worktreePath = await ensureWorktreeExists(path, task);
+      if (!worktreePath) return;
       hideKanbanBoard();
       await projectRegistry.addProjectTerminal?.(undefined, {
         existingWorktree: {
-          path: task.worktreePath,
+          path: worktreePath,
           branch: task.branch || '',
           createdAt: task.createdAt,
           sandboxed: task.sandboxed,
@@ -427,6 +472,10 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
 
     const onSandbox = limaAvailable ? async () => {
       if (task.status === 'done') {
+        if (task.worktreePath) {
+          const wtPath = await ensureWorktreeExists(path, task);
+          if (!wtPath) return;
+        }
         const worktreeOpts = {
           path: task.worktreePath!,
           branch: task.branch || '',
@@ -462,10 +511,12 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
           sandboxed: true,
         });
       } else {
+        const worktreePath = await ensureWorktreeExists(path, task);
+        if (!worktreePath) return;
         hideKanbanBoard();
         await projectRegistry.addProjectTerminal?.(undefined, {
           existingWorktree: {
-            path: task.worktreePath,
+            path: worktreePath,
             branch: task.branch || '',
             prompt: task.prompt,
             createdAt: task.createdAt,
@@ -486,6 +537,10 @@ function buildKanbanCard(task: TaskWithWorkspace, path: string, limaAvailable: b
 
     const onCloseOrReopen = async () => {
       if (task.status === 'done') {
+        if (task.worktreePath) {
+          const wtPath = await ensureWorktreeExists(path, task);
+          if (!wtPath) return;
+        }
         await reopenTask(path, task);
       } else {
         await closeTask(path, task);
@@ -539,16 +594,26 @@ function setupSortable(): void {
 async function handleSortableEnd(evt: Sortable.SortableEvent): Promise<void> {
   const item = evt.item as HTMLElement;
   const taskNumber = parseInt(item.dataset.taskNumber || '', 10);
-  if (isNaN(taskNumber)) return;
+  if (isNaN(taskNumber)) {
+    console.error('[kanban] drag: no task number on dragged element', item.tagName, item.className, item.outerHTML.slice(0, 200));
+    return;
+  }
 
   const toColumn = (evt.to as HTMLElement).closest('.kanban-column') as HTMLElement | null;
   const newStatus = toColumn?.dataset.status as TaskStatus | undefined;
-  if (!newStatus) return;
+  if (!newStatus) {
+    console.error(`[kanban] drag #${taskNumber}: could not determine target column`);
+    return;
+  }
 
   const path = projectPath.value;
-  if (!path) return;
+  if (!path) {
+    console.error(`[kanban] drag #${taskNumber}: no project path`);
+    return;
+  }
 
   const targetIndex = evt.newIndex ?? 0;
+  console.info(`[kanban] drag #${taskNumber} → ${newStatus} at index ${targetIndex}`);
 
   // Dropping a task into in_progress — create worktree if needed + show start command dialog
   if (newStatus === 'in_progress') {
@@ -630,6 +695,8 @@ async function handleSortableEnd(evt: Sortable.SortableEvent): Promise<void> {
   if (result.success) {
     invalidateTaskList();
     await populateKanbanBoard();
+  } else {
+    console.error(`[kanban] reorder failed for #${taskNumber} → ${newStatus}:`, result.error);
   }
 }
 

--- a/src/components/project/worktreeDropdown.ts
+++ b/src/components/project/worktreeDropdown.ts
@@ -72,6 +72,72 @@ function showDeleteConfirmDialog(taskName: string): Promise<boolean> {
 }
 
 /**
+ * Show a dialog when a task's worktree directory is missing
+ * Returns 'recover' if user wants to recreate, or null if cancelled
+ */
+export function showMissingWorktreeDialog(task: TaskWithWorkspace, branchExists: boolean): Promise<'recover' | null> {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+
+    const dialog = document.createElement('div');
+    dialog.className = 'import-dialog';
+    dialog.style.maxWidth = '420px';
+
+    const branchHtml = task.branch
+      ? `<p class="import-dialog-text" style="margin-top: 4px; font-size: 12px; opacity: 0.7;">Branch: <code>${task.branch}</code></p>`
+      : '';
+
+    dialog.innerHTML = `
+      <h2 class="import-dialog-title">Worktree Not Found</h2>
+      <p class="import-dialog-text">
+        The worktree directory for "<strong>${task.name}</strong>" no longer exists on disk.
+      </p>
+      ${branchHtml}
+      <div class="import-actions">
+        <button class="btn btn-secondary" data-action="cancel">Cancel</button>
+        ${branchExists ? '<button class="btn btn-primary" data-action="recover">Recreate Worktree</button>' : ''}
+      </div>
+    `;
+
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    const cleanup = () => {
+      unregisterHotkey('escape', Scopes.MODAL);
+      popScope();
+      dialog.classList.remove('import-dialog--visible');
+      overlay.classList.remove('modal-overlay--visible');
+      setTimeout(() => overlay.remove(), 150);
+    };
+
+    const handleRecover = () => {
+      cleanup();
+      resolve('recover');
+    };
+
+    const handleCancel = () => {
+      cleanup();
+      resolve(null);
+    };
+
+    dialog.querySelector('[data-action="recover"]')?.addEventListener('click', handleRecover);
+    dialog.querySelector('[data-action="cancel"]')?.addEventListener('click', handleCancel);
+    overlay.addEventListener('mousedown', (e) => {
+      if (e.target === overlay) handleCancel();
+    });
+
+    pushScope(Scopes.MODAL);
+    registerHotkey('escape', Scopes.MODAL, handleCancel);
+
+    requestAnimationFrame(() => {
+      overlay.classList.add('modal-overlay--visible');
+      dialog.classList.add('import-dialog--visible');
+    });
+  });
+}
+
+/**
  * Close a task - marks as closed and closes any open terminals for it
  */
 export async function closeTask(path: string, task: TaskWithWorkspace): Promise<void> {
@@ -103,6 +169,7 @@ export async function closeTask(path: string, task: TaskWithWorkspace): Promise<
  */
 export async function reopenTask(path: string, task: TaskWithWorkspace): Promise<void> {
   if (task.taskNumber == null) return;
+  console.info(`[task] reopening #${task.taskNumber} worktreePath=${task.worktreePath || '(none)'}`);
   const result = await window.api.task.setStatus(path, task.taskNumber, 'in_progress');
   if (result.success) {
     invalidateTaskList();
@@ -120,6 +187,7 @@ export async function reopenTask(path: string, task: TaskWithWorkspace): Promise
       sandboxed: false,
     });
   } else {
+    console.error(`[task] reopen failed for #${task.taskNumber}:`, result.error);
     showToast(result.error || 'Failed to reopen task', 'error');
   }
 }

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -25,6 +25,7 @@ import type {
   WorktreeInfo,
   WorktreeRemoveResult,
   TaskWorktreeResult,
+  CheckWorktreeResult,
   TaskWithWorkspace,
   TaskStatus,
   ScriptHook,
@@ -84,6 +85,8 @@ export interface IpcInvokeContract {
   'task:set-name':                { args: [projectPath: string, taskNumber: number, name: string];          return: { success: boolean; error?: string } };
   'task:set-description':         { args: [projectPath: string, taskNumber: number, description: string];   return: { success: boolean; error?: string } };
   'task:reorder':                 { args: [projectPath: string, taskNumber: number, newStatus: TaskStatus, targetIndex: number]; return: { success: boolean; error?: string; hookWarning?: string } };
+  'task:check-worktree':          { args: [projectPath: string, taskNumber: number];                        return: CheckWorktreeResult };
+  'task:recover':                 { args: [projectPath: string, taskNumber: number];                        return: TaskWorktreeResult };
 
   // ── Worktree ─────────────────────────────────────────────────────────
   'worktree:validate-branch-name': { args: [projectPath: string, branchName: string];                      return: { valid: boolean; error?: string } };

--- a/src/ipc/handlers/task.ts
+++ b/src/ipc/handlers/task.ts
@@ -1,5 +1,5 @@
 import { typedHandle } from '../helpers';
-import { createTaskWorktree, createTodoTask, startTask } from '../../worktree';
+import { createTaskWorktree, createTodoTask, startTask, checkTaskWorktree, recoverTaskWorktree } from '../../worktree';
 import {
   setTaskMergeTarget,
   setTaskSandboxed,
@@ -56,5 +56,13 @@ export function registerTaskHandlers(): void {
 
   typedHandle('task:reorder', (projectPath, taskNumber, newStatus, targetIndex) =>
     reorderTaskWithHooks(projectPath, taskNumber, newStatus, targetIndex),
+  );
+
+  typedHandle('task:check-worktree', (projectPath, taskNumber) =>
+    checkTaskWorktree(projectPath, taskNumber),
+  );
+
+  typedHandle('task:recover', (projectPath, taskNumber) =>
+    recoverTaskWorktree(projectPath, taskNumber),
   );
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -110,6 +110,8 @@ contextBridge.exposeInMainWorld('api', {
     setName: (projectPath: string, taskNumber: number, name: string) => typedInvoke('task:set-name', projectPath, taskNumber, name),
     setDescription: (projectPath: string, taskNumber: number, description: string) => typedInvoke('task:set-description', projectPath, taskNumber, description),
     reorder: (projectPath: string, taskNumber: number, newStatus: TaskStatus, targetIndex: number) => typedInvoke('task:reorder', projectPath, taskNumber, newStatus, targetIndex),
+    checkWorktree: (projectPath: string, taskNumber: number) => typedInvoke('task:check-worktree', projectPath, taskNumber),
+    recover: (projectPath: string, taskNumber: number) => typedInvoke('task:recover', projectPath, taskNumber),
   },
 
   hooks: {

--- a/src/taskLifecycle.ts
+++ b/src/taskLifecycle.ts
@@ -65,6 +65,9 @@ export async function setTaskStatusWithHooks(
 ): Promise<{ success: boolean; error?: string; hookWarning?: string }> {
   const hookWarning = await runCleanupHookIfNeeded(projectPath, taskNumber, status);
   const result = await setTaskStatus(projectPath, taskNumber, status);
+  if (!result.success) {
+    console.error(`[task] setStatusWithHooks failed for #${taskNumber} → ${status}: ${result.error}`);
+  }
   return { ...result, hookWarning };
 }
 
@@ -79,6 +82,9 @@ export async function reorderTaskWithHooks(
 ): Promise<{ success: boolean; error?: string; hookWarning?: string }> {
   const hookWarning = await runCleanupHookIfNeeded(projectPath, taskNumber, newStatus);
   const result = await reorderTask(projectPath, taskNumber, newStatus, targetIndex);
+  if (!result.success) {
+    console.error(`[task] reorderWithHooks failed for #${taskNumber} → ${newStatus}: ${result.error}`);
+  }
   return { ...result, hookWarning };
 }
 
@@ -96,10 +102,15 @@ export async function deleteTaskWithWorktree(
       ? worktrees.find(w => w.branch === task.branch)
       : worktrees.find(w => w.path === task.worktreePath);
     if (wt) {
+      console.info(`[task] deleting #${taskNumber} with worktree at ${wt.path}`);
       const removeResult = await removeTaskWorktree(projectPath, wt.path, taskNumber);
-      if (!removeResult.success) return removeResult;
+      if (!removeResult.success) {
+        console.error(`[task] worktree removal failed for #${taskNumber}: ${removeResult.error}`);
+        return removeResult;
+      }
       return { success: true };
     }
+    console.info(`[task] deleting #${taskNumber} (no live worktree found, metadata-only delete)`);
   }
   return deleteTaskByNumber(projectPath, taskNumber);
 }

--- a/src/taskMetadata.ts
+++ b/src/taskMetadata.ts
@@ -124,7 +124,15 @@ export async function getProjectTasks(projectPath: string): Promise<TaskMetadata
     return [];
   }
 
-  return [...projectData.tasks].sort((a, b) => {
+  const valid = projectData.tasks.filter(t => {
+    if (t.taskNumber == null) {
+      console.error('[task] dropping task with missing taskNumber:', JSON.stringify(t));
+      return false;
+    }
+    return true;
+  });
+
+  return [...valid].sort((a, b) => {
     const statusA = STATUS_ORDER[a.status];
     const statusB = STATUS_ORDER[b.status];
     if (statusA !== statusB) return statusA - statusB;
@@ -282,6 +290,7 @@ export async function setTaskStatus(
     }
 
     const oldStatus = task.status;
+    console.info(`[task] #${taskNumber} status: ${oldStatus} → ${status}`);
     task.status = status;
     if (status === 'done') {
       task.closedAt = new Date().toISOString();
@@ -509,10 +518,12 @@ export async function reorderTask(
 
     const task = projectData.tasks.find(t => t.taskNumber === taskNumber);
     if (!task) {
+      console.error(`[task] reorder: task #${taskNumber} not found`);
       return { success: false, error: 'Task not found' };
     }
 
     const oldStatus = task.status;
+    console.info(`[task] #${taskNumber} reorder: ${oldStatus} → ${newStatus} at index ${targetIndex}`);
 
     // Update status and closedAt
     task.status = newStatus;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 // Re-export all git types from git.ts (single source of truth)
 export type { GitStatus, GitDropdownInfo, ExtendedGitStatus, RecentBranch, UncommittedChanges, ChangedFile, DiffLine, DiffHunk, FileDiff, CompactGitStatus, WorktreeDiffSummary, BranchInfo } from './git';
 // Re-export worktree types from worktree.ts (single source of truth)
-export type { TaskWorktreeResult, WorktreeInfo, WorktreeRemoveResult } from './worktree';
+export type { TaskWorktreeResult, WorktreeInfo, WorktreeRemoveResult, CheckWorktreeResult } from './worktree';
 // Re-export task types from taskMetadata.ts (single source of truth)
 export type { TaskStatus, TaskMetadata } from './taskMetadata';
 // Re-export PTY session type from ptyManager.ts (single source of truth)
@@ -11,7 +11,7 @@ export type { SandboxStatus } from './lima/types';
 
 // Import for local use within this file
 import type { GitStatus, CompactGitStatus, GitDropdownInfo, ChangedFile, FileDiff, WorktreeDiffSummary, BranchInfo } from './git';
-import type { TaskWorktreeResult, WorktreeInfo, WorktreeRemoveResult } from './worktree';
+import type { TaskWorktreeResult, WorktreeInfo, WorktreeRemoveResult, CheckWorktreeResult } from './worktree';
 import type { TaskStatus, TaskMetadata } from './taskMetadata';
 import type { ActiveSession } from './ptyManager';
 import type { SandboxStatus } from './lima/types';
@@ -218,6 +218,8 @@ export interface TaskAPI {
   setName(projectPath: string, taskNumber: number, name: string): Promise<{ success: boolean; error?: string }>;
   setDescription(projectPath: string, taskNumber: number, description: string): Promise<{ success: boolean; error?: string }>;
   reorder(projectPath: string, taskNumber: number, newStatus: TaskStatus, targetIndex: number): Promise<{ success: boolean; error?: string; hookWarning?: string }>;
+  checkWorktree(projectPath: string, taskNumber: number): Promise<CheckWorktreeResult>;
+  recover(projectPath: string, taskNumber: number): Promise<TaskWorktreeResult>;
 }
 
 /**

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -267,6 +267,8 @@ export async function startTask(
     if (!task) return { success: false, error: 'Task not found' };
     if (task.status !== 'todo') return { success: false, error: 'Task is already started' };
 
+    console.info(`[worktree] starting task #${taskNumber} "${task.name}"`);
+
     const [hasHead, branchResult] = await Promise.all([
       execAsync('git rev-parse HEAD', { cwd: projectPath }).then(() => true, () => false),
       execAsync('git rev-parse --abbrev-ref HEAD', { cwd: projectPath })
@@ -310,9 +312,11 @@ export async function startTask(
       console.warn('[worktree] Background copy failed:', err);
     });
 
+    console.info(`[worktree] started task #${taskNumber} → ${worktreePath} branch=${branch}`);
     const updated = await getTaskByNumber(projectPath, taskNumber);
     return { success: true, task: updated || undefined, worktreePath };
   } catch (error) {
+    console.error(`[worktree] startTask #${taskNumber} failed:`, error instanceof Error ? error.message : error);
     return { success: false, error: error instanceof Error ? error.message : 'Failed to start task' };
   }
 }
@@ -469,6 +473,96 @@ export async function listWorktrees(projectPath: string): Promise<WorktreeInfo[]
     return worktrees;
   } catch {
     return [];
+  }
+}
+
+export interface CheckWorktreeResult {
+  exists: boolean;
+  branchExists: boolean;
+}
+
+/**
+ * Check if a task's worktree directory and branch still exist
+ */
+export async function checkTaskWorktree(
+  projectPath: string,
+  taskNumber: number,
+): Promise<CheckWorktreeResult> {
+  const task = await getTaskByNumber(projectPath, taskNumber);
+  if (!task || !task.worktreePath) {
+    console.info(`[worktree] check #${taskNumber}: no task or no worktreePath`);
+    return { exists: false, branchExists: false };
+  }
+
+  const [exists, branchExists] = await Promise.all([
+    fs.access(task.worktreePath).then(() => true, () => false),
+    task.branch
+      ? execAsync(`git rev-parse --verify refs/heads/${shellEscape(task.branch)}`, { cwd: projectPath })
+          .then(() => true, () => false)
+      : Promise.resolve(false),
+  ]);
+
+  console.info(`[worktree] check #${taskNumber}: exists=${exists} branchExists=${branchExists} path=${task.worktreePath}`);
+  return { exists, branchExists };
+}
+
+/**
+ * Recover a task whose worktree directory was deleted externally.
+ * Prunes stale worktrees, then re-creates from the existing branch.
+ */
+export async function recoverTaskWorktree(
+  projectPath: string,
+  taskNumber: number,
+): Promise<TaskWorktreeResult> {
+  try {
+    const task = await getTaskByNumber(projectPath, taskNumber);
+    if (!task) return { success: false, error: 'Task not found' };
+    if (!task.branch) return { success: false, error: 'Task has no branch' };
+
+    console.info(`[worktree] recovering #${taskNumber} branch=${task.branch} oldPath=${task.worktreePath}`);
+
+    // Prune stale worktree references so git doesn't complain about the old path
+    await execAsync('git worktree prune', { cwd: projectPath });
+
+    // Verify the branch still exists
+    try {
+      await execAsync(`git rev-parse --verify refs/heads/${shellEscape(task.branch)}`, { cwd: projectPath });
+    } catch {
+      return { success: false, error: 'Branch not found' };
+    }
+
+    // Find a new worktree directory path
+    const projectName = path.basename(projectPath);
+    const baseDir = getWorktreeBaseDir(projectName);
+    await fs.mkdir(baseDir, { recursive: true });
+
+    let worktreePath = path.join(baseDir, `T-${taskNumber}`);
+    let dirNum = taskNumber;
+    while (await fs.access(worktreePath).then(() => true, () => false)) {
+      dirNum++;
+      worktreePath = path.join(baseDir, `T-${dirNum}`);
+    }
+
+    // Re-create worktree from the existing branch (no -b flag)
+    const [, ignoredFiles] = await Promise.all([
+      execAsync(`git worktree add ${shellEscape(worktreePath)} ${shellEscape(task.branch)}`, { cwd: projectPath }),
+      fetchIgnoredFiles(projectPath),
+    ]);
+
+    // Update metadata with new path
+    await setTaskWorktreePath(projectPath, taskNumber, worktreePath);
+
+    // Fire-and-forget file copy
+    copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles).catch(err => {
+      console.warn('[worktree] Background copy failed:', err);
+    });
+
+    console.info(`[worktree] recovered #${taskNumber} → ${worktreePath}`);
+    const updated = await getTaskByNumber(projectPath, taskNumber);
+    return { success: true, task: updated || undefined, worktreePath };
+  } catch (error) {
+    console.error(`[worktree] recover #${taskNumber} failed:`, error instanceof Error ? error.message : error);
+    return { success: false, error: error instanceof Error ? error.message : 'Failed to recover worktree' };
   }
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,25 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    setupFiles: ['./src/__tests__/setup.ts'],
-    isolate: true,
-    exclude: ['e2e/**', 'node_modules/**'],
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          setupFiles: ['./src/__tests__/setup.ts'],
+          include: ['src/__tests__/*.test.ts'],
+          exclude: ['e2e/**', 'node_modules/**'],
+          isolate: true,
+        },
+      },
+      {
+        test: {
+          name: 'integration',
+          setupFiles: ['./src/__tests__/integration/setup.ts'],
+          include: ['src/__tests__/integration/**/*.test.ts'],
+          exclude: ['e2e/**', 'node_modules/**'],
+          isolate: true,
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary

- When a task's worktree directory is deleted externally, the app now detects this before opening a terminal and shows a "Worktree Not Found" recovery dialog
- If the git branch still exists, the user can recreate the worktree in place via two new IPC channels (`task:check-worktree` and `task:recover`)
- Filters legacy tasks missing `taskNumber` from the kanban board to prevent drag/drop failures
- Adds targeted `console.info`/`error`/`warn` logging across task and worktree flows for easier debugging
- Separates integration tests (real git repos, real koffi) into their own vitest project under `src/__tests__/integration/`