### PR TITLE
Add plan CLI commands for terminal sessions

### DIFF
--- a/src/__tests__/cli/commands/plan.test.ts
+++ b/src/__tests__/cli/commands/plan.test.ts
@@ -5,9 +5,10 @@ import { registerPlanCommands } from '../../../cli/commands/plan';
 vi.mock('../../../cli/api', () => ({
   get: vi.fn(),
   post: vi.fn(),
+  del: vi.fn(),
 }));
 
-import { get, post } from '../../../cli/api';
+import { get, post, del } from '../../../cli/api';
 
 function captureOutput() {
   const chunks: string[] = [];
@@ -24,12 +25,25 @@ function captureOutput() {
   };
 }
 
-const PROJECT = '/test/project';
+function captureStderr() {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stderr, 'write').mockImplementation((data) => {
+    chunks.push(typeof data === 'string' ? data : data.toString());
+    return true;
+  });
+  return {
+    spy,
+    getJson: () => {
+      spy.mockRestore();
+      return JSON.parse(chunks.join(''));
+    },
+  };
+}
 
 function createProgram() {
   const program = new Command();
   program.exitOverride();
-  registerPlanCommands(program, () => PROJECT);
+  registerPlanCommands(program);
   return program;
 }
 
@@ -56,6 +70,16 @@ describe('plan commands', () => {
     const result = output.getJson();
     expect(post).toHaveBeenCalledWith('/api/plan/pty123', { path: '/tmp/plan.md' });
     expect(result.success).toBe(true);
+  });
+
+  test('set resolves relative paths to absolute', async () => {
+    vi.mocked(post).mockResolvedValue({ success: true });
+    captureOutput();
+    await createProgram().parseAsync(['plan', 'set', './plan.md', 'pty123'], { from: 'user' });
+    const call = vi.mocked(post).mock.calls[0];
+    const sentPath = (call[1] as Record<string, unknown>).path as string;
+    expect(sentPath).toMatch(/^\/.*plan\.md$/);
+    expect(sentPath).not.toContain('./');
   });
 
   test('set falls back to OUIJIT_PTY_ID env var', async () => {
@@ -85,5 +109,34 @@ describe('plan commands', () => {
     const result = output.getJson();
     expect(get).toHaveBeenCalledWith('/api/plan/env-pty');
     expect(result.planPath).toBeNull();
+  });
+
+  test('unset calls DELETE /api/plan/:ptyId', async () => {
+    vi.mocked(del).mockResolvedValue({ success: true, ptyId: 'pty123' });
+    const output = captureOutput();
+    await createProgram().parseAsync(['plan', 'unset', 'pty123'], { from: 'user' });
+    const result = output.getJson();
+    expect(del).toHaveBeenCalledWith('/api/plan/pty123');
+    expect(result.success).toBe(true);
+  });
+
+  test('unset falls back to OUIJIT_PTY_ID env var', async () => {
+    process.env['OUIJIT_PTY_ID'] = 'env-pty';
+    vi.mocked(del).mockResolvedValue({ success: true, ptyId: 'env-pty' });
+    const output = captureOutput();
+    await createProgram().parseAsync(['plan', 'unset'], { from: 'user' });
+    const result = output.getJson();
+    expect(del).toHaveBeenCalledWith('/api/plan/env-pty');
+    expect(result.success).toBe(true);
+  });
+
+  test('errors when no pty-id and no OUIJIT_PTY_ID env var', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    const stderr = captureStderr();
+    await createProgram().parseAsync(['plan', 'get'], { from: 'user' });
+    const result = stderr.getJson();
+    expect(result.error).toMatch(/No pty-id provided/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
   });
 });

