### PR TITLE
Fix CLI missing from production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "package": "npm run build:cli && electron-forge package",
     "make": "npm run build:cli && electron-forge make",
     "make:linux": "./scripts/build-linux.sh",
-    "publish": "electron-forge publish",
+    "publish": "npm run build:cli && electron-forge publish",
     "typecheck": "tsc --noEmit",
     "check": "tsc --noEmit && eslint src/ && prettier --check src/",
     "lint": "eslint src/",


### PR DESCRIPTION
## Summary

- The `publish` script was missing the `npm run build:cli` prefix that `make` and `package` both had, so `dist-cli/ouijit.js` never existed when the `afterCopy` hook ran in CI — silently skipping the CLI bundle