### PR TITLE
Switch to terminal stack view when opening VM Console

### DIFF
--- a/src/components/project/projectMode.ts
+++ b/src/components/project/projectMode.ts
@@ -1441,6 +1441,7 @@ async function buildSandboxDropdownContent(
   consoleBtn.addEventListener('click', async (e) => {
     e.stopPropagation();
     hideSandboxDropdown();
+    if (kanbanVisible.value) hideKanbanBoard();
     await projectRegistry.addProjectTerminal?.(
       { name: 'VM Console', command: '', source: 'custom', priority: 0 },
       { sandboxed: true },


### PR DESCRIPTION
## Summary
- When the VM Console button is clicked from the sandbox dropdown while the kanban board is open, automatically switch to the terminal stack view so the console is immediately visible.