### PR TITLE
Add task branching for stacked PR workflows

### DIFF
--- a/src/__tests__/createBranchFromTask.test.ts
+++ b/src/__tests__/createBranchFromTask.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from 'vitest';
+import { createTask, getTaskByNumber } from '../db';
+import { createBranchFromTask } from '../taskLifecycle';
+
+describe('createBranchFromTask', () => {
+  test('creates a child task with parentTaskNumber and mergeTarget', async () => {
+    const project = '/test/branch-from';
+    await createTask(project, 1, 'Parent', { branch: 'feat/parent', status: 'in_progress' });
+
+    const result = await createBranchFromTask(project, 1, 'Child feature');
+    expect(result.success).toBe(true);
+    expect(result.task).toBeDefined();
+    expect(result.task!.name).toBe('Child feature');
+    expect(result.task!.status).toBe('todo');
+    expect(result.task!.parentTaskNumber).toBe(1);
+    expect(result.task!.mergeTarget).toBe('feat/parent');
+  });
+
+  test('returns error when parent task not found', async () => {
+    const result = await createBranchFromTask('/test/missing-parent', 99, 'Orphan');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Parent task not found');
+  });
+
+  test('returns error when parent has no branch', async () => {
+    const project = '/test/no-branch-parent';
+    await createTask(project, 1, 'Unstarted parent', { status: 'todo' });
+
+    const result = await createBranchFromTask(project, 1, 'Child');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Parent task has no branch');
+  });
+
+  test('assigns next sequential task number', async () => {
+    const project = '/test/branch-from-counter';
+    await createTask(project, 1, 'Parent', { branch: 'feat/parent', status: 'in_progress' });
+
+    const result = await createBranchFromTask(project, 1, 'Child');
+    expect(result.task!.taskNumber).toBe(2);
+  });
+
+  test('defaults name to Untitled when not provided', async () => {
+    const project = '/test/branch-from-unnamed';
+    await createTask(project, 1, 'Parent', { branch: 'feat/parent', status: 'in_progress' });
+
+    const result = await createBranchFromTask(project, 1);
+    expect(result.task!.name).toBe('Untitled');
+  });
+});

--- a/src/__tests__/ipcRefactor.test.ts
+++ b/src/__tests__/ipcRefactor.test.ts
@@ -13,6 +13,11 @@ vi.mock('node:child_process', () => ({
   exec: vi.fn((_cmd: string, _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
     cb(null, { stdout: '', stderr: '' });
   }),
+  execFile: vi.fn(
+    (_file: string, _args: string[], _opts: unknown, cb: (err: null, stdout: string, stderr: string) => void) => {
+      cb(null, '', '');
+    },
+  ),
   execSync: vi.fn(),
 }));
 

