### PR TITLE
Darken terminal and kanban background (#1a1a1a → #171717)

### DIFF
--- a/src/components/project/terminalCards.ts
+++ b/src/components/project/terminalCards.ts
@@ -144,12 +144,12 @@ export function resolveTerminalLabel(
  */
 export function getTerminalTheme(): Record<string, string> {
   return {
-    background: '#1a1a1a',
+    background: '#171717',
     foreground: '#e4e4e4',
     cursor: '#e4e4e4',
-    cursorAccent: '#1a1a1a',
+    cursorAccent: '#171717',
     selectionBackground: 'rgba(255, 255, 255, 0.15)',
-    black: '#1a1a1a',
+    black: '#171717',
     red: '#ff6b6b',
     green: '#69db7c',
     yellow: '#ffd43b',

--- a/src/index.css
+++ b/src/index.css
@@ -96,7 +96,7 @@
   --content-padding: 24px;
 
   /* Terminal */
-  --color-terminal-bg: #1a1a1a;
+  --color-terminal-bg: #171717;
 }
 
 
@@ -542,13 +542,13 @@ body.platform-darwin:not(.is-fullscreen) .header-content {
 
 .terminal-viewport {
   @apply h-[280px] p-4 rounded-lg border border-white/10 overflow-hidden flex flex-col;
-  background: var(--color-terminal-bg, #1a1a1a);
+  background: var(--color-terminal-bg, #171717);
 }
 
 /* Inner container for xterm - no padding so FitAddon measures correctly */
 .terminal-xterm-container {
   @apply flex-1 min-h-0 min-w-0 overflow-hidden;
-  background: var(--color-terminal-bg, #1a1a1a);
+  background: var(--color-terminal-bg, #171717);
 }
 
 /* Override xterm.js styles */
@@ -1036,7 +1036,7 @@ body.project-mode .project-list-header {
 
 .project-card {
   @apply absolute inset-0 rounded-lg border border-white/10 overflow-hidden flex flex-col;
-  background: var(--color-terminal-bg, #1a1a1a);
+  background: var(--color-terminal-bg, #171717);
   transition: translate 0.2s ease, scale 0.2s ease;
 }
 
@@ -1290,7 +1290,7 @@ body.project-mode .project-list-header {
 .runner-panel {
   @apply rounded-none border-0 border-l border-t border-solid border-white/10 shadow-none flex flex-col overflow-hidden;
   flex-basis: 0;
-  background: var(--color-terminal-bg, #1a1a1a);
+  background: var(--color-terminal-bg, #171717);
   transition: flex-basis 0.25s ease;
 }
 
@@ -1754,7 +1754,7 @@ body.kanban-open .project-stack {
 .kanban-board {
   @apply fixed top-[82px] left-4 right-4 bottom-4 z-[140] flex flex-col opacity-0 transition-all duration-200 ease-out rounded-lg overflow-hidden border border-white/10;
   transform: translateY(6px);
-  background: var(--color-terminal-bg, #1a1a1a);
+  background: var(--color-terminal-bg, #171717);
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2);
 }
 

--- a/src/styles/compare.css
+++ b/src/styles/compare.css
@@ -9,7 +9,7 @@
 /* Default styles for fixed position (legacy/global mode) */
 body > .diff-panel {
   @apply fixed top-[82px] right-4 bottom-4 w-0 rounded-md border border-white/10 z-[101] flex overflow-hidden opacity-0;
-  background: var(--color-terminal-bg, #1a1a1a);
+  background: var(--color-terminal-bg, #171717);
   box-shadow:
     0 0 0 1px rgba(0, 0, 0, 0.05),
     0 4px 12px rgba(0, 0, 0, 0.15),
@@ -272,7 +272,7 @@ body > .diff-panel--visible {
 /* Diff panel inside card - full width like ship panel */
 .project-card .diff-panel {
   @apply absolute inset-0 rounded-none border-0 border-t border-solid border-white/10 shadow-none z-20 flex overflow-hidden opacity-0 pointer-events-none;
-  background: var(--color-terminal-bg, #1a1a1a);
+  background: var(--color-terminal-bg, #171717);
   transition: opacity 0.15s ease;
 }
 


### PR DESCRIPTION
## Summary
- Darken terminal, kanban board, diff panel, and runner panel backgrounds from `#1a1a1a` to `#171717` for a slightly deeper appearance
- Update xterm.js theme colors to match
- Update all CSS fallback values to stay in sync with the CSS variable