### PR TITLE
Fix race between worktree file copy and task start hooks

### DIFF
--- a/src/__tests__/startTask.test.ts
+++ b/src/__tests__/startTask.test.ts
@@ -72,4 +72,26 @@ describe('startTask', () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe('Task not found');
   });
+
+  test('awaits gitignored file copy before returning', async () => {
+    const project = '/test/start-awaits-copy';
+    await createTask(project, 1, 'Copy test', { status: 'todo' });
+
+    // Make lstat take measurable time so we can detect fire-and-forget vs await
+    let copyFinished = false;
+    const fs = await import('node:fs/promises');
+    const lstatSpy = vi.spyOn(fs, 'lstat').mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      copyFinished = true;
+      throw new Error('ENOENT');
+    });
+
+    const result = await startTask(project, 1);
+    expect(result.success).toBe(true);
+    // If copyGitIgnoredFiles were fire-and-forget, startTask would resolve
+    // before the 50ms delay elapses and copyFinished would still be false
+    expect(copyFinished).toBe(true);
+
+    lstatSpy.mockRestore();
+  });
 });

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -80,6 +80,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     branchExists: boolean;
     resolve: (action: 'recover' | null) => void;
   } | null>(null);
+  const [settingUpTaskNumber, setSettingUpTaskNumber] = useState<number | null>(null);
 
   /**
    * Check if a task's worktree exists on disk. If missing, prompt the user to recover it.
@@ -345,7 +346,9 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
 
       // Create worktree BEFORE moving (while task is still todo)
       if (newStatus === 'in_progress' && !draggedTask.worktreePath) {
+        setSettingUpTaskNumber(draggedTask.taskNumber);
         const startResult = await window.api.task.start(projectPath, draggedTask.taskNumber);
+        setSettingUpTaskNumber(null);
         if (!startResult.success) {
           useProjectStore.getState().addToast(startResult.error || 'Failed to create worktree', 'error');
         } else if (startResult.worktreePath) {
@@ -579,6 +582,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
                 label={col.label}
                 tasks={items[col.status] ?? []}
                 projectPath={projectPath}
+                settingUpTaskNumber={settingUpTaskNumber}
                 onAddTask={col.status === 'todo' ? handleAddTask : undefined}
                 onRenameTask={handleRenameTask}
                 onUpdateDescription={handleUpdateDescription}

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -10,6 +10,7 @@ import { HookConfigDialog } from '../dialogs/HookConfigDialog';
 interface KanbanCardProps {
   task: TaskWithWorkspace;
   projectPath: string;
+  isSettingUp?: boolean;
   onRename: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
@@ -19,6 +20,7 @@ interface KanbanCardProps {
 export const KanbanCard = memo(function KanbanCard({
   task,
   projectPath,
+  isSettingUp,
   onRename,
   onUpdateDescription,
   onOpenTerminal,
@@ -289,6 +291,12 @@ export const KanbanCard = memo(function KanbanCard({
         />
       )}
       <div className="flex items-start gap-2">
+        {isSettingUp && (
+          <span
+            className="w-2 h-2 rounded-full bg-transparent border-[1.5px] border-white/30 border-t-white/80 shrink-0 mt-[5px]"
+            style={{ animation: 'loading-dot-spin 0.8s linear infinite' }}
+          />
+        )}
         {editing ? (
           <textarea
             ref={nameInputRef}
@@ -315,6 +323,8 @@ export const KanbanCard = memo(function KanbanCard({
           <Icon name="caret-down" />
         </button>
       </div>
+
+      {isSettingUp && <div className="font-mono text-xs text-white/40 mt-1">Setting up workspace\u2026</div>}
 
       {/* Connected terminal status dots */}
       {connectedDisplays.length > 0 && (

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -324,7 +324,7 @@ export const KanbanCard = memo(function KanbanCard({
         </button>
       </div>
 
-      {isSettingUp && <div className="font-mono text-xs text-white/40 mt-1">Setting up workspace\u2026</div>}
+      {isSettingUp && <div className="font-mono text-xs text-white/40 mt-1">Setting up workspace{'\u2026'}</div>}
 
       {/* Connected terminal status dots */}
       {connectedDisplays.length > 0 && (

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -20,6 +20,7 @@ interface KanbanColumnProps {
   label: string;
   tasks: TaskWithWorkspace[];
   projectPath: string;
+  settingUpTaskNumber?: number | null;
   onAddTask?: (name: string) => void;
   onRenameTask: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
@@ -34,6 +35,7 @@ export function KanbanColumn({
   label,
   tasks,
   projectPath,
+  settingUpTaskNumber,
   onAddTask,
   onRenameTask,
   onUpdateDescription,
@@ -86,6 +88,7 @@ export function KanbanColumn({
               key={task.taskNumber}
               task={task}
               projectPath={projectPath}
+              isSettingUp={settingUpTaskNumber === task.taskNumber}
               onRename={onRenameTask}
               onUpdateDescription={onUpdateDescription}
               onOpenTerminal={onOpenTerminal}
@@ -104,6 +107,7 @@ export function KanbanColumn({
 function SortableCard({
   task,
   projectPath,
+  isSettingUp,
   onRename,
   onUpdateDescription,
   onOpenTerminal,
@@ -111,6 +115,7 @@ function SortableCard({
 }: {
   task: TaskWithWorkspace;
   projectPath: string;
+  isSettingUp?: boolean;
   onRename: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
@@ -152,6 +157,7 @@ function SortableCard({
       <KanbanCard
         task={task}
         projectPath={projectPath}
+        isSettingUp={isSettingUp}
         onRename={onRename}
         onUpdateDescription={onUpdateDescription}
         onOpenTerminal={onOpenTerminal}

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -355,12 +355,7 @@ export async function startTask(
       await setTaskMergeTarget(projectPath, taskNumber, mergeTarget);
     }
 
-    copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles).catch((err) => {
-      worktreeLog.warn('background copy failed', {
-        taskNumber,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
+    await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
 
     worktreeLog.info('started task', { taskNumber, worktreePath, branch });
     const updated = await getTaskByNumber(projectPath, taskNumber);
@@ -447,10 +442,7 @@ export async function createTaskWorktree(
       worktreePath,
     });
 
-    // Fire-and-forget file copy with pre-fetched list
-    copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles).catch((err) => {
-      worktreeLog.warn('background copy failed', { error: err instanceof Error ? err.message : String(err) });
-    });
+    await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
 
     return {
       success: true,
@@ -660,13 +652,7 @@ export async function recoverTaskWorktree(projectPath: string, taskNumber: numbe
     // Update metadata with new path
     await setTaskWorktreePath(projectPath, taskNumber, worktreePath);
 
-    // Fire-and-forget file copy
-    copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles).catch((err) => {
-      worktreeLog.warn('background copy failed', {
-        taskNumber,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
+    await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
 
     worktreeLog.info('recovered', { taskNumber, worktreePath });
     const updated = await getTaskByNumber(projectPath, taskNumber);


### PR DESCRIPTION
## Summary

- `copyGitIgnoredFiles` was fire-and-forget in `startTask`, `createTaskWorktree`, and `recoverTaskWorktree` — start hooks like `npm install` would run concurrently with the background copy, corrupting shared directories like `node_modules/`
- Now awaits the copy before returning so hooks run against a fully populated worktree
- Adds a loading spinner + "Setting up workspace..." on the kanban card during worktree setup so the user sees progress while the copy runs
- Adds test verifying the copy is awaited (not fire-and-forget) before `startTask` resolves