### PR TITLE
Fix inconsistent status lights

### DIFF
--- a/src/ptyManager.ts
+++ b/src/ptyManager.ts
@@ -165,7 +165,7 @@ export async function spawnPty(
 
       if (expandedCommand) {
         const escapedCmd = expandedCommand.replace(/'/g, "'\\''");
-        shellArgs = ['-ic', `${escapedCmd}; exec ${shell}`];
+        shellArgs = ['-ic', `export PATH="$OUIJIT_WRAPPER_DIR:$PATH"; ${escapedCmd}; exec ${shell}`];
       }
     } else if (isBash) {
       // --rcfile/--init-file: bash sources this instead of ~/.bashrc.
@@ -174,14 +174,14 @@ export async function spawnPty(
 
       if (expandedCommand) {
         const escapedCmd = expandedCommand.replace(/'/g, "'\\''");
-        shellArgs = ['-ic', `${escapedCmd}; exec bash --rcfile ${rcfile}`];
+        shellArgs = ['-ic', `export PATH="$OUIJIT_WRAPPER_DIR:$PATH"; ${escapedCmd}; exec bash --rcfile ${rcfile}`];
       } else {
         shellArgs = ['--init-file', rcfile];
       }
     } else if (expandedCommand) {
       // Fallback for other shells
       const escapedCmd = expandedCommand.replace(/'/g, "'\\''");
-      shellArgs = ['-ic', `${escapedCmd}; exec ${shell}`];
+      shellArgs = ['-ic', `export PATH="$OUIJIT_WRAPPER_DIR:$PATH"; ${escapedCmd}; exec ${shell}`];
     }
 
     const ptyProcess = pty.spawn(shell, shellArgs, {


### PR DESCRIPTION
## Summary

- Prepends `$OUIJIT_WRAPPER_DIR` to `PATH` in PTY shell args so wrapper scripts are available when initial commands execute
- Applies to all three shell paths: zsh, bash, and fallback