### PR TITLE
Combine start/continue hook config, refactor dialog system

### DIFF
--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -129,7 +129,7 @@ test('project mode: terminals, kanban, context menu, and task lifecycle', async 
   // Confirm deletion in the modal dialog
   const deleteDialog = appPage.locator('.modal-overlay--visible');
   await expect(deleteDialog).toBeVisible({ timeout: 5_000 });
-  await expect(deleteDialog.locator('.import-dialog-title')).toHaveText('Delete Task?');
+  await expect(deleteDialog.locator('.dialog-title')).toHaveText('Delete Task?');
   await deleteDialog.locator('[data-action="delete"]').click();
 
   // Task should be gone from the board
@@ -150,7 +150,7 @@ test('project mode: terminals, kanban, context menu, and task lifecycle', async 
 
   // No start hook configured — no dialog should appear
   await appPage.waitForTimeout(1_000);
-  await expect(appPage.locator('.modal-overlay--visible .import-dialog')).not.toBeVisible();
+  await expect(appPage.locator('.modal-overlay--visible .dialog')).not.toBeVisible();
 
   // Task should be in in_progress column
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(1, { timeout: 5_000 });
@@ -199,9 +199,9 @@ test('lifecycle hooks: configure, run, cancel, and drag transitions', async ({ a
   const inProgressBody = inProgressColumn.locator('.kanban-column-body');
   await todoColumn.locator('.kanban-card').first().dragTo(inProgressBody);
 
-  const hookDialog = appPage.locator('.modal-overlay--visible .import-dialog');
+  const hookDialog = appPage.locator('.modal-overlay--visible .dialog');
   await expect(hookDialog).toBeVisible({ timeout: 15_000 });
-  await expect(hookDialog.locator('.import-dialog-title')).toHaveText('Start Task');
+  await expect(hookDialog.locator('.dialog-title')).toHaveText('Start Task');
   await expect(hookDialog.locator('textarea.start-command-textarea')).toHaveValue('echo starting');
 
   // Click "Run" — terminal created in background, kanban stays visible
@@ -222,7 +222,7 @@ test('lifecycle hooks: configure, run, cancel, and drag transitions', async ({ a
   await todoColumn.locator('.kanban-card').first().dragTo(inProgressBody);
 
   await expect(hookDialog).toBeVisible({ timeout: 15_000 });
-  await expect(hookDialog.locator('.import-dialog-title')).toHaveText('Start Task');
+  await expect(hookDialog.locator('.dialog-title')).toHaveText('Start Task');
 
   // Click "Cancel" — no terminal created, task moves to in_progress (worktree was created before dialog)
   await hookDialog.locator('.btn-secondary', { hasText: 'Cancel' }).click();
@@ -241,7 +241,7 @@ test('lifecycle hooks: configure, run, cancel, and drag transitions', async ({ a
 
   // Review dialog should appear with pre-filled command
   await expect(hookDialog).toBeVisible({ timeout: 15_000 });
-  await expect(hookDialog.locator('.import-dialog-title')).toHaveText('Review Task');
+  await expect(hookDialog.locator('.dialog-title')).toHaveText('Review Task');
   await expect(hookDialog.locator('textarea.start-command-textarea')).toHaveValue('echo reviewing');
 
   // Click "Run" — terminal in background, kanban stays
@@ -258,7 +258,7 @@ test('lifecycle hooks: configure, run, cancel, and drag transitions', async ({ a
 
   // Wait briefly and verify no dialog appeared
   await appPage.waitForTimeout(1_000);
-  await expect(appPage.locator('.modal-overlay--visible .import-dialog')).not.toBeVisible();
+  await expect(appPage.locator('.modal-overlay--visible .dialog')).not.toBeVisible();
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(2, { timeout: 5_000 });
   await expect(inReviewColumn.locator('.kanban-card')).toHaveCount(0);
 
@@ -271,7 +271,7 @@ test('lifecycle hooks: configure, run, cancel, and drag transitions', async ({ a
 
   // Cleanup dialog should appear
   await expect(hookDialog).toBeVisible({ timeout: 15_000 });
-  await expect(hookDialog.locator('.import-dialog-title')).toHaveText('Done — Cleanup');
+  await expect(hookDialog.locator('.dialog-title')).toHaveText('Done — Cleanup');
   await expect(hookDialog.locator('textarea.start-command-textarea')).toHaveValue('echo cleaning');
 
   // Click "Run" — terminal in background
@@ -294,7 +294,7 @@ test('lifecycle hooks: configure, run, cancel, and drag transitions', async ({ a
 
   // Wait briefly and verify no dialog appeared
   await appPage.waitForTimeout(1_000);
-  await expect(appPage.locator('.modal-overlay--visible .import-dialog')).not.toBeVisible();
+  await expect(appPage.locator('.modal-overlay--visible .dialog')).not.toBeVisible();
   await expect(inReviewColumn.locator('.kanban-card')).toHaveCount(1, { timeout: 5_000 });
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(0);
 
@@ -313,7 +313,7 @@ test('lifecycle hooks: configure, run, cancel, and drag transitions', async ({ a
 
   // No start hook — no dialog should appear
   await appPage.waitForTimeout(1_000);
-  await expect(appPage.locator('.modal-overlay--visible .import-dialog')).not.toBeVisible();
+  await expect(appPage.locator('.modal-overlay--visible .dialog')).not.toBeVisible();
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(1, { timeout: 5_000 });
   await expect(todoColumn.locator('.kanban-card')).toHaveCount(0);
 });

--- a/src/components/hookConfigDialog.ts
+++ b/src/components/hookConfigDialog.ts
@@ -81,7 +81,7 @@ export function showCombinedHookConfigDialog(
     overlay.className = 'modal-overlay';
 
     const dialog = document.createElement('div');
-    dialog.className = 'import-dialog';
+    dialog.className = 'dialog';
 
     const envVarsList = [
       '$OUIJIT_PROJECT_PATH',
@@ -98,7 +98,7 @@ export function showCombinedHookConfigDialog(
     `;
 
     dialog.innerHTML = `
-      <h2 class="import-dialog-title">Start & Continue Hooks</h2>
+      <h2 class="dialog-title">Start & Continue Hooks</h2>
 
       <div class="new-project-form">
         <div class="form-group">
@@ -130,7 +130,7 @@ export function showCombinedHookConfigDialog(
         ${envVarsHtml}
       </div>
 
-      <div class="import-actions">
+      <div class="dialog-actions">
         <button class="btn btn-secondary" data-action="cancel">Cancel</button>
         <button class="btn btn-primary" data-action="save">Save</button>
       </div>
@@ -161,7 +161,7 @@ export function showCombinedHookConfigDialog(
 
     requestAnimationFrame(() => {
       overlay.classList.add('modal-overlay--visible');
-      dialog.classList.add('import-dialog--visible');
+      dialog.classList.add('dialog--visible');
       startInput.focus();
     });
 
@@ -169,7 +169,7 @@ export function showCombinedHookConfigDialog(
       unregisterHotkey('escape', Scopes.MODAL);
       popScope();
       overlay.classList.remove('modal-overlay--visible');
-      dialog.classList.remove('import-dialog--visible');
+      dialog.classList.remove('dialog--visible');
       setTimeout(() => overlay.remove(), 200);
     };
 
@@ -245,7 +245,7 @@ export function showHookConfigDialog(
     overlay.className = 'modal-overlay';
 
     const dialog = document.createElement('div');
-    dialog.className = 'import-dialog';
+    dialog.className = 'dialog';
 
     const envVarsList = [
       '$OUIJIT_PROJECT_PATH',
@@ -262,7 +262,7 @@ export function showHookConfigDialog(
     ` : '';
 
     dialog.innerHTML = `
-      <h2 class="import-dialog-title">${labels.title}</h2>
+      <h2 class="dialog-title">${labels.title}</h2>
       <p class="hook-description">${labels.description}</p>
 
       <div class="new-project-form">
@@ -290,7 +290,7 @@ export function showHookConfigDialog(
         ${envVarsHtml}
       </div>
 
-      <div class="import-actions">
+      <div class="dialog-actions">
         <button class="btn btn-secondary" data-action="cancel">Cancel</button>
         <button class="btn btn-primary" data-action="save">Save</button>
       </div>
@@ -319,7 +319,7 @@ export function showHookConfigDialog(
 
     requestAnimationFrame(() => {
       overlay.classList.add('modal-overlay--visible');
-      dialog.classList.add('import-dialog--visible');
+      dialog.classList.add('dialog--visible');
       commandInput.focus();
     });
 
@@ -327,7 +327,7 @@ export function showHookConfigDialog(
       unregisterHotkey('escape', Scopes.MODAL);
       popScope();
       overlay.classList.remove('modal-overlay--visible');
-      dialog.classList.remove('import-dialog--visible');
+      dialog.classList.remove('dialog--visible');
       setTimeout(() => overlay.remove(), 200);
     };
 

--- a/src/components/newProjectDialog.ts
+++ b/src/components/newProjectDialog.ts
@@ -24,10 +24,10 @@ export function showNewProjectDialog(): Promise<NewProjectDialogResult | null> {
     overlay.className = 'modal-overlay';
 
     const dialog = document.createElement('div');
-    dialog.className = 'import-dialog';
+    dialog.className = 'dialog';
 
     dialog.innerHTML = `
-      <h2 class="import-dialog-title">New Project</h2>
+      <h2 class="dialog-title">New Project</h2>
 
       <div class="new-project-form">
         <div class="form-group">
@@ -43,7 +43,7 @@ export function showNewProjectDialog(): Promise<NewProjectDialogResult | null> {
         </div>
       </div>
 
-      <div class="import-actions">
+      <div class="dialog-actions">
         <button class="btn btn-secondary" data-action="cancel">Cancel</button>
         <button class="btn btn-primary" data-action="create" disabled>Create</button>
       </div>
@@ -65,7 +65,7 @@ export function showNewProjectDialog(): Promise<NewProjectDialogResult | null> {
     // Animate in
     requestAnimationFrame(() => {
       overlay.classList.add('modal-overlay--visible');
-      dialog.classList.add('import-dialog--visible');
+      dialog.classList.add('dialog--visible');
       nameInput.focus();
     });
 
@@ -74,7 +74,7 @@ export function showNewProjectDialog(): Promise<NewProjectDialogResult | null> {
       unregisterHotkey('enter', Scopes.MODAL);
       popScope();
       overlay.classList.remove('modal-overlay--visible');
-      dialog.classList.remove('import-dialog--visible');
+      dialog.classList.remove('dialog--visible');
       setTimeout(() => overlay.remove(), 200);
     };
 

--- a/src/components/project/kanbanBoard.ts
+++ b/src/components/project/kanbanBoard.ts
@@ -1011,10 +1011,10 @@ async function showStartCommandDialog(path: string, hookType: 'start' | 'continu
     overlay.className = 'modal-overlay';
 
     const dialog = document.createElement('div');
-    dialog.className = 'import-dialog';
+    dialog.className = 'dialog';
 
     const title = document.createElement('div');
-    title.className = 'import-dialog-title';
+    title.className = 'dialog-title';
     title.textContent = HOOK_DIALOG_TITLES[hookType] || 'Run Command';
     dialog.appendChild(title);
 
@@ -1082,7 +1082,7 @@ async function showStartCommandDialog(path: string, hookType: 'start' | 'continu
 
     // Action buttons
     const actions = document.createElement('div');
-    actions.className = 'import-actions';
+    actions.className = 'dialog-actions';
     actions.style.justifyContent = 'space-between';
 
     if (limaAvailable) {
@@ -1131,7 +1131,7 @@ async function showStartCommandDialog(path: string, hookType: 'start' | 'continu
     const cleanup = () => {
       unregisterHotkey('escape', Scopes.MODAL);
       popScope();
-      dialog.classList.remove('import-dialog--visible');
+      dialog.classList.remove('dialog--visible');
       overlay.classList.remove('modal-overlay--visible');
       setTimeout(() => overlay.remove(), 150);
     };
@@ -1154,7 +1154,7 @@ async function showStartCommandDialog(path: string, hookType: 'start' | 'continu
     // Animate in
     requestAnimationFrame(() => {
       overlay.classList.add('modal-overlay--visible');
-      dialog.classList.add('import-dialog--visible');
+      dialog.classList.add('dialog--visible');
       textarea.focus();
     });
   });

--- a/src/components/project/worktreeDropdown.ts
+++ b/src/components/project/worktreeDropdown.ts
@@ -21,15 +21,15 @@ function showDeleteConfirmDialog(taskName: string): Promise<boolean> {
     overlay.className = 'modal-overlay';
 
     const dialog = document.createElement('div');
-    dialog.className = 'import-dialog';
+    dialog.className = 'dialog';
     dialog.style.maxWidth = '380px';
 
     dialog.innerHTML = `
-      <h2 class="import-dialog-title">Delete Task?</h2>
-      <p class="import-dialog-text">
+      <h2 class="dialog-title">Delete Task?</h2>
+      <p class="dialog-text">
         This will permanently remove the worktree and branch for "<strong>${taskName}</strong>".
       </p>
-      <div class="import-actions">
+      <div class="dialog-actions">
         <button class="btn btn-secondary" data-action="cancel">Cancel</button>
         <button class="btn btn-danger" data-action="delete">Delete</button>
       </div>
@@ -41,7 +41,7 @@ function showDeleteConfirmDialog(taskName: string): Promise<boolean> {
     const cleanup = () => {
       unregisterHotkey('escape', Scopes.MODAL);
       popScope();
-      dialog.classList.remove('import-dialog--visible');
+      dialog.classList.remove('dialog--visible');
       overlay.classList.remove('modal-overlay--visible');
       setTimeout(() => overlay.remove(), 150);
     };
@@ -70,7 +70,7 @@ function showDeleteConfirmDialog(taskName: string): Promise<boolean> {
     // Animate in
     requestAnimationFrame(() => {
       overlay.classList.add('modal-overlay--visible');
-      dialog.classList.add('import-dialog--visible');
+      dialog.classList.add('dialog--visible');
     });
   });
 }
@@ -85,20 +85,20 @@ export function showMissingWorktreeDialog(task: TaskWithWorkspace, branchExists:
     overlay.className = 'modal-overlay';
 
     const dialog = document.createElement('div');
-    dialog.className = 'import-dialog';
+    dialog.className = 'dialog';
     dialog.style.maxWidth = '420px';
 
     const branchHtml = task.branch
-      ? `<p class="import-dialog-text" style="margin-top: 4px; font-size: 12px; opacity: 0.7;">Branch: <code>${task.branch}</code></p>`
+      ? `<p class="dialog-text" style="margin-top: 4px; font-size: 12px; opacity: 0.7;">Branch: <code>${task.branch}</code></p>`
       : '';
 
     dialog.innerHTML = `
-      <h2 class="import-dialog-title">Worktree Not Found</h2>
-      <p class="import-dialog-text">
+      <h2 class="dialog-title">Worktree Not Found</h2>
+      <p class="dialog-text">
         The worktree directory for "<strong>${task.name}</strong>" no longer exists on disk.
       </p>
       ${branchHtml}
-      <div class="import-actions">
+      <div class="dialog-actions">
         <button class="btn btn-secondary" data-action="cancel">Cancel</button>
         ${branchExists ? '<button class="btn btn-primary" data-action="recover">Recreate Worktree</button>' : ''}
       </div>
@@ -110,7 +110,7 @@ export function showMissingWorktreeDialog(task: TaskWithWorkspace, branchExists:
     const cleanup = () => {
       unregisterHotkey('escape', Scopes.MODAL);
       popScope();
-      dialog.classList.remove('import-dialog--visible');
+      dialog.classList.remove('dialog--visible');
       overlay.classList.remove('modal-overlay--visible');
       setTimeout(() => overlay.remove(), 150);
     };
@@ -136,7 +136,7 @@ export function showMissingWorktreeDialog(task: TaskWithWorkspace, branchExists:
 
     requestAnimationFrame(() => {
       overlay.classList.add('modal-overlay--visible');
-      dialog.classList.add('import-dialog--visible');
+      dialog.classList.add('dialog--visible');
     });
   });
 }

--- a/src/components/projectRow.ts
+++ b/src/components/projectRow.ts
@@ -198,15 +198,15 @@ function showRemoveConfirmDialog(projectName: string): Promise<boolean> {
     overlay.className = 'modal-overlay';
 
     const dialog = document.createElement('div');
-    dialog.className = 'import-dialog';
+    dialog.className = 'dialog';
     dialog.style.maxWidth = '380px';
 
     dialog.innerHTML = `
-      <h2 class="import-dialog-title">Remove Project?</h2>
-      <p class="import-dialog-text">
+      <h2 class="dialog-title">Remove Project?</h2>
+      <p class="dialog-text">
         This will remove <strong>${projectName}</strong> from Ouijit. The project folder will not be deleted.
       </p>
-      <div class="import-actions">
+      <div class="dialog-actions">
         <button class="btn btn-secondary" data-action="cancel">Cancel</button>
         <button class="btn btn-danger" data-action="remove">Remove</button>
       </div>
@@ -218,7 +218,7 @@ function showRemoveConfirmDialog(projectName: string): Promise<boolean> {
     const cleanup = () => {
       unregisterHotkey('escape', Scopes.MODAL);
       popScope();
-      dialog.classList.remove('import-dialog--visible');
+      dialog.classList.remove('dialog--visible');
       overlay.classList.remove('modal-overlay--visible');
       setTimeout(() => overlay.remove(), 150);
     };
@@ -247,7 +247,7 @@ function showRemoveConfirmDialog(projectName: string): Promise<boolean> {
     // Animate in
     requestAnimationFrame(() => {
       overlay.classList.add('modal-overlay--visible');
-      dialog.classList.add('import-dialog--visible');
+      dialog.classList.add('dialog--visible');
     });
   });
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./styles/compare.css";
+@import "./styles/dialog.css";
 
 @font-face {
   font-family: 'Iosevka Extended';
@@ -570,42 +571,6 @@ textarea,
   @apply bg-white/30;
 }
 
-/* ===================================
-   Modal & Import Dialog Styles
-   =================================== */
-
-.modal-overlay {
-  @apply fixed inset-0 flex justify-center z-[10001] opacity-0 transition-opacity duration-200 ease-out p-10 overflow-y-auto;
-  background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-}
-
-.modal-overlay--visible {
-  @apply opacity-100;
-}
-
-/* Dialog box styles (used by import dialog, hook config dialog, etc.) */
-.import-dialog {
-  @apply bg-surface rounded-[32px] shadow-lg max-w-[400px] w-[90%] p-6 opacity-0 border border-border overflow-hidden shrink-0;
-  margin-top: auto;
-  margin-bottom: auto;
-  transform: scale(0.95) translateY(10px);
-  transition: opacity 200ms ease-out, transform 200ms ease-out;
-}
-
-.import-dialog--visible {
-  @apply opacity-100;
-  transform: scale(1) translateY(0);
-}
-
-.import-dialog-title {
-  @apply text-lg font-semibold text-text-primary mb-4 text-center;
-}
-
-.import-actions {
-  @apply flex gap-2 justify-end mt-4 items-center;
-}
 
 /* ===================================
    New Project Dialog Form

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -1,0 +1,39 @@
+/* ===================================
+   Modal & Dialog Styles
+   =================================== */
+
+.modal-overlay {
+  @apply fixed inset-0 flex justify-center z-[10001] opacity-0 transition-opacity duration-200 ease-out p-10 overflow-y-auto;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.modal-overlay--visible {
+  @apply opacity-100;
+}
+
+.dialog {
+  @apply bg-surface rounded-[32px] shadow-lg max-w-[400px] w-[90%] p-6 opacity-0 border border-border overflow-hidden shrink-0;
+  margin-top: auto;
+  margin-bottom: auto;
+  transform: scale(0.95) translateY(10px);
+  transition: opacity 200ms ease-out, transform 200ms ease-out;
+}
+
+.dialog--visible {
+  @apply opacity-100;
+  transform: scale(1) translateY(0);
+}
+
+.dialog-title {
+  @apply text-lg font-semibold text-text-primary mb-4 text-center;
+}
+
+.dialog-text {
+  @apply text-sm text-text-secondary leading-relaxed;
+}
+
+.dialog-actions {
+  @apply flex gap-2 justify-end mt-4 items-center;
+}


### PR DESCRIPTION
## Summary
- Combine start and continue hook configuration into a single dialog instead of two separate ones
- Fix modal overflow so dialogs scroll properly when content exceeds viewport
- Rename legacy `import-dialog` / `import-actions` CSS classes to `dialog` / `dialog-actions`
- Extract modal and dialog styles from `index.css` into `src/styles/dialog.css`
- Add missing `.dialog-text` CSS rule