--- a/src/__tests__/cli/commands/plan.test.ts
+++ b/src/__tests__/cli/commands/plan.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { registerPlanCommands } from '../../../cli/commands/plan';
+
+vi.mock('../../../cli/api', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+import { get, post } from '../../../cli/api';
+
+function captureOutput() {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation((data) => {
+    chunks.push(typeof data === 'string' ? data : data.toString());
+    return true;
+  });
+  return {
+    spy,
+    getJson: () => {
+      spy.mockRestore();
+      return JSON.parse(chunks.join(''));
+    },
+  };
+}
+
+const PROJECT = '/test/project';
+
+function createProgram() {
+  const program = new Command();
+  program.exitOverride();
+  registerPlanCommands(program, () => PROJECT);
+  return program;
+}
+
+describe('plan commands', () => {
+  const originalEnv = process.env['OUIJIT_PTY_ID'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env['OUIJIT_PTY_ID'];
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env['OUIJIT_PTY_ID'] = originalEnv;
+    } else {
+      delete process.env['OUIJIT_PTY_ID'];
+    }
+  });
+
+  test('set calls POST /api/plan/:ptyId with explicit pty-id', async () => {
+    vi.mocked(post).mockResolvedValue({ success: true, ptyId: 'pty123', planPath: '/tmp/plan.md' });
+    const output = captureOutput();
+    await createProgram().parseAsync(['plan', 'set', '/tmp/plan.md', 'pty123'], { from: 'user' });
+    const result = output.getJson();
+    expect(post).toHaveBeenCalledWith('/api/plan/pty123', { path: '/tmp/plan.md' });
+    expect(result.success).toBe(true);
+  });
+
+  test('set falls back to OUIJIT_PTY_ID env var', async () => {
+    process.env['OUIJIT_PTY_ID'] = 'env-pty';
+    vi.mocked(post).mockResolvedValue({ success: true, ptyId: 'env-pty', planPath: '/tmp/plan.md' });
+    const output = captureOutput();
+    await createProgram().parseAsync(['plan', 'set', '/tmp/plan.md'], { from: 'user' });
+    const result = output.getJson();
+    expect(post).toHaveBeenCalledWith('/api/plan/env-pty', { path: '/tmp/plan.md' });
+    expect(result.success).toBe(true);
+  });
+
+  test('get calls GET /api/plan/:ptyId with explicit pty-id', async () => {
+    vi.mocked(get).mockResolvedValue({ ptyId: 'pty123', planPath: '/tmp/plan.md' });
+    const output = captureOutput();
+    await createProgram().parseAsync(['plan', 'get', 'pty123'], { from: 'user' });
+    const result = output.getJson();
+    expect(get).toHaveBeenCalledWith('/api/plan/pty123');
+    expect(result.planPath).toBe('/tmp/plan.md');
+  });
+
+  test('get falls back to OUIJIT_PTY_ID env var', async () => {
+    process.env['OUIJIT_PTY_ID'] = 'env-pty';
+    vi.mocked(get).mockResolvedValue({ ptyId: 'env-pty', planPath: null });
+    const output = captureOutput();
+    await createProgram().parseAsync(['plan', 'get'], { from: 'user' });
+    const result = output.getJson();
+    expect(get).toHaveBeenCalledWith('/api/plan/env-pty');
+    expect(result.planPath).toBeNull();
+  });
+});

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -7,6 +7,7 @@
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { BrowserWindow } from 'electron';
+import * as path from 'node:path';
 import { createTodoTask, createTaskWorktree } from '../worktree';
 import {
   setTaskMergeTarget,
@@ -32,6 +33,8 @@ import {
   getTaskWithWorkspace,
 } from '../taskLifecycle';
 import { getProjectList } from '../scanner';
+import { getPlanPath, setPlanPath } from '../hookServer';
+import { isPtyActive } from '../ptyManager';
 import { typedPush } from '../ipc/helpers';
 import { getLogger } from '../logger';
 
@@ -343,6 +346,29 @@ const routes: Route[] = [
     },
     true,
   ),
+
+  // ── Plan ──────────────────────────────────────────────────────────
+  route('GET', 'plan/:ptyId', (r) => {
+    const ptyId = r.segments[1];
+    return { ptyId, planPath: getPlanPath(ptyId) };
+  }),
+
+  route('POST', 'plan/:ptyId', (r) => {
+    const ptyId = r.segments[1];
+    const planPath = r.body.path;
+    if (typeof planPath !== 'string' || !planPath) {
+      throw new HttpError(400, 'Missing path in body');
+    }
+    if (!planPath.endsWith('.md')) {
+      throw new HttpError(400, 'Plan path must be a .md file');
+    }
+    if (!isPtyActive(ptyId)) {
+      throw new HttpError(404, `PTY ${ptyId} not found or inactive`);
+    }
+    const resolved = path.resolve(planPath);
+    setPlanPath(ptyId, resolved);
+    return { success: true, ptyId, planPath: resolved };
+  }),
 ];
 
 // ── Main handler ─────────────────────────────────────────────────────

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -33,7 +33,7 @@ import {
   getTaskWithWorkspace,
 } from '../taskLifecycle';
 import { getProjectList } from '../scanner';
