### PR TITLE
Add kanban trash drop zone for recoverable task deletion

### DIFF
--- a/src/components/project/kanbanBoard.ts
+++ b/src/components/project/kanbanBoard.ts
@@ -623,6 +623,102 @@ function setupColumnScrollIndicators(): void {
 }
 
 /**
+ * Show the trash drop zone on the right edge of the kanban board during drag.
+ */
+let trashSortable: Sortable | null = null;
+let trashZoneEl: HTMLElement | null = null;
+let trashDragListener: ((e: DragEvent) => void) | null = null;
+
+/**
+ * Create the trash zone element (hidden) and append it to the kanban columns.
+ * Called on drag start so it's in the DOM and ready to reveal.
+ */
+function initTrashZone(evt: Sortable.SortableEvent): void {
+  const columns = document.querySelector('.kanban-columns');
+  if (!columns || trashZoneEl) return;
+
+  const zone = document.createElement('div');
+  zone.className = 'kanban-trash-zone';
+  zone.innerHTML = '<i data-lucide="trash-2"></i><span>Delete</span>';
+  columns.appendChild(zone);
+  trashZoneEl = zone;
+
+  createIcons({ icons, nameAttr: 'data-lucide', attrs: {}, nodes: [zone] });
+
+  trashSortable = Sortable.create(zone, {
+    group: 'kanban',
+    draggable: '.kanban-card',
+    onAdd: (evt) => { handleTrashDrop(evt); },
+  });
+
+  // Track drag position — reveal when cursor reaches the Done column's left edge.
+  // HTML5 DnD suppresses mousemove; dragover fires instead.
+  const doneCol = columns.querySelector('.kanban-column[data-status="done"]') as HTMLElement | null;
+  const threshold = doneCol ? doneCol.getBoundingClientRect().left : window.innerWidth * 0.75;
+
+  trashDragListener = (e: DragEvent) => {
+    if (!trashZoneEl || e.clientX === 0) return; // clientX 0 = synthetic/end event
+    if (e.clientX >= threshold) {
+      trashZoneEl.classList.add('kanban-trash-zone--visible');
+    } else {
+      trashZoneEl.classList.remove('kanban-trash-zone--visible');
+    }
+  };
+  document.addEventListener('dragover', trashDragListener);
+
+  // If dragging from the Done column, the cursor is already past the threshold
+  const fromColumn = (evt.from as HTMLElement).closest('.kanban-column') as HTMLElement | null;
+  if (fromColumn?.dataset.status === 'done') {
+    requestAnimationFrame(() => zone.classList.add('kanban-trash-zone--visible'));
+  }
+}
+
+function teardownTrashZone(): void {
+  if (trashDragListener) {
+    document.removeEventListener('dragover', trashDragListener);
+    trashDragListener = null;
+  }
+  if (!trashZoneEl) return;
+  const zone = trashZoneEl;
+  zone.classList.remove('kanban-trash-zone--visible');
+  if (trashSortable) {
+    trashSortable.destroy();
+    trashSortable = null;
+  }
+  setTimeout(() => zone.remove(), 200);
+  trashZoneEl = null;
+}
+
+async function handleTrashDrop(evt: Sortable.SortableEvent): Promise<void> {
+  const item = evt.item as HTMLElement;
+  const taskNumber = parseInt(item.dataset.taskNumber || '', 10);
+  if (isNaN(taskNumber)) return;
+
+  item.remove();
+
+  const path = projectPath.value;
+  if (!path) return;
+
+  // Close any open terminals for this task
+  const currentTerminals = terminals.value;
+  for (let i = currentTerminals.length - 1; i >= 0; i--) {
+    if (currentTerminals[i].taskId === taskNumber) {
+      projectRegistry.closeProjectTerminal?.(i);
+    }
+  }
+
+  const result = await window.api.task.trash(path, taskNumber);
+  if (result.success) {
+    invalidateTaskList();
+    showToast(result.trashed ? 'Task moved to trash' : 'Task deleted', 'success');
+  } else {
+    showToast(result.error || 'Failed to delete task', 'error');
+  }
+
+  await populateKanbanBoard();
+}
+
+/**
  * Set up SortableJS instances for each kanban column body.
  * Called after populateKanbanBoard rebuilds the DOM.
  */
