### PR TITLE
Fix npm version failing when tag matches package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Set package.json version from the git tag (after npm ci to avoid lockfile mismatch)
       - name: Set version from tag
-        run: npm version "${GITHUB_REF#refs/tags/v}" --no-git-tag-version
+        run: npm version "${GITHUB_REF#refs/tags/v}" --no-git-tag-version --allow-same-version
 
       # -- macOS Code Signing ------------------------------------------------
       - name: Import Apple signing certificate


### PR DESCRIPTION
## Summary
- `npm version` exits with error when `package.json` already has the same version as the git tag
- Adds `--allow-same-version` flag so it becomes a no-op instead of failing

## Test plan
- [x] `npm version "1.0.1" --no-git-tag-version --allow-same-version` succeeds when version already matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)