-import { getPlanPath, setPlanPath } from '../hookServer';
+import { getPlanPath, setPlanPath, clearPlanPath } from '../hookServer';
 import { isPtyActive } from '../ptyManager';
 import { typedPush } from '../ipc/helpers';
 import { getLogger } from '../logger';
@@ -368,6 +368,12 @@ const routes: Route[] = [
     const resolved = path.resolve(planPath);
     setPlanPath(ptyId, resolved);
     return { success: true, ptyId, planPath: resolved };
+  }),
+
+  route('DELETE', 'plan/:ptyId', (r) => {
+    const ptyId = r.segments[1];
+    clearPlanPath(ptyId);
+    return { success: true, ptyId };
   }),
 ];
 

--- a/src/cli/commands/plan.ts
+++ b/src/cli/commands/plan.ts
@@ -1,9 +1,10 @@
 /**
- * CLI plan commands — get and set plan file for a terminal session via REST API.
+ * CLI plan commands — get, set, and unset plan file for a terminal session via REST API.
  */
 
+import * as path from 'node:path';
 import type { Command } from 'commander';
-import { get, post } from '../api';
+import { get, post, del } from '../api';
 import { printJson, printError } from '../output';
 
 function resolvePtyId(explicitPtyId?: string): string {
@@ -14,7 +15,7 @@ function resolvePtyId(explicitPtyId?: string): string {
   return ptyId;
 }
 
-export function registerPlanCommands(parent: Command, _requireProject: () => string) {
+export function registerPlanCommands(parent: Command) {
   const plan = parent
     .command('plan')
     .description('Manage plan files for terminal sessions')
@@ -25,7 +26,8 @@ Examples:
   ouijit plan set ./plan.md
   ouijit plan set ./plan.md pty_abc123
   ouijit plan get
-  ouijit plan get pty_abc123`,
+  ouijit plan get pty_abc123
+  ouijit plan unset`,
     );
 
   plan
@@ -35,7 +37,8 @@ Examples:
     .argument('[pty-id]', 'terminal session id (defaults to OUIJIT_PTY_ID)')
     .action(async (planPath: string, explicitPtyId?: string) => {
       const ptyId = resolvePtyId(explicitPtyId);
-      const result = await post(`/api/plan/${encodeURIComponent(ptyId)}`, { path: planPath });
+      const resolved = path.resolve(planPath);
+      const result = await post(`/api/plan/${encodeURIComponent(ptyId)}`, { path: resolved });
       printJson(result);
     });
 
@@ -46,6 +49,16 @@ Examples:
     .action(async (explicitPtyId?: string) => {
       const ptyId = resolvePtyId(explicitPtyId);
       const result = await get(`/api/plan/${encodeURIComponent(ptyId)}`);
+      printJson(result);
+    });
+
+  plan
+    .command('unset')
+    .description('Clear plan file for a terminal session')
+    .argument('[pty-id]', 'terminal session id (defaults to OUIJIT_PTY_ID)')
+    .action(async (explicitPtyId?: string) => {
+      const ptyId = resolvePtyId(explicitPtyId);
+      const result = await del(`/api/plan/${encodeURIComponent(ptyId)}`);
       printJson(result);
     });
 }

--- a/src/cli/commands/plan.ts
+++ b/src/cli/commands/plan.ts
@@ -1,0 +1,51 @@
+/**
+ * CLI plan commands — get and set plan file for a terminal session via REST API.
+ */
+
+import type { Command } from 'commander';
+import { get, post } from '../api';
+import { printJson, printError } from '../output';
+
+function resolvePtyId(explicitPtyId?: string): string {
+  const ptyId = explicitPtyId || process.env['OUIJIT_PTY_ID'];
+  if (!ptyId) {
+    return printError('No pty-id provided and OUIJIT_PTY_ID not set. Provide <pty-id> or run from an Ouijit terminal.');
+  }
+  return ptyId;
+}
+
+export function registerPlanCommands(parent: Command, _requireProject: () => string) {
+  const plan = parent
+    .command('plan')
+    .description('Manage plan files for terminal sessions')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  ouijit plan set ./plan.md
+  ouijit plan set ./plan.md pty_abc123
+  ouijit plan get
+  ouijit plan get pty_abc123`,
+    );
+
+  plan
+    .command('set')
+    .description('Set plan file for a terminal session')
+    .argument('<path>', 'path to plan file (.md)')
+    .argument('[pty-id]', 'terminal session id (defaults to OUIJIT_PTY_ID)')
+    .action(async (planPath: string, explicitPtyId?: string) => {
+      const ptyId = resolvePtyId(explicitPtyId);
+      const result = await post(`/api/plan/${encodeURIComponent(ptyId)}`, { path: planPath });
+      printJson(result);
+    });
+
+  plan
+    .command('get')
+    .description('Get plan file path for a terminal session')
+    .argument('[pty-id]', 'terminal session id (defaults to OUIJIT_PTY_ID)')
+    .action(async (explicitPtyId?: string) => {
+      const ptyId = resolvePtyId(explicitPtyId);
+      const result = await get(`/api/plan/${encodeURIComponent(ptyId)}`);
+      printJson(result);
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import { registerHookCommands } from './commands/hook';
 import { registerTagCommands } from './commands/tag';
 import { registerProjectCommands } from './commands/project';
 import { registerScriptCommands } from './commands/script';
+import { registerPlanCommands } from './commands/plan';
 
 const program = new Command();
 
@@ -43,5 +44,6 @@ registerHookCommands(program, requireProject);
 registerTagCommands(program, requireProject);
 registerProjectCommands(program);
 registerScriptCommands(program, requireProject);
+registerPlanCommands(program, requireProject);
 
 program.parse();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -44,6 +44,6 @@ registerHookCommands(program, requireProject);
 registerTagCommands(program, requireProject);
 registerProjectCommands(program);
 registerScriptCommands(program, requireProject);
-registerPlanCommands(program, requireProject);
+registerPlanCommands(program);
 
 program.parse();

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -74,6 +74,17 @@ export function setPlanPath(ptyId: string, planPath: string): boolean {
   return true;
 }
 
+/** Clear the plan file path for a pty and notify the renderer. */
+export function clearPlanPath(ptyId: string): boolean {
+  if (!planPathMap.has(ptyId)) return false;
+  planPathMap.delete(ptyId);
+  hookServerLog.info('plan cleared', { ptyId });
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('claude-plan-detected', ptyId, null);
+  }
+  return true;
+}
+
 // ── Action handlers ──────────────────────────────────────────────────
 
 type ActionHandler = (body: Record<string, unknown>) => void;

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -60,6 +60,20 @@ export function clearAllHookStatuses(): void {
   planPathMap.clear();
 }
 
+/**
+ * Set the plan file path for a pty and notify the renderer.
+ * Called by both the hook action handler and the REST API route.
+ */
+export function setPlanPath(ptyId: string, planPath: string): boolean {
+  if (!isPtyActive(ptyId)) return false;
+  planPathMap.set(ptyId, planPath);
+  hookServerLog.info('plan set', { ptyId, planPath });
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('claude-plan-detected', ptyId, planPath);
+  }
+  return true;
+}
+
 // ── Action handlers ──────────────────────────────────────────────────
 
 type ActionHandler = (body: Record<string, unknown>) => void;
@@ -98,15 +112,9 @@ const actionHandlers: Record<string, ActionHandler> = {
     const { ptyId, filename } = body;
     if (typeof ptyId !== 'string' || typeof filename !== 'string') return;
     if (!/^[a-zA-Z0-9._-]+$/.test(filename)) return;
-    if (!isPtyActive(ptyId)) return;
 
     const planPath = path.join(os.homedir(), '.claude', 'plans', filename);
-    planPathMap.set(ptyId, planPath);
-    hookServerLog.info('plan detected', { ptyId, planPath });
-
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('claude-plan-detected', ptyId, planPath);
-    }
+    setPlanPath(ptyId, planPath);
   },
 
   'plan-ready'(body) {


### PR DESCRIPTION
## Summary

- Add `ouijit plan set <path> [pty-id]` and `ouijit plan get [pty-id]` CLI commands for managing plan files on terminal sessions
- Add `GET/POST /api/plan/:ptyId` REST API routes with `.md` validation and path resolution
- Extract `setPlanPath()` from the hook action handler into a reusable export in `hookServer.ts`