@@ -643,7 +739,8 @@ function setupSortable(): void {
       ghostClass: 'kanban-card--ghost',
       filter: '.kanban-add-input, .kanban-card-name-input, .kanban-card-detail-value--editing',
       preventOnFilter: false,
-      onEnd: (evt) => { handleSortableEnd(evt); },
+      onStart: (evt) => { initTrashZone(evt); },
+      onEnd: (evt) => { teardownTrashZone(); handleSortableEnd(evt); },
     });
   });
 }
@@ -705,6 +802,9 @@ async function runTransitionHookInTerminal(
  * Handle a SortableJS onEnd event — persist reorder and handle special status transitions.
  */
 async function handleSortableEnd(evt: Sortable.SortableEvent): Promise<void> {
+  // If the card was dropped on the trash zone, its onAdd handler takes care of deletion
+  if ((evt.to as HTMLElement).closest('.kanban-trash-zone')) return;
+
   const item = evt.item as HTMLElement;
   const taskNumber = parseInt(item.dataset.taskNumber || '', 10);
   if (isNaN(taskNumber)) {

--- a/src/index.css
+++ b/src/index.css
@@ -2054,5 +2054,39 @@ body.kanban-open .project-stack {
   line-height: 1.5;
 }
 
+/* Kanban Trash Drop Zone */
+.kanban-trash-zone {
+  @apply flex flex-col items-center justify-center gap-2 shrink-0 overflow-hidden;
+  width: 0;
+  opacity: 0;
+  transition: width 200ms ease-out, opacity 200ms ease-out, background 150ms ease;
+  border-left: 1px solid transparent;
+  color: var(--color-text-tertiary);
+}
+
+.kanban-trash-zone--visible {
+  width: 120px;
+  opacity: 1;
+  border-left-color: rgba(255, 255, 255, 0.06);
+}
+
+.kanban-trash-zone svg {
+  @apply w-5 h-5;
+}
+
+.kanban-trash-zone span {
+  @apply text-xs font-medium;
+}
+
+.kanban-trash-zone:has(.kanban-card) {
+  background: rgba(255, 69, 58, 0.12);
+  color: var(--color-error);
+  border-left-color: rgba(255, 69, 58, 0.3);
+}
+
+.kanban-trash-zone .kanban-card {
+  display: none;
+}
+
 
 

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -79,6 +79,7 @@ export interface IpcInvokeContract {
   'task:get-by-number':           { args: [projectPath: string, taskNumber: number];                        return: TaskWithWorkspace | null };
   'task:set-status':              { args: [projectPath: string, taskNumber: number, status: TaskStatus];    return: { success: boolean; error?: string; hookWarning?: string } };
   'task:delete':                  { args: [projectPath: string, taskNumber: number];                        return: { success: boolean; error?: string } };
+  'task:trash':                   { args: [projectPath: string, taskNumber: number];                        return: { success: boolean; error?: string; trashed?: boolean } };
   'task:set-merge-target':        { args: [projectPath: string, taskNumber: number, mergeTarget: string];   return: { success: boolean; error?: string } };
   'task:set-sandboxed':           { args: [projectPath: string, taskNumber: number, sandboxed: boolean];    return: { success: boolean; error?: string } };
   'task:set-name':                { args: [projectPath: string, taskNumber: number, name: string];          return: { success: boolean; error?: string } };

--- a/src/ipc/handlers/task.ts
+++ b/src/ipc/handlers/task.ts
@@ -10,6 +10,7 @@ import {
   setTaskStatusWithHooks,
   reorderTaskWithHooks,
   deleteTaskWithWorktree,
+  trashTaskWithWorktree,
   getTasksWithWorkspaces,
   getTaskWithWorkspace,
 } from '../../taskLifecycle';
@@ -36,6 +37,10 @@ export function registerTaskHandlers(): void {
 
   typedHandle('task:delete', (projectPath, taskNumber) =>
     deleteTaskWithWorktree(projectPath, taskNumber),
+  );
+
+  typedHandle('task:trash', (projectPath, taskNumber) =>
+    trashTaskWithWorktree(projectPath, taskNumber),
   );
 
   typedHandle('task:set-merge-target', (projectPath, taskNumber, mergeTarget) =>

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -104,6 +104,7 @@ contextBridge.exposeInMainWorld('api', {
     getByNumber: (projectPath: string, taskNumber: number) => typedInvoke('task:get-by-number', projectPath, taskNumber),
     setStatus: (projectPath: string, taskNumber: number, status: TaskStatus) => typedInvoke('task:set-status', projectPath, taskNumber, status),
     delete: (projectPath: string, taskNumber: number) => typedInvoke('task:delete', projectPath, taskNumber),
+    trash: (projectPath: string, taskNumber: number) => typedInvoke('task:trash', projectPath, taskNumber),
     setMergeTarget: (projectPath: string, taskNumber: number, mergeTarget: string) => typedInvoke('task:set-merge-target', projectPath, taskNumber, mergeTarget),
     setSandboxed: (projectPath: string, taskNumber: number, sandboxed: boolean) => typedInvoke('task:set-sandboxed', projectPath, taskNumber, sandboxed),
     setName: (projectPath: string, taskNumber: number, name: string) => typedInvoke('task:set-name', projectPath, taskNumber, name),

--- a/src/taskLifecycle.ts
+++ b/src/taskLifecycle.ts
@@ -3,6 +3,10 @@
  * Extracted from IPC handlers to keep handlers as thin one-liner delegations.
  */
 
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync } from 'node:fs';
+import { shell } from 'electron';
 import {
   getProjectTasks,
   getTaskByNumber,
@@ -14,6 +18,8 @@ import {
 import { listWorktrees, removeTaskWorktree } from './worktree';
 import type { TaskWithWorkspace } from './types';
 import log from './log';
+
+const execAsync = promisify(exec);
 
 const taskLog = log.scope('task');
 
@@ -72,6 +78,54 @@ export async function deleteTaskWithWorktree(
     }
     taskLog.info('deleting task (metadata-only)', { taskNumber });
   }
+  return deleteTaskByNumber(projectPath, taskNumber);
+}
+
+/**
+ * Delete a task, moving its worktree directory to the OS trash (recoverable)
+ * instead of permanently deleting it with `git worktree remove --force`.
+ */
+export async function trashTaskWithWorktree(
+  projectPath: string,
+  taskNumber: number,
+): Promise<{ success: boolean; error?: string; trashed?: boolean }> {
+  const task = await getTaskByNumber(projectPath, taskNumber);
+
+  // Resolve the worktree path — prefer the DB path, fall back to git worktree list
+  let worktreePath: string | undefined;
+  if (task?.worktreePath && existsSync(task.worktreePath)) {
+    worktreePath = task.worktreePath;
+  } else if (task?.branch) {
+    const worktrees = await listWorktrees(projectPath);
+    const wt = worktrees.find(w => w.branch === task.branch);
+    if (wt) worktreePath = wt.path;
+  }
+
+  if (worktreePath) {
+    taskLog.info('trashing task worktree', { taskNumber, worktreePath });
+    try {
+      await shell.trashItem(worktreePath);
+      await execAsync('git worktree prune', { cwd: projectPath, encoding: 'utf8' });
+    } catch (trashError) {
+      const msg = trashError instanceof Error ? trashError.message : String(trashError);
+      taskLog.error('trashItem failed', { taskNumber, error: msg });
+      return { success: false, error: `Failed to move worktree to trash: ${msg}` };
+    }
+
+    // Delete the branch
+    if (task?.branch) {
+      try {
+        await execAsync(`git branch -D "${task.branch}"`, { cwd: projectPath, encoding: 'utf8' });
+      } catch {
+        // Branch may already be deleted
+      }
+    }
+
+    const dbResult = await deleteTaskByNumber(projectPath, taskNumber);
+    return { ...dbResult, trashed: true };
+  }
+
+  taskLog.info('trashing task (metadata-only)', { taskNumber });
   return deleteTaskByNumber(projectPath, taskNumber);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,7 @@ export interface TaskAPI {
   getByNumber(projectPath: string, taskNumber: number): Promise<TaskWithWorkspace | null>;
   setStatus(projectPath: string, taskNumber: number, status: TaskStatus): Promise<{ success: boolean; error?: string; hookWarning?: string }>;
   delete(projectPath: string, taskNumber: number): Promise<{ success: boolean; error?: string }>;
+  trash(projectPath: string, taskNumber: number): Promise<{ success: boolean; error?: string; trashed?: boolean }>;
   setMergeTarget(projectPath: string, taskNumber: number, mergeTarget: string): Promise<{ success: boolean; error?: string }>;
   setSandboxed(projectPath: string, taskNumber: number, sandboxed: boolean): Promise<{ success: boolean; error?: string }>;
   setName(projectPath: string, taskNumber: number, name: string): Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
## Summary
- Drag a task card past the Done column to reveal a trash drop zone on the right edge of the kanban board
- Dropping a card onto the trash zone moves its worktree to OS trash (recoverable) instead of permanently deleting it
- Cleans up the git branch and task metadata after trashing