--- a/src/__tests__/startTask.test.ts
+++ b/src/__tests__/startTask.test.ts
@@ -35,6 +35,32 @@ vi.mock('koffi', () => ({
 import { startTask } from '../worktree';
 import { beginTask } from '../taskLifecycle';
 
+async function mockExecBranchNotFound() {
+  const { exec } = await import('node:child_process');
+  vi.mocked(exec).mockImplementation(((
+    cmd: string,
+    _opts: unknown,
+    cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+  ) => {
+    if (typeof cmd === 'string' && cmd.includes('rev-parse --verify')) {
+      cb(new Error('not found'), { stdout: '', stderr: '' });
+    } else {
+      cb(null, { stdout: 'main\n', stderr: '' });
+    }
+  }) as typeof exec);
+}
+
+async function restoreExecMock() {
+  const { exec } = await import('node:child_process');
+  vi.mocked(exec).mockImplementation(((
+    _cmd: string,
+    _opts: unknown,
+    cb: (err: null, result: { stdout: string; stderr: string }) => void,
+  ) => {
+    cb(null, { stdout: 'main\n', stderr: '' });
+  }) as typeof exec);
+}
+
 describe('startTask', () => {
   test('does not change a todo task status to in_progress', async () => {
     const project = '/test/start-keeps-todo';
@@ -76,18 +102,7 @@ describe('startTask', () => {
 
   test('passes baseBranch as start point to git worktree add', async () => {
     const { exec } = await import('node:child_process');
-    // Override exec to make rev-parse --verify fail (branch doesn't exist yet)
-    vi.mocked(exec).mockImplementation(((
-      cmd: string,
-      _opts: unknown,
-      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
-    ) => {
-      if (typeof cmd === 'string' && cmd.includes('rev-parse --verify')) {
-        cb(new Error('not found'), { stdout: '', stderr: '' });
-      } else {
-        cb(null, { stdout: 'main\n', stderr: '' });
-      }
-    }) as typeof exec);
+    await mockExecBranchNotFound();
 
     const project = '/test/start-with-base';
     await createTask(project, 1, 'Child task', { status: 'todo' });
@@ -99,14 +114,7 @@ describe('startTask', () => {
     expect(wtAddCall).toBeDefined();
     expect(wtAddCall![0]).toContain('feat/parent-branch');
 
-    // Restore default mock
-    vi.mocked(exec).mockImplementation(((
-      _cmd: string,
-      _opts: unknown,
-      cb: (err: null, result: { stdout: string; stderr: string }) => void,
-    ) => {
-      cb(null, { stdout: 'main\n', stderr: '' });
-    }) as typeof exec);
+    await restoreExecMock();
   });
 
   test('sets mergeTarget to baseBranch when provided', async () => {
@@ -133,17 +141,7 @@ describe('startTask', () => {
 
   test('beginTask passes parent branch as baseBranch', async () => {
     const { exec } = await import('node:child_process');
-    vi.mocked(exec).mockImplementation(((
-      cmd: string,
-      _opts: unknown,
-      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
-    ) => {
-      if (typeof cmd === 'string' && cmd.includes('rev-parse --verify')) {
-        cb(new Error('not found'), { stdout: '', stderr: '' });
-      } else {
-        cb(null, { stdout: 'main\n', stderr: '' });
-      }
-    }) as typeof exec);
+    await mockExecBranchNotFound();
 
     const project = '/test/begin-with-parent';
     await createTask(project, 1, 'Parent', { branch: 'feat/parent', status: 'in_progress' });
@@ -156,13 +154,7 @@ describe('startTask', () => {
     expect(wtAddCall).toBeDefined();
     expect(wtAddCall![0]).toContain('feat/parent');
 
-    vi.mocked(exec).mockImplementation(((
-      _cmd: string,
-      _opts: unknown,
-      cb: (err: null, result: { stdout: string; stderr: string }) => void,
-    ) => {
-      cb(null, { stdout: 'main\n', stderr: '' });
-    }) as typeof exec);
+    await restoreExecMock();
   });
 
   test('beginTask falls back to HEAD when parent is missing', async () => {

--- a/src/__tests__/startTask.test.ts
+++ b/src/__tests__/startTask.test.ts
@@ -8,8 +8,18 @@ vi.mock('node:child_process', () => ({
     cb(null, { stdout: 'main\n', stderr: '' });
   }),
   execFile: vi.fn(
-    (_file: string, _args: string[], _opts: unknown, cb: (err: null, stdout: string, stderr: string) => void) => {
-      cb(null, '', '');
+    (
+      _file: string,
+      args: string[],
+      _opts: unknown,
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      // Default: rev-parse --verify always fails (branch doesn't exist) so tests exercise the -b path
+      if (Array.isArray(args) && args.includes('--verify')) {
+        cb(new Error('not found'), '', '');
+      } else {
+        cb(null, '', '');
+      }
     },
   ),
 }));
@@ -34,32 +44,6 @@ vi.mock('koffi', () => ({
 
 import { startTask } from '../worktree';
 import { beginTask } from '../taskLifecycle';
-
-async function mockExecBranchNotFound() {
-  const { exec } = await import('node:child_process');
-  vi.mocked(exec).mockImplementation(((
-    cmd: string,
-    _opts: unknown,
-    cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
-  ) => {
-    if (typeof cmd === 'string' && cmd.includes('rev-parse --verify')) {
-      cb(new Error('not found'), { stdout: '', stderr: '' });
-    } else {
-      cb(null, { stdout: 'main\n', stderr: '' });
-    }
-  }) as typeof exec);
-}
-
-async function restoreExecMock() {
-  const { exec } = await import('node:child_process');
-  vi.mocked(exec).mockImplementation(((
-    _cmd: string,
-    _opts: unknown,
-    cb: (err: null, result: { stdout: string; stderr: string }) => void,
-  ) => {
-    cb(null, { stdout: 'main\n', stderr: '' });
-  }) as typeof exec);
-}
 
 describe('startTask', () => {
   test('does not change a todo task status to in_progress', async () => {
@@ -101,20 +85,22 @@ describe('startTask', () => {
   });
 
   test('passes baseBranch as start point to git worktree add', async () => {
-    const { exec } = await import('node:child_process');
-    await mockExecBranchNotFound();
+    const { execFile } = await import('node:child_process');
+    vi.mocked(execFile).mockClear();
 
     const project = '/test/start-with-base';
     await createTask(project, 1, 'Child task', { status: 'todo' });
 
     await startTask(project, 1, undefined, 'feat/parent-branch');
 
-    const execCalls = vi.mocked(exec).mock.calls;
-    const wtAddCall = execCalls.find(([cmd]) => typeof cmd === 'string' && cmd.includes('git worktree add -b'));
+    const execFileCalls = vi.mocked(execFile).mock.calls;
+    const wtAddCall = execFileCalls.find(
+      ([file, args]) => file === 'git' && Array.isArray(args) && args.includes('worktree'),
+    );
     expect(wtAddCall).toBeDefined();
-    expect(wtAddCall![0]).toContain('feat/parent-branch');
-
-    await restoreExecMock();
+    const args = wtAddCall![1] as string[];
+    expect(args).toContain('-b');
+    expect(args).toContain('feat/parent-branch');
   });
 
   test('sets mergeTarget to baseBranch when provided', async () => {
@@ -140,8 +126,8 @@ describe('startTask', () => {
   });
 
   test('beginTask passes parent branch as baseBranch', async () => {
-    const { exec } = await import('node:child_process');
-    await mockExecBranchNotFound();
+    const { execFile } = await import('node:child_process');
+    vi.mocked(execFile).mockClear();
 
     const project = '/test/begin-with-parent';
     await createTask(project, 1, 'Parent', { branch: 'feat/parent', status: 'in_progress' });
@@ -149,12 +135,14 @@ describe('startTask', () => {
 
     await beginTask(project, 2);
 
-    const execCalls = vi.mocked(exec).mock.calls;
-    const wtAddCall = execCalls.find(([cmd]) => typeof cmd === 'string' && cmd.includes('git worktree add -b'));
+    const execFileCalls = vi.mocked(execFile).mock.calls;
+    const wtAddCall = execFileCalls.find(
+      ([file, args]) => file === 'git' && Array.isArray(args) && args.includes('worktree'),
+    );
     expect(wtAddCall).toBeDefined();
-    expect(wtAddCall![0]).toContain('feat/parent');
-
-    await restoreExecMock();
+    const args = wtAddCall![1] as string[];
+    expect(args).toContain('-b');
+    expect(args).toContain('feat/parent');
   });
 
   test('beginTask falls back to HEAD when parent is missing', async () => {

--- a/src/__tests__/startTask.test.ts
+++ b/src/__tests__/startTask.test.ts
@@ -33,6 +33,7 @@ vi.mock('koffi', () => ({
 }));
 
 import { startTask } from '../worktree';
+import { beginTask } from '../taskLifecycle';
 
 describe('startTask', () => {
   test('does not change a todo task status to in_progress', async () => {
@@ -71,5 +72,104 @@ describe('startTask', () => {
     const result = await startTask('/test/start-missing', 99);
     expect(result.success).toBe(false);
     expect(result.error).toBe('Task not found');
+  });
+
+  test('passes baseBranch as start point to git worktree add', async () => {
+    const { exec } = await import('node:child_process');
+    // Override exec to make rev-parse --verify fail (branch doesn't exist yet)
+    vi.mocked(exec).mockImplementation(((
+      cmd: string,
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      if (typeof cmd === 'string' && cmd.includes('rev-parse --verify')) {
+        cb(new Error('not found'), { stdout: '', stderr: '' });
+      } else {
+        cb(null, { stdout: 'main\n', stderr: '' });
+      }
+    }) as typeof exec);
+
+    const project = '/test/start-with-base';
+    await createTask(project, 1, 'Child task', { status: 'todo' });
+
+    await startTask(project, 1, undefined, 'feat/parent-branch');
+
+    const execCalls = vi.mocked(exec).mock.calls;
+    const wtAddCall = execCalls.find(([cmd]) => typeof cmd === 'string' && cmd.includes('git worktree add -b'));
+    expect(wtAddCall).toBeDefined();
+    expect(wtAddCall![0]).toContain('feat/parent-branch');
+
+    // Restore default mock
+    vi.mocked(exec).mockImplementation(((
+      _cmd: string,
+      _opts: unknown,
+      cb: (err: null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      cb(null, { stdout: 'main\n', stderr: '' });
+    }) as typeof exec);
+  });
+
+  test('sets mergeTarget to baseBranch when provided', async () => {
+    const project = '/test/start-merge-target';
+    await createTask(project, 1, 'Child task', { status: 'todo' });
+
+    const result = await startTask(project, 1, undefined, 'feat/parent-branch');
+    expect(result.success).toBe(true);
+
+    const task = await getTaskByNumber(project, 1);
+    expect(task!.mergeTarget).toBe('feat/parent-branch');
+  });
+
+  test('falls back to HEAD branch when no baseBranch provided', async () => {
+    const project = '/test/start-no-base';
+    await createTask(project, 1, 'Regular task', { status: 'todo' });
+
+    const result = await startTask(project, 1);
+    expect(result.success).toBe(true);
+
+    const task = await getTaskByNumber(project, 1);
+    expect(task!.mergeTarget).toBe('main');
+  });
+
+  test('beginTask passes parent branch as baseBranch', async () => {
+    const { exec } = await import('node:child_process');
+    vi.mocked(exec).mockImplementation(((
+      cmd: string,
+      _opts: unknown,
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      if (typeof cmd === 'string' && cmd.includes('rev-parse --verify')) {
+        cb(new Error('not found'), { stdout: '', stderr: '' });
+      } else {
+        cb(null, { stdout: 'main\n', stderr: '' });
+      }
+    }) as typeof exec);
+
+    const project = '/test/begin-with-parent';
+    await createTask(project, 1, 'Parent', { branch: 'feat/parent', status: 'in_progress' });
+    await createTask(project, 2, 'Child', { status: 'todo', parentTaskNumber: 1 });
+
+    await beginTask(project, 2);
+
+    const execCalls = vi.mocked(exec).mock.calls;
+    const wtAddCall = execCalls.find(([cmd]) => typeof cmd === 'string' && cmd.includes('git worktree add -b'));
+    expect(wtAddCall).toBeDefined();
+    expect(wtAddCall![0]).toContain('feat/parent');
+
+    vi.mocked(exec).mockImplementation(((
+      _cmd: string,
+      _opts: unknown,
+      cb: (err: null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      cb(null, { stdout: 'main\n', stderr: '' });
+    }) as typeof exec);
+  });
+
+  test('beginTask falls back to HEAD when parent is missing', async () => {
+    const project = '/test/begin-missing-parent';
+    await createTask(project, 5, 'Orphan child', { status: 'todo', parentTaskNumber: 99 });
+
+    const result = await beginTask(project, 5);
+    expect(result.success).toBe(true);
   });
 });

--- a/src/__tests__/taskChain.test.ts
+++ b/src/__tests__/taskChain.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from 'vitest';
+import { buildChainMap, getChainColor, getChainBgColor, getChainHue } from '../utils/taskChain';
+import type { TaskWithWorkspace } from '../types';
+
+function task(num: number, parent?: number): TaskWithWorkspace {
+  return {
+    taskNumber: num,
+    name: `Task ${num}`,
+    status: 'in_progress',
+    createdAt: '2024-01-01',
+    parentTaskNumber: parent,
+  };
+}
+
+describe('buildChainMap', () => {
+  test('standalone tasks have depth 0 and root = self', () => {
+    const map = buildChainMap([task(1), task(2)]);
+
+    expect(map.get(1)).toEqual({ rootTaskNumber: 1, depth: 0, childTaskNumbers: [] });
+    expect(map.get(2)).toEqual({ rootTaskNumber: 2, depth: 0, childTaskNumbers: [] });
+  });
+
+  test('parent-child chain computes correct depth and root', () => {
+    const map = buildChainMap([task(1), task(2, 1), task(3, 2)]);
+
+    expect(map.get(1)!.rootTaskNumber).toBe(1);
+    expect(map.get(1)!.depth).toBe(0);
+    expect(map.get(1)!.childTaskNumbers).toEqual([2]);
+
+    expect(map.get(2)!.rootTaskNumber).toBe(1);
+    expect(map.get(2)!.depth).toBe(1);
+    expect(map.get(2)!.childTaskNumbers).toEqual([3]);
+
+    expect(map.get(3)!.rootTaskNumber).toBe(1);
+    expect(map.get(3)!.depth).toBe(2);
+    expect(map.get(3)!.childTaskNumbers).toEqual([]);
+  });
+
+  test('multiple children of same parent', () => {
+    const map = buildChainMap([task(1), task(2, 1), task(3, 1)]);
+
+    expect(map.get(1)!.childTaskNumbers).toEqual([2, 3]);
+    expect(map.get(2)!.depth).toBe(1);
+    expect(map.get(3)!.depth).toBe(1);
+    expect(map.get(2)!.rootTaskNumber).toBe(1);
+    expect(map.get(3)!.rootTaskNumber).toBe(1);
+  });
+
+  test('orphaned parentTaskNumber (parent not in list) treated as root', () => {
+    const map = buildChainMap([task(5, 99)]);
+
+    expect(map.get(5)!.rootTaskNumber).toBe(5);
+    expect(map.get(5)!.depth).toBe(0);
+  });
+
+  test('empty task list returns empty map', () => {
+    const map = buildChainMap([]);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe('getChainColor / getChainBgColor', () => {
+  test('returns valid HSL string', () => {
+    expect(getChainColor(1, 0)).toMatch(/^hsl\(\d+(\.\d+)?, 55%, \d+%\)$/);
+    expect(getChainBgColor(1, 0)).toMatch(/^hsla\(\d+(\.\d+)?, 55%, \d+%, 0\.15\)$/);
+  });
+
+  test('deeper depth produces lower lightness', () => {
+    const light0 = parseInt(getChainColor(1, 0).match(/(\d+)%\)/)![1]);
+    const light1 = parseInt(getChainColor(1, 1).match(/(\d+)%\)/)![1]);
+    const light2 = parseInt(getChainColor(1, 2).match(/(\d+)%\)/)![1]);
+
+    expect(light0).toBeGreaterThan(light1);
+    expect(light1).toBeGreaterThan(light2);
+  });
+
+  test('lightness has a floor of 30%', () => {
+    const lightDeep = parseInt(getChainColor(1, 100).match(/(\d+)%\)/)![1]);
+    expect(lightDeep).toBe(30);
+  });
+
+  test('different root task numbers produce different hues', () => {
+    expect(getChainHue(1)).not.toBe(getChainHue(2));
+  });
+});

--- a/src/__tests__/taskChain.test.ts
+++ b/src/__tests__/taskChain.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { buildChainMap, getChainColor, getChainBgColor, getChainHue } from '../utils/taskChain';
+import { buildChainMap, getChainColor, getChainBgColor, getChainHue, isDescendantOf } from '../utils/taskChain';
 import type { TaskWithWorkspace } from '../types';
 
 function task(num: number, parent?: number): TaskWithWorkspace {
@@ -81,5 +81,32 @@ describe('getChainColor / getChainBgColor', () => {
 
   test('different root task numbers produce different hues', () => {
     expect(getChainHue(1)).not.toBe(getChainHue(2));
+  });
+});
+
+describe('isDescendantOf', () => {
+  test('direct child is a descendant', () => {
+    const map = buildChainMap([task(1), task(2, 1)]);
+    expect(isDescendantOf(2, 1, map)).toBe(true);
+  });
+
+  test('grandchild is a descendant', () => {
+    const map = buildChainMap([task(1), task(2, 1), task(3, 2)]);
+    expect(isDescendantOf(3, 1, map)).toBe(true);
+  });
+
+  test('parent is not a descendant of child', () => {
+    const map = buildChainMap([task(1), task(2, 1)]);
+    expect(isDescendantOf(1, 2, map)).toBe(false);
+  });
+
+  test('unrelated tasks are not descendants', () => {
+    const map = buildChainMap([task(1), task(2)]);
+    expect(isDescendantOf(2, 1, map)).toBe(false);
+  });
+
+  test('task is not its own descendant', () => {
+    const map = buildChainMap([task(1)]);
+    expect(isDescendantOf(1, 1, map)).toBe(false);
   });
 });

--- a/src/__tests__/taskMetadata.test.ts
+++ b/src/__tests__/taskMetadata.test.ts
@@ -10,6 +10,8 @@ import {
   setTaskSandboxed,
   setTaskName,
   setTaskDescription,
+  setTaskParent,
+  clearParentReferences,
   deleteTaskByNumber,
   reorderTask,
 } from '../db';
@@ -385,5 +387,95 @@ describe('taskMetadata', () => {
     const tasks = await getProjectTasks(project);
     const child = tasks.find((t) => t.taskNumber === 2);
     expect(child!.parentTaskNumber).toBe(1);
+  });
+
+  test('setTaskParent links tasks and updates mergeTarget', async () => {
+    const project = '/test/set-parent';
+    await createTask(project, 1, 'Parent', { branch: 'feat/parent', status: 'in_progress' });
+    await createTask(project, 2, 'Child', { status: 'todo' });
+
+    const result = await setTaskParent(project, 2, 1, 'feat/parent');
+    expect(result.success).toBe(true);
+
+    const child = await getTaskByNumber(project, 2);
+    expect(child!.parentTaskNumber).toBe(1);
+    expect(child!.mergeTarget).toBe('feat/parent');
+  });
+
+  test('setTaskParent rejects self-reference', async () => {
+    const project = '/test/self-parent';
+    await createTask(project, 1, 'Task', { status: 'todo' });
+
+    const result = await setTaskParent(project, 1, 1);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Task cannot be its own parent');
+  });
+
+  test('setTaskParent rejects cycle (A→B→C, set C as parent of A)', async () => {
+    const project = '/test/cycle';
+    await createTask(project, 1, 'A', { status: 'todo' });
+    await createTask(project, 2, 'B', { status: 'todo', parentTaskNumber: 1 });
+    await createTask(project, 3, 'C', { status: 'todo', parentTaskNumber: 2 });
+
+    const result = await setTaskParent(project, 1, 3);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Cannot create a cycle');
+  });
+
+  test('setTaskParent rejects direct cycle (A→B, set B as parent of A)', async () => {
+    const project = '/test/direct-cycle';
+    await createTask(project, 1, 'A', { status: 'todo' });
+    await createTask(project, 2, 'B', { status: 'todo', parentTaskNumber: 1 });
+
+    const result = await setTaskParent(project, 1, 2);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Cannot create a cycle');
+  });
+
+  test('setTaskParent with null detaches child and clears mergeTarget', async () => {
+    const project = '/test/detach';
+    await createTask(project, 1, 'Parent', { branch: 'feat/parent', status: 'in_progress' });
+    await createTask(project, 2, 'Child', { status: 'todo', parentTaskNumber: 1, mergeTarget: 'feat/parent' });
+
+    const result = await setTaskParent(project, 2, null, 'main');
+    expect(result.success).toBe(true);
+
+    const child = await getTaskByNumber(project, 2);
+    expect(child!.parentTaskNumber).toBeUndefined();
+    expect(child!.mergeTarget).toBe('main');
+  });
+
+  test('clearParentReferences orphans all children of deleted parent', async () => {
+    const project = '/test/cascade';
+    await createTask(project, 1, 'Parent', { branch: 'feat/parent', status: 'in_progress' });
+    await createTask(project, 2, 'Child A', { status: 'todo', parentTaskNumber: 1, mergeTarget: 'feat/parent' });
+    await createTask(project, 3, 'Child B', { status: 'todo', parentTaskNumber: 1, mergeTarget: 'feat/parent' });
+
+    await clearParentReferences(project, 1);
+
+    const childA = await getTaskByNumber(project, 2);
+    const childB = await getTaskByNumber(project, 3);
+    expect(childA!.parentTaskNumber).toBeUndefined();
+    expect(childA!.mergeTarget).toBeUndefined();
+    expect(childB!.parentTaskNumber).toBeUndefined();
+    expect(childB!.mergeTarget).toBeUndefined();
+  });
+
+  test('clearParentReferences does not affect grandchildren', async () => {
+    const project = '/test/cascade-depth';
+    await createTask(project, 1, 'Grandparent', { branch: 'feat/gp', status: 'in_progress' });
+    await createTask(project, 2, 'Parent', { status: 'todo', parentTaskNumber: 1, mergeTarget: 'feat/gp' });
+    await createTask(project, 3, 'Child', { status: 'todo', parentTaskNumber: 2, mergeTarget: 'feat/parent' });
+
+    await clearParentReferences(project, 1);
+
+    // Direct child is orphaned
+    const parent = await getTaskByNumber(project, 2);
+    expect(parent!.parentTaskNumber).toBeUndefined();
+
+    // Grandchild still points to task 2
+    const child = await getTaskByNumber(project, 3);
+    expect(child!.parentTaskNumber).toBe(2);
+    expect(child!.mergeTarget).toBe('feat/parent');
   });
 });

--- a/src/__tests__/taskMetadata.test.ts
+++ b/src/__tests__/taskMetadata.test.ts
@@ -353,4 +353,37 @@ describe('taskMetadata', () => {
     const after = await getTaskByNumber(project, 1);
     expect(after!.order).toBe(orderBefore);
   });
+
+  test('createTask with parentTaskNumber persists the relationship', async () => {
+    const project = '/test/parent-task';
+    await createTask(project, 1, 'Parent', { status: 'in_progress', branch: 'feat/parent' });
+    const child = await createTask(project, 2, 'Child', {
+      status: 'todo',
+      parentTaskNumber: 1,
+      mergeTarget: 'feat/parent',
+    });
+
+    expect(child.parentTaskNumber).toBe(1);
+    expect(child.mergeTarget).toBe('feat/parent');
+
+    const fetched = await getTaskByNumber(project, 2);
+    expect(fetched!.parentTaskNumber).toBe(1);
+  });
+
+  test('createTask without parentTaskNumber leaves it undefined', async () => {
+    const project = '/test/no-parent';
+    const task = await createTask(project, 1, 'Standalone', { status: 'todo' });
+
+    expect(task.parentTaskNumber).toBeUndefined();
+  });
+
+  test('parentTaskNumber is visible via getProjectTasks', async () => {
+    const project = '/test/parent-in-list';
+    await createTask(project, 1, 'Parent', { branch: 'feat/p' });
+    await createTask(project, 2, 'Child', { status: 'todo', parentTaskNumber: 1 });
+
+    const tasks = await getProjectTasks(project);
+    const child = tasks.find((t) => t.taskNumber === 2);
+    expect(child!.parentTaskNumber).toBe(1);
+  });
 });

--- a/src/components/dialogs/BranchFromTaskDialog.tsx
+++ b/src/components/dialogs/BranchFromTaskDialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { TaskWithWorkspace } from '../../types';
+import { useProjectStore } from '../../stores/projectStore';
 import { DialogOverlay } from './DialogOverlay';
 
 interface BranchFromTaskDialogProps {
@@ -13,6 +14,7 @@ export function BranchFromTaskDialog({ projectPath, parentTask, onClose }: Branc
   const [name, setName] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
     requestAnimationFrame(() => setVisible(true));
@@ -22,10 +24,13 @@ export function BranchFromTaskDialog({ projectPath, parentTask, onClose }: Branc
     if (visible) inputRef.current?.focus();
   }, [visible]);
 
+  // Clear dismiss timeout on unmount
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
   const dismiss = useCallback(
     (created: boolean) => {
       setVisible(false);
-      setTimeout(() => onClose(created), 200);
+      timerRef.current = setTimeout(() => onClose(created), 200);
     },
     [onClose],
   );
@@ -37,6 +42,8 @@ export function BranchFromTaskDialog({ projectPath, parentTask, onClose }: Branc
     setSubmitting(false);
     if (result.success) {
       dismiss(true);
+    } else {
+      useProjectStore.getState().addToast(result.error || 'Failed to create task', 'error');
     }
   }, [projectPath, parentTask.taskNumber, name, submitting, dismiss]);
 

--- a/src/components/dialogs/BranchFromTaskDialog.tsx
+++ b/src/components/dialogs/BranchFromTaskDialog.tsx
@@ -30,6 +30,7 @@ export function BranchFromTaskDialog({ projectPath, parentTask, onClose }: Branc
   const dismiss = useCallback(
     (created: boolean) => {
       setVisible(false);
+      clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => onClose(created), 200);
     },
     [onClose],

--- a/src/components/dialogs/BranchFromTaskDialog.tsx
+++ b/src/components/dialogs/BranchFromTaskDialog.tsx
@@ -1,0 +1,78 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { TaskWithWorkspace } from '../../types';
+import { DialogOverlay } from './DialogOverlay';
+
+interface BranchFromTaskDialogProps {
+  projectPath: string;
+  parentTask: TaskWithWorkspace;
+  onClose: (created: boolean) => void;
+}
+
+export function BranchFromTaskDialog({ projectPath, parentTask, onClose }: BranchFromTaskDialogProps) {
+  const [visible, setVisible] = useState(false);
+  const [name, setName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    requestAnimationFrame(() => setVisible(true));
+  }, []);
+
+  useEffect(() => {
+    if (visible) inputRef.current?.focus();
+  }, [visible]);
+
+  const dismiss = useCallback(
+    (created: boolean) => {
+      setVisible(false);
+      setTimeout(() => onClose(created), 200);
+    },
+    [onClose],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    const result = await window.api.task.createFromTask(projectPath, parentTask.taskNumber, name || undefined);
+    setSubmitting(false);
+    if (result.success) {
+      dismiss(true);
+    }
+  }, [projectPath, parentTask.taskNumber, name, submitting, dismiss]);
+
+  return (
+    <DialogOverlay visible={visible} onDismiss={() => dismiss(false)} maxWidth={420}>
+      <h2 className="text-lg font-semibold text-text-primary mb-1 text-center">Branch from #{parentTask.taskNumber}</h2>
+      <p className="text-xs text-text-secondary/70 text-center mb-4">
+        New task will branch from <code className="font-mono">{parentTask.branch}</code>
+      </p>
+      <input
+        ref={inputRef}
+        type="text"
+        className="w-full px-3 py-2 rounded-lg bg-black/20 border border-border text-sm text-text-primary font-mono outline-none focus:border-accent"
+        placeholder="Task name..."
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') handleSubmit();
+          if (e.key === 'Escape') dismiss(false);
+        }}
+      />
+      <div className="flex gap-2 justify-end mt-4">
+        <button
+          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-accent bg-accent-light hover:bg-[rgba(0,122,255,0.15)]"
+          onClick={() => dismiss(false)}
+        >
+          Cancel
+        </button>
+        <button
+          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
+          onClick={handleSubmit}
+          disabled={submitting}
+        >
+          Create
+        </button>
+      </div>
+    </DialogOverlay>
+  );
+}

--- a/src/components/diff/DiffPanel.tsx
+++ b/src/components/diff/DiffPanel.tsx
@@ -78,7 +78,12 @@ export function DiffPanel({ ptyId, projectPath, onClose }: DiffPanelProps) {
             try {
               let diff: FileDiff | null;
               if (effectiveMode === 'worktree' && instance?.worktreeBranch) {
-                diff = await window.api.worktree.getFileDiff(projectPath, instance.worktreeBranch, file.path);
+                diff = await window.api.worktree.getFileDiff(
+                  projectPath,
+                  instance.worktreeBranch,
+                  file.path,
+                  instance.mergeTarget,
+                );
               } else {
                 diff = await window.api.getFileDiff(gitPath, file.path);
               }

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -25,7 +25,7 @@ import { CombinedHookConfigDialog } from '../dialogs/CombinedHookConfigDialog';
 import { MissingWorktreeDialog } from '../dialogs/MissingWorktreeDialog';
 import { RunHookDialog, type RunHookResult } from '../dialogs/RunHookDialog';
 import { Icon } from '../terminal/Icon';
-import { buildChainMap } from '../../utils/taskChain';
+import { buildChainMap, isDescendantOf } from '../../utils/taskChain';
 import log from 'electron-log/renderer';
 
 const kanbanLog = log.scope('kanban');
@@ -64,6 +64,8 @@ interface KanbanBoardProps {
 export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
   const storeTasks = useProjectStore((s) => s.tasks);
   const [activeTask, setActiveTask] = useState<TaskWithWorkspace | null>(null);
+  const [activeBadgeDrag, setActiveBadgeDrag] = useState<{ taskNumber: number } | null>(null);
+  const [badgeDragOverTask, setBadgeDragOverTask] = useState<number | null>(null);
   const [configuredHooks, setConfiguredHooks] = useState<Record<string, boolean>>({});
   const [runHookDialog, setRunHookDialog] = useState<{
     hookType: HookType;
@@ -177,6 +179,25 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     return () => document.removeEventListener('keydown', handler, true);
   }, [onHide, hasOpenDialog]);
 
+  // Track Option/Alt key for showing standalone badges
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (useProjectStore.getState().optionKeyHeld !== e.altKey) {
+        useProjectStore.setState({ optionKeyHeld: e.altKey });
+      }
+    };
+    const onBlur = () => useProjectStore.setState({ optionKeyHeld: false });
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('keyup', onKey);
+    window.addEventListener('blur', onBlur);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('keyup', onKey);
+      window.removeEventListener('blur', onBlur);
+      useProjectStore.setState({ optionKeyHeld: false });
+    };
+  }, []);
+
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: { distance: 8 },
@@ -201,7 +222,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
 
   // Track pointer proximity to right edge during drag, and whether pointer is over the trash zone
   useEffect(() => {
-    if (!activeTask) {
+    if (!activeTask || activeBadgeDrag) {
       setShowTrash(false);
       setOverTrash(false);
       return;
@@ -223,18 +244,33 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     };
     window.addEventListener('pointermove', onMove);
     return () => window.removeEventListener('pointermove', onMove);
-  }, [activeTask]);
+  }, [activeTask, activeBadgeDrag]);
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
-    const task = event.active.data.current?.task as TaskWithWorkspace | undefined;
-    setActiveTask(task ?? null);
-    if (task) originalStatusRef.current = task.status;
+    const data = event.active.data.current;
+    if (data?.type === 'badge') {
+      setActiveBadgeDrag({ taskNumber: data.taskNumber as number });
+      setActiveTask(null);
+    } else {
+      const task = data?.task as TaskWithWorkspace | undefined;
+      setActiveTask(task ?? null);
+      setActiveBadgeDrag(null);
+      if (task) originalStatusRef.current = task.status;
+    }
   }, []);
 
   const handleDragOver = useCallback(
     (event: DragOverEvent) => {
       const { active, over } = event;
       if (!over) return;
+
+      // Badge drags don't reorder cards — just track the hovered target
+      if (active.data.current?.type === 'badge') {
+        const overId = over.id as string;
+        const overTaskNum = overId.startsWith('task-') ? parseInt(overId.replace('task-', ''), 10) : null;
+        setBadgeDragOverTask(overTaskNum);
+        return;
+      }
 
       const activeId = active.id as string;
       const overId = over.id as string;
@@ -277,12 +313,39 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
 
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
+      const { active, over } = event;
+
+      // ── Badge drop: link tasks ──────────────────────────────────────
+      if (activeBadgeDrag) {
+        const sourceTaskNum = activeBadgeDrag.taskNumber;
+        setActiveBadgeDrag(null);
+        setBadgeDragOverTask(null);
+        useProjectStore.getState().setHighlightedChainTask(null);
+        useProjectStore.getState().setDetachHoverParent(null);
+
+        const overId = over?.id as string | undefined;
+        if (!overId) return;
+
+        const targetTaskNum = overId.startsWith('task-') ? parseInt(overId.replace('task-', ''), 10) : null;
+        if (!targetTaskNum || targetTaskNum === sourceTaskNum) return;
+        if (isDescendantOf(targetTaskNum, sourceTaskNum, chainMap)) return;
+
+        const targetTask = storeTasks.find((t) => t.taskNumber === targetTaskNum);
+        const result = await window.api.task.setParent(projectPath, sourceTaskNum, targetTaskNum, targetTask?.branch);
+        if (result.success) {
+          useProjectStore.getState().loadTasks(projectPath);
+        } else {
+          useProjectStore.getState().addToast(result.error || 'Failed to link tasks', 'error');
+        }
+        return;
+      }
+
+      // ── Card drop: reorder / trash ──────────────────────────────────
       let draggedTask = activeTask;
       const origStatus = originalStatusRef.current;
       const droppedOnTrash = overTrash;
       originalStatusRef.current = null;
 
-      const { active, over } = event;
       if (!draggedTask) {
         setActiveTask(null);
         return;
@@ -391,7 +454,17 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
         }
       }
     },
-    [activeTask, overTrash, items, findContainer, projectPath, ensureWorktreeExists],
+    [
+      activeTask,
+      activeBadgeDrag,
+      chainMap,
+      storeTasks,
+      overTrash,
+      items,
+      findContainer,
+      projectPath,
+      ensureWorktreeExists,
+    ],
   );
 
   // Task CRUD
@@ -525,6 +598,14 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
+      onDragCancel={() => {
+        setActiveTask(null);
+        setActiveBadgeDrag(null);
+        setBadgeDragOverTask(null);
+        originalStatusRef.current = null;
+        useProjectStore.getState().setHighlightedChainTask(null);
+        useProjectStore.getState().setDetachHoverParent(null);
+      }}
     >
       <div
         className="kanban-board fixed top-[82px] bottom-4 z-[140] flex flex-col opacity-100 rounded-[14px] overflow-hidden border border-white/10"
@@ -582,6 +663,8 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
                 tasks={items[col.status] ?? []}
                 projectPath={projectPath}
                 chainMap={chainMap}
+                activeBadgeDrag={activeBadgeDrag}
+                badgeDragOverTask={badgeDragOverTask}
                 onAddTask={col.status === 'todo' ? handleAddTask : undefined}
                 onRenameTask={handleRenameTask}
                 onUpdateDescription={handleUpdateDescription}
@@ -614,6 +697,19 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
               </span>
             </div>
           </div>
+        )}
+        {activeBadgeDrag && (
+          <span
+            className="inline-flex items-center gap-0.5 font-mono text-[11px] leading-none px-2 py-1 rounded-full whitespace-nowrap"
+            style={{
+              color: 'rgba(255, 255, 255, 0.7)',
+              background: 'rgba(255, 255, 255, 0.12)',
+              boxShadow: '0 4px 12px rgba(0, 0, 0, 0.4)',
+            }}
+          >
+            <span className="opacity-50">#</span>
+            {activeBadgeDrag.taskNumber}
+          </span>
         )}
       </DragOverlay>
     </DndContext>

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState, useRef, forwardRef } from 'react';
+import { useEffect, useCallback, useState, useMemo, useRef, forwardRef } from 'react';
 import {
   DndContext,
   DragOverlay,
@@ -25,6 +25,7 @@ import { CombinedHookConfigDialog } from '../dialogs/CombinedHookConfigDialog';
 import { MissingWorktreeDialog } from '../dialogs/MissingWorktreeDialog';
 import { RunHookDialog, type RunHookResult } from '../dialogs/RunHookDialog';
 import { Icon } from '../terminal/Icon';
+import { buildChainMap } from '../../utils/taskChain';
 import log from 'electron-log/renderer';
 
 const kanbanLog = log.scope('kanban');
@@ -133,6 +134,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
   }, [projectPath]);
 
   // Local task state for drag preview — synced from store, mutated during drag
+  const chainMap = useMemo(() => buildChainMap(storeTasks), [storeTasks]);
   const [items, setItems] = useState<Record<string, TaskWithWorkspace[]>>({});
   const originalStatusRef = useRef<string | null>(null);
 
@@ -579,6 +581,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
                 label={col.label}
                 tasks={items[col.status] ?? []}
                 projectPath={projectPath}
+                chainMap={chainMap}
                 onAddTask={col.status === 'todo' ? handleAddTask : undefined}
                 onRenameTask={handleRenameTask}
                 onUpdateDescription={handleUpdateDescription}

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -83,6 +83,13 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     resolve: (action: 'recover' | null) => void;
   } | null>(null);
   const [settingUpTaskNumber, setSettingUpTaskNumber] = useState<number | null>(null);
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    [],
+  );
 
   /**
    * Check if a task's worktree exists on disk. If missing, prompt the user to recover it.
@@ -186,7 +193,9 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
         useProjectStore.setState({ optionKeyHeld: e.altKey });
       }
     };
-    const onBlur = () => useProjectStore.setState({ optionKeyHeld: false });
+    const onBlur = () => {
+      if (useProjectStore.getState().optionKeyHeld) useProjectStore.setState({ optionKeyHeld: false });
+    };
     window.addEventListener('keydown', onKey);
     window.addEventListener('keyup', onKey);
     window.addEventListener('blur', onBlur);
@@ -358,6 +367,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
         setActiveTask(null);
         const taskNum = parseInt(activeId.replace('task-', ''), 10);
         await window.api.task.trash(projectPath, taskNum);
+        if (!mountedRef.current) return;
         useProjectStore.getState().loadTasks(projectPath);
         useProjectStore.getState().addToast('Task deleted', 'success');
         return;
@@ -406,12 +416,14 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       // Persist status + position optimistically BEFORE async work (worktree creation, etc.)
       // This updates the store so that when we clear activeTask the effect re-syncs to the new position.
       await useProjectStore.getState().moveTask(projectPath, activeTaskNum, finalContainer, targetIndex);
+      if (!mountedRef.current) return;
       setActiveTask(null);
 
       // Create worktree BEFORE moving (while task is still todo)
       if (newStatus === 'in_progress' && !draggedTask.worktreePath) {
         setSettingUpTaskNumber(draggedTask.taskNumber);
         const startResult = await window.api.task.start(projectPath, draggedTask.taskNumber);
+        if (!mountedRef.current) return;
         setSettingUpTaskNumber(null);
         if (!startResult.success) {
           useProjectStore.getState().addToast(startResult.error || 'Failed to create worktree', 'error');
@@ -428,15 +440,18 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       // Verify existing worktree is still on disk; offer recovery if missing
       if (draggedTask.worktreePath) {
         const wtPath = await ensureWorktreeExists(draggedTask);
+        if (!mountedRef.current) return;
         if (!wtPath) return;
         draggedTask = { ...draggedTask, worktreePath: wtPath };
       }
 
       await useProjectStore.getState().loadTasks(projectPath);
+      if (!mountedRef.current) return;
 
       // Show hook dialog if configured for this transition
       if (origStatus && origStatus !== finalContainer) {
         const hooks = await window.api.hooks.get(projectPath);
+        if (!mountedRef.current) return;
         let hookType: HookType | null = null;
         let hook = null;
 

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -64,8 +64,7 @@ interface KanbanBoardProps {
 export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
   const storeTasks = useProjectStore((s) => s.tasks);
   const [activeTask, setActiveTask] = useState<TaskWithWorkspace | null>(null);
-  const [activeBadgeDrag, setActiveBadgeDrag] = useState<{ taskNumber: number } | null>(null);
-  const [badgeDragOverTask, setBadgeDragOverTask] = useState<number | null>(null);
+  const activeBadgeDrag = useProjectStore((s) => s.activeBadgeDrag);
   const [configuredHooks, setConfiguredHooks] = useState<Record<string, boolean>>({});
   const [runHookDialog, setRunHookDialog] = useState<{
     hookType: HookType;
@@ -249,12 +248,12 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
   const handleDragStart = useCallback((event: DragStartEvent) => {
     const data = event.active.data.current;
     if (data?.type === 'badge') {
-      setActiveBadgeDrag({ taskNumber: data.taskNumber as number });
+      useProjectStore.getState().setActiveBadgeDrag(data.taskNumber as number);
       setActiveTask(null);
     } else {
       const task = data?.task as TaskWithWorkspace | undefined;
       setActiveTask(task ?? null);
-      setActiveBadgeDrag(null);
+      useProjectStore.getState().setActiveBadgeDrag(null);
       if (task) originalStatusRef.current = task.status;
     }
   }, []);
@@ -268,7 +267,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       if (active.data.current?.type === 'badge') {
         const overId = over.id as string;
         const overTaskNum = overId.startsWith('task-') ? parseInt(overId.replace('task-', ''), 10) : null;
-        setBadgeDragOverTask(overTaskNum);
+        useProjectStore.getState().setBadgeDragOverTask(overTaskNum);
         return;
       }
 
@@ -316,12 +315,12 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       const { active, over } = event;
 
       // ── Badge drop: link tasks ──────────────────────────────────────
-      if (activeBadgeDrag) {
-        const sourceTaskNum = activeBadgeDrag.taskNumber;
-        setActiveBadgeDrag(null);
-        setBadgeDragOverTask(null);
-        useProjectStore.getState().setHighlightedChainTask(null);
-        useProjectStore.getState().setDetachHoverParent(null);
+      const badgeDrag = useProjectStore.getState().activeBadgeDrag;
+      if (badgeDrag != null) {
+        const sourceTaskNum = badgeDrag;
+        useProjectStore.getState().setActiveBadgeDrag(null);
+        useProjectStore.getState().setBadgeDragOverTask(null);
+        useProjectStore.getState().clearChainHighlights();
 
         const overId = over?.id as string | undefined;
         if (!overId) return;
@@ -454,17 +453,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
         }
       }
     },
-    [
-      activeTask,
-      activeBadgeDrag,
-      chainMap,
-      storeTasks,
-      overTrash,
-      items,
-      findContainer,
-      projectPath,
-      ensureWorktreeExists,
-    ],
+    [activeTask, chainMap, storeTasks, overTrash, items, findContainer, projectPath, ensureWorktreeExists],
   );
 
   // Task CRUD
@@ -600,11 +589,10 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       onDragEnd={handleDragEnd}
       onDragCancel={() => {
         setActiveTask(null);
-        setActiveBadgeDrag(null);
-        setBadgeDragOverTask(null);
+        useProjectStore.getState().setActiveBadgeDrag(null);
+        useProjectStore.getState().setBadgeDragOverTask(null);
+        useProjectStore.getState().clearChainHighlights();
         originalStatusRef.current = null;
-        useProjectStore.getState().setHighlightedChainTask(null);
-        useProjectStore.getState().setDetachHoverParent(null);
       }}
     >
       <div
@@ -663,8 +651,6 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
                 tasks={items[col.status] ?? []}
                 projectPath={projectPath}
                 chainMap={chainMap}
-                activeBadgeDrag={activeBadgeDrag}
-                badgeDragOverTask={badgeDragOverTask}
                 onAddTask={col.status === 'todo' ? handleAddTask : undefined}
                 onRenameTask={handleRenameTask}
                 onUpdateDescription={handleUpdateDescription}
@@ -698,7 +684,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
             </div>
           </div>
         )}
-        {activeBadgeDrag && (
+        {activeBadgeDrag != null && (
           <span
             className="inline-flex items-center gap-0.5 font-mono text-[11px] leading-none px-2 py-1 rounded-full whitespace-nowrap"
             style={{
@@ -708,7 +694,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
             }}
           >
             <span className="opacity-50">#</span>
-            {activeBadgeDrag.taskNumber}
+            {activeBadgeDrag}
           </span>
         )}
       </DragOverlay>

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -248,7 +248,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
   const handleDragStart = useCallback((event: DragStartEvent) => {
     const data = event.active.data.current;
     if (data?.type === 'badge') {
-      useProjectStore.getState().setActiveBadgeDrag(data.taskNumber as number);
+      if (typeof data.taskNumber === 'number') useProjectStore.getState().setActiveBadgeDrag(data.taskNumber);
       setActiveTask(null);
     } else {
       const task = data?.task as TaskWithWorkspace | undefined;
@@ -317,20 +317,17 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       // ── Badge drop: link tasks ──────────────────────────────────────
       const badgeDrag = useProjectStore.getState().activeBadgeDrag;
       if (badgeDrag != null) {
-        const sourceTaskNum = badgeDrag;
-        useProjectStore.getState().setActiveBadgeDrag(null);
-        useProjectStore.getState().setBadgeDragOverTask(null);
-        useProjectStore.getState().clearChainHighlights();
+        useProjectStore.getState().resetBadgeDragState();
 
         const overId = over?.id as string | undefined;
         if (!overId) return;
 
         const targetTaskNum = overId.startsWith('task-') ? parseInt(overId.replace('task-', ''), 10) : null;
-        if (!targetTaskNum || targetTaskNum === sourceTaskNum) return;
-        if (isDescendantOf(targetTaskNum, sourceTaskNum, chainMap)) return;
+        if (!targetTaskNum || targetTaskNum === badgeDrag) return;
+        if (isDescendantOf(targetTaskNum, badgeDrag, chainMap)) return;
 
         const targetTask = storeTasks.find((t) => t.taskNumber === targetTaskNum);
-        const result = await window.api.task.setParent(projectPath, sourceTaskNum, targetTaskNum, targetTask?.branch);
+        const result = await window.api.task.setParent(projectPath, badgeDrag, targetTaskNum, targetTask?.branch);
         if (result.success) {
           useProjectStore.getState().loadTasks(projectPath);
         } else {
@@ -589,9 +586,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       onDragEnd={handleDragEnd}
       onDragCancel={() => {
         setActiveTask(null);
-        useProjectStore.getState().setActiveBadgeDrag(null);
-        useProjectStore.getState().setBadgeDragOverTask(null);
-        useProjectStore.getState().clearChainHighlights();
+        useProjectStore.getState().resetBadgeDragState();
         originalStatusRef.current = null;
       }}
     >

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -129,7 +129,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     window.api.hooks.get(projectPath).then((hooks) => {
       const configured: Record<string, boolean> = {};
       for (const key of Object.keys(hooks)) {
-        if ((hooks as any)[key]) configured[key] = true;
+        if (hooks[key as HookType]) configured[key] = true;
       }
       setConfiguredHooks(configured);
     });
@@ -218,6 +218,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
 
   const [showTrash, setShowTrash] = useState(false);
   const [overTrash, setOverTrash] = useState(false);
+  const overTrashRef = useRef(false);
   const trashRef = useRef<HTMLDivElement>(null);
 
   // Track pointer proximity to right edge during drag, and whether pointer is over the trash zone
@@ -235,10 +236,12 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       const el = trashRef.current;
       if (el) {
         const rect = el.getBoundingClientRect();
-        setOverTrash(
-          e.clientX >= rect.left && e.clientX <= rect.right && e.clientY >= rect.top && e.clientY <= rect.bottom,
-        );
+        const isOver =
+          e.clientX >= rect.left && e.clientX <= rect.right && e.clientY >= rect.top && e.clientY <= rect.bottom;
+        overTrashRef.current = isOver;
+        setOverTrash(isOver);
       } else {
+        overTrashRef.current = false;
         setOverTrash(false);
       }
     };
@@ -340,7 +343,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       // ── Card drop: reorder / trash ──────────────────────────────────
       let draggedTask = activeTask;
       const origStatus = originalStatusRef.current;
-      const droppedOnTrash = overTrash;
+      const droppedOnTrash = overTrashRef.current;
       originalStatusRef.current = null;
 
       if (!draggedTask) {
@@ -439,13 +442,13 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
 
         if (newStatus === 'in_progress') {
           hookType = origStatus === 'todo' ? 'start' : 'continue';
-          hook = (hooks as any)[hookType] || null;
+          hook = hooks[hookType] ?? null;
         } else if (newStatus === 'in_review') {
           hookType = 'review';
-          hook = (hooks as any).review || null;
+          hook = hooks.review ?? null;
         } else if (newStatus === 'done') {
           hookType = 'cleanup';
-          hook = (hooks as any).cleanup || null;
+          hook = hooks.cleanup ?? null;
         }
 
         if (hook && hookType) {
@@ -453,7 +456,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
         }
       }
     },
-    [activeTask, chainMap, storeTasks, overTrash, items, findContainer, projectPath, ensureWorktreeExists],
+    [activeTask, chainMap, storeTasks, items, findContainer, projectPath, ensureWorktreeExists],
   );
 
   // Task CRUD
@@ -556,12 +559,12 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       if (hookTypes.length === 2 && hookTypes.includes('start') && hookTypes.includes('continue')) {
         setHookDialog({
           mode: 'combined',
-          start: (hooks as any).start || undefined,
-          continue: (hooks as any).continue || undefined,
+          start: hooks.start ?? undefined,
+          continue: hooks.continue ?? undefined,
         });
       } else {
         const hookType = hookTypes[0];
-        const existing = (hooks as any)[hookType] || undefined;
+        const existing = hooks[hookType] ?? undefined;
         setHookDialog({ mode: 'single', hookType, existingHook: existing });
       }
     },
@@ -574,7 +577,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     window.api.hooks.get(projectPath).then((hooks) => {
       const configured: Record<string, boolean> = {};
       for (const key of Object.keys(hooks)) {
-        if ((hooks as any)[key]) configured[key] = true;
+        if (hooks[key as HookType]) configured[key] = true;
       }
       setConfiguredHooks(configured);
     });

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -10,7 +10,7 @@ import { HookConfigDialog } from '../dialogs/HookConfigDialog';
 import { BranchFromTaskDialog } from '../dialogs/BranchFromTaskDialog';
 import { Tooltip } from '../ui/Tooltip';
 import type { TaskChainInfo } from '../../utils/taskChain';
-import { getChainColor, getChainBgColor, isDescendantOf } from '../../utils/taskChain';
+import { getChainColor, getChainBgColor, isChainMember, isDescendantOf } from '../../utils/taskChain';
 
 interface KanbanCardProps {
   task: TaskWithWorkspace;
@@ -46,7 +46,7 @@ export const KanbanCard = memo(function KanbanCard({
   const descInputRef = useRef<HTMLSpanElement>(null);
 
   const isDone = task.status === 'done';
-  const isInChain = chainInfo != null && (chainInfo.depth > 0 || chainInfo.childTaskNumbers.length > 0);
+  const isInChain = isChainMember(chainInfo);
 
   // Badge drag visual feedback — derive per-card booleans in selectors to avoid O(N) re-renders
   const activeBadgeDragSource = useProjectStore((s) => s.activeBadgeDrag);
@@ -503,7 +503,7 @@ function DraggableBadge({
   chainInfo?: TaskChainInfo;
   chainMap?: Map<number, TaskChainInfo>;
 }) {
-  const isInChain = chainInfo != null && (chainInfo.depth > 0 || chainInfo.childTaskNumbers.length > 0);
+  const isInChain = isChainMember(chainInfo);
 
   const highlightedChainTask = useProjectStore((s) => s.highlightedChainTask);
   const hoveredChainRoot = highlightedChainTask != null ? chainMap?.get(highlightedChainTask)?.rootTaskNumber : null;

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -1,4 +1,5 @@
-import { memo, useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { memo, useState, useCallback, useRef, useEffect, useMemo, type ReactNode } from 'react';
+import { useDraggable } from '@dnd-kit/core';
 import type { TaskWithWorkspace } from '../../types';
 import { useTerminalStore, type TerminalDisplayState } from '../../stores/terminalStore';
 import { useProjectStore } from '../../stores/projectStore';
@@ -9,13 +10,15 @@ import { HookConfigDialog } from '../dialogs/HookConfigDialog';
 import { BranchFromTaskDialog } from '../dialogs/BranchFromTaskDialog';
 import { Tooltip } from '../ui/Tooltip';
 import type { TaskChainInfo } from '../../utils/taskChain';
-import { getChainColor, getChainBgColor } from '../../utils/taskChain';
+import { getChainColor, getChainBgColor, isDescendantOf } from '../../utils/taskChain';
 
 interface KanbanCardProps {
   task: TaskWithWorkspace;
   projectPath: string;
   chainInfo?: TaskChainInfo;
   chainMap?: Map<number, TaskChainInfo>;
+  activeBadgeDrag?: { taskNumber: number } | null;
+  badgeDragOverTask?: number | null;
   onRename: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
@@ -27,6 +30,8 @@ export const KanbanCard = memo(function KanbanCard({
   projectPath,
   chainInfo,
   chainMap,
+  activeBadgeDrag,
+  badgeDragOverTask,
   onRename,
   onUpdateDescription,
   onOpenTerminal,
@@ -53,6 +58,26 @@ export const KanbanCard = memo(function KanbanCard({
     hoveredChainRoot != null &&
     hoveredChainRoot === chainInfo!.rootTaskNumber &&
     highlightedChainTask !== task.taskNumber;
+
+  const badgeColor = isInChain
+    ? getChainColor(chainInfo!.rootTaskNumber, chainInfo!.depth)
+    : 'rgba(255, 255, 255, 0.2)';
+  const badgeBg = isInChain
+    ? getChainBgColor(chainInfo!.rootTaskNumber, chainInfo!.depth)
+    : 'rgba(255, 255, 255, 0.04)';
+
+  // Badge drag visual feedback
+  const isBadgeDragActive = activeBadgeDrag != null;
+  const isValidBadgeTarget =
+    isBadgeDragActive &&
+    activeBadgeDrag.taskNumber !== task.taskNumber &&
+    chainMap != null &&
+    !isDescendantOf(task.taskNumber, activeBadgeDrag.taskNumber, chainMap);
+  const isHoveredBadgeTarget = isValidBadgeTarget && badgeDragOverTask === task.taskNumber;
+  const isInvalidBadgeTarget = isBadgeDragActive && !isValidBadgeTarget;
+
+  const optionKeyHeld = useProjectStore((s) => s.optionKeyHeld);
+  const showBadge = isInChain || optionKeyHeld || isBadgeDragActive;
 
   // Find connected terminals for this task (reactive — re-renders when display states change)
   const displayStates = useTerminalStore((s) => s.displayStates);
@@ -285,9 +310,20 @@ export const KanbanCard = memo(function KanbanCard({
     <div
       className="kanban-card group px-3 py-3.5 ease-out [-webkit-app-region:no-drag] hover:bg-black/10 active:bg-black/[0.12]"
       style={{
-        background: expanded ? 'rgba(0, 0, 0, 0.15)' : 'var(--color-terminal-bg)',
-        transition: 'background 150ms ease-out, opacity 150ms ease-out',
+        background: isHoveredBadgeTarget
+          ? 'rgba(10, 132, 255, 0.08)'
+          : expanded
+            ? 'rgba(0, 0, 0, 0.15)'
+            : 'var(--color-terminal-bg)',
+        transition: 'background 150ms ease-out, opacity 150ms ease-out, outline-color 150ms ease-out',
         borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
+        outline: isHoveredBadgeTarget
+          ? '1px solid rgba(10, 132, 255, 0.6)'
+          : isValidBadgeTarget
+            ? '1px dashed rgba(10, 132, 255, 0.3)'
+            : 'none',
+        outlineOffset: -1,
+        ...(isInvalidBadgeTarget && { opacity: 0.4 }),
       }}
       data-task-number={task.taskNumber}
       onContextMenu={(e) => {
@@ -343,45 +379,16 @@ export const KanbanCard = memo(function KanbanCard({
             {task.name}
           </span>
         )}
-        {isInChain && (
-          <Tooltip
-            text={
-              <div className="flex flex-col gap-0.5">
-                {task.parentTaskNumber != null && (
-                  <span>
-                    Branches from <span className="opacity-50">#</span>
-                    {task.parentTaskNumber}
-                  </span>
-                )}
-                {chainInfo!.childTaskNumbers.length > 0 && (
-                  <span>
-                    Parent of{' '}
-                    {chainInfo!.childTaskNumbers.map((n, i) => (
-                      <span key={n}>
-                        {i > 0 && ', '}
-                        <span className="opacity-50">#</span>
-                        {n}
-                      </span>
-                    ))}
-                  </span>
-                )}
-              </div>
-            }
-            placement="top"
-            referenceClassName="inline-flex items-center gap-0.5 shrink-0 font-mono text-[11px] leading-none px-2 py-1 rounded-full whitespace-nowrap"
-            referenceStyle={{
-              color: getChainColor(chainInfo!.rootTaskNumber, chainInfo!.depth),
-              background: getChainBgColor(chainInfo!.rootTaskNumber, chainInfo!.depth),
-              ...(shouldJitter && { animation: 'chain-badge-jitter 0.4s ease-out forwards' }),
-            }}
-            onHoverChange={(hovering) =>
-              useProjectStore.getState().setHighlightedChainTask(hovering ? task.taskNumber : null)
-            }
-          >
-            {chainInfo!.depth > 0 && <Icon name="git-merge" className="w-3 h-3" />}
-            <span className="opacity-50">#</span>
-            {task.taskNumber}
-          </Tooltip>
+        {showBadge && (
+          <DraggableBadge
+            task={task}
+            projectPath={projectPath}
+            isInChain={isInChain}
+            chainInfo={chainInfo}
+            badgeColor={badgeColor}
+            badgeBg={badgeBg}
+            shouldJitter={shouldJitter}
+          />
         )}
         <button
           className={`flex items-center justify-center w-5 h-5 p-0 bg-transparent border-none rounded text-text-secondary opacity-0 transition-all duration-150 ease-out shrink-0 [-webkit-app-region:no-drag] group-hover:opacity-60 hover:!opacity-100 [&>svg]:w-3 [&>svg]:h-3 [&>svg]:transition-transform [&>svg]:duration-150 [&>svg]:ease-out${expanded ? ' [&>svg]:rotate-180' : ''}`}
@@ -508,3 +515,114 @@ export const KanbanCard = memo(function KanbanCard({
     </div>
   );
 });
+
+// ── Draggable badge with × unlink ───────────────────────────────────
+
+function DraggableBadge({
+  task,
+  projectPath,
+  isInChain,
+  chainInfo,
+  badgeColor,
+  badgeBg,
+  shouldJitter,
+}: {
+  task: TaskWithWorkspace;
+  projectPath: string;
+  isInChain: boolean;
+  chainInfo?: TaskChainInfo;
+  badgeColor: string;
+  badgeBg: string;
+  shouldJitter: boolean;
+}) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `badge-${task.taskNumber}`,
+    data: { type: 'badge', taskNumber: task.taskNumber },
+  });
+
+  const [detachHovered, setDetachHovered] = useState(false);
+  const detachHoverParent = useProjectStore((s) => s.detachHoverParent);
+  const isDimmedByDetach = detachHoverParent === task.taskNumber;
+
+  const tooltipContent: ReactNode = isInChain ? (
+    <div className="flex flex-col gap-0.5">
+      {task.parentTaskNumber != null && (
+        <span>
+          Branches from <span className="opacity-50">#</span>
+          {task.parentTaskNumber}
+        </span>
+      )}
+      {chainInfo!.childTaskNumbers.length > 0 && (
+        <span>
+          Parent of{' '}
+          {chainInfo!.childTaskNumbers.map((n, i) => (
+            <span key={n}>
+              {i > 0 && ', '}
+              <span className="opacity-50">#</span>
+              {n}
+            </span>
+          ))}
+        </span>
+      )}
+    </div>
+  ) : (
+    <span>
+      Task <span className="opacity-50">#</span>
+      {task.taskNumber}
+    </span>
+  );
+
+  return (
+    <Tooltip
+      text={tooltipContent}
+      placement="top"
+      disabled={isDragging || detachHovered}
+      referenceClassName="group/badge inline-flex items-center gap-0.5 shrink-0 font-mono text-[11px] leading-none px-2 py-1 rounded-full whitespace-nowrap"
+      referenceStyle={{
+        color: badgeColor,
+        background: badgeBg,
+        ...(shouldJitter && { animation: 'chain-badge-jitter 0.4s ease-out forwards' }),
+        ...(isDragging && { opacity: 0.3 }),
+        ...(isDimmedByDetach && { opacity: 0.4 }),
+      }}
+      onHoverChange={
+        isInChain
+          ? (hovering) => useProjectStore.getState().setHighlightedChainTask(hovering ? task.taskNumber : null)
+          : undefined
+      }
+    >
+      <span ref={setNodeRef} {...listeners} {...attributes} className="inline-flex items-center gap-0.5">
+        {chainInfo && chainInfo.depth > 0 && <Icon name="git-merge" className="w-3 h-3" />}
+        <span className="opacity-50">#</span>
+        {task.taskNumber}
+      </span>
+      {task.parentTaskNumber != null && (
+        <Tooltip text={`Detach from #${task.parentTaskNumber}`} placement="top" delay={300}>
+          <button
+            className="w-0 overflow-hidden group-hover/badge:w-4 flex items-center justify-center border-none bg-transparent text-white/30 hover:text-red-400 transition-all duration-150 [-webkit-app-region:no-drag] [&>svg]:w-2.5 [&>svg]:h-2.5 shrink-0 p-0"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={async (e) => {
+              e.stopPropagation();
+              setDetachHovered(false);
+              useProjectStore.getState().setDetachHoverParent(null);
+              useProjectStore.getState().setHighlightedChainTask(null);
+              const mainBranch = await window.api.worktree.getMainBranch(projectPath);
+              await window.api.task.setParent(projectPath, task.taskNumber, null, mainBranch);
+              useProjectStore.getState().loadTasks(projectPath);
+            }}
+            onMouseEnter={() => {
+              setDetachHovered(true);
+              useProjectStore.getState().setDetachHoverParent(task.parentTaskNumber!);
+            }}
+            onMouseLeave={() => {
+              setDetachHovered(false);
+              useProjectStore.getState().setDetachHoverParent(null);
+            }}
+          >
+            <Icon name="x" />
+          </button>
+        </Tooltip>
+      )}
+    </Tooltip>
+  );
+}

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -62,17 +62,16 @@ export const KanbanCard = memo(function KanbanCard({
     ? getChainBgColor(chainInfo!.rootTaskNumber, chainInfo!.depth)
     : 'rgba(255, 255, 255, 0.04)';
 
-  // Badge drag visual feedback (read from store, not props)
-  const activeBadgeDrag = useProjectStore((s) => s.activeBadgeDrag);
-  const badgeDragOverTask = useProjectStore((s) => s.badgeDragOverTask);
+  // Badge drag visual feedback — derive per-card booleans in selectors to avoid O(N) re-renders
+  const activeBadgeDragSource = useProjectStore((s) => s.activeBadgeDrag);
+  const isHoveredByBadgeDrag = useProjectStore((s) => s.badgeDragOverTask === task.taskNumber);
   const optionKeyHeld = useProjectStore((s) => s.optionKeyHeld);
-  const isBadgeDragActive = activeBadgeDrag != null;
-  const isValidBadgeTarget =
-    isBadgeDragActive &&
-    activeBadgeDrag !== task.taskNumber &&
-    chainMap != null &&
-    !isDescendantOf(task.taskNumber, activeBadgeDrag, chainMap);
-  const isHoveredBadgeTarget = isValidBadgeTarget && badgeDragOverTask === task.taskNumber;
+  const isBadgeDragActive = activeBadgeDragSource != null;
+  const isValidBadgeTarget = useMemo(() => {
+    if (activeBadgeDragSource == null || activeBadgeDragSource === task.taskNumber || !chainMap) return false;
+    return !isDescendantOf(task.taskNumber, activeBadgeDragSource, chainMap);
+  }, [activeBadgeDragSource, task.taskNumber, chainMap]);
+  const isHoveredBadgeTarget = isValidBadgeTarget && isHoveredByBadgeDrag;
   const isInvalidBadgeTarget = isBadgeDragActive && !isValidBadgeTarget;
   const showBadge = isInChain || optionKeyHeld || isBadgeDragActive;
 

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -1,5 +1,6 @@
 import { memo, useState, useCallback, useRef, useEffect, useMemo, type ReactNode } from 'react';
 import { useDraggable } from '@dnd-kit/core';
+import { useShallow } from 'zustand/react/shallow';
 import type { TaskWithWorkspace } from '../../types';
 import { useTerminalStore, type TerminalDisplayState } from '../../stores/terminalStore';
 import { useProjectStore } from '../../stores/projectStore';
@@ -63,20 +64,18 @@ export const KanbanCard = memo(function KanbanCard({
   const isInvalidBadgeTarget = isBadgeDragActive && !isValidBadgeTarget;
   const showBadge = isInChain || optionKeyHeld || isBadgeDragActive;
 
-  // Find connected terminals for this task (reactive — re-renders when display states change)
-  const displayStates = useTerminalStore((s) => s.displayStates);
-  const terminalPtyIds = useTerminalStore((s) => s.terminalsByProject[projectPath]);
-  const connectedDisplays = useMemo(() => {
-    const result: TerminalDisplayState[] = [];
-    const ids = terminalPtyIds ?? [];
-    for (const ptyId of ids) {
-      const display = displayStates[ptyId];
-      if (display?.taskId === task.taskNumber) {
-        result.push(display);
+  // Find connected terminals for this task — shallow compare avoids re-renders from unrelated terminal updates
+  const connectedDisplays = useTerminalStore(
+    useShallow((s) => {
+      const ids = s.terminalsByProject[projectPath] ?? [];
+      const result: TerminalDisplayState[] = [];
+      for (const ptyId of ids) {
+        const d = s.displayStates[ptyId];
+        if (d?.taskId === task.taskNumber) result.push(d);
       }
-    }
-    return result;
-  }, [displayStates, terminalPtyIds, task.taskNumber]);
+      return result;
+    }),
+  );
 
   // Handle inline name editing
   const startEditing = useCallback(() => {
@@ -159,7 +158,7 @@ export const KanbanCard = memo(function KanbanCard({
   const [hasEditorHook, setHasEditorHook] = useState(false);
   useEffect(() => {
     window.api.lima.status(projectPath).then((s) => setSandboxAvailable(s.available));
-    window.api.hooks.get(projectPath).then((hooks) => setHasEditorHook(!!(hooks as any).editor));
+    window.api.hooks.get(projectPath).then((hooks) => setHasEditorHook(!!hooks.editor));
   }, [projectPath]);
 
   // Build context menu items
@@ -519,52 +518,62 @@ function DraggableBadge({
   const hoveredChainRoot = highlightedChainTask != null ? chainMap?.get(highlightedChainTask)?.rootTaskNumber : null;
   const shouldJitter =
     isInChain &&
+    chainInfo != null &&
     hoveredChainRoot != null &&
-    hoveredChainRoot === chainInfo!.rootTaskNumber &&
+    hoveredChainRoot === chainInfo.rootTaskNumber &&
     highlightedChainTask !== task.taskNumber;
 
-  const badgeColor = isInChain
-    ? getChainColor(chainInfo!.rootTaskNumber, chainInfo!.depth)
-    : 'rgba(255, 255, 255, 0.2)';
-  const badgeBg = isInChain
-    ? getChainBgColor(chainInfo!.rootTaskNumber, chainInfo!.depth)
-    : 'rgba(255, 255, 255, 0.04)';
+  const badgeColor =
+    isInChain && chainInfo ? getChainColor(chainInfo.rootTaskNumber, chainInfo.depth) : 'rgba(255, 255, 255, 0.2)';
+  const badgeBg =
+    isInChain && chainInfo ? getChainBgColor(chainInfo.rootTaskNumber, chainInfo.depth) : 'rgba(255, 255, 255, 0.04)';
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `badge-${task.taskNumber}`,
     data: { type: 'badge', taskNumber: task.taskNumber },
   });
 
   const [detachHovered, setDetachHovered] = useState(false);
+  const detachingRef = useRef(false);
   const detachHoverParent = useProjectStore((s) => s.detachHoverParent);
   const isDimmedByDetach = detachHoverParent === task.taskNumber;
 
-  const tooltipContent: ReactNode = isInChain ? (
-    <div className="flex flex-col gap-0.5">
-      {task.parentTaskNumber != null && (
-        <span>
-          Branches from <span className="opacity-50">#</span>
-          {task.parentTaskNumber}
-        </span>
-      )}
-      {chainInfo!.childTaskNumbers.length > 0 && (
-        <span>
-          Parent of{' '}
-          {chainInfo!.childTaskNumbers.map((n, i) => (
-            <span key={n}>
-              {i > 0 && ', '}
-              <span className="opacity-50">#</span>
-              {n}
-            </span>
-          ))}
-        </span>
-      )}
-    </div>
-  ) : (
-    <span>
-      Task <span className="opacity-50">#</span>
-      {task.taskNumber}
-    </span>
-  );
+  // Clear detachHoverParent on unmount to prevent stuck dimmed state
+  useEffect(() => {
+    return () => {
+      if (useProjectStore.getState().detachHoverParent != null) {
+        useProjectStore.getState().setDetachHoverParent(null);
+      }
+    };
+  }, []);
+
+  const tooltipContent: ReactNode =
+    isInChain && chainInfo ? (
+      <div className="flex flex-col gap-0.5">
+        {task.parentTaskNumber != null && (
+          <span>
+            Branches from <span className="opacity-50">#</span>
+            {task.parentTaskNumber}
+          </span>
+        )}
+        {chainInfo.childTaskNumbers.length > 0 && (
+          <span>
+            Parent of{' '}
+            {chainInfo.childTaskNumbers.map((n, i) => (
+              <span key={n}>
+                {i > 0 && ', '}
+                <span className="opacity-50">#</span>
+                {n}
+              </span>
+            ))}
+          </span>
+        )}
+      </div>
+    ) : (
+      <span>
+        Task <span className="opacity-50">#</span>
+        {task.taskNumber}
+      </span>
+    );
 
   return (
     <Tooltip
@@ -597,15 +606,23 @@ function DraggableBadge({
             onPointerDown={(e) => e.stopPropagation()}
             onClick={async (e) => {
               e.stopPropagation();
-              setDetachHovered(false);
-              useProjectStore.getState().clearChainHighlights();
-              const mainBranch = await window.api.worktree.getMainBranch(projectPath);
-              await window.api.task.setParent(projectPath, task.taskNumber, null, mainBranch);
-              useProjectStore.getState().loadTasks(projectPath);
+              if (detachingRef.current) return;
+              detachingRef.current = true;
+              try {
+                setDetachHovered(false);
+                useProjectStore.getState().clearChainHighlights();
+                const mainBranch = await window.api.worktree.getMainBranch(projectPath);
+                await window.api.task.setParent(projectPath, task.taskNumber, null, mainBranch);
+                useProjectStore.getState().loadTasks(projectPath);
+              } finally {
+                detachingRef.current = false;
+              }
             }}
             onMouseEnter={() => {
               setDetachHovered(true);
-              useProjectStore.getState().setDetachHoverParent(task.parentTaskNumber!);
+              if (task.parentTaskNumber != null) {
+                useProjectStore.getState().setDetachHoverParent(task.parentTaskNumber);
+              }
             }}
             onMouseLeave={() => {
               setDetachHovered(false);

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -15,6 +15,7 @@ interface KanbanCardProps {
   task: TaskWithWorkspace;
   projectPath: string;
   chainInfo?: TaskChainInfo;
+  chainMap?: Map<number, TaskChainInfo>;
   onRename: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
@@ -25,6 +26,7 @@ export const KanbanCard = memo(function KanbanCard({
   task,
   projectPath,
   chainInfo,
+  chainMap,
   onRename,
   onUpdateDescription,
   onOpenTerminal,
@@ -44,6 +46,13 @@ export const KanbanCard = memo(function KanbanCard({
 
   const isDone = task.status === 'done';
   const isInChain = chainInfo != null && (chainInfo.depth > 0 || chainInfo.childTaskNumbers.length > 0);
+  const highlightedChainTask = useProjectStore((s) => s.highlightedChainTask);
+  const hoveredChainRoot = highlightedChainTask != null ? chainMap?.get(highlightedChainTask)?.rootTaskNumber : null;
+  const shouldJitter =
+    isInChain &&
+    hoveredChainRoot != null &&
+    hoveredChainRoot === chainInfo!.rootTaskNumber &&
+    highlightedChainTask !== task.taskNumber;
 
   // Find connected terminals for this task (reactive — re-renders when display states change)
   const displayStates = useTerminalStore((s) => s.displayStates);
@@ -279,9 +288,6 @@ export const KanbanCard = memo(function KanbanCard({
         background: expanded ? 'rgba(0, 0, 0, 0.15)' : 'var(--color-terminal-bg)',
         transition: 'background 150ms ease-out, opacity 150ms ease-out',
         borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
-        ...(isInChain && {
-          borderLeft: `3px solid ${getChainColor(chainInfo!.rootTaskNumber, chainInfo!.depth)}`,
-        }),
       }}
       data-task-number={task.taskNumber}
       onContextMenu={(e) => {
@@ -362,18 +368,19 @@ export const KanbanCard = memo(function KanbanCard({
               </div>
             }
             placement="top"
+            referenceClassName="inline-flex items-center gap-0.5 shrink-0 font-mono text-[11px] leading-none px-2 py-1 rounded-full whitespace-nowrap"
+            referenceStyle={{
+              color: getChainColor(chainInfo!.rootTaskNumber, chainInfo!.depth),
+              background: getChainBgColor(chainInfo!.rootTaskNumber, chainInfo!.depth),
+              ...(shouldJitter && { animation: 'chain-badge-jitter 0.4s ease-out forwards' }),
+            }}
+            onHoverChange={(hovering) =>
+              useProjectStore.getState().setHighlightedChainTask(hovering ? task.taskNumber : null)
+            }
           >
-            <span
-              className="inline-flex items-center gap-0.5 shrink-0 font-mono text-[11px] leading-none px-2 py-1 rounded-full whitespace-nowrap"
-              style={{
-                color: getChainColor(chainInfo!.rootTaskNumber, chainInfo!.depth),
-                background: getChainBgColor(chainInfo!.rootTaskNumber, chainInfo!.depth),
-              }}
-            >
-              {chainInfo!.depth > 0 && <Icon name="git-merge" className="w-3 h-3" />}
-              <span className="opacity-50">#</span>
-              {task.taskNumber}
-            </span>
+            {chainInfo!.depth > 0 && <Icon name="git-merge" className="w-3 h-3" />}
+            <span className="opacity-50">#</span>
+            {task.taskNumber}
           </Tooltip>
         )}
         <button

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -47,20 +47,6 @@ export const KanbanCard = memo(function KanbanCard({
 
   const isDone = task.status === 'done';
   const isInChain = chainInfo != null && (chainInfo.depth > 0 || chainInfo.childTaskNumbers.length > 0);
-  const highlightedChainTask = useProjectStore((s) => s.highlightedChainTask);
-  const hoveredChainRoot = highlightedChainTask != null ? chainMap?.get(highlightedChainTask)?.rootTaskNumber : null;
-  const shouldJitter =
-    isInChain &&
-    hoveredChainRoot != null &&
-    hoveredChainRoot === chainInfo!.rootTaskNumber &&
-    highlightedChainTask !== task.taskNumber;
-
-  const badgeColor = isInChain
-    ? getChainColor(chainInfo!.rootTaskNumber, chainInfo!.depth)
-    : 'rgba(255, 255, 255, 0.2)';
-  const badgeBg = isInChain
-    ? getChainBgColor(chainInfo!.rootTaskNumber, chainInfo!.depth)
-    : 'rgba(255, 255, 255, 0.04)';
 
   // Badge drag visual feedback — derive per-card booleans in selectors to avoid O(N) re-renders
   const activeBadgeDragSource = useProjectStore((s) => s.activeBadgeDrag);
@@ -376,15 +362,7 @@ export const KanbanCard = memo(function KanbanCard({
           </span>
         )}
         {showBadge && (
-          <DraggableBadge
-            task={task}
-            projectPath={projectPath}
-            isInChain={isInChain}
-            chainInfo={chainInfo}
-            badgeColor={badgeColor}
-            badgeBg={badgeBg}
-            shouldJitter={shouldJitter}
-          />
+          <DraggableBadge task={task} projectPath={projectPath} chainInfo={chainInfo} chainMap={chainMap} />
         )}
         <button
           className={`flex items-center justify-center w-5 h-5 p-0 bg-transparent border-none rounded text-text-secondary opacity-0 transition-all duration-150 ease-out shrink-0 [-webkit-app-region:no-drag] group-hover:opacity-60 hover:!opacity-100 [&>svg]:w-3 [&>svg]:h-3 [&>svg]:transition-transform [&>svg]:duration-150 [&>svg]:ease-out${expanded ? ' [&>svg]:rotate-180' : ''}`}
@@ -517,20 +495,30 @@ export const KanbanCard = memo(function KanbanCard({
 function DraggableBadge({
   task,
   projectPath,
-  isInChain,
   chainInfo,
-  badgeColor,
-  badgeBg,
-  shouldJitter,
+  chainMap,
 }: {
   task: TaskWithWorkspace;
   projectPath: string;
-  isInChain: boolean;
   chainInfo?: TaskChainInfo;
-  badgeColor: string;
-  badgeBg: string;
-  shouldJitter: boolean;
+  chainMap?: Map<number, TaskChainInfo>;
 }) {
+  const isInChain = chainInfo != null && (chainInfo.depth > 0 || chainInfo.childTaskNumbers.length > 0);
+
+  const highlightedChainTask = useProjectStore((s) => s.highlightedChainTask);
+  const hoveredChainRoot = highlightedChainTask != null ? chainMap?.get(highlightedChainTask)?.rootTaskNumber : null;
+  const shouldJitter =
+    isInChain &&
+    hoveredChainRoot != null &&
+    hoveredChainRoot === chainInfo!.rootTaskNumber &&
+    highlightedChainTask !== task.taskNumber;
+
+  const badgeColor = isInChain
+    ? getChainColor(chainInfo!.rootTaskNumber, chainInfo!.depth)
+    : 'rgba(255, 255, 255, 0.2)';
+  const badgeBg = isInChain
+    ? getChainBgColor(chainInfo!.rootTaskNumber, chainInfo!.depth)
+    : 'rgba(255, 255, 255, 0.04)';
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `badge-${task.taskNumber}`,
     data: { type: 'badge', taskNumber: task.taskNumber },

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -580,7 +580,7 @@ function DraggableBadge({
   return (
     <Tooltip
       text={tooltipContent}
-      placement="top"
+      placement="bottom"
       disabled={isDragging || detachHovered}
       referenceClassName="group/badge inline-flex items-center gap-0.5 shrink-0 font-mono text-[11px] leading-none px-2 py-1 rounded-full whitespace-nowrap"
       referenceStyle={{
@@ -602,7 +602,7 @@ function DraggableBadge({
         {task.taskNumber}
       </span>
       {task.parentTaskNumber != null && (
-        <Tooltip text={`Detach from #${task.parentTaskNumber}`} placement="top" delay={300}>
+        <Tooltip text={`Detach from #${task.parentTaskNumber}`} placement="bottom" delay={300}>
           <button
             className="w-0 overflow-hidden group-hover/badge:w-4 flex items-center justify-center border-none bg-transparent text-white/30 hover:text-red-400 transition-all duration-150 [-webkit-app-region:no-drag] [&>svg]:w-2.5 [&>svg]:h-2.5 shrink-0 p-0"
             onPointerDown={(e) => e.stopPropagation()}

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -17,8 +17,6 @@ interface KanbanCardProps {
   projectPath: string;
   chainInfo?: TaskChainInfo;
   chainMap?: Map<number, TaskChainInfo>;
-  activeBadgeDrag?: { taskNumber: number } | null;
-  badgeDragOverTask?: number | null;
   onRename: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
@@ -30,8 +28,6 @@ export const KanbanCard = memo(function KanbanCard({
   projectPath,
   chainInfo,
   chainMap,
-  activeBadgeDrag,
-  badgeDragOverTask,
   onRename,
   onUpdateDescription,
   onOpenTerminal,
@@ -66,17 +62,18 @@ export const KanbanCard = memo(function KanbanCard({
     ? getChainBgColor(chainInfo!.rootTaskNumber, chainInfo!.depth)
     : 'rgba(255, 255, 255, 0.04)';
 
-  // Badge drag visual feedback
+  // Badge drag visual feedback (read from store, not props)
+  const activeBadgeDrag = useProjectStore((s) => s.activeBadgeDrag);
+  const badgeDragOverTask = useProjectStore((s) => s.badgeDragOverTask);
+  const optionKeyHeld = useProjectStore((s) => s.optionKeyHeld);
   const isBadgeDragActive = activeBadgeDrag != null;
   const isValidBadgeTarget =
     isBadgeDragActive &&
-    activeBadgeDrag.taskNumber !== task.taskNumber &&
+    activeBadgeDrag !== task.taskNumber &&
     chainMap != null &&
-    !isDescendantOf(task.taskNumber, activeBadgeDrag.taskNumber, chainMap);
+    !isDescendantOf(task.taskNumber, activeBadgeDrag, chainMap);
   const isHoveredBadgeTarget = isValidBadgeTarget && badgeDragOverTask === task.taskNumber;
   const isInvalidBadgeTarget = isBadgeDragActive && !isValidBadgeTarget;
-
-  const optionKeyHeld = useProjectStore((s) => s.optionKeyHeld);
   const showBadge = isInChain || optionKeyHeld || isBadgeDragActive;
 
   // Find connected terminals for this task (reactive — re-renders when display states change)
@@ -604,8 +601,7 @@ function DraggableBadge({
             onClick={async (e) => {
               e.stopPropagation();
               setDetachHovered(false);
-              useProjectStore.getState().setDetachHoverParent(null);
-              useProjectStore.getState().setHighlightedChainTask(null);
+              useProjectStore.getState().clearChainHighlights();
               const mainBranch = await window.api.worktree.getMainBranch(projectPath);
               await window.api.task.setParent(projectPath, task.taskNumber, null, mainBranch);
               useProjectStore.getState().loadTasks(projectPath);

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -62,7 +62,7 @@ export const KanbanCard = memo(function KanbanCard({
   }, [activeBadgeDragSource, task.taskNumber, chainMap]);
   const isHoveredBadgeTarget = isValidBadgeTarget && isHoveredByBadgeDrag;
   const isInvalidBadgeTarget = isBadgeDragActive && !isValidBadgeTarget;
-  const showBadge = isInChain || optionKeyHeld || isBadgeDragActive;
+  const showBadge = isInChain || optionKeyHeld;
 
   // Find connected terminals for this task — shallow compare avoids re-renders from unrelated terminal updates
   const connectedDisplays = useTerminalStore(
@@ -368,9 +368,6 @@ export const KanbanCard = memo(function KanbanCard({
             {task.name}
           </span>
         )}
-        {showBadge && (
-          <DraggableBadge task={task} projectPath={projectPath} chainInfo={chainInfo} chainMap={chainMap} />
-        )}
         <button
           className={`flex items-center justify-center w-5 h-5 p-0 bg-transparent border-none rounded text-text-secondary opacity-0 transition-all duration-150 ease-out shrink-0 [-webkit-app-region:no-drag] group-hover:opacity-60 hover:!opacity-100 [&>svg]:w-3 [&>svg]:h-3 [&>svg]:transition-transform [&>svg]:duration-150 [&>svg]:ease-out${expanded ? ' [&>svg]:rotate-180' : ''}`}
           onClick={(e) => {
@@ -381,6 +378,11 @@ export const KanbanCard = memo(function KanbanCard({
           <Icon name="caret-down" />
         </button>
       </div>
+      {showBadge && (
+        <div className="mt-1">
+          <DraggableBadge task={task} projectPath={projectPath} chainInfo={chainInfo} chainMap={chainMap} />
+        </div>
+      )}
 
       {isSettingUp && <div className="font-mono text-xs text-white/40 mt-1">Setting up workspace{'\u2026'}</div>}
 

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -6,10 +6,15 @@ import { terminalInstances } from '../terminal/terminalReact';
 import { Icon } from '../terminal/Icon';
 import { ContextMenu, type ContextMenuEntry } from '../ui/ContextMenu';
 import { HookConfigDialog } from '../dialogs/HookConfigDialog';
+import { BranchFromTaskDialog } from '../dialogs/BranchFromTaskDialog';
+import { Tooltip } from '../ui/Tooltip';
+import type { TaskChainInfo } from '../../utils/taskChain';
+import { getChainColor, getChainBgColor } from '../../utils/taskChain';
 
 interface KanbanCardProps {
   task: TaskWithWorkspace;
   projectPath: string;
+  chainInfo?: TaskChainInfo;
   onRename: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
@@ -19,6 +24,7 @@ interface KanbanCardProps {
 export const KanbanCard = memo(function KanbanCard({
   task,
   projectPath,
+  chainInfo,
   onRename,
   onUpdateDescription,
   onOpenTerminal,
@@ -29,6 +35,7 @@ export const KanbanCard = memo(function KanbanCard({
   const [editingDesc, setEditingDesc] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [editorHookDialog, setEditorHookDialog] = useState(false);
+  const [branchFromDialog, setBranchFromDialog] = useState(false);
   const [terminalContextMenu, setTerminalContextMenu] = useState<{ x: number; y: number; ptyId: string } | null>(null);
   const [renamingTerminalId, setRenamingTerminalId] = useState<string | null>(null);
   const terminalRenameRef = useRef<HTMLInputElement>(null);
@@ -36,6 +43,7 @@ export const KanbanCard = memo(function KanbanCard({
   const descInputRef = useRef<HTMLSpanElement>(null);
 
   const isDone = task.status === 'done';
+  const isInChain = chainInfo != null && (chainInfo.depth > 0 || chainInfo.childTaskNumbers.length > 0);
 
   // Find connected terminals for this task (reactive — re-renders when display states change)
   const displayStates = useTerminalStore((s) => s.displayStates);
@@ -202,6 +210,15 @@ export const KanbanCard = memo(function KanbanCard({
 
     items.push({ separator: true });
 
+    // Branch from this task (only for started tasks with a branch)
+    if (task.branch && task.status !== 'done') {
+      items.push({
+        label: 'Branch from this task',
+        icon: 'git-branch',
+        onClick: () => setBranchFromDialog(true),
+      });
+    }
+
     // Rename
     items.push({
       label: 'Rename',
@@ -262,6 +279,9 @@ export const KanbanCard = memo(function KanbanCard({
         background: expanded ? 'rgba(0, 0, 0, 0.15)' : 'var(--color-terminal-bg)',
         transition: 'background 150ms ease-out, opacity 150ms ease-out',
         borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
+        ...(isInChain && {
+          borderLeft: `3px solid ${getChainColor(chainInfo!.rootTaskNumber, chainInfo!.depth)}`,
+        }),
       }}
       data-task-number={task.taskNumber}
       onContextMenu={(e) => {
@@ -288,6 +308,18 @@ export const KanbanCard = memo(function KanbanCard({
           }}
         />
       )}
+      {branchFromDialog && (
+        <BranchFromTaskDialog
+          projectPath={projectPath}
+          parentTask={task}
+          onClose={(created) => {
+            setBranchFromDialog(false);
+            if (created) {
+              useProjectStore.getState().loadTasks(projectPath);
+            }
+          }}
+        />
+      )}
       <div className="flex items-start gap-2">
         {editing ? (
           <textarea
@@ -304,6 +336,45 @@ export const KanbanCard = memo(function KanbanCard({
           >
             {task.name}
           </span>
+        )}
+        {isInChain && (
+          <Tooltip
+            text={
+              <div className="flex flex-col gap-0.5">
+                {task.parentTaskNumber != null && (
+                  <span>
+                    Branches from <span className="opacity-50">#</span>
+                    {task.parentTaskNumber}
+                  </span>
+                )}
+                {chainInfo!.childTaskNumbers.length > 0 && (
+                  <span>
+                    Parent of{' '}
+                    {chainInfo!.childTaskNumbers.map((n, i) => (
+                      <span key={n}>
+                        {i > 0 && ', '}
+                        <span className="opacity-50">#</span>
+                        {n}
+                      </span>
+                    ))}
+                  </span>
+                )}
+              </div>
+            }
+            placement="top"
+          >
+            <span
+              className="inline-flex items-center gap-0.5 shrink-0 font-mono text-[11px] leading-none px-2 py-1 rounded-full whitespace-nowrap"
+              style={{
+                color: getChainColor(chainInfo!.rootTaskNumber, chainInfo!.depth),
+                background: getChainBgColor(chainInfo!.rootTaskNumber, chainInfo!.depth),
+              }}
+            >
+              {chainInfo!.depth > 0 && <Icon name="git-merge" className="w-3 h-3" />}
+              <span className="opacity-50">#</span>
+              {task.taskNumber}
+            </span>
+          </Tooltip>
         )}
         <button
           className={`flex items-center justify-center w-5 h-5 p-0 bg-transparent border-none rounded text-text-secondary opacity-0 transition-all duration-150 ease-out shrink-0 [-webkit-app-region:no-drag] group-hover:opacity-60 hover:!opacity-100 [&>svg]:w-3 [&>svg]:h-3 [&>svg]:transition-transform [&>svg]:duration-150 [&>svg]:ease-out${expanded ? ' [&>svg]:rotate-180' : ''}`}

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -29,8 +29,6 @@ interface KanbanColumnProps {
   onConfigureHook?: (hookTypes: HookType[]) => void;
   hasConfiguredHook?: boolean;
   chainMap?: Map<number, TaskChainInfo>;
-  activeBadgeDrag?: { taskNumber: number } | null;
-  badgeDragOverTask?: number | null;
 }
 
 export function KanbanColumn({
@@ -46,8 +44,6 @@ export function KanbanColumn({
   onConfigureHook,
   hasConfiguredHook,
   chainMap,
-  activeBadgeDrag,
-  badgeDragOverTask,
 }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: status });
   const taskIds = useMemo(() => tasks.map((t) => `task-${t.taskNumber}`), [tasks]);
@@ -94,8 +90,6 @@ export function KanbanColumn({
               task={task}
               projectPath={projectPath}
               chainMap={chainMap}
-              activeBadgeDrag={activeBadgeDrag}
-              badgeDragOverTask={badgeDragOverTask}
               onRename={onRenameTask}
               onUpdateDescription={onUpdateDescription}
               onOpenTerminal={onOpenTerminal}
@@ -115,8 +109,6 @@ function SortableCard({
   task,
   projectPath,
   chainMap,
-  activeBadgeDrag,
-  badgeDragOverTask,
   onRename,
   onUpdateDescription,
   onOpenTerminal,
@@ -125,8 +117,6 @@ function SortableCard({
   task: TaskWithWorkspace;
   projectPath: string;
   chainMap?: Map<number, TaskChainInfo>;
-  activeBadgeDrag?: { taskNumber: number } | null;
-  badgeDragOverTask?: number | null;
   onRename: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
@@ -170,8 +160,6 @@ function SortableCard({
         projectPath={projectPath}
         chainInfo={chainMap?.get(task.taskNumber)}
         chainMap={chainMap}
-        activeBadgeDrag={activeBadgeDrag}
-        badgeDragOverTask={badgeDragOverTask}
         onRename={onRename}
         onUpdateDescription={onUpdateDescription}
         onOpenTerminal={onOpenTerminal}

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -29,6 +29,8 @@ interface KanbanColumnProps {
   onConfigureHook?: (hookTypes: HookType[]) => void;
   hasConfiguredHook?: boolean;
   chainMap?: Map<number, TaskChainInfo>;
+  activeBadgeDrag?: { taskNumber: number } | null;
+  badgeDragOverTask?: number | null;
 }
 
 export function KanbanColumn({
@@ -44,6 +46,8 @@ export function KanbanColumn({
   onConfigureHook,
   hasConfiguredHook,
   chainMap,
+  activeBadgeDrag,
+  badgeDragOverTask,
 }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: status });
   const taskIds = useMemo(() => tasks.map((t) => `task-${t.taskNumber}`), [tasks]);
@@ -90,6 +94,8 @@ export function KanbanColumn({
               task={task}
               projectPath={projectPath}
               chainMap={chainMap}
+              activeBadgeDrag={activeBadgeDrag}
+              badgeDragOverTask={badgeDragOverTask}
               onRename={onRenameTask}
               onUpdateDescription={onUpdateDescription}
               onOpenTerminal={onOpenTerminal}
@@ -109,6 +115,8 @@ function SortableCard({
   task,
   projectPath,
   chainMap,
+  activeBadgeDrag,
+  badgeDragOverTask,
   onRename,
   onUpdateDescription,
   onOpenTerminal,
@@ -117,6 +125,8 @@ function SortableCard({
   task: TaskWithWorkspace;
   projectPath: string;
   chainMap?: Map<number, TaskChainInfo>;
+  activeBadgeDrag?: { taskNumber: number } | null;
+  badgeDragOverTask?: number | null;
   onRename: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
@@ -124,7 +134,7 @@ function SortableCard({
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: `task-${task.taskNumber}`,
-    data: { task },
+    data: { task, type: 'card' },
   });
 
   const style: React.CSSProperties = {
@@ -160,6 +170,8 @@ function SortableCard({
         projectPath={projectPath}
         chainInfo={chainMap?.get(task.taskNumber)}
         chainMap={chainMap}
+        activeBadgeDrag={activeBadgeDrag}
+        badgeDragOverTask={badgeDragOverTask}
         onRename={onRename}
         onUpdateDescription={onUpdateDescription}
         onOpenTerminal={onOpenTerminal}

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -3,6 +3,7 @@ import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { TaskWithWorkspace, HookType } from '../../types';
+import type { TaskChainInfo } from '../../utils/taskChain';
 import { KanbanCard } from './KanbanCard';
 import { KanbanAddInput } from './KanbanAddInput';
 import { Icon } from '../terminal/Icon';
@@ -27,6 +28,7 @@ interface KanbanColumnProps {
   onSwitchToTerminal: (ptyId: string) => void;
   onConfigureHook?: (hookTypes: HookType[]) => void;
   hasConfiguredHook?: boolean;
+  chainMap?: Map<number, TaskChainInfo>;
 }
 
 export function KanbanColumn({
@@ -41,6 +43,7 @@ export function KanbanColumn({
   onSwitchToTerminal,
   onConfigureHook,
   hasConfiguredHook,
+  chainMap,
 }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: status });
   const taskIds = useMemo(() => tasks.map((t) => `task-${t.taskNumber}`), [tasks]);
@@ -86,6 +89,7 @@ export function KanbanColumn({
               key={task.taskNumber}
               task={task}
               projectPath={projectPath}
+              chainMap={chainMap}
               onRename={onRenameTask}
               onUpdateDescription={onUpdateDescription}
               onOpenTerminal={onOpenTerminal}
@@ -104,6 +108,7 @@ export function KanbanColumn({
 function SortableCard({
   task,
   projectPath,
+  chainMap,
   onRename,
   onUpdateDescription,
   onOpenTerminal,
@@ -111,6 +116,7 @@ function SortableCard({
 }: {
   task: TaskWithWorkspace;
   projectPath: string;
+  chainMap?: Map<number, TaskChainInfo>;
   onRename: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
@@ -152,6 +158,7 @@ function SortableCard({
       <KanbanCard
         task={task}
         projectPath={projectPath}
+        chainInfo={chainMap?.get(task.taskNumber)}
         onRename={onRename}
         onUpdateDescription={onUpdateDescription}
         onOpenTerminal={onOpenTerminal}

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -159,6 +159,7 @@ function SortableCard({
         task={task}
         projectPath={projectPath}
         chainInfo={chainMap?.get(task.taskNumber)}
+        chainMap={chainMap}
         onRename={onRename}
         onUpdateDescription={onUpdateDescription}
         onOpenTerminal={onOpenTerminal}

--- a/src/components/terminal/terminalActions.ts
+++ b/src/components/terminal/terminalActions.ts
@@ -106,11 +106,13 @@ export async function addProjectTerminal(
     terminalCwd = worktreeInfo.path;
   }
 
-  // Look up current task name
+  // Look up current task name and merge target
   let taskName: string | undefined;
+  let mergeTarget: string | undefined;
   if (options?.taskId != null) {
     const task = await window.api.task.getByNumber(projectPath, options.taskId);
     taskName = task?.name;
+    mergeTarget = task?.mergeTarget;
   }
 
   if (isStale()) return false;
@@ -163,6 +165,7 @@ export async function addProjectTerminal(
     taskPrompt,
     worktreePath: worktreeInfo?.path,
     worktreeBranch: worktreeInfo?.branch,
+    mergeTarget,
   });
 
   // Open xterm into viewport element (not yet in DOM — React will attach via XTermContainer)
@@ -267,7 +270,7 @@ export function closeProjectTerminal(ptyId: string): void {
 
 export async function reconnectTerminal(
   session: ActiveSession,
-  opts: { worktreeBranch?: string; initialStatus?: SummaryType } = {},
+  opts: { worktreeBranch?: string; mergeTarget?: string; initialStatus?: SummaryType } = {},
 ): Promise<OuijitTerminal | null> {
   const term = new OuijitTerminal({
     ptyId: session.ptyId,
@@ -278,6 +281,7 @@ export async function reconnectTerminal(
     taskId: session.taskId ?? null,
     worktreePath: session.worktreePath,
     worktreeBranch: opts.worktreeBranch,
+    mergeTarget: opts.mergeTarget,
     initialSummaryType: opts.initialStatus,
   });
 
@@ -493,9 +497,11 @@ export async function reconnectOrphanedSessions(projectPath: string): Promise<vo
   // Reconnect main terminals first
   for (const session of mainSessions) {
     let worktreeBranch: string | undefined;
+    let mergeTarget: string | undefined;
     if (session.taskId != null) {
       const task = await window.api.task.getByNumber(projectPath, session.taskId);
       worktreeBranch = task?.branch;
+      mergeTarget = task?.mergeTarget;
     }
 
     const [hookStatus, planPath] = await Promise.all([
@@ -504,7 +510,7 @@ export async function reconnectOrphanedSessions(projectPath: string): Promise<vo
     ]);
     const initialStatus: SummaryType = hookStatus?.status === 'thinking' ? 'thinking' : 'ready';
 
-    const term = await reconnectTerminal(session, { worktreeBranch, initialStatus });
+    const term = await reconnectTerminal(session, { worktreeBranch, mergeTarget, initialStatus });
     if (term && planPath) {
       term.planPath = planPath;
       term.pushDisplayState({ planPath });

--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -229,22 +229,26 @@ export async function refreshAllTerminalGitStatus(projectPath: string): Promise<
   const ptyIds = store.terminalsByProject[projectPath] ?? [];
   if (ptyIds.length === 0) return;
 
-  const pathToTerminals = new Map<string, OuijitTerminal[]>();
+  // Group by gitPath + mergeTarget so child-task terminals diff against their parent branch
+  const groupToTerminals = new Map<string, OuijitTerminal[]>();
   for (const ptyId of ptyIds) {
     const term = terminalInstances.get(ptyId);
     if (!term) continue;
     const gitPath = term.worktreePath || term.projectPath;
-    const group = pathToTerminals.get(gitPath);
+    const key = `${gitPath}\0${term.mergeTarget ?? ''}`;
+    const group = groupToTerminals.get(key);
     if (group) {
       group.push(term);
     } else {
-      pathToTerminals.set(gitPath, [term]);
+      groupToTerminals.set(key, [term]);
     }
   }
 
   await Promise.all(
-    Array.from(pathToTerminals.entries()).map(async ([gitPath, terms]) => {
-      const fileStatus = await window.api.getGitFileStatus(gitPath);
+    Array.from(groupToTerminals.entries()).map(async ([key, terms]) => {
+      const gitPath = key.split('\0')[0];
+      const mergeTarget = terms[0].mergeTarget;
+      const fileStatus = await window.api.getGitFileStatus(gitPath, mergeTarget);
       for (const t of terms) {
         t.gitFileStatus = fileStatus;
         t.pushDisplayState({ gitFileStatus: fileStatus });

--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -30,6 +30,7 @@ export interface TerminalOptions {
   taskPrompt?: string;
   worktreePath?: string;
   worktreeBranch?: string;
+  mergeTarget?: string;
   tags?: string[];
   isRunner?: boolean;
   initialSummaryType?: SummaryType;
@@ -218,7 +219,7 @@ function scheduleTerminalGitStatusRefresh(term: OuijitTerminal): void {
 
 export async function refreshTerminalGitStatus(term: OuijitTerminal): Promise<void> {
   const gitPath = term.worktreePath || term.projectPath;
-  const fileStatus = await window.api.getGitFileStatus(gitPath);
+  const fileStatus = await window.api.getGitFileStatus(gitPath, term.mergeTarget);
   term.gitFileStatus = fileStatus;
   term.pushDisplayState({ gitFileStatus: fileStatus });
 }
@@ -285,6 +286,7 @@ export class OuijitTerminal {
   readonly taskPrompt?: string;
   worktreePath?: string;
   worktreeBranch?: string;
+  mergeTarget?: string;
 
   // ── Per-terminal diff panel state ───────────────────────────────────
   diffPanelOpen = false;
@@ -338,6 +340,7 @@ export class OuijitTerminal {
     this.taskPrompt = opts.taskPrompt;
     this.worktreePath = opts.worktreePath;
     this.worktreeBranch = opts.worktreeBranch;
+    this.mergeTarget = opts.mergeTarget;
 
     if (opts.taskId != null) {
       this.diffPanelMode = 'worktree';

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -19,15 +19,30 @@ interface TooltipProps {
   placement?: Placement;
   delay?: number;
   disabled?: boolean;
+  referenceClassName?: string;
+  referenceStyle?: React.CSSProperties;
+  onHoverChange?: (hovering: boolean) => void;
   children: ReactNode;
 }
 
-export function Tooltip({ text, placement = 'bottom', delay = 100, disabled, children }: TooltipProps) {
+export function Tooltip({
+  text,
+  placement = 'bottom',
+  delay = 100,
+  disabled,
+  referenceClassName,
+  referenceStyle,
+  onHoverChange,
+  children,
+}: TooltipProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const { refs, floatingStyles, context } = useFloating({
     open: isOpen,
-    onOpenChange: setIsOpen,
+    onOpenChange: (open) => {
+      setIsOpen(open);
+      onHoverChange?.(open);
+    },
     placement,
     strategy: 'fixed',
     middleware: [offset(6), flip(), shift({ padding: 8 })],
@@ -43,7 +58,12 @@ export function Tooltip({ text, placement = 'bottom', delay = 100, disabled, chi
 
   return (
     <>
-      <div ref={refs.setReference} {...getReferenceProps()} className="inline-flex">
+      <div
+        ref={refs.setReference}
+        {...getReferenceProps()}
+        className={referenceClassName ?? 'inline-flex'}
+        style={referenceStyle}
+      >
         {children}
       </div>
       {isOpen &&

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -15,7 +15,7 @@ import {
 } from '@floating-ui/react';
 
 interface TooltipProps {
-  text: string;
+  text: ReactNode;
   placement?: Placement;
   delay?: number;
   disabled?: boolean;

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -19,9 +19,11 @@ interface TooltipProps {
   placement?: Placement;
   delay?: number;
   disabled?: boolean;
+  offsetPx?: number;
   referenceClassName?: string;
   referenceStyle?: React.CSSProperties;
   onHoverChange?: (hovering: boolean) => void;
+  onClick?: (e: React.MouseEvent) => void;
   children: ReactNode;
 }
 
@@ -30,9 +32,11 @@ export function Tooltip({
   placement = 'bottom',
   delay = 100,
   disabled,
+  offsetPx,
   referenceClassName,
   referenceStyle,
   onHoverChange,
+  onClick,
   children,
 }: TooltipProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -45,7 +49,7 @@ export function Tooltip({
     },
     placement,
     strategy: 'fixed',
-    middleware: [offset(6), flip(), shift({ padding: 8 })],
+    middleware: [offset(offsetPx ?? 6), flip(), shift({ padding: 8 })],
     whileElementsMounted: autoUpdate,
   });
 
@@ -63,6 +67,7 @@ export function Tooltip({
         {...getReferenceProps()}
         className={referenceClassName ?? 'inline-flex'}
         style={referenceStyle}
+        onClick={onClick}
       >
         {children}
       </div>

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -23,7 +23,6 @@ interface TooltipProps {
   referenceClassName?: string;
   referenceStyle?: React.CSSProperties;
   onHoverChange?: (hovering: boolean) => void;
-  onClick?: (e: React.MouseEvent) => void;
   children: ReactNode;
 }
 
@@ -36,7 +35,6 @@ export function Tooltip({
   referenceClassName,
   referenceStyle,
   onHoverChange,
-  onClick,
   children,
 }: TooltipProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -67,7 +65,6 @@ export function Tooltip({
         {...getReferenceProps()}
         className={referenceClassName ?? 'inline-flex'}
         style={referenceStyle}
-        onClick={onClick}
       >
         {children}
       </div>

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -6,6 +6,7 @@ import { up as migration004 } from './migrations/004-global-settings';
 import { up as migration005 } from './migrations/005-project-sort-order';
 import { up as migration006 } from './migrations/006-add-scripts';
 import { up as migration007 } from './migrations/007-remove-sandbox-config';
+import { up as migration008 } from './migrations/008-add-parent-task';
 
 const migrations = [
   { version: 1, up: migration001 },
@@ -15,6 +16,7 @@ const migrations = [
   { version: 5, up: migration005 },
   { version: 6, up: migration006 },
   { version: 7, up: migration007 },
+  { version: 8, up: migration008 },
 ];
 
 let db: Database.Database | null = null;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -38,6 +38,7 @@ export interface TaskMetadata {
   prompt?: string;
   sandboxed?: boolean;
   order?: number;
+  parentTaskNumber?: number;
 }
 
 // ── Lazy singleton repos ─────────────────────────────────────────────
@@ -107,6 +108,7 @@ function rowToTask(row: TaskRow): TaskMetadata {
     ...(row.merge_target && { mergeTarget: row.merge_target }),
     ...(row.prompt && { prompt: row.prompt }),
     ...(row.sandboxed === 1 && { sandboxed: true }),
+    ...(row.parent_task_number != null && { parentTaskNumber: row.parent_task_number }),
   };
 }
 
@@ -165,6 +167,7 @@ export async function createTask(
     prompt?: string;
     sandboxed?: boolean;
     worktreePath?: string;
+    parentTaskNumber?: number;
   },
 ): Promise<TaskMetadata> {
   ensureProject(projectPath);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -248,14 +248,14 @@ export async function setTaskParent(
 
     // Prevent cycles: walk up from proposed parent to root
     if (parentTaskNumber != null) {
-      let current = parentTaskNumber;
+      let current: number | null = parentTaskNumber;
       const visited = new Set<number>();
       while (current != null) {
         if (current === taskNumber) return { success: false, error: 'Cannot create a cycle' };
         if (visited.has(current)) break;
         visited.add(current);
         const parentRow = tr.getByTaskNumber(projectPath, current);
-        current = parentRow?.parent_task_number as number;
+        current = parentRow?.parent_task_number ?? null;
       }
     }
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -232,6 +232,27 @@ export async function setTaskMergeTarget(
   }
 }
 
+export async function setTaskParent(
+  projectPath: string,
+  taskNumber: number,
+  parentTaskNumber: number | null,
+  mergeTarget?: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const { taskRepo: tr } = repos();
+    const row = tr.getByTaskNumber(projectPath, taskNumber);
+    if (!row) return { success: false, error: 'Task not found' };
+
+    tr.updateParentTaskNumber(projectPath, taskNumber, parentTaskNumber);
+    if (mergeTarget !== undefined) {
+      tr.updateMergeTarget(projectPath, taskNumber, mergeTarget);
+    }
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+}
+
 export async function setTaskWorktreePath(
   projectPath: string,
   taskNumber: number,

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -243,14 +243,34 @@ export async function setTaskParent(
     const row = tr.getByTaskNumber(projectPath, taskNumber);
     if (!row) return { success: false, error: 'Task not found' };
 
-    tr.updateParentTaskNumber(projectPath, taskNumber, parentTaskNumber);
-    if (mergeTarget !== undefined) {
-      tr.updateMergeTarget(projectPath, taskNumber, mergeTarget);
+    // Prevent self-reference
+    if (parentTaskNumber === taskNumber) return { success: false, error: 'Task cannot be its own parent' };
+
+    // Prevent cycles: walk up from proposed parent to root
+    if (parentTaskNumber != null) {
+      let current = parentTaskNumber;
+      const visited = new Set<number>();
+      while (current != null) {
+        if (current === taskNumber) return { success: false, error: 'Cannot create a cycle' };
+        if (visited.has(current)) break;
+        visited.add(current);
+        const parentRow = tr.getByTaskNumber(projectPath, current);
+        current = parentRow?.parent_task_number as number;
+      }
     }
+
+    tr.updateParentTaskNumber(projectPath, taskNumber, parentTaskNumber);
+    // Always update mergeTarget to prevent stale values from a previous parent
+    tr.updateMergeTarget(projectPath, taskNumber, mergeTarget ?? null);
     return { success: true };
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
   }
+}
+
+export async function clearParentReferences(projectPath: string, parentTaskNumber: number): Promise<void> {
+  const { taskRepo: tr } = repos();
+  tr.clearParentReferences(projectPath, parentTaskNumber);
 }
 
 export async function setTaskWorktreePath(

--- a/src/db/migrations/008-add-parent-task.ts
+++ b/src/db/migrations/008-add-parent-task.ts
@@ -1,0 +1,5 @@
+import type Database from 'better-sqlite3';
+
+export function up(db: Database.Database): void {
+  db.exec('ALTER TABLE tasks ADD COLUMN parent_task_number INTEGER');
+}

--- a/src/db/repos/taskRepo.ts
+++ b/src/db/repos/taskRepo.ts
@@ -158,6 +158,12 @@ export class TaskRepo {
       .run(mergeTarget, projectPath, taskNumber);
   }
 
+  updateParentTaskNumber(projectPath: string, taskNumber: number, parentTaskNumber: number | null): void {
+    this.db
+      .prepare('UPDATE tasks SET parent_task_number = ? WHERE project_path = ? AND task_number = ?')
+      .run(parentTaskNumber, projectPath, taskNumber);
+  }
+
   updateName(projectPath: string, taskNumber: number, name: string): void {
     this.db
       .prepare('UPDATE tasks SET name = ? WHERE project_path = ? AND task_number = ?')

--- a/src/db/repos/taskRepo.ts
+++ b/src/db/repos/taskRepo.ts
@@ -152,7 +152,7 @@ export class TaskRepo {
       .run(worktreePath, projectPath, taskNumber);
   }
 
-  updateMergeTarget(projectPath: string, taskNumber: number, mergeTarget: string): void {
+  updateMergeTarget(projectPath: string, taskNumber: number, mergeTarget: string | null): void {
     this.db
       .prepare('UPDATE tasks SET merge_target = ? WHERE project_path = ? AND task_number = ?')
       .run(mergeTarget, projectPath, taskNumber);
@@ -224,6 +224,14 @@ export class TaskRepo {
         }
       }
     })();
+  }
+
+  clearParentReferences(projectPath: string, parentTaskNumber: number): void {
+    this.db
+      .prepare(
+        'UPDATE tasks SET parent_task_number = NULL, merge_target = NULL WHERE project_path = ? AND parent_task_number = ?',
+      )
+      .run(projectPath, parentTaskNumber);
   }
 
   delete(projectPath: string, taskNumber: number): void {

--- a/src/db/repos/taskRepo.ts
+++ b/src/db/repos/taskRepo.ts
@@ -16,6 +16,7 @@ export interface TaskRow {
   sort_order: number;
   created_at: string;
   closed_at: string | null;
+  parent_task_number: number | null;
 }
 
 export class TaskRepo {
@@ -58,6 +59,7 @@ export class TaskRepo {
       sandboxed?: boolean;
       worktreePath?: string;
       createdAt?: string;
+      parentTaskNumber?: number;
     },
   ): TaskRow {
     return this.db.transaction(() => {
@@ -72,8 +74,8 @@ export class TaskRepo {
       this.db
         .prepare(
           `
-        INSERT INTO tasks (project_path, task_number, name, status, prompt, branch, worktree_path, merge_target, sandboxed, sort_order, created_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO tasks (project_path, task_number, name, status, prompt, branch, worktree_path, merge_target, sandboxed, sort_order, created_at, parent_task_number)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
         )
         .run(
@@ -88,6 +90,7 @@ export class TaskRepo {
           options?.sandboxed ? 1 : 0,
           sortOrder,
           options?.createdAt ?? new Date().toISOString(),
+          options?.parentTaskNumber ?? null,
         );
 
       // Bump counter if this task number matches or exceeds it

--- a/src/git.ts
+++ b/src/git.ts
@@ -651,7 +651,7 @@ function parseNameStatus(
  * Gets detailed git file status — single source of truth for both the GitStats
  * button and the DiffPanel. Fully async to avoid blocking the main thread.
  */
-export async function getGitFileStatus(projectPath: string): Promise<GitFileStatus | null> {
+export async function getGitFileStatus(projectPath: string, diffBase?: string): Promise<GitFileStatus | null> {
   try {
     let branch: string;
     try {
@@ -661,7 +661,8 @@ export async function getGitFileStatus(projectPath: string): Promise<GitFileStat
     }
 
     const mainBranch = getMainBranch(projectPath);
-    const isOnMain = branch === mainBranch;
+    const base = diffBase || mainBranch;
+    const isOnBase = branch === base;
 
     // Run all independent git commands in parallel
     const [
@@ -675,9 +676,9 @@ export async function getGitFileStatus(projectPath: string): Promise<GitFileStat
       gitAsync(['diff', '--numstat', 'HEAD'], projectPath),
       gitAsync(['diff', '--name-status', 'HEAD'], projectPath),
       gitAsync(['ls-files', '--others', '--exclude-standard'], projectPath),
-      isOnMain ? Promise.resolve('') : gitAsync(['rev-list', '--count', `${mainBranch}..HEAD`], projectPath),
-      isOnMain ? Promise.resolve('') : gitAsync(['diff', '--numstat', `${mainBranch}...HEAD`], projectPath),
-      isOnMain ? Promise.resolve('') : gitAsync(['diff', '--name-status', `${mainBranch}...HEAD`], projectPath),
+      isOnBase ? Promise.resolve('') : gitAsync(['rev-list', '--count', `${base}..HEAD`], projectPath),
+      isOnBase ? Promise.resolve('') : gitAsync(['diff', '--numstat', `${base}...HEAD`], projectPath),
+      isOnBase ? Promise.resolve('') : gitAsync(['diff', '--name-status', `${base}...HEAD`], projectPath),
     ]);
 
     // Build uncommitted tracked files

--- a/src/index.css
+++ b/src/index.css
@@ -225,6 +225,24 @@ textarea,
   }
 }
 
+@keyframes chain-badge-jitter {
+  0% {
+    transform: scale(1);
+  }
+  15% {
+    transform: scale(1.2);
+  }
+  40% {
+    transform: scale(1.12);
+  }
+  70% {
+    transform: scale(1.05);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
 /* Sidebar home logo mask — CSS url() resolves relative to this file */
 .sidebar-home-logo-mask {
   -webkit-mask-image: url('./assets/ouijit-logomark.svg');

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -122,6 +122,10 @@ export interface IpcInvokeContract {
     args: [projectPath: string, parentTaskNumber: number, name?: string];
     return: TaskWorktreeResult;
   };
+  'task:set-parent': {
+    args: [projectPath: string, taskNumber: number, parentTaskNumber: number | null, mergeTarget?: string];
+    return: { success: boolean; error?: string };
+  };
 
   // ── Worktree ─────────────────────────────────────────────────────────
   'worktree:validate-branch-name': {

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -66,7 +66,7 @@ export interface IpcInvokeContract {
 
   // ── Git ──────────────────────────────────────────────────────────────
   'get-git-status': { args: [projectPath: string]; return: GitStatus | null };
-  'get-git-file-status': { args: [projectPath: string]; return: GitFileStatus | null };
+  'get-git-file-status': { args: [projectPath: string, diffBase?: string]; return: GitFileStatus | null };
   'get-git-dropdown-info': { args: [projectPath: string]; return: GitDropdownInfo | null };
   'git-checkout': { args: [projectPath: string, branchName: string]; return: GitCheckoutResult };
   'git-create-branch': { args: [projectPath: string, branchName: string]; return: GitCheckoutResult };
@@ -118,6 +118,10 @@ export interface IpcInvokeContract {
   };
   'task:check-worktree': { args: [projectPath: string, taskNumber: number]; return: CheckWorktreeResult };
   'task:recover': { args: [projectPath: string, taskNumber: number]; return: TaskWorktreeResult };
+  'task:create-from-task': {
+    args: [projectPath: string, parentTaskNumber: number, name?: string];
+    return: TaskWorktreeResult;
+  };
 
   // ── Worktree ─────────────────────────────────────────────────────────
   'worktree:validate-branch-name': {

--- a/src/ipc/handlers/git.ts
+++ b/src/ipc/handlers/git.ts
@@ -11,7 +11,7 @@ import {
 
 export function registerGitHandlers(): void {
   typedHandle('get-git-status', (projectPath) => getGitStatus(projectPath));
-  typedHandle('get-git-file-status', (projectPath) => getGitFileStatus(projectPath));
+  typedHandle('get-git-file-status', (projectPath, diffBase) => getGitFileStatus(projectPath, diffBase));
   typedHandle('get-git-dropdown-info', (projectPath) => getGitDropdownInfo(projectPath));
   typedHandle('git-checkout', (projectPath, branchName) => checkoutBranch(projectPath, branchName));
   typedHandle('git-create-branch', (projectPath, branchName) => createBranch(projectPath, branchName));

--- a/src/ipc/handlers/task.ts
+++ b/src/ipc/handlers/task.ts
@@ -9,6 +9,7 @@ import {
   trashTaskWithWorktree,
   getTasksWithWorkspaces,
   getTaskWithWorkspace,
+  createBranchFromTask,
 } from '../../taskLifecycle';
 
 export function registerTaskHandlers(): void {
@@ -52,4 +53,8 @@ export function registerTaskHandlers(): void {
   typedHandle('task:check-worktree', (projectPath, taskNumber) => checkTaskWorktree(projectPath, taskNumber));
 
   typedHandle('task:recover', (projectPath, taskNumber) => recoverTaskWorktree(projectPath, taskNumber));
+
+  typedHandle('task:create-from-task', (projectPath, parentTaskNumber, name) =>
+    createBranchFromTask(projectPath, parentTaskNumber, name),
+  );
 }

--- a/src/ipc/handlers/task.ts
+++ b/src/ipc/handlers/task.ts
@@ -1,6 +1,6 @@
 import { typedHandle } from '../helpers';
 import { createTaskWorktree, createTodoTask, checkTaskWorktree, recoverTaskWorktree } from '../../worktree';
-import { setTaskMergeTarget, setTaskSandboxed, setTaskName, setTaskDescription } from '../../db';
+import { setTaskMergeTarget, setTaskSandboxed, setTaskName, setTaskDescription, setTaskParent } from '../../db';
 import {
   beginTask,
   setTaskStatusWithHooks,
@@ -56,5 +56,9 @@ export function registerTaskHandlers(): void {
 
   typedHandle('task:create-from-task', (projectPath, parentTaskNumber, name) =>
     createBranchFromTask(projectPath, parentTaskNumber, name),
+  );
+
+  typedHandle('task:set-parent', (projectPath, taskNumber, parentTaskNumber, mergeTarget) =>
+    setTaskParent(projectPath, taskNumber, parentTaskNumber, mergeTarget),
   );
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -52,7 +52,8 @@ contextBridge.exposeInMainWorld('api', {
     typedInvoke('settings:set-kill-existing-on-run', projectPath, kill),
 
   getGitStatus: (projectPath: string) => typedInvoke('get-git-status', projectPath),
-  getGitFileStatus: (projectPath: string) => typedInvoke('get-git-file-status', projectPath),
+  getGitFileStatus: (projectPath: string, diffBase?: string) =>
+    typedInvoke('get-git-file-status', projectPath, diffBase),
   getGitDropdownInfo: (projectPath: string) => typedInvoke('get-git-dropdown-info', projectPath),
   gitCheckout: (projectPath: string, branchName: string) => typedInvoke('git-checkout', projectPath, branchName),
   gitCreateBranch: (projectPath: string, branchName: string) =>
@@ -135,6 +136,8 @@ contextBridge.exposeInMainWorld('api', {
     checkWorktree: (projectPath: string, taskNumber: number) =>
       typedInvoke('task:check-worktree', projectPath, taskNumber),
     recover: (projectPath: string, taskNumber: number) => typedInvoke('task:recover', projectPath, taskNumber),
+    createFromTask: (projectPath: string, parentTaskNumber: number, name?: string) =>
+      typedInvoke('task:create-from-task', projectPath, parentTaskNumber, name),
   },
 
   hooks: {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -138,6 +138,8 @@ contextBridge.exposeInMainWorld('api', {
     recover: (projectPath: string, taskNumber: number) => typedInvoke('task:recover', projectPath, taskNumber),
     createFromTask: (projectPath: string, parentTaskNumber: number, name?: string) =>
       typedInvoke('task:create-from-task', projectPath, parentTaskNumber, name),
+    setParent: (projectPath: string, taskNumber: number, parentTaskNumber: number | null, mergeTarget?: string) =>
+      typedInvoke('task:set-parent', projectPath, taskNumber, parentTaskNumber, mergeTarget),
   },
 
   hooks: {

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -8,6 +8,8 @@ interface ProjectStoreState {
   scripts: Script[];
   taskVersion: number;
   highlightedChainTask: number | null;
+  detachHoverParent: number | null;
+  optionKeyHeld: boolean;
   activeModal: string | null;
   toasts: Array<{
     id: string;
@@ -40,6 +42,7 @@ interface ProjectStoreActions {
   ) => void;
   removeToast: (id: string) => void;
   setHighlightedChainTask: (taskNumber: number | null) => void;
+  setDetachHoverParent: (taskNumber: number | null) => void;
   setActivePanel: (panel: 'terminals' | 'settings') => void;
   resetForProject: () => void;
 
@@ -62,6 +65,8 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   scripts: [],
   taskVersion: 0,
   highlightedChainTask: null,
+  detachHoverParent: null,
+  optionKeyHeld: false,
   activeModal: null,
   toasts: [],
   _version: 0,
@@ -75,6 +80,8 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   toggleKanban: () => set((s) => ({ kanbanVisible: !s.kanbanVisible })),
 
   setHighlightedChainTask: (taskNumber) => set({ highlightedChainTask: taskNumber }),
+
+  setDetachHoverParent: (taskNumber) => set({ detachHoverParent: taskNumber }),
 
   setActivePanel: (panel) => set({ activePanel: panel }),
 
@@ -111,6 +118,8 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
       scripts: [],
       taskVersion: 0,
       highlightedChainTask: null,
+      detachHoverParent: null,
+      optionKeyHeld: false,
       activeModal: null,
       _version: 0,
     });

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -87,9 +87,13 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
 
   toggleKanban: () => set((s) => ({ kanbanVisible: !s.kanbanVisible })),
 
-  setHighlightedChainTask: (taskNumber) => set({ highlightedChainTask: taskNumber }),
+  setHighlightedChainTask: (taskNumber) => {
+    if (get().highlightedChainTask !== taskNumber) set({ highlightedChainTask: taskNumber });
+  },
 
-  setDetachHoverParent: (taskNumber) => set({ detachHoverParent: taskNumber }),
+  setDetachHoverParent: (taskNumber) => {
+    if (get().detachHoverParent !== taskNumber) set({ detachHoverParent: taskNumber });
+  },
 
   setActiveBadgeDrag: (taskNumber) => set({ activeBadgeDrag: taskNumber }),
 

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -7,6 +7,7 @@ interface ProjectStoreState {
   activePanel: 'terminals' | 'settings';
   scripts: Script[];
   taskVersion: number;
+  highlightedChainTask: number | null;
   activeModal: string | null;
   toasts: Array<{
     id: string;
@@ -38,6 +39,7 @@ interface ProjectStoreActions {
         },
   ) => void;
   removeToast: (id: string) => void;
+  setHighlightedChainTask: (taskNumber: number | null) => void;
   setActivePanel: (panel: 'terminals' | 'settings') => void;
   resetForProject: () => void;
 
@@ -59,6 +61,7 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   activePanel: 'terminals',
   scripts: [],
   taskVersion: 0,
+  highlightedChainTask: null,
   activeModal: null,
   toasts: [],
   _version: 0,
@@ -70,6 +73,8 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   setKanbanVisible: (visible) => set({ kanbanVisible: visible }),
 
   toggleKanban: () => set((s) => ({ kanbanVisible: !s.kanbanVisible })),
+
+  setHighlightedChainTask: (taskNumber) => set({ highlightedChainTask: taskNumber }),
 
   setActivePanel: (panel) => set({ activePanel: panel }),
 
@@ -105,6 +110,7 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
       activePanel: 'terminals',
       scripts: [],
       taskVersion: 0,
+      highlightedChainTask: null,
       activeModal: null,
       _version: 0,
     });

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -48,6 +48,7 @@ interface ProjectStoreActions {
   setActiveBadgeDrag: (taskNumber: number | null) => void;
   setBadgeDragOverTask: (taskNumber: number | null) => void;
   clearChainHighlights: () => void;
+  resetBadgeDragState: () => void;
   setActivePanel: (panel: 'terminals' | 'settings') => void;
   resetForProject: () => void;
 
@@ -95,6 +96,9 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   setBadgeDragOverTask: (taskNumber) => set({ badgeDragOverTask: taskNumber }),
 
   clearChainHighlights: () => set({ highlightedChainTask: null, detachHoverParent: null }),
+
+  resetBadgeDragState: () =>
+    set({ activeBadgeDrag: null, badgeDragOverTask: null, highlightedChainTask: null, detachHoverParent: null }),
 
   setActivePanel: (panel) => set({ activePanel: panel }),
 

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -202,7 +202,12 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
 
     try {
       const result = await window.api.task.reorder(projectPath, taskNumber, newStatus as any, targetIndex);
-      if (!result.success) rollbackOrReload();
+      if (!result.success) {
+        rollbackOrReload();
+      } else if (moveCounter !== moveVersion) {
+        // Another move happened while this one was in flight — reconcile with server
+        get().loadTasks(projectPath);
+      }
     } catch {
       rollbackOrReload();
     }

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -10,6 +10,8 @@ interface ProjectStoreState {
   highlightedChainTask: number | null;
   detachHoverParent: number | null;
   optionKeyHeld: boolean;
+  activeBadgeDrag: number | null;
+  badgeDragOverTask: number | null;
   activeModal: string | null;
   toasts: Array<{
     id: string;
@@ -43,6 +45,9 @@ interface ProjectStoreActions {
   removeToast: (id: string) => void;
   setHighlightedChainTask: (taskNumber: number | null) => void;
   setDetachHoverParent: (taskNumber: number | null) => void;
+  setActiveBadgeDrag: (taskNumber: number | null) => void;
+  setBadgeDragOverTask: (taskNumber: number | null) => void;
+  clearChainHighlights: () => void;
   setActivePanel: (panel: 'terminals' | 'settings') => void;
   resetForProject: () => void;
 
@@ -67,6 +72,8 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   highlightedChainTask: null,
   detachHoverParent: null,
   optionKeyHeld: false,
+  activeBadgeDrag: null,
+  badgeDragOverTask: null,
   activeModal: null,
   toasts: [],
   _version: 0,
@@ -82,6 +89,12 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   setHighlightedChainTask: (taskNumber) => set({ highlightedChainTask: taskNumber }),
 
   setDetachHoverParent: (taskNumber) => set({ detachHoverParent: taskNumber }),
+
+  setActiveBadgeDrag: (taskNumber) => set({ activeBadgeDrag: taskNumber }),
+
+  setBadgeDragOverTask: (taskNumber) => set({ badgeDragOverTask: taskNumber }),
+
+  clearChainHighlights: () => set({ highlightedChainTask: null, detachHoverParent: null }),
 
   setActivePanel: (panel) => set({ activePanel: panel }),
 
@@ -120,6 +133,8 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
       highlightedChainTask: null,
       detachHoverParent: null,
       optionKeyHeld: false,
+      activeBadgeDrag: null,
+      badgeDragOverTask: null,
       activeModal: null,
       _version: 0,
     });

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -95,9 +95,13 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
     if (get().detachHoverParent !== taskNumber) set({ detachHoverParent: taskNumber });
   },
 
-  setActiveBadgeDrag: (taskNumber) => set({ activeBadgeDrag: taskNumber }),
+  setActiveBadgeDrag: (taskNumber) => {
+    if (get().activeBadgeDrag !== taskNumber) set({ activeBadgeDrag: taskNumber });
+  },
 
-  setBadgeDragOverTask: (taskNumber) => set({ badgeDragOverTask: taskNumber }),
+  setBadgeDragOverTask: (taskNumber) => {
+    if (get().badgeDragOverTask !== taskNumber) set({ badgeDragOverTask: taskNumber });
+  },
 
   clearChainHighlights: () => set({ highlightedChainTask: null, detachHoverParent: null }),
 

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -63,6 +63,7 @@ interface ProjectStoreActions {
 type ProjectStore = ProjectStoreState & ProjectStoreActions;
 
 let toastCounter = 0;
+let moveCounter = 0;
 
 export const useProjectStore = create<ProjectStore>()((set, get) => ({
   tasks: [],
@@ -175,6 +176,7 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
 
   moveTask: async (projectPath, taskNumber, newStatus, targetIndex) => {
     const prev = get().tasks;
+    const moveVersion = ++moveCounter;
     // Optimistic: reorder locally
     const task = prev.find((t) => t.taskNumber === taskNumber);
     if (!task) return;
@@ -188,15 +190,21 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
     const orderedStatusTasks = statusTasks.map((t, i) => ({ ...t, order: i }));
     set({ tasks: [...otherTasks, ...orderedStatusTasks] });
 
+    const rollbackOrReload = () => {
+      // Only rollback if no other move has happened since our snapshot
+      if (moveCounter === moveVersion) {
+        set({ tasks: prev });
+      } else {
+        get().loadTasks(projectPath);
+      }
+      get().addToast('Failed to move task', 'error');
+    };
+
     try {
       const result = await window.api.task.reorder(projectPath, taskNumber, newStatus as any, targetIndex);
-      if (!result.success) {
-        set({ tasks: prev });
-        get().addToast('Failed to move task', 'error');
-      }
+      if (!result.success) rollbackOrReload();
     } catch {
-      set({ tasks: prev });
-      get().addToast('Failed to move task', 'error');
+      rollbackOrReload();
     }
   },
 }));

--- a/src/taskLifecycle.ts
+++ b/src/taskLifecycle.ts
@@ -3,7 +3,7 @@
  * Extracted from IPC handlers to keep handlers as thin one-liner delegations.
  */
 
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { existsSync } from 'node:fs';
 import { trashItem } from './platform';
@@ -22,7 +22,7 @@ import { listWorktrees, removeTaskWorktree, startTask } from './worktree';
 import type { TaskWithWorkspace, TaskWorktreeResult } from './types';
 import { getLogger } from './logger';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const taskLog = getLogger().scope('task');
 
@@ -175,7 +175,7 @@ export async function trashTaskWithWorktree(
     taskLog.info('trashing task worktree', { taskNumber, worktreePath });
     try {
       await trashItem(worktreePath);
-      await execAsync('git worktree prune', { cwd: projectPath, encoding: 'utf8' });
+      await execFileAsync('git', ['worktree', 'prune'], { cwd: projectPath, encoding: 'utf8' });
     } catch (trashError) {
       const msg = trashError instanceof Error ? trashError.message : String(trashError);
       taskLog.error('trashItem failed', { taskNumber, error: msg });
@@ -185,7 +185,7 @@ export async function trashTaskWithWorktree(
     // Delete the branch
     if (task?.branch) {
       try {
-        await execAsync(`git branch -D "${task.branch}"`, { cwd: projectPath, encoding: 'utf8' });
+        await execFileAsync('git', ['branch', '-D', task.branch], { cwd: projectPath, encoding: 'utf8' });
       } catch {
         // Branch may already be deleted
       }

--- a/src/taskLifecycle.ts
+++ b/src/taskLifecycle.ts
@@ -52,9 +52,8 @@ export async function beginTask(
   const result = await startTask(projectPath, taskNumber, branchName, baseBranch);
   if (!result.success) return result;
 
-  // Move to in_progress if currently todo
-  const updated = await getTaskByNumber(projectPath, taskNumber);
-  if (updated?.status === 'todo') {
+  // Move to in_progress if currently todo (startTask doesn't change status)
+  if (task?.status === 'todo') {
     const statusResult = await setTaskStatus(projectPath, taskNumber, 'in_progress');
     if (!statusResult.success) {
       taskLog.error('beginTask: failed to set status', { taskNumber, error: statusResult.error });
@@ -239,5 +238,6 @@ export async function getTaskWithWorkspace(projectPath: string, taskNumber: numb
     prompt: task.prompt,
     sandboxed: task.sandboxed,
     order: task.order,
+    parentTaskNumber: task.parentTaskNumber,
   };
 }

--- a/src/taskLifecycle.ts
+++ b/src/taskLifecycle.ts
@@ -14,6 +14,7 @@ import {
   createTask,
   setTaskStatus,
   deleteTaskByNumber,
+  clearParentReferences,
   reorderTask,
   type TaskStatus,
 } from './db';
@@ -124,6 +125,10 @@ export async function deleteTaskWithWorktree(
   taskNumber: number,
 ): Promise<{ success: boolean; error?: string }> {
   const task = await getTaskByNumber(projectPath, taskNumber);
+
+  // Clear parent references on children before deleting
+  await clearParentReferences(projectPath, taskNumber);
+
   if (task?.worktreePath || task?.branch) {
     const worktrees = await listWorktrees(projectPath);
     const wt = task.branch
@@ -152,6 +157,9 @@ export async function trashTaskWithWorktree(
   taskNumber: number,
 ): Promise<{ success: boolean; error?: string; trashed?: boolean }> {
   const task = await getTaskByNumber(projectPath, taskNumber);
+
+  // Clear parent references on children before deleting
+  await clearParentReferences(projectPath, taskNumber);
 
   // Resolve the worktree path — prefer the DB path, fall back to git worktree list
   let worktreePath: string | undefined;

--- a/src/taskLifecycle.ts
+++ b/src/taskLifecycle.ts
@@ -10,6 +10,8 @@ import { trashItem } from './platform';
 import {
   getProjectTasks,
   getTaskByNumber,
+  getNextTaskNumber,
+  createTask,
   setTaskStatus,
   deleteTaskByNumber,
   reorderTask,
@@ -32,12 +34,27 @@ export async function beginTask(
   taskNumber: number,
   branchName?: string,
 ): Promise<TaskWorktreeResult> {
-  const result = await startTask(projectPath, taskNumber, branchName);
+  // Detect parent relationship to determine base branch
+  let baseBranch: string | undefined;
+  const task = await getTaskByNumber(projectPath, taskNumber);
+  if (task?.parentTaskNumber) {
+    const parent = await getTaskByNumber(projectPath, task.parentTaskNumber);
+    if (parent?.branch) {
+      baseBranch = parent.branch;
+    } else {
+      taskLog.warn('parent task or branch missing, falling back to HEAD', {
+        taskNumber,
+        parentTaskNumber: task.parentTaskNumber,
+      });
+    }
+  }
+
+  const result = await startTask(projectPath, taskNumber, branchName, baseBranch);
   if (!result.success) return result;
 
   // Move to in_progress if currently todo
-  const task = await getTaskByNumber(projectPath, taskNumber);
-  if (task?.status === 'todo') {
+  const updated = await getTaskByNumber(projectPath, taskNumber);
+  if (updated?.status === 'todo') {
     const statusResult = await setTaskStatus(projectPath, taskNumber, 'in_progress');
     if (!statusResult.success) {
       taskLog.error('beginTask: failed to set status', { taskNumber, error: statusResult.error });
@@ -45,6 +62,28 @@ export async function beginTask(
   }
 
   return result;
+}
+
+/**
+ * Create a new TODO task that will branch from an existing task's branch when started.
+ */
+export async function createBranchFromTask(
+  projectPath: string,
+  parentTaskNumber: number,
+  name?: string,
+): Promise<TaskWorktreeResult> {
+  const parent = await getTaskByNumber(projectPath, parentTaskNumber);
+  if (!parent) return { success: false, error: 'Parent task not found' };
+  if (!parent.branch) return { success: false, error: 'Parent task has no branch' };
+
+  const taskNumber = await getNextTaskNumber(projectPath);
+  const displayName = name || 'Untitled';
+  const task = await createTask(projectPath, taskNumber, displayName, {
+    status: 'todo',
+    parentTaskNumber,
+    mergeTarget: parent.branch,
+  });
+  return { success: true, task };
 }
 
 /**
@@ -175,6 +214,7 @@ export async function getTasksWithWorkspaces(projectPath: string): Promise<TaskW
       prompt: task.prompt,
       sandboxed: task.sandboxed,
       order: task.order,
+      parentTaskNumber: task.parentTaskNumber,
     };
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,6 +236,7 @@ export interface TaskWithWorkspace {
   prompt?: string;
   sandboxed?: boolean;
   order?: number;
+  parentTaskNumber?: number;
 }
 
 /**
@@ -316,6 +317,7 @@ export interface TaskAPI {
   ): Promise<{ success: boolean; error?: string; hookWarning?: string }>;
   checkWorktree(projectPath: string, taskNumber: number): Promise<CheckWorktreeResult>;
   recover(projectPath: string, taskNumber: number): Promise<TaskWorktreeResult>;
+  createFromTask(projectPath: string, parentTaskNumber: number, name?: string): Promise<TaskWorktreeResult>;
 }
 
 /**
@@ -388,7 +390,7 @@ export interface ElectronAPI {
   /** Get git status (branch and dirty state) for a project */
   getGitStatus(projectPath: string): Promise<GitStatus | null>;
   /** Get detailed file-level git status (single source of truth for button + diff panel) */
-  getGitFileStatus(projectPath: string): Promise<GitFileStatus | null>;
+  getGitFileStatus(projectPath: string, diffBase?: string): Promise<GitFileStatus | null>;
   /** Get extended git dropdown info for a project */
   getGitDropdownInfo(projectPath: string): Promise<GitDropdownInfo | null>;
   /** Checkout a git branch */

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,6 +318,12 @@ export interface TaskAPI {
   checkWorktree(projectPath: string, taskNumber: number): Promise<CheckWorktreeResult>;
   recover(projectPath: string, taskNumber: number): Promise<TaskWorktreeResult>;
   createFromTask(projectPath: string, parentTaskNumber: number, name?: string): Promise<TaskWorktreeResult>;
+  setParent(
+    projectPath: string,
+    taskNumber: number,
+    parentTaskNumber: number | null,
+    mergeTarget?: string,
+  ): Promise<{ success: boolean; error?: string }>;
 }
 
 /**

--- a/src/utils/taskChain.ts
+++ b/src/utils/taskChain.ts
@@ -49,7 +49,7 @@ export function buildChainMap(tasks: TaskWithWorkspace[]): Map<number, TaskChain
       childTaskNumbers: childrenMap.get(taskNumber) ?? [],
     };
     result.set(taskNumber, info);
-    return { root: parent.root, depth: parent.depth + 1 };
+    return { root: info.rootTaskNumber, depth: info.depth };
   }
 
   for (const task of tasks) {

--- a/src/utils/taskChain.ts
+++ b/src/utils/taskChain.ts
@@ -27,27 +27,33 @@ export function buildChainMap(tasks: TaskWithWorkspace[]): Map<number, TaskChain
     }
   }
 
-  // Compute root + depth for each task via parent walk
+  // Compute root + depth for each task via parent walk, memoizing as we go
   function resolve(taskNumber: number): { root: number; depth: number } {
     const cached = result.get(taskNumber);
     if (cached) return { root: cached.rootTaskNumber, depth: cached.depth };
 
     const task = byNumber.get(taskNumber);
     if (!task?.parentTaskNumber || !byNumber.has(task.parentTaskNumber)) {
+      result.set(taskNumber, {
+        rootTaskNumber: taskNumber,
+        depth: 0,
+        childTaskNumbers: childrenMap.get(taskNumber) ?? [],
+      });
       return { root: taskNumber, depth: 0 };
     }
 
     const parent = resolve(task.parentTaskNumber);
+    const info = {
+      rootTaskNumber: parent.root,
+      depth: parent.depth + 1,
+      childTaskNumbers: childrenMap.get(taskNumber) ?? [],
+    };
+    result.set(taskNumber, info);
     return { root: parent.root, depth: parent.depth + 1 };
   }
 
   for (const task of tasks) {
-    const { root, depth } = resolve(task.taskNumber);
-    result.set(task.taskNumber, {
-      rootTaskNumber: root,
-      depth,
-      childTaskNumbers: childrenMap.get(task.taskNumber) ?? [],
-    });
+    resolve(task.taskNumber);
   }
 
   return result;
@@ -80,12 +86,13 @@ export function isDescendantOf(
 ): boolean {
   const queue = [...(chainMap.get(ancestor)?.childTaskNumbers ?? [])];
   const visited = new Set<number>();
-  while (queue.length > 0) {
-    const current = queue.shift()!;
+  for (let i = 0; i < queue.length; i++) {
+    const current = queue[i];
     if (current === possibleDescendant) return true;
     if (visited.has(current)) continue;
     visited.add(current);
-    queue.push(...(chainMap.get(current)?.childTaskNumbers ?? []));
+    const children = chainMap.get(current)?.childTaskNumbers;
+    if (children) queue.push(...children);
   }
   return false;
 }

--- a/src/utils/taskChain.ts
+++ b/src/utils/taskChain.ts
@@ -1,0 +1,73 @@
+import type { TaskWithWorkspace } from '../types';
+
+export interface TaskChainInfo {
+  rootTaskNumber: number;
+  depth: number;
+  childTaskNumbers: number[];
+}
+
+/**
+ * Build a map of chain info for all tasks in a project.
+ * Walks parent chains to compute root and depth for each task.
+ */
+export function buildChainMap(tasks: TaskWithWorkspace[]): Map<number, TaskChainInfo> {
+  const byNumber = new Map(tasks.map((t) => [t.taskNumber, t]));
+  const childrenMap = new Map<number, number[]>();
+  const result = new Map<number, TaskChainInfo>();
+
+  // Build children index
+  for (const task of tasks) {
+    if (task.parentTaskNumber != null) {
+      const siblings = childrenMap.get(task.parentTaskNumber);
+      if (siblings) {
+        siblings.push(task.taskNumber);
+      } else {
+        childrenMap.set(task.parentTaskNumber, [task.taskNumber]);
+      }
+    }
+  }
+
+  // Compute root + depth for each task via parent walk
+  function resolve(taskNumber: number): { root: number; depth: number } {
+    const cached = result.get(taskNumber);
+    if (cached) return { root: cached.rootTaskNumber, depth: cached.depth };
+
+    const task = byNumber.get(taskNumber);
+    if (!task?.parentTaskNumber || !byNumber.has(task.parentTaskNumber)) {
+      return { root: taskNumber, depth: 0 };
+    }
+
+    const parent = resolve(task.parentTaskNumber);
+    return { root: parent.root, depth: parent.depth + 1 };
+  }
+
+  for (const task of tasks) {
+    const { root, depth } = resolve(task.taskNumber);
+    result.set(task.taskNumber, {
+      rootTaskNumber: root,
+      depth,
+      childTaskNumbers: childrenMap.get(task.taskNumber) ?? [],
+    });
+  }
+
+  return result;
+}
+
+/** Deterministic hue from root task number (golden angle for good distribution). */
+export function getChainHue(rootTaskNumber: number): number {
+  return (rootTaskNumber * 137.508) % 360;
+}
+
+/** HSL color string for a badge at a given depth within a chain. */
+export function getChainColor(rootTaskNumber: number, depth: number): string {
+  const hue = getChainHue(rootTaskNumber);
+  const lightness = Math.max(72 - depth * 14, 30);
+  return `hsl(${hue}, 55%, ${lightness}%)`;
+}
+
+/** Semi-transparent background for badge. */
+export function getChainBgColor(rootTaskNumber: number, depth: number): string {
+  const hue = getChainHue(rootTaskNumber);
+  const lightness = Math.max(72 - depth * 14, 30);
+  return `hsla(${hue}, 55%, ${lightness}%, 0.15)`;
+}

--- a/src/utils/taskChain.ts
+++ b/src/utils/taskChain.ts
@@ -28,12 +28,13 @@ export function buildChainMap(tasks: TaskWithWorkspace[]): Map<number, TaskChain
   }
 
   // Compute root + depth for each task via parent walk, memoizing as we go
+  const visiting = new Set<number>();
   function resolve(taskNumber: number): { root: number; depth: number } {
     const cached = result.get(taskNumber);
     if (cached) return { root: cached.rootTaskNumber, depth: cached.depth };
 
     const task = byNumber.get(taskNumber);
-    if (!task?.parentTaskNumber || !byNumber.has(task.parentTaskNumber)) {
+    if (!task?.parentTaskNumber || !byNumber.has(task.parentTaskNumber) || visiting.has(taskNumber)) {
       result.set(taskNumber, {
         rootTaskNumber: taskNumber,
         depth: 0,
@@ -42,7 +43,9 @@ export function buildChainMap(tasks: TaskWithWorkspace[]): Map<number, TaskChain
       return { root: taskNumber, depth: 0 };
     }
 
+    visiting.add(taskNumber);
     const parent = resolve(task.parentTaskNumber);
+    visiting.delete(taskNumber);
     const info = {
       rootTaskNumber: parent.root,
       depth: parent.depth + 1,
@@ -64,17 +67,19 @@ export function getChainHue(rootTaskNumber: number): number {
   return (rootTaskNumber * 137.508) % 360;
 }
 
+function getChainHsl(rootTaskNumber: number, depth: number): [number, number] {
+  return [getChainHue(rootTaskNumber), Math.max(72 - depth * 14, 30)];
+}
+
 /** HSL color string for a badge at a given depth within a chain. */
 export function getChainColor(rootTaskNumber: number, depth: number): string {
-  const hue = getChainHue(rootTaskNumber);
-  const lightness = Math.max(72 - depth * 14, 30);
+  const [hue, lightness] = getChainHsl(rootTaskNumber, depth);
   return `hsl(${hue}, 55%, ${lightness}%)`;
 }
 
 /** Semi-transparent background for badge. */
 export function getChainBgColor(rootTaskNumber: number, depth: number): string {
-  const hue = getChainHue(rootTaskNumber);
-  const lightness = Math.max(72 - depth * 14, 30);
+  const [hue, lightness] = getChainHsl(rootTaskNumber, depth);
   return `hsla(${hue}, 55%, ${lightness}%, 0.15)`;
 }
 

--- a/src/utils/taskChain.ts
+++ b/src/utils/taskChain.ts
@@ -6,6 +6,11 @@ export interface TaskChainInfo {
   childTaskNumbers: number[];
 }
 
+/** Whether a task is part of a parent-child chain (has a parent or children). */
+export function isChainMember(info: TaskChainInfo | undefined): boolean {
+  return info != null && (info.depth > 0 || info.childTaskNumbers.length > 0);
+}
+
 /**
  * Build a map of chain info for all tasks in a project.
  * Walks parent chains to compute root and depth for each task.

--- a/src/utils/taskChain.ts
+++ b/src/utils/taskChain.ts
@@ -71,3 +71,21 @@ export function getChainBgColor(rootTaskNumber: number, depth: number): string {
   const lightness = Math.max(72 - depth * 14, 30);
   return `hsla(${hue}, 55%, ${lightness}%, 0.15)`;
 }
+
+/** Check if possibleDescendant is a descendant of ancestor in the chain map. */
+export function isDescendantOf(
+  possibleDescendant: number,
+  ancestor: number,
+  chainMap: Map<number, TaskChainInfo>,
+): boolean {
+  const queue = [...(chainMap.get(ancestor)?.childTaskNumbers ?? [])];
+  const visited = new Set<number>();
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (current === possibleDescendant) return true;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    queue.push(...(chainMap.get(current)?.childTaskNumbers ?? []));
+  }
+  return false;
+}

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -3,7 +3,7 @@
  * Creates isolated worktrees for CLI agents to work without affecting the main branch
  */
 
-import { exec } from 'node:child_process';
+import { exec, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
@@ -26,6 +26,7 @@ import { mergeWorktreeBranch } from './git';
 const worktreeLog = getLogger().scope('worktree');
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 // Native CoW clone support via koffi FFI
 // macOS: clonefile() clones files and directories atomically in one kernel call
@@ -334,17 +335,18 @@ export async function startTask(
     await execAsync('git worktree prune', { cwd: projectPath });
 
     // Check if branch already exists (e.g. leftover from a previous failed attempt)
-    const branchExists = await execAsync(`git rev-parse --verify "${branch}"`, { cwd: projectPath }).then(
+    const branchExists = await execFileAsync('git', ['rev-parse', '--verify', branch], { cwd: projectPath }).then(
       () => true,
       () => false,
     );
-    const startPoint = baseBranch && !branchExists ? ` "${baseBranch}"` : '';
-    const wtAddCmd = branchExists
-      ? `git worktree add "${worktreePath}" "${branch}"`
-      : `git worktree add -b "${branch}" "${worktreePath}"${startPoint}`;
+    const wtAddArgs = branchExists
+      ? ['worktree', 'add', worktreePath, branch]
+      : baseBranch
+        ? ['worktree', 'add', '-b', branch, worktreePath, baseBranch]
+        : ['worktree', 'add', '-b', branch, worktreePath];
 
     const [, ignoredFiles] = await Promise.all([
-      execAsync(wtAddCmd, { cwd: projectPath }),
+      execFileAsync('git', wtAddArgs, { cwd: projectPath }),
       fetchIgnoredFiles(projectPath),
     ]);
 

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -421,21 +421,21 @@ export async function createTaskWorktree(
     const branch = branchName || generateBranchName(name, currentTaskNumber);
 
     // Prune stale worktree registrations so deleted directories can be reused
-    await execAsync('git worktree prune', { cwd: projectPath });
+    await execFileAsync('git', ['worktree', 'prune'], { cwd: projectPath });
 
     // Check if branch already exists (e.g. leftover from a previous failed attempt)
-    const branchExists = await execAsync(`git rev-parse --verify "${branch}"`, { cwd: projectPath }).then(
+    const branchExists = await execFileAsync('git', ['rev-parse', '--verify', branch], { cwd: projectPath }).then(
       () => true,
       () => false,
     );
-    const wtAddCmd = branchExists
-      ? `git worktree add "${worktreePath}" "${branch}"`
-      : `git worktree add -b "${branch}" "${worktreePath}"`;
+    const wtAddArgs = branchExists
+      ? ['worktree', 'add', worktreePath, branch]
+      : ['worktree', 'add', '-b', branch, worktreePath];
 
     // Start ls-files in parallel with git worktree add
     // ls-files reads from source dir, doesn't need the worktree to exist
     const [, ignoredFiles] = await Promise.all([
-      execAsync(wtAddCmd, { cwd: projectPath }),
+      execFileAsync('git', wtAddArgs, { cwd: projectPath }),
       fetchIgnoredFiles(projectPath),
     ]);
 
@@ -475,7 +475,7 @@ export async function removeTaskWorktree(
     const branchName = task?.branch;
 
     // Remove the worktree
-    await execAsync(`git worktree remove "${worktreePath}" --force`, {
+    await execFileAsync('git', ['worktree', 'remove', worktreePath, '--force'], {
       cwd: projectPath,
       encoding: 'utf8',
     });
@@ -483,7 +483,7 @@ export async function removeTaskWorktree(
     // Delete the branch
     if (branchName) {
       try {
-        await execAsync(`git branch -D "${branchName}"`, {
+        await execFileAsync('git', ['branch', '-D', branchName], {
           cwd: projectPath,
           encoding: 'utf8',
         });

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -284,6 +284,7 @@ export async function startTask(
   projectPath: string,
   taskNumber: number,
   branchName?: string,
+  baseBranch?: string,
 ): Promise<TaskWorktreeResult> {
   try {
     const task = await getTaskByNumber(projectPath, taskNumber);
@@ -310,7 +311,7 @@ export async function startTask(
       await execAsync('git commit --allow-empty -m "Initial commit"', { cwd: projectPath });
     }
 
-    const mergeTarget = branchResult;
+    const mergeTarget = baseBranch || branchResult;
     const projectName = path.basename(projectPath);
     const baseDir = getWorktreeBaseDir(projectName);
     await fs.mkdir(baseDir, { recursive: true });
@@ -337,9 +338,10 @@ export async function startTask(
       () => true,
       () => false,
     );
+    const startPoint = baseBranch && !branchExists ? ` "${baseBranch}"` : '';
     const wtAddCmd = branchExists
       ? `git worktree add "${worktreePath}" "${branch}"`
-      : `git worktree add -b "${branch}" "${worktreePath}"`;
+      : `git worktree add -b "${branch}" "${worktreePath}"${startPoint}`;
 
     const [, ignoredFiles] = await Promise.all([
       execAsync(wtAddCmd, { cwd: projectPath }),


### PR DESCRIPTION
## Summary

- Add parent-child task relationships with a `parent_task_number` column (migration 008) so child tasks branch from a parent's branch instead of main
- Drag-to-link badge UI on kanban cards: hold Option to show badges, drag a badge onto another card to set parent, click x to detach — with chain coloring, jitter animation, and cycle prevention
- "Branch from this task" context menu item and dialog for creating child tasks from started tasks
- Diff panel and git status now diff against the parent branch (`mergeTarget`) instead of main when viewing worktree changes
- Store efficiency: change-detection guards on all high-frequency setters to avoid no-op re-renders during drag