### PR TITLE
Fix test failures in CI by setting local git identity

### DIFF
--- a/src/__tests__/cli/detect.test.ts
+++ b/src/__tests__/cli/detect.test.ts
@@ -46,6 +46,8 @@ describe('detectProject', () => {
     const mainRepo = path.join(tempDir, 'main-repo');
     fs.mkdirSync(mainRepo);
     execSync('git init', { cwd: mainRepo, stdio: 'ignore' });
+    execSync('git config user.email "test@test.com"', { cwd: mainRepo, stdio: 'ignore' });
+    execSync('git config user.name "Test"', { cwd: mainRepo, stdio: 'ignore' });
     execSync('git commit --allow-empty -m "init"', { cwd: mainRepo, stdio: 'ignore' });
 
     // Add project to DB (mainRepo is a real directory, so addProject validation passes)

--- a/src/__tests__/integration/recoverTaskWorktree.test.ts
+++ b/src/__tests__/integration/recoverTaskWorktree.test.ts
@@ -22,6 +22,8 @@ beforeEach(async () => {
   await fs.mkdir(repoDir, { recursive: true });
 
   execSync('git init', { cwd: repoDir });
+  execSync('git config user.email "test@test.com"', { cwd: repoDir });
+  execSync('git config user.name "Test"', { cwd: repoDir });
   execSync('git commit --allow-empty -m "Initial commit"', { cwd: repoDir });
 });
 


### PR DESCRIPTION
## Summary

- Set local `user.email` and `user.name` in temp git repos used by `detect.test.ts` and `recoverTaskWorktree.test.ts` so `git commit` works in CI environments without global git identity