### PR TITLE
Complete execAsync→execFileAsync migration in worktree.ts

### DIFF
--- a/src/__tests__/ipcRefactor.test.ts
+++ b/src/__tests__/ipcRefactor.test.ts
@@ -9,17 +9,24 @@ import { createTask, _resetCacheForTesting } from '../db';
 
 // ── Mocks (superset needed by all describe blocks) ──────────────────
 
-vi.mock('node:child_process', () => ({
-  exec: vi.fn((_cmd: string, _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
-    cb(null, { stdout: '', stderr: '' });
-  }),
-  execFile: vi.fn(
+vi.mock('node:child_process', () => {
+  const execFileFn = vi.fn(
     (_file: string, _args: string[], _opts: unknown, cb: (err: null, stdout: string, stderr: string) => void) => {
       cb(null, '', '');
     },
-  ),
-  execSync: vi.fn(),
-}));
+  );
+  // Replicate Node's custom promisify for execFile so promisify() returns { stdout, stderr }
+  (execFileFn as Record<symbol, unknown>)[Symbol.for('nodejs.util.promisify.custom')] = (
+    ...args: unknown[]
+  ): Promise<{ stdout: string; stderr: string }> =>
+    new Promise((resolve, reject) => {
+      execFileFn(...(args as Parameters<typeof execFileFn>), (err: Error | null, stdout: string, stderr: string) => {
+        if (err) reject(err);
+        else resolve({ stdout, stderr });
+      });
+    });
+  return { exec: vi.fn(), execSync: vi.fn(), execFile: execFileFn };
+});
 
 vi.mock('koffi', () => ({
   default: { load: vi.fn() },
@@ -47,7 +54,7 @@ vi.mock('../hookRunner', () => ({
 
 // ── Imports (after mocks) ───────────────────────────────────────────
 
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { listWorktrees, shipWorktree } from '../worktree';
 import { createProject } from '../projectCreator';
 import { getTasksWithWorkspaces } from '../taskLifecycle';
@@ -57,28 +64,30 @@ import { getTasksWithWorkspaces } from '../taskLifecycle';
 const homedir = os.homedir();
 const baseDir = `${homedir}/Ouijit/worktrees/myproject`;
 
-function mockExec(handler: (cmd: string) => { stdout: string; stderr: string } | Error) {
-  vi.mocked(exec).mockImplementation(((...args: unknown[]) => {
-    const cmd = args[0] as string;
-    const cb = args[2] as (err: Error | null, result: { stdout: string; stderr: string }) => void;
+function mockExecFile(handler: (cmd: string) => { stdout: string; stderr: string } | Error) {
+  vi.mocked(execFile).mockImplementation(((...args: unknown[]) => {
+    const file = args[0] as string;
+    const fileArgs = args[1] as string[];
+    const cb = args[args.length - 1] as (err: Error | null, stdout: string, stderr: string) => void;
+    const cmd = [file, ...fileArgs].join(' ');
     const result = handler(cmd);
     if (result instanceof Error) {
-      cb(result, { stdout: '', stderr: '' });
+      cb(result, '', '');
     } else {
-      cb(null, result);
+      cb(null, result.stdout, result.stderr);
     }
-  }) as typeof exec);
+  }) as typeof execFile);
 }
 
 // ── listWorktrees ───────────────────────────────────────────────────
 
 describe('listWorktrees (async)', () => {
   beforeEach(() => {
-    vi.mocked(exec).mockReset();
+    vi.mocked(execFile).mockReset();
   });
 
   test('returns a Promise (not a synchronous value)', () => {
-    mockExec(() => ({ stdout: '', stderr: '' }));
+    mockExecFile(() => ({ stdout: '', stderr: '' }));
     const result = listWorktrees('/projects/myproject');
     expect(result).toBeInstanceOf(Promise);
   });
@@ -102,7 +111,7 @@ describe('listWorktrees (async)', () => {
       `branch refs/heads/feature-2`,
     ].join('\n');
 
-    mockExec(() => ({ stdout: porcelain, stderr: '' }));
+    mockExecFile(() => ({ stdout: porcelain, stderr: '' }));
 
     const worktrees = await listWorktrees('/projects/myproject');
     expect(worktrees).toHaveLength(2);
@@ -113,7 +122,7 @@ describe('listWorktrees (async)', () => {
   });
 
   test('returns empty array when git command fails', async () => {
-    mockExec(() => new Error('fatal: not a git repository'));
+    mockExecFile(() => new Error('fatal: not a git repository'));
     const worktrees = await listWorktrees('/not-a-repo');
     expect(worktrees).toEqual([]);
   });
@@ -121,7 +130,7 @@ describe('listWorktrees (async)', () => {
   test('returns empty array when no managed worktrees exist', async () => {
     const porcelain = [`worktree /projects/myproject`, `HEAD abc123`, `branch refs/heads/main`].join('\n');
 
-    mockExec(() => ({ stdout: porcelain, stderr: '' }));
+    mockExecFile(() => ({ stdout: porcelain, stderr: '' }));
     const worktrees = await listWorktrees('/projects/myproject');
     expect(worktrees).toEqual([]);
   });
@@ -137,7 +146,7 @@ describe('listWorktrees (async)', () => {
       `branch refs/heads/newer-2000000000`,
     ].join('\n');
 
-    mockExec(() => ({ stdout: porcelain, stderr: '' }));
+    mockExecFile(() => ({ stdout: porcelain, stderr: '' }));
     const worktrees = await listWorktrees('/projects/myproject');
     expect(worktrees[0].branch).toBe('newer-2000000000');
     expect(worktrees[1].branch).toBe('older-1000000000');
@@ -148,7 +157,7 @@ describe('listWorktrees (async)', () => {
 
 describe('shipWorktree (async)', () => {
   beforeEach(() => {
-    vi.mocked(exec).mockReset();
+    vi.mocked(execFile).mockReset();
   });
 
   const worktreePorcelain = (branch: string) =>
@@ -156,7 +165,7 @@ describe('shipWorktree (async)', () => {
 
   test('detects uncommitted changes and returns error', async () => {
     const branch = 'dirty-branch';
-    mockExec((cmd) => {
+    mockExecFile((cmd) => {
       if (cmd.includes('git worktree list')) return { stdout: worktreePorcelain(branch), stderr: '' };
       if (cmd.includes('git status --porcelain')) return { stdout: ' M dirty-file.ts\n', stderr: '' };
       return { stdout: '', stderr: '' };
@@ -171,7 +180,7 @@ describe('shipWorktree (async)', () => {
 
   test('proceeds with merge when worktree is clean', async () => {
     const branch = 'clean-branch';
-    mockExec((cmd) => {
+    mockExecFile((cmd) => {
       if (cmd.includes('git worktree list')) return { stdout: worktreePorcelain(branch), stderr: '' };
       if (cmd.includes('git status --porcelain')) return { stdout: '', stderr: '' };
       return { stdout: '', stderr: '' };
@@ -184,7 +193,7 @@ describe('shipWorktree (async)', () => {
   });
 
   test('proceeds with merge when worktree is not found', async () => {
-    mockExec(() => ({ stdout: '', stderr: '' }));
+    mockExecFile(() => ({ stdout: '', stderr: '' }));
     await createTask('/projects/myproject', 3, 'Orphan task', { branch: 'orphan-branch', mergeTarget: 'main' });
 
     const result = await shipWorktree('/projects/myproject', 'orphan-branch');
@@ -230,7 +239,7 @@ describe('createProject path traversal', () => {
 
 describe('getTasksWithWorkspaces', () => {
   beforeEach(() => {
-    vi.mocked(exec).mockReset();
+    vi.mocked(execFile).mockReset();
     _resetCacheForTesting();
   });
 
@@ -239,7 +248,7 @@ describe('getTasksWithWorkspaces', () => {
     const livePath = `${baseDir}/T-1`;
 
     // Return a worktree list that maps feature-1 → livePath
-    mockExec(() => {
+    mockExecFile(() => {
       const porcelain = [
         `worktree /projects/myproject`,
         `HEAD abc123`,

--- a/src/__tests__/startTask.test.ts
+++ b/src/__tests__/startTask.test.ts
@@ -1,28 +1,39 @@
 import { describe, test, expect, vi } from 'vitest';
 import { createTask, getTaskByNumber } from '../db';
 
-// Mock child_process so execAsync resolves without real git commands
-vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
-  exec: vi.fn((_cmd: string, _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
-    cb(null, { stdout: 'main\n', stderr: '' });
-  }),
-  execFile: vi.fn(
+// Mock child_process so execFileAsync resolves without real git commands
+vi.mock('node:child_process', () => {
+  const execFileFn = vi.fn(
     (
       _file: string,
       args: string[],
       _opts: unknown,
       cb: (err: Error | null, stdout: string, stderr: string) => void,
     ) => {
-      // Default: rev-parse --verify always fails (branch doesn't exist) so tests exercise the -b path
+      // rev-parse --verify always fails (branch doesn't exist) so tests exercise the -b path
       if (Array.isArray(args) && args.includes('--verify')) {
         cb(new Error('not found'), '', '');
+      } else if (Array.isArray(args) && args.includes('--abbrev-ref')) {
+        cb(null, 'main\n', '');
+      } else if (Array.isArray(args) && args.includes('ls-files')) {
+        cb(null, 'node_modules/\n', '');
       } else {
         cb(null, '', '');
       }
     },
-  ),
-}));
+  );
+  // Replicate Node's custom promisify for execFile so promisify() returns { stdout, stderr }
+  (execFileFn as Record<symbol, unknown>)[Symbol.for('nodejs.util.promisify.custom')] = (
+    ...args: unknown[]
+  ): Promise<{ stdout: string; stderr: string }> =>
+    new Promise((resolve, reject) => {
+      execFileFn(...(args as Parameters<typeof execFileFn>), (err: Error | null, stdout: string, stderr: string) => {
+        if (err) reject(err);
+        else resolve({ stdout, stderr });
+      });
+    });
+  return { exec: vi.fn(), execSync: vi.fn(), execFile: execFileFn };
+});
 
 // Mock fs/promises — keep real readFile/writeFile for taskMetadata, stub mkdir/access/cp for worktree
 vi.mock('node:fs/promises', async (importOriginal) => {
@@ -95,7 +106,7 @@ describe('startTask', () => {
 
     const execFileCalls = vi.mocked(execFile).mock.calls;
     const wtAddCall = execFileCalls.find(
-      ([file, args]) => file === 'git' && Array.isArray(args) && args.includes('worktree'),
+      ([file, args]) => file === 'git' && Array.isArray(args) && args[0] === 'worktree' && args[1] === 'add',
     );
     expect(wtAddCall).toBeDefined();
     const args = wtAddCall![1] as string[];
@@ -137,7 +148,7 @@ describe('startTask', () => {
 
     const execFileCalls = vi.mocked(execFile).mock.calls;
     const wtAddCall = execFileCalls.find(
-      ([file, args]) => file === 'git' && Array.isArray(args) && args.includes('worktree'),
+      ([file, args]) => file === 'git' && Array.isArray(args) && args[0] === 'worktree' && args[1] === 'add',
     );
     expect(wtAddCall).toBeDefined();
     const args = wtAddCall![1] as string[];

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -3,7 +3,7 @@
  * Creates isolated worktrees for CLI agents to work without affecting the main branch
  */
 
-import { exec, execFile } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
@@ -25,7 +25,6 @@ import { mergeWorktreeBranch } from './git';
 
 const worktreeLog = getLogger().scope('worktree');
 
-const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
 // Native CoW clone support via koffi FFI
@@ -75,13 +74,6 @@ export function getWorktreeBaseDir(projectName: string): string {
 }
 
 /**
- * Escape a path for use in shell commands
- */
-function shellEscape(str: string): string {
-  return `'${str.replace(/'/g, "'\\''")}'`;
-}
-
-/**
  * Check if a resolved path is within the expected base directory
  * Prevents path traversal attacks via ../ sequences
  */
@@ -105,8 +97,9 @@ async function fetchIgnoredFiles(sourcePath: string): Promise<string[]> {
   // --ignored: only show ignored files
   // --exclude-standard: use .gitignore, .git/info/exclude, global gitignore
   // --directory: show directory names instead of their contents (efficient for copying whole dirs)
-  const { stdout } = await execAsync(
-    'git ls-files --others --ignored --exclude-standard --directory',
+  const { stdout } = await execFileAsync(
+    'git',
+    ['ls-files', '--others', '--ignored', '--exclude-standard', '--directory'],
     { cwd: sourcePath, maxBuffer: 10 * 1024 * 1024 }, // 10MB buffer for large lists
   );
   return stdout.split('\n').filter((item) => item.trim());
@@ -180,11 +173,17 @@ async function copyGitIgnoredFiles(
 
         // Fallback: cp command
         if (stat.isDirectory()) {
-          const cpFlags = os.platform() === 'darwin' ? '-RPpc' : '-RPp --reflink=auto';
-          await execAsync(`cp ${cpFlags} ${shellEscape(sourceItem)} ${shellEscape(destItem)}`);
+          const cpArgs =
+            os.platform() === 'darwin'
+              ? ['-RPpc', sourceItem, destItem]
+              : ['-RPp', '--reflink=auto', sourceItem, destItem];
+          await execFileAsync('cp', cpArgs);
         } else {
-          const cpFlags = os.platform() === 'darwin' ? '-Ppc' : '-Pp --reflink=auto';
-          await execAsync(`cp ${cpFlags} ${shellEscape(sourceItem)} ${shellEscape(destItem)}`);
+          const cpArgs =
+            os.platform() === 'darwin'
+              ? ['-Ppc', sourceItem, destItem]
+              : ['-Pp', '--reflink=auto', sourceItem, destItem];
+          await execFileAsync('cp', cpArgs);
         }
       } catch (error) {
         // Log but don't fail - some files might be transient or locked
@@ -252,14 +251,14 @@ export async function validateBranchName(
 
   // Check git ref format validity
   try {
-    await execAsync(`git check-ref-format --branch ${shellEscape(branchName)}`, { cwd: projectPath });
+    await execFileAsync('git', ['check-ref-format', '--branch', branchName], { cwd: projectPath });
   } catch {
     return { valid: false, error: 'Invalid branch name' };
   }
 
   // Check for conflicts with existing branches
   try {
-    const { stdout } = await execAsync(`git branch --list ${shellEscape(branchName)}`, { cwd: projectPath });
+    const { stdout } = await execFileAsync('git', ['branch', '--list', branchName], { cwd: projectPath });
     if (stdout.trim()) {
       return { valid: false, error: 'Branch already exists' };
     }
@@ -299,17 +298,17 @@ export async function startTask(
     worktreeLog.info('starting task', { taskNumber, name: task.name });
 
     const [hasHead, branchResult] = await Promise.all([
-      execAsync('git rev-parse HEAD', { cwd: projectPath }).then(
+      execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: projectPath }).then(
         () => true,
         () => false,
       ),
-      execAsync('git rev-parse --abbrev-ref HEAD', { cwd: projectPath })
+      execFileAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: projectPath })
         .then(({ stdout }) => stdout.trim())
         .catch((): undefined => undefined),
     ]);
 
     if (!hasHead) {
-      await execAsync('git commit --allow-empty -m "Initial commit"', { cwd: projectPath });
+      await execFileAsync('git', ['commit', '--allow-empty', '-m', 'Initial commit'], { cwd: projectPath });
     }
 
     const mergeTarget = baseBranch || branchResult;
@@ -332,7 +331,7 @@ export async function startTask(
     const branch = branchName || generateBranchName(task.name, taskNumber);
 
     // Prune stale worktree registrations so deleted directories can be reused
-    await execAsync('git worktree prune', { cwd: projectPath });
+    await execFileAsync('git', ['worktree', 'prune'], { cwd: projectPath });
 
     // Check if branch already exists (e.g. leftover from a previous failed attempt)
     const branchExists = await execFileAsync('git', ['rev-parse', '--verify', branch], { cwd: projectPath }).then(
@@ -382,12 +381,12 @@ export async function createTaskWorktree(
   try {
     const [hasHead, branchResult, taskNumber] = await Promise.all([
       // Check if repo has any commits (worktrees require a valid HEAD)
-      execAsync('git rev-parse HEAD', { cwd: projectPath }).then(
+      execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: projectPath }).then(
         () => true,
         () => false,
       ),
       // Capture source branch as the default merge target
-      execAsync('git rev-parse --abbrev-ref HEAD', { cwd: projectPath })
+      execFileAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: projectPath })
         .then(({ stdout }) => stdout.trim())
         .catch((): undefined => undefined),
       // Get next task number
@@ -395,7 +394,7 @@ export async function createTaskWorktree(
     ]);
 
     if (!hasHead) {
-      await execAsync('git commit --allow-empty -m "Initial commit"', { cwd: projectPath });
+      await execFileAsync('git', ['commit', '--allow-empty', '-m', 'Initial commit'], { cwd: projectPath });
     }
 
     const mergeTarget = branchResult;
@@ -514,7 +513,7 @@ export async function listWorktrees(projectPath: string): Promise<WorktreeInfo[]
     const projectName = path.basename(projectPath);
     const baseDir = getWorktreeBaseDir(projectName);
 
-    const { stdout: output } = await execAsync('git worktree list --porcelain', {
+    const { stdout: output } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {
       cwd: projectPath,
       encoding: 'utf8',
     });
@@ -576,7 +575,7 @@ export async function checkTaskWorktree(projectPath: string, taskNumber: number)
       () => false,
     ),
     task.branch
-      ? execAsync(`git rev-parse --verify refs/heads/${shellEscape(task.branch)}`, { cwd: projectPath }).then(
+      ? execFileAsync('git', ['rev-parse', '--verify', `refs/heads/${task.branch}`], { cwd: projectPath }).then(
           () => true,
           () => false,
         )
@@ -600,18 +599,21 @@ export async function recoverTaskWorktree(projectPath: string, taskNumber: numbe
     worktreeLog.info('recovering', { taskNumber, branch: task.branch, oldPath: task.worktreePath });
 
     // Prune stale worktree references so git doesn't complain about the old path
-    await execAsync('git worktree prune', { cwd: projectPath });
+    await execFileAsync('git', ['worktree', 'prune'], { cwd: projectPath });
 
     // Verify the branch still exists
     try {
-      await execAsync(`git rev-parse --verify refs/heads/${shellEscape(task.branch)}`, { cwd: projectPath });
+      await execFileAsync('git', ['rev-parse', '--verify', `refs/heads/${task.branch}`], { cwd: projectPath });
     } catch {
       return { success: false, error: 'Branch not found' };
     }
 
     // Check if the branch is already checked out in another worktree
     // (use raw git output — listWorktrees filters to managed dirs only)
-    const { stdout: wtList } = await execAsync('git worktree list --porcelain', { cwd: projectPath, encoding: 'utf8' });
+    const { stdout: wtList } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {
+      cwd: projectPath,
+      encoding: 'utf8',
+    });
     let existing: { path: string } | undefined;
     for (const entry of wtList.split('\n\n').filter(Boolean)) {
       const lines = entry.split('\n');
@@ -649,7 +651,7 @@ export async function recoverTaskWorktree(projectPath: string, taskNumber: numbe
 
     // Re-create worktree from the existing branch (no -b flag)
     const [, ignoredFiles] = await Promise.all([
-      execAsync(`git worktree add ${shellEscape(worktreePath)} ${shellEscape(task.branch)}`, { cwd: projectPath }),
+      execFileAsync('git', ['worktree', 'add', worktreePath, task.branch], { cwd: projectPath }),
       fetchIgnoredFiles(projectPath),
     ]);
 
@@ -681,7 +683,7 @@ export async function shipWorktree(
 
   if (worktree) {
     try {
-      const { stdout: status } = await execAsync('git status --porcelain', {
+      const { stdout: status } = await execFileAsync('git', ['status', '--porcelain'], {
         cwd: worktree.path,
         encoding: 'utf8',
       });


### PR DESCRIPTION
## Summary

- Convert all 19 remaining shell-interpolated `execAsync` calls in `worktree.ts` to `execFileAsync` with argument arrays for defense-in-depth against shell injection
- Remove now-unused `shellEscape` helper and `exec` import
- Update test mocks in `startTask.test.ts` and `ipcRefactor.test.ts` to route through `execFile` with custom promisify symbol