### PR TITLE
Hide run button on home shell terminals

### DIFF
--- a/src/components/homeView.ts
+++ b/src/components/homeView.ts
@@ -362,7 +362,7 @@ function updateHomeCardStack(): void {
 
     if (index === homeActiveIndex) {
       if (shortcutEl) shortcutEl.style.display = 'none';
-      if (runnerBtn) runnerBtn.style.display = '';
+      if (runnerBtn) runnerBtn.style.display = term.taskId != null ? '' : 'none';
     } else {
       const stackPosition = shortcutOrder.indexOf(index);
       if (shortcutEl) {


### PR DESCRIPTION
## Summary
- Home shell terminals in the home view were showing a run button on the active card, but home shells have no associated task to run
- Added a `taskId` check in `homeView.ts` so the run button only appears on task terminals