### PR TITLE
Canvas layout for terminals with react-flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
+        "@xyflow/react": "^12.10.2",
         "better-sqlite3": "^12.6.2",
         "commander": "^14.0.3",
         "dompurify": "^3.3.3",
@@ -4140,6 +4141,55 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5228,6 +5278,66 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -5889,6 +5999,12 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -6188,6 +6304,112 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -12745,6 +12967,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/username": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "@xyflow/react": "^12.10.2",
     "better-sqlite3": "^12.6.2",
     "commander": "^14.0.3",
     "dompurify": "^3.3.3",

--- a/src/components/ProjectViewReact.tsx
+++ b/src/components/ProjectViewReact.tsx
@@ -2,7 +2,9 @@ import { useEffect, useCallback } from 'react';
 import { useAppStore } from '../stores/appStore';
 import { useProjectStore } from '../stores/projectStore';
 import { useTerminalStore, getTerminalIndexByStackPosition, STACK_PAGE_SIZE } from '../stores/terminalStore';
+import { useCanvasStore, persistCanvas } from '../stores/canvasStore';
 import { TerminalCardStack } from './terminal/TerminalCardStack';
+import { TerminalCanvas } from './canvas/TerminalCanvas';
 import { KanbanBoard } from './kanban/KanbanBoard';
 import { ProjectSettingsPanel } from './scripts/ProjectSettingsPanel';
 import { focusKanbanAddInput } from './kanban/KanbanAddInput';
@@ -18,11 +20,33 @@ const isMac = navigator.platform.toLowerCase().includes('mac');
 const GIT_STATUS_PERIODIC_INTERVAL = 30000;
 const EMPTY: string[] = [];
 
+/** Get the currently selected ptyId from the canvas (first selected node). */
+function getCanvasSelectedPtyId(projectPath: string): string | undefined {
+  const project = useCanvasStore.getState().canvasByProject[projectPath];
+  if (!project) return undefined;
+  const selected = project.nodes.find((n) => n.selected);
+  return selected?.id;
+}
+
+/** Get the active ptyId based on the current layout mode. */
+function getActivePtyId(projectPath: string): string | undefined {
+  const layout = useProjectStore.getState().terminalLayout;
+  if (layout === 'canvas') {
+    return getCanvasSelectedPtyId(projectPath);
+  }
+  // Stack mode
+  const store = useTerminalStore.getState();
+  const terms = store.terminalsByProject[projectPath] ?? [];
+  const activeIdx = store.activeIndices[projectPath] ?? 0;
+  return terms[activeIdx];
+}
+
 export function ProjectView() {
   const projectPath = useAppStore((s) => s.activeProjectPath);
   const projectData = useAppStore((s) => s.activeProjectData);
   const kanbanVisible = useProjectStore((s) => s.kanbanVisible);
   const activePanel = useProjectStore((s) => s.activePanel);
+  const terminalLayout = useProjectStore((s) => s.terminalLayout);
 
   const activeIndex = useTerminalStore((s) => (projectPath ? (s.activeIndices[projectPath] ?? 0) : 0));
   const terminalList = useTerminalStore((s) => (projectPath ? s.terminalsByProject[projectPath] : undefined));
@@ -50,14 +74,11 @@ export function ProjectView() {
         return;
       }
 
-      // Cmd+W — close active terminal
+      // Cmd+W — close active/selected terminal
       if (key === 'w') {
         e.preventDefault();
         e.stopPropagation();
-        const store = useTerminalStore.getState();
-        const terms = store.terminalsByProject[projectPath] ?? [];
-        const activeIdx = store.activeIndices[projectPath] ?? 0;
-        const ptyId = terms[activeIdx];
+        const ptyId = getActivePtyId(projectPath);
         if (ptyId) closeProjectTerminal(ptyId);
         return;
       }
@@ -73,7 +94,7 @@ export function ProjectView() {
         return;
       }
 
-      // Cmd+T — toggle kanban board / terminal stack
+      // Cmd+T — toggle kanban board
       if (key === 't') {
         e.preventDefault();
         e.stopPropagation();
@@ -81,14 +102,32 @@ export function ProjectView() {
         return;
       }
 
+      // Cmd+L — toggle terminal layout (stack / canvas)
+      if (key === 'l') {
+        e.preventDefault();
+        e.stopPropagation();
+        useProjectStore.getState().toggleTerminalLayout();
+        return;
+      }
+
+      // Cmd+G / Cmd+Shift+G — group/ungroup (canvas mode only)
+      if (key === 'g' && useProjectStore.getState().terminalLayout === 'canvas') {
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.shiftKey) {
+          useCanvasStore.getState().ungroupSelected(projectPath);
+        } else {
+          useCanvasStore.getState().groupSelected(projectPath);
+        }
+        persistCanvas(projectPath);
+        return;
+      }
+
       // Cmd+P — play or toggle runner for active terminal
       if (key === 'p') {
         e.preventDefault();
         e.stopPropagation();
-        const pStore = useTerminalStore.getState();
-        const pTerms = pStore.terminalsByProject[projectPath] ?? [];
-        const pIdx = pStore.activeIndices[projectPath] ?? 0;
-        const pPtyId = pTerms[pIdx];
+        const pPtyId = getActivePtyId(projectPath);
         if (pPtyId) {
           const inst = terminalInstances.get(pPtyId);
           if (inst) {
@@ -113,10 +152,7 @@ export function ProjectView() {
       if (key === 'd') {
         e.preventDefault();
         e.stopPropagation();
-        const tStore = useTerminalStore.getState();
-        const tTerms = tStore.terminalsByProject[projectPath] ?? [];
-        const tIdx = tStore.activeIndices[projectPath] ?? 0;
-        const tPtyId = tTerms[tIdx];
+        const tPtyId = getActivePtyId(projectPath);
         if (tPtyId) {
           const inst = terminalInstances.get(tPtyId);
           if (inst) {
@@ -128,31 +164,57 @@ export function ProjectView() {
         return;
       }
 
-      // Cmd+1-9 — switch to stacked terminal by position
+      // Cmd+1-9 — switch terminal by position
       const num = parseInt(key, 10);
       if (num >= 1 && num <= 9) {
         e.preventDefault();
         e.stopPropagation();
-        const targetIndex = getTerminalIndexByStackPosition(projectPath, num);
-        if (targetIndex !== -1) {
-          useTerminalStore.getState().setActiveIndex(projectPath, targetIndex);
+        const layout = useProjectStore.getState().terminalLayout;
+        if (layout === 'canvas') {
+          // Canvas mode: select Nth terminal node
+          const terms = useTerminalStore.getState().terminalsByProject[projectPath] ?? [];
+          const targetIdx = num - 1;
+          if (targetIdx < terms.length) {
+            const targetPtyId = terms[targetIdx];
+            const canvas = useCanvasStore.getState().canvasByProject[projectPath];
+            if (canvas) {
+              const updatedNodes = canvas.nodes.map((n) => ({
+                ...n,
+                selected: n.id === targetPtyId,
+              }));
+              useCanvasStore.getState().loadCanvas(projectPath, { ...canvas, nodes: updatedNodes });
+            }
+            const inst = terminalInstances.get(targetPtyId);
+            if (inst) {
+              requestAnimationFrame(() => inst.xterm.focus());
+            }
+          }
+        } else {
+          // Stack mode: switch by stack position
+          const targetIndex = getTerminalIndexByStackPosition(projectPath, num);
+          if (targetIndex !== -1) {
+            useTerminalStore.getState().setActiveIndex(projectPath, targetIndex);
+          }
         }
         return;
       }
 
-      // Cmd+Shift+Left/Right — page navigation
+      // Cmd+Shift+Left/Right — page navigation (stack mode only)
       if (e.shiftKey && (key === 'arrowleft' || key === 'arrowright')) {
-        e.preventDefault();
-        e.stopPropagation();
-        const store = useTerminalStore.getState();
-        const terms = store.terminalsByProject[projectPath] ?? [];
-        const currentIndex = store.activeIndices[projectPath] ?? 0;
-        const currentPage = Math.floor(currentIndex / STACK_PAGE_SIZE);
-        const totalPages = Math.max(1, Math.ceil(terms.length / STACK_PAGE_SIZE));
-        const direction = key === 'arrowleft' ? -1 : 1;
-        const targetPage = currentPage + direction;
-        if (targetPage >= 0 && targetPage < totalPages) {
-          store.setActiveIndex(projectPath, targetPage * STACK_PAGE_SIZE);
+        const layout = useProjectStore.getState().terminalLayout;
+        if (layout === 'stack') {
+          e.preventDefault();
+          e.stopPropagation();
+          const store = useTerminalStore.getState();
+          const terms = store.terminalsByProject[projectPath] ?? [];
+          const currentIndex = store.activeIndices[projectPath] ?? 0;
+          const currentPage = Math.floor(currentIndex / STACK_PAGE_SIZE);
+          const totalPages = Math.max(1, Math.ceil(terms.length / STACK_PAGE_SIZE));
+          const direction = key === 'arrowleft' ? -1 : 1;
+          const targetPage = currentPage + direction;
+          if (targetPage >= 0 && targetPage < totalPages) {
+            store.setActiveIndex(projectPath, targetPage * STACK_PAGE_SIZE);
+          }
         }
       }
     };
@@ -250,9 +312,9 @@ export function ProjectView() {
     };
   }, [projectPath]);
 
-  // Focus active terminal when active index changes
+  // Focus active terminal when active index changes (stack mode only)
   useEffect(() => {
-    if (!projectPath || terminals.length === 0 || kanbanVisible) return;
+    if (!projectPath || terminals.length === 0 || kanbanVisible || terminalLayout !== 'stack') return;
     const ptyId = terminals[activeIndex];
     if (!ptyId) return;
     const instance = terminalInstances.get(ptyId);
@@ -262,7 +324,7 @@ export function ProjectView() {
         instance.xterm.focus();
       });
     }
-  }, [activeIndex, terminals, projectPath, kanbanVisible]);
+  }, [activeIndex, terminals, projectPath, kanbanVisible, terminalLayout]);
 
   const handleHideKanban = useCallback(() => {
     useProjectStore.getState().setKanbanVisible(false);
@@ -272,6 +334,13 @@ export function ProjectView() {
     return <div className="project-view-empty">No project selected</div>;
   }
 
+  const renderTerminals = () => {
+    if (terminalLayout === 'canvas') {
+      return <TerminalCanvas projectPath={projectPath} />;
+    }
+    return <TerminalCardStack projectPath={projectPath} />;
+  };
+
   return (
     <div className="project-view h-full">
       {activePanel === 'settings' ? (
@@ -279,7 +348,7 @@ export function ProjectView() {
       ) : (
         <>
           {kanbanVisible && <KanbanBoard projectPath={projectPath} onHide={handleHideKanban} />}
-          {!kanbanVisible && <TerminalCardStack projectPath={projectPath} />}
+          {!kanbanVisible && renderTerminals()}
         </>
       )}
     </div>

--- a/src/components/ProjectViewReact.tsx
+++ b/src/components/ProjectViewReact.tsx
@@ -4,7 +4,7 @@ import { useProjectStore } from '../stores/projectStore';
 import { useTerminalStore, getTerminalIndexByStackPosition, STACK_PAGE_SIZE } from '../stores/terminalStore';
 import { useCanvasStore, persistCanvas } from '../stores/canvasStore';
 import { TerminalCardStack } from './terminal/TerminalCardStack';
-import { TerminalCanvas } from './canvas/TerminalCanvas';
+import { TerminalCanvas, syncCanvasWithTerminals } from './canvas/TerminalCanvas';
 import { KanbanBoard } from './kanban/KanbanBoard';
 import { ProjectSettingsPanel } from './scripts/ProjectSettingsPanel';
 import { focusKanbanAddInput } from './kanban/KanbanAddInput';
@@ -227,9 +227,17 @@ export function ProjectView() {
   useEffect(() => {
     if (!projectPath) return;
     const existing = useTerminalStore.getState().terminalsByProject[projectPath];
-    if (existing && existing.length > 0) return;
+    if (existing && existing.length > 0) {
+      // Terminals already exist — sync canvas to prune any stale persisted nodes
+      syncCanvasWithTerminals(projectPath);
+      return;
+    }
 
     reconnectOrphanedSessions(projectPath).then(() => {
+      // Reconnection is done — terminal list is now final.
+      // Sync canvas to prune stale nodes from previous sessions.
+      syncCanvasWithTerminals(projectPath);
+
       // Only show kanban if reconnection didn't restore any terminals
       const reconnected = useTerminalStore.getState().terminalsByProject[projectPath];
       if (!reconnected || reconnected.length === 0) {

--- a/src/components/TitleBarReact.tsx
+++ b/src/components/TitleBarReact.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAppStore } from '../stores/appStore';
-import { useProjectStore } from '../stores/projectStore';
+import { useProjectStore, type TerminalLayout } from '../stores/projectStore';
 import { useUIStore } from '../stores/uiStore';
 import { stringToColor, getInitials } from '../utils/projectIcon';
 import { Icon } from './terminal/Icon';
@@ -21,6 +21,7 @@ export function TitleBar({ mode }: TitleBarProps) {
   const activeView = useAppStore((s) => s.activeView);
   const fullscreen = useAppStore((s) => s.fullscreen);
   const kanbanVisible = useProjectStore((s) => s.kanbanVisible);
+  const terminalLayout = useProjectStore((s) => s.terminalLayout);
   const activePanel = useProjectStore((s) => s.activePanel);
   const homeGroupMode = useUIStore((s) => s.homeGroupMode);
   const [username, setUsername] = useState('');
@@ -40,13 +41,17 @@ export function TitleBar({ mode }: TitleBarProps) {
     });
   }, [activeProjectPath]);
 
-  const handleToggleView = useCallback((view: 'board' | 'stack' | 'settings') => {
+  const handleToggleView = useCallback((view: 'board' | 'stack' | 'canvas' | 'settings') => {
     const store = useProjectStore.getState();
     if (view === 'settings') {
       store.setActivePanel('settings');
+    } else if (view === 'board') {
+      store.setActivePanel('terminals');
+      store.setKanbanVisible(true);
     } else {
       store.setActivePanel('terminals');
-      store.setKanbanVisible(view === 'board');
+      store.setKanbanVisible(false);
+      store.setTerminalLayout(view as TerminalLayout);
     }
   }, []);
 
@@ -128,10 +133,17 @@ export function TitleBar({ mode }: TitleBarProps) {
               </TooltipButton>
               <TooltipButton
                 text="Terminal stack"
-                className={`w-9 h-full flex items-center justify-center text-text-secondary transition-all duration-150 ease-out hover:text-text-primary hover:bg-background-tertiary [&>svg]:w-5 [&>svg]:h-5${activePanel !== 'settings' && !kanbanVisible ? ' text-text-primary bg-background-tertiary' : ''}`}
+                className={`w-9 h-full flex items-center justify-center text-text-secondary transition-all duration-150 ease-out hover:text-text-primary hover:bg-background-tertiary [&>svg]:w-5 [&>svg]:h-5${activePanel !== 'settings' && !kanbanVisible && terminalLayout === 'stack' ? ' text-text-primary bg-background-tertiary' : ''}`}
                 onClick={() => handleToggleView('stack')}
               >
                 <Icon name="cards-three" />
+              </TooltipButton>
+              <TooltipButton
+                text="Canvas"
+                className={`w-9 h-full flex items-center justify-center text-text-secondary transition-all duration-150 ease-out hover:text-text-primary hover:bg-background-tertiary [&>svg]:w-5 [&>svg]:h-5${activePanel !== 'settings' && !kanbanVisible && terminalLayout === 'canvas' ? ' text-text-primary bg-background-tertiary' : ''}`}
+                onClick={() => handleToggleView('canvas')}
+              >
+                <CanvasIcon />
               </TooltipButton>
               <TooltipButton
                 text="Settings"
@@ -206,5 +218,17 @@ export function TitleBar({ mode }: TitleBarProps) {
         </button>
       )}
     </header>
+  );
+}
+
+/** Inline canvas/artboard icon — no Phosphor equivalent available. */
+function CanvasIcon() {
+  return (
+    <svg viewBox="0 0 256 256" fill="currentColor" className="w-5 h-5 shrink-0">
+      <rect x="40" y="40" width="72" height="72" rx="8" opacity="0.9" />
+      <rect x="144" y="40" width="72" height="52" rx="8" opacity="0.7" />
+      <rect x="40" y="144" width="72" height="52" rx="8" opacity="0.7" />
+      <rect x="144" y="124" width="72" height="72" rx="8" opacity="0.9" />
+    </svg>
   );
 }

--- a/src/components/canvas/AlignMenu.tsx
+++ b/src/components/canvas/AlignMenu.tsx
@@ -289,21 +289,17 @@ export const AlignMenu = memo(function AlignMenu({ projectPath, position, onClos
   const canvasNodes = useCanvasStore((s) => s.canvasByProject[projectPath]?.nodes);
   const selectedCount = canvasNodes?.filter((n) => n.selected).length ?? 0;
 
-  if (!position) return null;
+  if (!position || selectedCount < 2) return null;
 
-  const items: ContextMenuEntry[] = [];
-
-  if (selectedCount >= 2) {
-    items.push(
-      { label: 'Align Left', icon: 'align-left', onClick: () => handleAlign('left') },
-      { label: 'Align Center', icon: 'align-center-horizontal', onClick: () => handleAlign('center-h') },
-      { label: 'Align Right', icon: 'align-right', onClick: () => handleAlign('right') },
-      { separator: true },
-      { label: 'Align Top', icon: 'align-top', onClick: () => handleAlign('top') },
-      { label: 'Align Middle', icon: 'align-center-vertical', onClick: () => handleAlign('center-v') },
-      { label: 'Align Bottom', icon: 'align-bottom', onClick: () => handleAlign('bottom') },
-    );
-  }
+  const items: ContextMenuEntry[] = [
+    { label: 'Align Left', icon: 'align-left', onClick: () => handleAlign('left') },
+    { label: 'Align Center', icon: 'align-center-horizontal', onClick: () => handleAlign('center-h') },
+    { label: 'Align Right', icon: 'align-right', onClick: () => handleAlign('right') },
+    { separator: true },
+    { label: 'Align Top', icon: 'align-top', onClick: () => handleAlign('top') },
+    { label: 'Align Middle', icon: 'align-center-vertical', onClick: () => handleAlign('center-v') },
+    { label: 'Align Bottom', icon: 'align-bottom', onClick: () => handleAlign('bottom') },
+  ];
 
   if (selectedCount >= 3) {
     items.push(
@@ -317,11 +313,7 @@ export const AlignMenu = memo(function AlignMenu({ projectPath, position, onClos
     );
   }
 
-  if (selectedCount >= 2) {
-    items.push({ separator: true }, { label: 'Grid Layout', icon: 'grid-four', onClick: handleGridLayout });
-  }
-
-  if (items.length > 0) items.push({ separator: true });
+  items.push({ separator: true }, { label: 'Grid Layout', icon: 'grid-four', onClick: handleGridLayout });
   items.push({ label: 'Chain Tree Layout', icon: 'tree-structure', onClick: handleChainLayout });
 
   return <ContextMenu x={position.x} y={position.y} items={items} onClose={onClose} />;

--- a/src/components/canvas/AlignMenu.tsx
+++ b/src/components/canvas/AlignMenu.tsx
@@ -1,0 +1,200 @@
+import { memo, useCallback, useEffect } from 'react';
+import { useCanvasStore, type TerminalNode } from '../../stores/canvasStore';
+
+interface AlignMenuProps {
+  projectPath: string;
+  position: { x: number; y: number } | null;
+  onClose: () => void;
+}
+
+type AlignType = 'left' | 'center-h' | 'right' | 'top' | 'center-v' | 'bottom';
+type DistributeType = 'horizontal' | 'vertical';
+
+/** Context menu for aligning and distributing selected nodes. */
+export const AlignMenu = memo(function AlignMenu({ projectPath, position, onClose }: AlignMenuProps) {
+  // Close on click outside or Escape
+  useEffect(() => {
+    if (!position) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    const clickHandler = () => {
+      // Delay to allow menu item clicks to fire first
+      requestAnimationFrame(() => onClose());
+    };
+    document.addEventListener('keydown', handler);
+    document.addEventListener('mousedown', clickHandler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+      document.removeEventListener('mousedown', clickHandler);
+    };
+  }, [position, onClose]);
+
+  const handleAlign = useCallback(
+    (type: AlignType) => {
+      const canvas = useCanvasStore.getState().canvasByProject[projectPath];
+      if (!canvas) return;
+      const selected = canvas.nodes.filter((n) => n.selected);
+      if (selected.length < 2) return;
+
+      const getWidth = (n: TerminalNode) => n.measured?.width ?? (n.style?.width ? Number(n.style.width) : 720);
+      const getHeight = (n: TerminalNode) => n.measured?.height ?? (n.style?.height ? Number(n.style.height) : 480);
+
+      let updatedNodes = [...canvas.nodes];
+
+      switch (type) {
+        case 'left': {
+          const minX = Math.min(...selected.map((n) => n.position.x));
+          updatedNodes = updatedNodes.map((n) => (n.selected ? { ...n, position: { ...n.position, x: minX } } : n));
+          break;
+        }
+        case 'right': {
+          const maxRight = Math.max(...selected.map((n) => n.position.x + getWidth(n)));
+          updatedNodes = updatedNodes.map((n) =>
+            n.selected ? { ...n, position: { ...n.position, x: maxRight - getWidth(n) } } : n,
+          );
+          break;
+        }
+        case 'center-h': {
+          const centerX =
+            (Math.min(...selected.map((n) => n.position.x)) +
+              Math.max(...selected.map((n) => n.position.x + getWidth(n)))) /
+            2;
+          updatedNodes = updatedNodes.map((n) =>
+            n.selected ? { ...n, position: { ...n.position, x: centerX - getWidth(n) / 2 } } : n,
+          );
+          break;
+        }
+        case 'top': {
+          const minY = Math.min(...selected.map((n) => n.position.y));
+          updatedNodes = updatedNodes.map((n) => (n.selected ? { ...n, position: { ...n.position, y: minY } } : n));
+          break;
+        }
+        case 'bottom': {
+          const maxBottom = Math.max(...selected.map((n) => n.position.y + getHeight(n)));
+          updatedNodes = updatedNodes.map((n) =>
+            n.selected ? { ...n, position: { ...n.position, y: maxBottom - getHeight(n) } } : n,
+          );
+          break;
+        }
+        case 'center-v': {
+          const centerY =
+            (Math.min(...selected.map((n) => n.position.y)) +
+              Math.max(...selected.map((n) => n.position.y + getHeight(n)))) /
+            2;
+          updatedNodes = updatedNodes.map((n) =>
+            n.selected ? { ...n, position: { ...n.position, y: centerY - getHeight(n) / 2 } } : n,
+          );
+          break;
+        }
+      }
+
+      useCanvasStore.getState().loadCanvas(projectPath, { ...canvas, nodes: updatedNodes as TerminalNode[] });
+    },
+    [projectPath],
+  );
+
+  const handleDistribute = useCallback(
+    (type: DistributeType) => {
+      const canvas = useCanvasStore.getState().canvasByProject[projectPath];
+      if (!canvas) return;
+      const selected = canvas.nodes.filter((n) => n.selected);
+      if (selected.length < 3) return;
+
+      const getWidth = (n: TerminalNode) => n.measured?.width ?? (n.style?.width ? Number(n.style.width) : 720);
+      const getHeight = (n: TerminalNode) => n.measured?.height ?? (n.style?.height ? Number(n.style.height) : 480);
+
+      let updatedNodes = [...canvas.nodes];
+
+      if (type === 'horizontal') {
+        const sorted = [...selected].sort((a, b) => a.position.x - b.position.x);
+        const totalWidth = sorted.reduce((sum, n) => sum + getWidth(n), 0);
+        const minX = sorted[0].position.x;
+        const maxRight = sorted[sorted.length - 1].position.x + getWidth(sorted[sorted.length - 1]);
+        const spacing = (maxRight - minX - totalWidth) / (sorted.length - 1);
+
+        let currentX = minX;
+        const positions = new Map<string, number>();
+        for (const node of sorted) {
+          positions.set(node.id, currentX);
+          currentX += getWidth(node) + spacing;
+        }
+
+        updatedNodes = updatedNodes.map((n) =>
+          positions.has(n.id) ? { ...n, position: { ...n.position, x: positions.get(n.id)! } } : n,
+        );
+      } else {
+        const sorted = [...selected].sort((a, b) => a.position.y - b.position.y);
+        const totalHeight = sorted.reduce((sum, n) => sum + getHeight(n), 0);
+        const minY = sorted[0].position.y;
+        const maxBottom = sorted[sorted.length - 1].position.y + getHeight(sorted[sorted.length - 1]);
+        const spacing = (maxBottom - minY - totalHeight) / (sorted.length - 1);
+
+        let currentY = minY;
+        const positions = new Map<string, number>();
+        for (const node of sorted) {
+          positions.set(node.id, currentY);
+          currentY += getHeight(node) + spacing;
+        }
+
+        updatedNodes = updatedNodes.map((n) =>
+          positions.has(n.id) ? { ...n, position: { ...n.position, y: positions.get(n.id)! } } : n,
+        );
+      }
+
+      useCanvasStore.getState().loadCanvas(projectPath, { ...canvas, nodes: updatedNodes as TerminalNode[] });
+    },
+    [projectPath],
+  );
+
+  if (!position) return null;
+
+  return (
+    <div
+      className="fixed z-[200] rounded-lg border border-white/10 py-1 min-w-[160px]"
+      style={{
+        left: position.x,
+        top: position.y,
+        background: 'rgba(28, 28, 30, 0.95)',
+        backdropFilter: 'blur(12px)',
+        WebkitBackdropFilter: 'blur(12px)',
+      }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <MenuLabel>Align</MenuLabel>
+      <MenuItem onClick={() => handleAlign('left')}>Left</MenuItem>
+      <MenuItem onClick={() => handleAlign('center-h')}>Center Horizontal</MenuItem>
+      <MenuItem onClick={() => handleAlign('right')}>Right</MenuItem>
+      <MenuDivider />
+      <MenuItem onClick={() => handleAlign('top')}>Top</MenuItem>
+      <MenuItem onClick={() => handleAlign('center-v')}>Center Vertical</MenuItem>
+      <MenuItem onClick={() => handleAlign('bottom')}>Bottom</MenuItem>
+      <MenuDivider />
+      <MenuLabel>Distribute</MenuLabel>
+      <MenuItem onClick={() => handleDistribute('horizontal')}>Horizontal Spacing</MenuItem>
+      <MenuItem onClick={() => handleDistribute('vertical')}>Vertical Spacing</MenuItem>
+    </div>
+  );
+});
+
+function MenuLabel({ children }: { children: React.ReactNode }) {
+  return <div className="px-3 py-1 text-xs font-medium text-white/30">{children}</div>;
+}
+
+function MenuItem({ children, onClick }: { children: React.ReactNode; onClick: () => void }) {
+  return (
+    <button
+      className="w-full text-left px-3 py-1.5 text-sm text-white/70 bg-transparent border-none hover:bg-white/5 hover:text-white/90 transition-colors duration-100"
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function MenuDivider() {
+  return <div className="my-1 border-t border-white/5" />;
+}

--- a/src/components/canvas/AlignMenu.tsx
+++ b/src/components/canvas/AlignMenu.tsx
@@ -1,8 +1,9 @@
-import { memo, useCallback, useEffect } from 'react';
+import { memo, useCallback } from 'react';
 import { useCanvasStore, persistCanvas, type TerminalNode } from '../../stores/canvasStore';
 import { useTerminalStore } from '../../stores/terminalStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { buildChainMap, type TaskChainInfo } from '../../utils/taskChain';
+import { ContextMenu, type ContextMenuEntry } from '../ui/ContextMenu';
 
 interface AlignMenuProps {
   projectPath: string;
@@ -15,24 +16,6 @@ type DistributeType = 'horizontal' | 'vertical';
 
 /** Context menu for aligning and distributing selected nodes. */
 export const AlignMenu = memo(function AlignMenu({ projectPath, position, onClose }: AlignMenuProps) {
-  // Close on click outside or Escape
-  useEffect(() => {
-    if (!position) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    const clickHandler = () => {
-      // Delay to allow menu item clicks to fire first
-      requestAnimationFrame(() => onClose());
-    };
-    document.addEventListener('keydown', handler);
-    document.addEventListener('mousedown', clickHandler);
-    return () => {
-      document.removeEventListener('keydown', handler);
-      document.removeEventListener('mousedown', clickHandler);
-    };
-  }, [position, onClose]);
-
   const handleAlign = useCallback(
     (type: AlignType) => {
       const canvas = useCanvasStore.getState().canvasByProject[projectPath];
@@ -303,61 +286,46 @@ export const AlignMenu = memo(function AlignMenu({ projectPath, position, onClos
     persistCanvas(projectPath);
   }, [projectPath, tasks, displayStates]);
 
+  const canvasNodes = useCanvasStore((s) => s.canvasByProject[projectPath]?.nodes);
+  const selectedCount = canvasNodes?.filter((n) => n.selected).length ?? 0;
+
   if (!position) return null;
 
-  return (
-    <div
-      className="fixed z-[200] rounded-lg border border-white/10 py-1 min-w-[160px]"
-      style={{
-        left: position.x,
-        top: position.y,
-        background: 'rgba(28, 28, 30, 0.95)',
-        backdropFilter: 'blur(12px)',
-        WebkitBackdropFilter: 'blur(12px)',
-      }}
-      onMouseDown={(e) => e.stopPropagation()}
-    >
-      <MenuLabel>Align</MenuLabel>
-      <MenuItem onClick={() => handleAlign('left')}>Left</MenuItem>
-      <MenuItem onClick={() => handleAlign('center-h')}>Center Horizontal</MenuItem>
-      <MenuItem onClick={() => handleAlign('right')}>Right</MenuItem>
-      <MenuDivider />
-      <MenuItem onClick={() => handleAlign('top')}>Top</MenuItem>
-      <MenuItem onClick={() => handleAlign('center-v')}>Center Vertical</MenuItem>
-      <MenuItem onClick={() => handleAlign('bottom')}>Bottom</MenuItem>
-      <MenuDivider />
-      <MenuLabel>Distribute</MenuLabel>
-      <MenuItem onClick={() => handleDistribute('horizontal')}>Horizontal Spacing</MenuItem>
-      <MenuItem onClick={() => handleDistribute('vertical')}>Vertical Spacing</MenuItem>
-      <MenuDivider />
-      <MenuLabel>Layout</MenuLabel>
-      <MenuItem onClick={handleGridLayout}>Grid</MenuItem>
-      <MenuItem onClick={handleChainLayout}>Chain Tree</MenuItem>
-    </div>
-  );
+  const items: ContextMenuEntry[] = [];
+
+  if (selectedCount >= 2) {
+    items.push(
+      { label: 'Align Left', icon: 'align-left', onClick: () => handleAlign('left') },
+      { label: 'Align Center', icon: 'align-center-horizontal', onClick: () => handleAlign('center-h') },
+      { label: 'Align Right', icon: 'align-right', onClick: () => handleAlign('right') },
+      { separator: true },
+      { label: 'Align Top', icon: 'align-top', onClick: () => handleAlign('top') },
+      { label: 'Align Middle', icon: 'align-center-vertical', onClick: () => handleAlign('center-v') },
+      { label: 'Align Bottom', icon: 'align-bottom', onClick: () => handleAlign('bottom') },
+    );
+  }
+
+  if (selectedCount >= 3) {
+    items.push(
+      { separator: true },
+      {
+        label: 'Distribute Horizontal',
+        icon: 'arrows-out-line-horizontal',
+        onClick: () => handleDistribute('horizontal'),
+      },
+      { label: 'Distribute Vertical', icon: 'arrows-out-line-vertical', onClick: () => handleDistribute('vertical') },
+    );
+  }
+
+  if (selectedCount >= 2) {
+    items.push({ separator: true }, { label: 'Grid Layout', icon: 'grid-four', onClick: handleGridLayout });
+  }
+
+  if (items.length > 0) items.push({ separator: true });
+  items.push({ label: 'Chain Tree Layout', icon: 'tree-structure', onClick: handleChainLayout });
+
+  return <ContextMenu x={position.x} y={position.y} items={items} onClose={onClose} />;
 });
-
-function MenuLabel({ children }: { children: React.ReactNode }) {
-  return <div className="px-3 py-1 text-xs font-medium text-white/30">{children}</div>;
-}
-
-function MenuItem({ children, onClick }: { children: React.ReactNode; onClick: () => void }) {
-  return (
-    <button
-      className="w-full text-left px-3 py-1.5 text-sm text-white/70 bg-transparent border-none hover:bg-white/5 hover:text-white/90 transition-colors duration-100"
-      onClick={(e) => {
-        e.stopPropagation();
-        onClick();
-      }}
-    >
-      {children}
-    </button>
-  );
-}
-
-function MenuDivider() {
-  return <div className="my-1 border-t border-white/5" />;
-}
 
 /** Estimate total height of a subtree without placing nodes. */
 function estimateSubtreeHeight(

--- a/src/components/canvas/AlignMenu.tsx
+++ b/src/components/canvas/AlignMenu.tsx
@@ -1,5 +1,8 @@
 import { memo, useCallback, useEffect } from 'react';
-import { useCanvasStore, type TerminalNode } from '../../stores/canvasStore';
+import { useCanvasStore, persistCanvas, type TerminalNode } from '../../stores/canvasStore';
+import { useTerminalStore } from '../../stores/terminalStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { buildChainMap, type TaskChainInfo } from '../../utils/taskChain';
 
 interface AlignMenuProps {
   projectPath: string;
@@ -90,6 +93,7 @@ export const AlignMenu = memo(function AlignMenu({ projectPath, position, onClos
       }
 
       useCanvasStore.getState().loadCanvas(projectPath, { ...canvas, nodes: updatedNodes as TerminalNode[] });
+      persistCanvas(projectPath);
     },
     [projectPath],
   );
@@ -143,9 +147,161 @@ export const AlignMenu = memo(function AlignMenu({ projectPath, position, onClos
       }
 
       useCanvasStore.getState().loadCanvas(projectPath, { ...canvas, nodes: updatedNodes as TerminalNode[] });
+      persistCanvas(projectPath);
     },
     [projectPath],
   );
+
+  const tasks = useProjectStore((s) => s.tasks);
+  const displayStates = useTerminalStore((s) => s.displayStates);
+
+  const handleGridLayout = useCallback(() => {
+    const canvas = useCanvasStore.getState().canvasByProject[projectPath];
+    if (!canvas) return;
+    const selected = canvas.nodes.filter((n) => n.selected);
+    if (selected.length < 2) return;
+
+    const getWidth = (n: TerminalNode) => n.measured?.width ?? (n.style?.width ? Number(n.style.width) : 740);
+    const getHeight = (n: TerminalNode) => n.measured?.height ?? (n.style?.height ? Number(n.style.height) : 556);
+    const gap = 24;
+
+    // Grid dimensions: prefer wider than tall
+    const cols = Math.ceil(Math.sqrt(selected.length));
+    const sorted = [...selected].sort((a, b) => a.position.x - b.position.x || a.position.y - b.position.y);
+
+    // Compute column widths and row heights
+    const colWidths: number[] = [];
+    const rowHeights: number[] = [];
+    for (let i = 0; i < sorted.length; i++) {
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      colWidths[col] = Math.max(colWidths[col] ?? 0, getWidth(sorted[i]));
+      rowHeights[row] = Math.max(rowHeights[row] ?? 0, getHeight(sorted[i]));
+    }
+
+    // Place from the top-left of the current bounding box
+    const originX = Math.min(...selected.map((n) => n.position.x));
+    const originY = Math.min(...selected.map((n) => n.position.y));
+
+    const positions = new Map<string, { x: number; y: number }>();
+    for (let i = 0; i < sorted.length; i++) {
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      const x = originX + colWidths.slice(0, col).reduce((s, w) => s + w + gap, 0);
+      const y = originY + rowHeights.slice(0, row).reduce((s, h) => s + h + gap, 0);
+      positions.set(sorted[i].id, { x, y });
+    }
+
+    const updatedNodes = canvas.nodes.map((n) => {
+      const pos = positions.get(n.id);
+      return pos ? { ...n, position: pos } : n;
+    });
+
+    useCanvasStore.getState().loadCanvas(projectPath, { ...canvas, nodes: updatedNodes as TerminalNode[] });
+    persistCanvas(projectPath);
+  }, [projectPath]);
+
+  const handleChainLayout = useCallback(() => {
+    const canvas = useCanvasStore.getState().canvasByProject[projectPath];
+    if (!canvas) return;
+
+    const chainMap = buildChainMap(tasks);
+    const getWidth = (n: TerminalNode) => n.measured?.width ?? (n.style?.width ? Number(n.style.width) : 740);
+    const getHeight = (n: TerminalNode) => n.measured?.height ?? (n.style?.height ? Number(n.style.height) : 556);
+    const hGap = 80;
+    const vGap = 60;
+
+    // Build taskNumber → nodes lookup
+    const taskToNodes = new Map<number, TerminalNode[]>();
+    for (const node of canvas.nodes) {
+      const display = displayStates[node.data.ptyId];
+      if (display?.taskId != null) {
+        const list = taskToNodes.get(display.taskId);
+        if (list) list.push(node);
+        else taskToNodes.set(display.taskId, [node]);
+      }
+    }
+
+    // Only layout nodes that are part of chains
+    const chainTaskNumbers = new Set<number>();
+    for (const [taskNum, info] of chainMap) {
+      if (info.depth > 0 || info.childTaskNumbers.length > 0) {
+        chainTaskNumbers.add(taskNum);
+      }
+    }
+    if (chainTaskNumbers.size === 0) return;
+
+    // Find root tasks and build tree
+    const roots: number[] = [];
+    for (const taskNum of chainTaskNumbers) {
+      const info = chainMap.get(taskNum);
+      if (info && info.depth === 0) roots.push(taskNum);
+    }
+
+    // Recursive layout: each subtree returns its total height
+    const positions = new Map<string, { x: number; y: number }>();
+
+    function layoutSubtree(taskNum: number, x: number, y: number): number {
+      const info = chainMap.get(taskNum);
+      const nodes = taskToNodes.get(taskNum) ?? [];
+      if (nodes.length === 0 && (!info || info.childTaskNumbers.length === 0)) return 0;
+
+      // Place this task's terminals stacked vertically
+      let nodeY = y;
+      for (const node of nodes) {
+        positions.set(node.id, { x, y: nodeY });
+        nodeY += getHeight(node) + vGap;
+      }
+      const thisHeight = nodes.length > 0 ? nodeY - y - vGap : 0;
+
+      // Layout children to the right
+      if (!info || info.childTaskNumbers.length === 0) return Math.max(thisHeight, 0);
+
+      const maxNodeWidth = nodes.length > 0 ? Math.max(...nodes.map(getWidth)) : 0;
+      const childX = x + maxNodeWidth + hGap;
+
+      // Center children vertically relative to this task's nodes
+      let totalChildHeight = 0;
+      const childHeights: number[] = [];
+      // First pass: compute total height needed
+      for (const childNum of info.childTaskNumbers) {
+        if (!chainTaskNumbers.has(childNum)) continue;
+        const h = estimateSubtreeHeight(childNum, chainMap, taskToNodes, getHeight, vGap);
+        childHeights.push(h);
+        totalChildHeight += h;
+      }
+      const filteredChildren = info.childTaskNumbers.filter((c) => chainTaskNumbers.has(c));
+      if (filteredChildren.length > 1) totalChildHeight += (filteredChildren.length - 1) * vGap;
+
+      // Start children so they center on parent
+      const parentCenterY = y + thisHeight / 2;
+      let childY = parentCenterY - totalChildHeight / 2;
+
+      for (let i = 0; i < filteredChildren.length; i++) {
+        const actualHeight = layoutSubtree(filteredChildren[i], childX, childY);
+        childY += (actualHeight > 0 ? actualHeight : childHeights[i]) + vGap;
+      }
+
+      return Math.max(thisHeight, totalChildHeight);
+    }
+
+    // Layout all root chains, stacked vertically
+    const originX = Math.min(...canvas.nodes.map((n) => n.position.x));
+    let currentY = Math.min(...canvas.nodes.map((n) => n.position.y));
+    for (const root of roots) {
+      const height = layoutSubtree(root, originX, currentY);
+      currentY += height + vGap * 2;
+    }
+
+    // Apply positions (only update chain nodes, leave non-chain nodes untouched)
+    const updatedNodes = canvas.nodes.map((n) => {
+      const pos = positions.get(n.id);
+      return pos ? { ...n, position: pos } : n;
+    });
+
+    useCanvasStore.getState().loadCanvas(projectPath, { ...canvas, nodes: updatedNodes as TerminalNode[] });
+    persistCanvas(projectPath);
+  }, [projectPath, tasks, displayStates]);
 
   if (!position) return null;
 
@@ -173,6 +329,10 @@ export const AlignMenu = memo(function AlignMenu({ projectPath, position, onClos
       <MenuLabel>Distribute</MenuLabel>
       <MenuItem onClick={() => handleDistribute('horizontal')}>Horizontal Spacing</MenuItem>
       <MenuItem onClick={() => handleDistribute('vertical')}>Vertical Spacing</MenuItem>
+      <MenuDivider />
+      <MenuLabel>Layout</MenuLabel>
+      <MenuItem onClick={handleGridLayout}>Grid</MenuItem>
+      <MenuItem onClick={handleChainLayout}>Chain Tree</MenuItem>
     </div>
   );
 });
@@ -197,4 +357,32 @@ function MenuItem({ children, onClick }: { children: React.ReactNode; onClick: (
 
 function MenuDivider() {
   return <div className="my-1 border-t border-white/5" />;
+}
+
+/** Estimate total height of a subtree without placing nodes. */
+function estimateSubtreeHeight(
+  taskNum: number,
+  chainMap: Map<number, TaskChainInfo>,
+  taskToNodes: Map<number, TerminalNode[]>,
+  getHeight: (n: TerminalNode) => number,
+  vGap: number,
+): number {
+  const nodes = taskToNodes.get(taskNum) ?? [];
+  const info = chainMap.get(taskNum);
+
+  const thisHeight = nodes.length > 0 ? nodes.reduce((sum, n) => sum + getHeight(n) + vGap, 0) - vGap : 0;
+
+  if (!info || info.childTaskNumbers.length === 0) return Math.max(thisHeight, 0);
+
+  let childTotal = 0;
+  let childCount = 0;
+  for (const childNum of info.childTaskNumbers) {
+    const childInfo = chainMap.get(childNum);
+    if (!childInfo || (childInfo.depth === 0 && childInfo.childTaskNumbers.length === 0)) continue;
+    childTotal += estimateSubtreeHeight(childNum, chainMap, taskToNodes, getHeight, vGap);
+    childCount++;
+  }
+  if (childCount > 1) childTotal += (childCount - 1) * vGap;
+
+  return Math.max(thisHeight, childTotal);
 }

--- a/src/components/canvas/CanvasControls.tsx
+++ b/src/components/canvas/CanvasControls.tsx
@@ -1,0 +1,165 @@
+import { memo, useCallback } from 'react';
+import { Panel, useReactFlow, useViewport } from '@xyflow/react';
+import { useCanvasStore } from '../../stores/canvasStore';
+
+interface CanvasControlsProps {
+  projectPath: string;
+}
+
+export const CanvasControls = memo(function CanvasControls({ projectPath }: CanvasControlsProps) {
+  const { zoomIn, zoomOut, fitView } = useReactFlow();
+  const { zoom } = useViewport();
+  const gridSnap = useCanvasStore((s) => s.canvasByProject[projectPath]?.gridSnap ?? false);
+
+  const handleZoomIn = useCallback(() => zoomIn({ duration: 200 }), [zoomIn]);
+  const handleZoomOut = useCallback(() => zoomOut({ duration: 200 }), [zoomOut]);
+  const handleFitView = useCallback(() => fitView({ duration: 300, padding: 0.1 }), [fitView]);
+  const handleToggleGrid = useCallback(
+    () => useCanvasStore.getState().setGridSnap(projectPath, !gridSnap),
+    [projectPath, gridSnap],
+  );
+
+  const zoomPercent = Math.round(zoom * 100);
+
+  return (
+    <Panel position="top-center" className="!m-0" style={{ top: 8 }}>
+      <div
+        className="flex items-center gap-0.5 px-1.5 rounded-lg border border-white/10"
+        style={{
+          height: 32,
+          background: 'rgba(28, 28, 30, 0.8)',
+          backdropFilter: 'blur(12px)',
+          WebkitBackdropFilter: 'blur(12px)',
+        }}
+      >
+        <ControlButton onClick={handleZoomOut} title="Zoom out (Cmd+-)">
+          <MinusIcon />
+        </ControlButton>
+
+        <button
+          className="px-1.5 font-mono text-xs text-white/50 bg-transparent border-none hover:text-white/80 transition-colors duration-150"
+          onClick={handleFitView}
+          title="Fit view (Cmd+0)"
+          style={{ minWidth: 40, textAlign: 'center' }}
+        >
+          {zoomPercent}%
+        </button>
+
+        <ControlButton onClick={handleZoomIn} title="Zoom in (Cmd+=)">
+          <PlusIcon />
+        </ControlButton>
+
+        <div className="w-px h-4 bg-white/10 mx-0.5" />
+
+        <ControlButton onClick={handleFitView} title="Fit all (Cmd+Shift+F)">
+          <FitIcon />
+        </ControlButton>
+
+        <ControlButton onClick={handleToggleGrid} title="Toggle snap to grid" active={gridSnap}>
+          <GridIcon />
+        </ControlButton>
+      </div>
+    </Panel>
+  );
+});
+
+// ── Button ──────────────────────────────────────────────────────────
+
+function ControlButton({
+  onClick,
+  title,
+  active,
+  children,
+}: {
+  onClick: () => void;
+  title: string;
+  active?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      className={`w-7 h-7 flex items-center justify-center rounded bg-transparent border-none transition-colors duration-150 ${
+        active ? 'text-accent' : 'text-white/40 hover:text-white/70'
+      }`}
+      onClick={onClick}
+      title={title}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ── Icons ───────────────────────────────────────────────────────────
+
+function MinusIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    >
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    >
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
+function FitIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polyline points="15 3 21 3 21 9" />
+      <polyline points="9 21 3 21 3 15" />
+      <line x1="21" y1="3" x2="14" y2="10" />
+      <line x1="3" y1="21" x2="10" y2="14" />
+    </svg>
+  );
+}
+
+function GridIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="3" y="3" width="7" height="7" />
+      <rect x="14" y="3" width="7" height="7" />
+      <rect x="14" y="14" width="7" height="7" />
+      <rect x="3" y="14" width="7" height="7" />
+    </svg>
+  );
+}

--- a/src/components/canvas/ChainEdge.tsx
+++ b/src/components/canvas/ChainEdge.tsx
@@ -1,0 +1,25 @@
+import { memo } from 'react';
+import { BaseEdge, getBezierPath, type EdgeProps } from '@xyflow/react';
+
+/** Custom edge for task chain connections. Renders a bezier curve with chain-colored stroke and arrow. */
+export const ChainEdge = memo(function ChainEdge({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  markerEnd,
+  style,
+}: EdgeProps) {
+  const [edgePath] = getBezierPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  });
+
+  return <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />;
+});

--- a/src/components/canvas/ChainEdge.tsx
+++ b/src/components/canvas/ChainEdge.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
-import { BaseEdge, getBezierPath, type EdgeProps } from '@xyflow/react';
+import { BaseEdge, getBezierPath, type EdgeProps, type Position } from '@xyflow/react';
 
-/** Custom edge for task chain connections. Renders a bezier curve with chain-colored stroke and arrow. */
+/** Smooth bezier edge for task chain connections. */
 export const ChainEdge = memo(function ChainEdge({
   sourceX,
   sourceY,
@@ -9,17 +9,29 @@ export const ChainEdge = memo(function ChainEdge({
   targetY,
   sourcePosition,
   targetPosition,
-  markerEnd,
   style,
+  data,
 }: EdgeProps) {
+  const edgeData = data as { sourcePosition?: Position; targetPosition?: Position } | undefined;
+  const srcPos = edgeData?.sourcePosition ?? sourcePosition;
+  const tgtPos = edgeData?.targetPosition ?? targetPosition;
+  const strokeColor = (style as React.CSSProperties | undefined)?.stroke;
+
   const [edgePath] = getBezierPath({
     sourceX,
     sourceY,
     targetX,
     targetY,
-    sourcePosition,
-    targetPosition,
+    sourcePosition: srcPos,
+    targetPosition: tgtPos,
   });
 
-  return <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />;
+  return (
+    <>
+      {strokeColor && (
+        <path d={edgePath} fill="none" stroke={String(strokeColor)} strokeWidth={6} strokeOpacity={0.08} />
+      )}
+      <BaseEdge path={edgePath} style={style} />
+    </>
+  );
 });

--- a/src/components/canvas/SmartGuideOverlay.tsx
+++ b/src/components/canvas/SmartGuideOverlay.tsx
@@ -1,0 +1,63 @@
+import { memo } from 'react';
+import { useViewport } from '@xyflow/react';
+import type { GuideLine } from './useSmartGuides';
+
+interface SmartGuideOverlayProps {
+  guides: GuideLine[];
+}
+
+/** Renders alignment guide lines during node drag. */
+export const SmartGuideOverlay = memo(function SmartGuideOverlay({ guides }: SmartGuideOverlayProps) {
+  const viewport = useViewport();
+
+  if (guides.length === 0) return null;
+
+  // Convert canvas-space positions to screen-space for SVG overlay
+  const { x: panX, y: panY, zoom } = viewport;
+
+  return (
+    <svg
+      className="pointer-events-none"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        zIndex: 1000,
+        overflow: 'visible',
+      }}
+    >
+      {guides.map((guide, i) => {
+        if (guide.orientation === 'vertical') {
+          const screenX = guide.position * zoom + panX;
+          return (
+            <line
+              key={`v-${i}`}
+              x1={screenX}
+              y1={0}
+              x2={screenX}
+              y2="100%"
+              stroke="rgba(10, 132, 255, 0.5)"
+              strokeWidth={1}
+              strokeDasharray="4 4"
+            />
+          );
+        } else {
+          const screenY = guide.position * zoom + panY;
+          return (
+            <line
+              key={`h-${i}`}
+              x1={0}
+              y1={screenY}
+              x2="100%"
+              y2={screenY}
+              stroke="rgba(10, 132, 255, 0.5)"
+              strokeWidth={1}
+              strokeDasharray="4 4"
+            />
+          );
+        }
+      })}
+    </svg>
+  );
+});

--- a/src/components/canvas/SmartGuideOverlay.tsx
+++ b/src/components/canvas/SmartGuideOverlay.tsx
@@ -1,63 +1,51 @@
 import { memo } from 'react';
-import { useViewport } from '@xyflow/react';
+import { Panel } from '@xyflow/react';
 import type { GuideLine } from './useSmartGuides';
 
 interface SmartGuideOverlayProps {
   guides: GuideLine[];
 }
 
-/** Renders alignment guide lines during node drag. */
+/**
+ * Renders alignment guide lines during node drag.
+ * Uses a full-viewport SVG panel so lines span the entire visible area.
+ * Coordinates are in screen space (converted from canvas space in useSmartGuides).
+ */
 export const SmartGuideOverlay = memo(function SmartGuideOverlay({ guides }: SmartGuideOverlayProps) {
-  const viewport = useViewport();
-
   if (guides.length === 0) return null;
 
-  // Convert canvas-space positions to screen-space for SVG overlay
-  const { x: panX, y: panY, zoom } = viewport;
-
   return (
-    <svg
-      className="pointer-events-none"
-      style={{
-        position: 'absolute',
-        inset: 0,
-        width: '100%',
-        height: '100%',
-        zIndex: 1000,
-        overflow: 'visible',
-      }}
-    >
-      {guides.map((guide, i) => {
-        if (guide.orientation === 'vertical') {
-          const screenX = guide.position * zoom + panX;
-          return (
+    <Panel position="top-left" className="!m-0 !p-0" style={{ inset: 0, width: '100%', height: '100%' }}>
+      <svg
+        className="pointer-events-none"
+        style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', overflow: 'visible' }}
+      >
+        {guides.map((guide, i) =>
+          guide.orientation === 'vertical' ? (
             <line
               key={`v-${i}`}
-              x1={screenX}
+              x1={guide.screenPos}
               y1={0}
-              x2={screenX}
+              x2={guide.screenPos}
               y2="100%"
               stroke="rgba(10, 132, 255, 0.5)"
               strokeWidth={1}
               strokeDasharray="4 4"
             />
-          );
-        } else {
-          const screenY = guide.position * zoom + panY;
-          return (
+          ) : (
             <line
               key={`h-${i}`}
               x1={0}
-              y1={screenY}
+              y1={guide.screenPos}
               x2="100%"
-              y2={screenY}
+              y2={guide.screenPos}
               stroke="rgba(10, 132, 255, 0.5)"
               strokeWidth={1}
               strokeDasharray="4 4"
             />
-          );
-        }
-      })}
-    </svg>
+          ),
+        )}
+      </svg>
+    </Panel>
   );
 });

--- a/src/components/canvas/TerminalCanvas.tsx
+++ b/src/components/canvas/TerminalCanvas.tsx
@@ -28,6 +28,39 @@ import { useSmartGuides } from './useSmartGuides';
 import { getChainColor, buildChainMap } from '../../utils/taskChain';
 import { useProjectStore } from '../../stores/projectStore';
 
+/**
+ * Reconcile canvas nodes with the terminal store — add missing, remove stale.
+ * Treats missing terminal list as empty (all canvas nodes are stale).
+ */
+export function syncCanvasWithTerminals(projectPath: string): void {
+  const terminalPtyIds = useTerminalStore.getState().terminalsByProject[projectPath] ?? [];
+  const canvasState = useCanvasStore.getState().canvasByProject[projectPath];
+  if (!canvasState) return;
+
+  const terminalSet = new Set(terminalPtyIds);
+  const store = useCanvasStore.getState();
+
+  // Add canvas nodes for terminals that don't have one yet
+  const canvasNodeIds = new Set(canvasState.nodes.map((n) => n.id));
+  for (const ptyId of terminalPtyIds) {
+    if (!canvasNodeIds.has(ptyId)) {
+      store.addNode(projectPath, ptyId);
+    }
+  }
+
+  // Remove canvas nodes whose terminal no longer exists
+  let changed = false;
+  for (const node of canvasState.nodes) {
+    if (node.type === 'terminal' && !node.id.startsWith('group-') && !terminalSet.has(node.id)) {
+      store.removeNode(projectPath, node.id);
+      changed = true;
+    }
+  }
+  if (changed) {
+    persistCanvas(projectPath);
+  }
+}
+
 // Defined outside component to prevent re-renders
 const nodeTypes = { terminal: TerminalNode };
 const edgeTypes = { chain: ChainEdge };
@@ -79,7 +112,7 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
     [tasks, displayStates],
   );
 
-  // Load persisted canvas state on mount
+  // Load persisted canvas state on mount (sync happens after reconnection in ProjectViewReact)
   useEffect(() => {
     useCanvasStore.getState().ensureProject(projectPath);
     loadPersistedCanvas(projectPath).then((saved) => {
@@ -88,21 +121,6 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
       }
     });
   }, [projectPath]);
-
-  // Sync: ensure canvas nodes exist for all terminal ptyIds
-  const terminalPtyIds = useTerminalStore((s) => s.terminalsByProject[projectPath]);
-  useEffect(() => {
-    if (!terminalPtyIds) return;
-    const canvasState = useCanvasStore.getState().canvasByProject[projectPath];
-    if (!canvasState) return;
-
-    const canvasNodeIds = new Set(canvasState.nodes.map((n) => n.id));
-    for (const ptyId of terminalPtyIds) {
-      if (!canvasNodeIds.has(ptyId)) {
-        useCanvasStore.getState().addNode(projectPath, ptyId);
-      }
-    }
-  }, [terminalPtyIds, projectPath]);
 
   const onNodesChange = useCallback(
     (changes: NodeChange<TerminalNodeType>[]) => {
@@ -164,7 +182,7 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
         fitView
         proOptions={proOptions}
       >
-        <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="rgba(255,255,255,0.06)" />
+        <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="rgba(255,255,255,0.15)" />
         <CanvasControls projectPath={projectPath} />
         {nodes.length >= 3 && (
           <MiniMap

--- a/src/components/canvas/TerminalCanvas.tsx
+++ b/src/components/canvas/TerminalCanvas.tsx
@@ -99,6 +99,7 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
     setMenuPos({ x: event.clientX, y: event.clientY });
   }, []);
   const handleCloseMenu = useCallback(() => setMenuPos(null), []);
+  const handlePaneClick = useCallback(() => setMenuPos(null), []);
 
   // Phase 3: minimap node color from chain info
   const tasks = useProjectStore((s) => s.tasks);
@@ -171,6 +172,8 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
         onNodeDrag={onNodeDrag}
         onNodeDragStop={onNodeDragStop}
         onSelectionContextMenu={handleSelectionContextMenu}
+        onPaneClick={handlePaneClick}
+        onNodeClick={handlePaneClick}
         panOnScroll
         zoomOnScroll={false}
         zoomOnPinch

--- a/src/components/canvas/TerminalCanvas.tsx
+++ b/src/components/canvas/TerminalCanvas.tsx
@@ -171,7 +171,7 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
         zoomOnPinch
         panActivationKeyCode="Space"
         zoomActivationKeyCode="Meta"
-        minZoom={0.25}
+        minZoom={0.05}
         maxZoom={2}
         selectionKeyCode="Shift"
         multiSelectionKeyCode="Meta"

--- a/src/components/canvas/TerminalCanvas.tsx
+++ b/src/components/canvas/TerminalCanvas.tsx
@@ -227,8 +227,8 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
               </button>
             </Panel>
           ))}
+        <SmartGuideOverlay guides={guides} />
       </ReactFlow>
-      <SmartGuideOverlay guides={guides} />
       <AlignMenu projectPath={projectPath} position={menuPos} onClose={handleCloseMenu} />
     </div>
   );

--- a/src/components/canvas/TerminalCanvas.tsx
+++ b/src/components/canvas/TerminalCanvas.tsx
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  BackgroundVariant,
+  MiniMap,
+  SelectionMode,
+  type Viewport,
+  type NodeChange,
+  type EdgeChange,
+} from '@xyflow/react';
+import '@xyflow/react/dist/base.css';
+import {
+  useCanvasStore,
+  loadPersistedCanvas,
+  persistCanvas,
+  type TerminalNode as TerminalNodeType,
+} from '../../stores/canvasStore';
+import { useTerminalStore } from '../../stores/terminalStore';
+import { TerminalNode } from './TerminalNode';
+import { ChainEdge } from './ChainEdge';
+import { CanvasControls } from './CanvasControls';
+import { SmartGuideOverlay } from './SmartGuideOverlay';
+import { AlignMenu } from './AlignMenu';
+import { useChainEdges } from './useChainEdges';
+import { useSmartGuides } from './useSmartGuides';
+import { getChainColor, buildChainMap } from '../../utils/taskChain';
+import { useProjectStore } from '../../stores/projectStore';
+
+// Defined outside component to prevent re-renders
+const nodeTypes = { terminal: TerminalNode };
+const edgeTypes = { chain: ChainEdge };
+const snapGrid: [number, number] = [20, 20];
+const proOptions = { hideAttribution: true };
+
+const EMPTY_NODES: TerminalNodeType[] = [];
+const EMPTY_EDGES: import('@xyflow/react').Edge[] = [];
+
+interface TerminalCanvasProps {
+  projectPath: string;
+}
+
+function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
+  const project = useCanvasStore((s) => s.canvasByProject[projectPath]);
+  const nodes = project?.nodes ?? EMPTY_NODES;
+  const edges = project?.edges ?? EMPTY_EDGES;
+  const viewport = project?.viewport;
+  const gridSnap = project?.gridSnap ?? false;
+
+  // Phase 2: chain edges
+  useChainEdges(projectPath);
+
+  // Phase 3: smart guides
+  const { guides, onNodeDrag, onNodeDragStop } = useSmartGuides(nodes);
+
+  // Phase 3: align/distribute context menu
+  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
+  const handleSelectionContextMenu = useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
+    setMenuPos({ x: event.clientX, y: event.clientY });
+  }, []);
+  const handleCloseMenu = useCallback(() => setMenuPos(null), []);
+
+  // Phase 3: minimap node color from chain info
+  const tasks = useProjectStore((s) => s.tasks);
+  const displayStates = useTerminalStore((s) => s.displayStates);
+  const minimapNodeColor = useCallback(
+    (node: TerminalNodeType) => {
+      const ptyId = node.data?.ptyId;
+      if (!ptyId) return 'rgba(255, 255, 255, 0.15)';
+      const display = displayStates[ptyId];
+      if (!display?.taskId) return 'rgba(255, 255, 255, 0.15)';
+      const chainMap = buildChainMap(tasks);
+      const info = chainMap.get(display.taskId);
+      if (!info) return 'rgba(255, 255, 255, 0.15)';
+      return getChainColor(info.rootTaskNumber, info.depth);
+    },
+    [tasks, displayStates],
+  );
+
+  // Load persisted canvas state on mount
+  useEffect(() => {
+    useCanvasStore.getState().ensureProject(projectPath);
+    loadPersistedCanvas(projectPath).then((saved) => {
+      if (saved) {
+        useCanvasStore.getState().loadCanvas(projectPath, saved);
+      }
+    });
+  }, [projectPath]);
+
+  // Sync: ensure canvas nodes exist for all terminal ptyIds
+  const terminalPtyIds = useTerminalStore((s) => s.terminalsByProject[projectPath]);
+  useEffect(() => {
+    if (!terminalPtyIds) return;
+    const canvasState = useCanvasStore.getState().canvasByProject[projectPath];
+    if (!canvasState) return;
+
+    const canvasNodeIds = new Set(canvasState.nodes.map((n) => n.id));
+    for (const ptyId of terminalPtyIds) {
+      if (!canvasNodeIds.has(ptyId)) {
+        useCanvasStore.getState().addNode(projectPath, ptyId);
+      }
+    }
+  }, [terminalPtyIds, projectPath]);
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange<TerminalNodeType>[]) => {
+      useCanvasStore.getState().onNodesChange(projectPath, changes);
+      persistCanvas(projectPath);
+    },
+    [projectPath],
+  );
+
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) => {
+      useCanvasStore.getState().onEdgesChange(projectPath, changes);
+      persistCanvas(projectPath);
+    },
+    [projectPath],
+  );
+
+  const onViewportChange = useCallback(
+    (vp: Viewport) => {
+      useCanvasStore.getState().setViewport(projectPath, vp);
+      persistCanvas(projectPath);
+    },
+    [projectPath],
+  );
+
+  // Only pass viewport/onViewportChange when we have loaded state
+  const viewportProps = viewport
+    ? { viewport, onViewportChange }
+    : { defaultViewport: { x: 0, y: 0, zoom: 1 } as Viewport };
+
+  return (
+    <div className="terminal-canvas w-full h-full">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        {...viewportProps}
+        onNodeDrag={onNodeDrag}
+        onNodeDragStop={onNodeDragStop}
+        onSelectionContextMenu={handleSelectionContextMenu}
+        panOnScroll
+        zoomOnScroll={false}
+        zoomOnPinch
+        panActivationKeyCode="Space"
+        zoomActivationKeyCode="Meta"
+        minZoom={0.25}
+        maxZoom={2}
+        selectionKeyCode="Shift"
+        multiSelectionKeyCode="Meta"
+        selectionMode={SelectionMode.Partial}
+        snapToGrid={gridSnap}
+        snapGrid={snapGrid}
+        deleteKeyCode={null}
+        disableKeyboardA11y
+        colorMode="dark"
+        fitView
+        proOptions={proOptions}
+      >
+        <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="rgba(255,255,255,0.06)" />
+        <CanvasControls projectPath={projectPath} />
+        {nodes.length >= 3 && (
+          <MiniMap
+            pannable
+            zoomable
+            position="bottom-right"
+            nodeColor={minimapNodeColor as (node: any) => string}
+            maskColor="rgba(0, 0, 0, 0.7)"
+            bgColor="#1c1c1e"
+            nodeBorderRadius={8}
+          />
+        )}
+      </ReactFlow>
+      <SmartGuideOverlay guides={guides} />
+      <AlignMenu projectPath={projectPath} position={menuPos} onClose={handleCloseMenu} />
+    </div>
+  );
+}
+
+export function TerminalCanvas({ projectPath }: TerminalCanvasProps) {
+  return (
+    <ReactFlowProvider>
+      <TerminalCanvasInner projectPath={projectPath} />
+    </ReactFlowProvider>
+  );
+}

--- a/src/components/canvas/TerminalCanvas.tsx
+++ b/src/components/canvas/TerminalCanvas.tsx
@@ -112,13 +112,15 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
     [tasks, displayStates],
   );
 
-  // Load persisted canvas state on mount (sync happens after reconnection in ProjectViewReact)
+  // Load persisted canvas state on mount, then reconcile with current terminals
   useEffect(() => {
     useCanvasStore.getState().ensureProject(projectPath);
     loadPersistedCanvas(projectPath).then((saved) => {
       if (saved) {
         useCanvasStore.getState().loadCanvas(projectPath, saved);
       }
+      // Always sync after load to add terminals that exist but aren't in the saved state
+      syncCanvasWithTerminals(projectPath);
     });
   }, [projectPath]);
 

--- a/src/components/canvas/TerminalCanvas.tsx
+++ b/src/components/canvas/TerminalCanvas.tsx
@@ -5,6 +5,7 @@ import {
   Background,
   BackgroundVariant,
   MiniMap,
+  Panel,
   SelectionMode,
   type Viewport,
   type NodeChange,
@@ -86,6 +87,10 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
 
   // Phase 3: smart guides
   const { guides, onNodeDrag, onNodeDragStop } = useSmartGuides(nodes);
+
+  // Minimap toggle
+  const [minimapOpen, setMinimapOpen] = useState(true);
+  const handleToggleMinimap = useCallback(() => setMinimapOpen((v) => !v), []);
 
   // Phase 3: align/distribute context menu
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
@@ -186,17 +191,42 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
       >
         <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="rgba(255,255,255,0.15)" />
         <CanvasControls projectPath={projectPath} />
-        {nodes.length >= 3 && (
-          <MiniMap
-            pannable
-            zoomable
-            position="bottom-right"
-            nodeColor={minimapNodeColor as (node: any) => string}
-            maskColor="rgba(0, 0, 0, 0.7)"
-            bgColor="#1c1c1e"
-            nodeBorderRadius={8}
-          />
-        )}
+        {nodes.length >= 3 &&
+          (minimapOpen ? (
+            <MiniMap
+              pannable
+              zoomable
+              position="bottom-right"
+              nodeColor={minimapNodeColor as (node: any) => string}
+              maskColor="rgba(0, 0, 0, 0.25)"
+              bgColor="#1c1c1e"
+              nodeBorderRadius={16}
+              onClick={handleToggleMinimap}
+            />
+          ) : (
+            <Panel position="bottom-right">
+              <button
+                className="flex items-center justify-center w-8 h-8 rounded-lg border border-white/10 text-white/40 hover:text-white/70 transition-colors duration-150"
+                style={{ background: 'rgba(28, 28, 30, 0.8)', backdropFilter: 'blur(12px)' }}
+                onClick={handleToggleMinimap}
+                title="Show minimap"
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect x="3" y="3" width="18" height="18" rx="2" />
+                  <rect x="12" y="12" width="9" height="9" rx="1" />
+                </svg>
+              </button>
+            </Panel>
+          ))}
       </ReactFlow>
       <SmartGuideOverlay guides={guides} />
       <AlignMenu projectPath={projectPath} position={menuPos} onClose={handleCloseMenu} />

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -32,48 +32,44 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
   // Only intercept canvas gestures when this node is selected.
   const bodyClasses = selected ? 'nodrag nowheel nopan flex-1 min-h-0' : 'flex-1 min-h-0';
 
+  // Insets: the card is inset within the node wrapper so the NodeResizer
+  // at the wrapper edges naturally wraps title + card + metadata.
+  const INSET_TOP = 40;
+  const INSET_SIDE = 10;
+  const INSET_BOTTOM = 36;
+
   return (
     <>
-      <NodeTitle ptyId={ptyId} />
+      <NodeResizer
+        minWidth={400}
+        minHeight={200}
+        maxWidth={2400}
+        maxHeight={1600}
+        isVisible={!!selected}
+        lineClassName="!border-accent/30"
+        handleClassName="!w-2.5 !h-2.5 !bg-accent/60 !border-accent/80 !rounded-none"
+      />
+      <Handle id="top" type="source" position={Position.Top} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="top" type="target" position={Position.Top} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="bottom" type="source" position={Position.Bottom} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="bottom" type="target" position={Position.Bottom} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="left" type="source" position={Position.Left} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="left" type="target" position={Position.Left} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="right" type="source" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="right" type="target" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
+
+      <NodeTitle ptyId={ptyId} style={{ top: 4, left: INSET_SIDE, right: INSET_SIDE }} />
       <div
-        className={`canvas-terminal-node rounded-[14px] border overflow-hidden flex flex-col ${
-          selected ? 'border-accent/40' : 'border-white/10'
-        }`}
+        className="canvas-terminal-node absolute rounded-[14px] border border-white/10 overflow-hidden flex flex-col"
         style={{
-          width: '100%',
-          height: '100%',
+          top: INSET_TOP,
+          left: INSET_SIDE,
+          right: INSET_SIDE,
+          bottom: INSET_BOTTOM,
           background: 'var(--color-terminal-bg, #171717)',
           boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
         }}
       >
-        <NodeResizer
-          minWidth={400}
-          minHeight={200}
-          maxWidth={2400}
-          maxHeight={1600}
-          isVisible={!!selected}
-          lineClassName="!border-accent/30"
-          handleClassName="!w-2 !h-2 !bg-accent/50 !border-none !rounded-sm"
-        />
-        <Handle id="top" type="source" position={Position.Top} className="!bg-transparent !border-none !w-0 !h-0" />
-        <Handle id="top" type="target" position={Position.Top} className="!bg-transparent !border-none !w-0 !h-0" />
-        <Handle
-          id="bottom"
-          type="source"
-          position={Position.Bottom}
-          className="!bg-transparent !border-none !w-0 !h-0"
-        />
-        <Handle
-          id="bottom"
-          type="target"
-          position={Position.Bottom}
-          className="!bg-transparent !border-none !w-0 !h-0"
-        />
-        <Handle id="left" type="source" position={Position.Left} className="!bg-transparent !border-none !w-0 !h-0" />
-        <Handle id="left" type="target" position={Position.Left} className="!bg-transparent !border-none !w-0 !h-0" />
-        <Handle id="right" type="source" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
-        <Handle id="right" type="target" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
-
         <div className="terminal-drag-handle">
           <TerminalHeader
             ptyId={ptyId}
@@ -98,21 +94,21 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
           />
         </div>
       </div>
-      <NodeMetadata ptyId={ptyId} />
+      <NodeMetadata ptyId={ptyId} style={{ bottom: 4, left: INSET_SIDE, right: INSET_SIDE }} />
     </>
   );
 });
 
 // ── Task name label above the card ──────────────────────────────────
 
-const NodeTitle = memo(function NodeTitle({ ptyId }: { ptyId: string }) {
+const NodeTitle = memo(function NodeTitle({ ptyId, style }: { ptyId: string; style: React.CSSProperties }) {
   const label = useTerminalStore((s) => s.displayStates[ptyId]?.label ?? '');
   const taskId = useTerminalStore((s) => s.displayStates[ptyId]?.taskId ?? null);
 
   if (!label) return null;
 
   return (
-    <div className="px-1 pb-2" style={{ marginTop: -40 }}>
+    <div className="absolute px-1" style={style}>
       <span className="inline-flex items-center gap-2 text-xl font-semibold text-white/80 truncate max-w-full">
         {taskId != null && <span className="text-white/30 font-mono text-base">T-{taskId}</span>}
         {label}
@@ -125,7 +121,7 @@ const NodeTitle = memo(function NodeTitle({ ptyId }: { ptyId: string }) {
 
 const EMPTY_TAGS: string[] = [];
 
-const NodeMetadata = memo(function NodeMetadata({ ptyId }: { ptyId: string }) {
+const NodeMetadata = memo(function NodeMetadata({ ptyId, style }: { ptyId: string; style: React.CSSProperties }) {
   const taskId = useTerminalStore((s) => s.displayStates[ptyId]?.taskId ?? null);
   const worktreeBranch = useTerminalStore((s) => s.displayStates[ptyId]?.worktreeBranch ?? null);
   const tags = useTerminalStore((s) => s.displayStates[ptyId]?.tags) ?? EMPTY_TAGS;
@@ -142,7 +138,7 @@ const NodeMetadata = memo(function NodeMetadata({ ptyId }: { ptyId: string }) {
   if (!hasPills) return null;
 
   return (
-    <div className="flex items-center gap-1.5 px-1 pt-2 pb-1 flex-wrap" style={{ maxWidth: '100%' }}>
+    <div className="absolute flex items-center gap-1.5 px-1 flex-wrap" style={style}>
       {/* Task number */}
       {taskId != null && (
         <Pill>

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -54,19 +54,15 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
       <Handle id="right" type="source" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
       <Handle id="right" type="target" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
 
-      {/* ── Periphery above card: title + pills + actions ────────── */}
-      <div
-        className="terminal-drag-handle absolute flex flex-col gap-1 px-1"
-        style={{ top: 2, left: INSET_SIDE, right: INSET_SIDE }}
-      >
-        <NodeTitleRow
+      {/* ── Periphery above card ────────────────────────────────── */}
+      <div className="terminal-drag-handle absolute px-1" style={{ top: 2, left: INSET_SIDE, right: INSET_SIDE }}>
+        <NodePeriphery
           ptyId={ptyId}
           onClose={handleClose}
           onToggleDiffPanel={toggleDiffPanel}
           onTogglePlanPanel={togglePlanPanel}
           onToggleRunner={toggleRunner}
         />
-        <NodeInfoRow ptyId={ptyId} />
       </div>
 
       {/* ── Card: terminal only ──────────────────────────────────── */}
@@ -98,9 +94,11 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
   );
 });
 
-// ── Title row: label + action buttons ───────────────────────────────
+// ── Periphery: single row matching TerminalHeader layout ────────────
 
-interface TitleRowProps {
+const EMPTY_TAGS: string[] = [];
+
+interface PeripheryProps {
   ptyId: string;
   onClose: () => void;
   onToggleDiffPanel: () => void;
@@ -108,29 +106,38 @@ interface TitleRowProps {
   onToggleRunner: () => void;
 }
 
-const NodeTitleRow = memo(function NodeTitleRow({
+const NodePeriphery = memo(function NodePeriphery({
   ptyId,
   onClose,
   onToggleDiffPanel,
   onTogglePlanPanel,
   onToggleRunner,
-}: TitleRowProps) {
+}: PeripheryProps) {
   const label = useTerminalStore((s) => s.displayStates[ptyId]?.label ?? '');
+  const summary = useTerminalStore((s) => s.displayStates[ptyId]?.summary ?? '');
+  const summaryType = useTerminalStore((s) => s.displayStates[ptyId]?.summaryType ?? 'ready');
   const taskId = useTerminalStore((s) => s.displayStates[ptyId]?.taskId ?? null);
-  const planPath = useTerminalStore((s) => s.displayStates[ptyId]?.planPath ?? null);
-  const planPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.planPanelOpen ?? false);
-  const diffPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.diffPanelOpen ?? false);
   const gitFileStatus = useTerminalStore((s) => s.displayStates[ptyId]?.gitFileStatus ?? null);
+  const tags = useTerminalStore((s) => s.displayStates[ptyId]?.tags) ?? EMPTY_TAGS;
   const runnerStatus = useTerminalStore((s) => s.displayStates[ptyId]?.runnerStatus ?? 'idle');
   const runnerScriptName = useTerminalStore((s) => s.displayStates[ptyId]?.runnerScriptName ?? null);
   const runnerPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.runnerPanelOpen ?? false);
+  const diffPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.diffPanelOpen ?? false);
+  const planPath = useTerminalStore((s) => s.displayStates[ptyId]?.planPath ?? null);
+  const planPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.planPanelOpen ?? false);
   const worktreeBranch = useTerminalStore((s) => s.displayStates[ptyId]?.worktreeBranch ?? null);
-  const isWorktree = taskId != null && !!worktreeBranch;
+  const tasks = useProjectStore((s) => s.tasks);
 
+  const isWorktree = taskId != null && !!worktreeBranch;
   const dirtyFileCount = gitFileStatus?.uncommittedFiles.length ?? 0;
   const branchDiffCount = gitFileStatus?.branchDiffFiles.length ?? 0;
   const showDiff = dirtyFileCount > 0 || (isWorktree && branchDiffCount > 0);
 
+  const chainMap = taskId != null ? buildChainMap(tasks) : null;
+  const chainInfo = taskId != null && chainMap ? chainMap.get(taskId) : null;
+  const hasChain = isChainMember(chainInfo);
+
+  // Runner text + color
   let runText = 'Run';
   if (runnerStatus === 'running') runText = runnerScriptName ?? 'Running';
   else if (runnerStatus === 'success') runText = 'Done';
@@ -141,135 +148,107 @@ const NodeTitleRow = memo(function NodeTitleRow({
       ? 'text-[#69db7c]'
       : runnerStatus === 'error'
         ? 'text-[#ff6b6b]'
-        : 'text-white/50';
+        : 'text-white/60';
+
+  // Display text: label — summary (matching TerminalHeader pattern)
+  const displayText = summary ? `${label} \u2014 ${summary}` : label || 'Shell';
 
   return (
-    <div className="flex items-center justify-between min-w-0">
-      <span className="inline-flex items-center gap-2 text-lg font-semibold text-white/80 truncate min-w-0">
-        {taskId != null && <span className="text-white/30 font-mono text-sm">T-{taskId}</span>}
-        {label || 'Shell'}
-      </span>
-      <div className="flex items-center gap-1.5 shrink-0 ml-3 nodrag">
-        {planPath && (
-          <ActionBtn active={planPanelOpen} onClick={onTogglePlanPanel} title="Plan">
-            <Icon name="list-checks" className="w-3 h-3" />
-          </ActionBtn>
-        )}
-        {showDiff && (
-          <ActionBtn
-            active={diffPanelOpen}
-            onClick={onToggleDiffPanel}
-            title={dirtyFileCount > 0 ? `${dirtyFileCount} files` : 'Compare'}
+    <div className="flex flex-col gap-0.5 py-1 min-w-0">
+      {/* Top row: status + label + actions */}
+      <div className="flex items-center justify-between min-w-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <span
+            className={`w-3.5 h-3.5 rounded-full shrink-0 transition-all duration-200 ease-out ${summaryType === 'thinking' ? 'bg-[#da77f2]' : 'bg-[#69db7c]'}`}
+            data-status={summaryType}
+            style={{
+              boxShadow:
+                summaryType === 'thinking' ? '0 0 4px rgba(218, 119, 242, 0.5)' : '0 0 4px rgba(105, 219, 124, 0.5)',
+              ...(summaryType === 'thinking' ? { animation: 'terminal-status-pulse 1s ease-in-out infinite' } : {}),
+            }}
+          />
+          <span className="font-mono text-lg font-medium text-white/80 truncate min-w-0">{displayText}</span>
+        </div>
+
+        {/* Right: action buttons */}
+        <div className="flex items-center gap-2 shrink-0 ml-3 nodrag">
+          {planPath && (
+            <button
+              className={`flex items-center gap-1 px-2.5 py-1 rounded-full font-mono text-[13px] font-medium text-white/60 bg-white/[0.06] border-none transition-all duration-150 ease-out hover:bg-white/[0.12] hover:text-white/90 ${planPanelOpen ? '!bg-accent !text-white' : ''}`}
+              title="View plan"
+              onClick={(e) => {
+                e.stopPropagation();
+                onTogglePlanPanel();
+              }}
+            >
+              <Icon name="list-checks" className="w-3.5 h-3.5" />
+              <span>Plan</span>
+            </button>
+          )}
+          {showDiff && (
+            <button
+              className={`flex items-center gap-1 px-2.5 py-1 rounded-full font-mono text-[13px] font-medium text-white/60 bg-white/[0.06] border-none transition-all duration-150 ease-out hover:bg-white/[0.12] hover:text-white/90 ${diffPanelOpen ? '!bg-accent !text-white' : ''}`}
+              title="View changes"
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleDiffPanel();
+              }}
+            >
+              <span className="font-medium">
+                {dirtyFileCount > 0 ? `${dirtyFileCount} file${dirtyFileCount !== 1 ? 's' : ''}` : 'Compare'}
+              </span>
+            </button>
+          )}
+          <button
+            className={`px-2.5 py-1 bg-white/[0.06] border-none font-sans text-[13px] font-medium rounded-full transition-all duration-150 ease-out hover:bg-white/[0.12] hover:text-white/90 ${runnerPanelOpen ? '!bg-accent !text-white' : runColors}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleRunner();
+            }}
           >
-            <span className="text-[11px] font-mono">{dirtyFileCount > 0 ? dirtyFileCount : '~'}</span>
-          </ActionBtn>
+            {runText}
+          </button>
+          <button
+            className="w-7 h-7 flex items-center justify-center bg-transparent border-none text-white/40 hover:text-white/90 transition-colors duration-150 ml-1 [&_svg]:w-4 [&_svg]:h-4"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose();
+            }}
+          >
+            <Icon name="x" />
+          </button>
+        </div>
+      </div>
+      {/* Bottom row: branch + pills */}
+      <div className="flex items-center gap-1.5 min-w-0 pl-[22px]">
+        {(worktreeBranch || gitFileStatus?.branch) && (
+          <span className="inline-flex items-center gap-1 font-mono text-[13px] text-white/50 min-w-0 overflow-hidden">
+            <Icon name="git-branch" className="w-3.5 h-3.5 shrink-0 text-white/40" />
+            <span className="truncate min-w-0">{worktreeBranch || gitFileStatus?.branch}</span>
+          </span>
         )}
-        <ActionBtn active={runnerPanelOpen} onClick={onToggleRunner} title={runText} className={runColors}>
-          <span className="text-[11px] font-medium">{runText}</span>
-        </ActionBtn>
-        <button
-          className="w-6 h-6 flex items-center justify-center bg-transparent border-none text-white/30 hover:text-white/70 transition-colors duration-150"
-          onClick={(e) => {
-            e.stopPropagation();
-            onClose();
-          }}
-        >
-          <Icon name="x" className="w-3.5 h-3.5" />
-        </button>
+        {hasChain && chainInfo && (
+          <span
+            className="inline-flex items-center gap-1 font-mono text-[11px] rounded-full px-2 py-px shrink-0"
+            style={{
+              color: getChainColor(chainInfo.rootTaskNumber, chainInfo.depth),
+              backgroundColor: getChainBgColor(chainInfo.rootTaskNumber, chainInfo.depth),
+            }}
+          >
+            {chainInfo.depth === 0
+              ? `root \u00b7 ${chainInfo.childTaskNumbers.length} child${chainInfo.childTaskNumbers.length !== 1 ? 'ren' : ''}`
+              : `depth ${chainInfo.depth}`}
+          </span>
+        )}
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="font-mono text-[11px] text-white/50 bg-white/[0.06] rounded-full px-2 py-px shrink-0"
+          >
+            {tag}
+          </span>
+        ))}
       </div>
     </div>
   );
 });
-
-function ActionBtn({
-  children,
-  active,
-  onClick,
-  title,
-  className,
-}: {
-  children: React.ReactNode;
-  active?: boolean;
-  onClick: () => void;
-  title: string;
-  className?: string;
-}) {
-  return (
-    <button
-      className={`flex items-center gap-1 px-2 py-0.5 rounded-full font-mono text-[11px] bg-white/[0.06] border-none transition-colors duration-150 hover:bg-white/[0.12] ${active ? '!bg-accent !text-white' : (className ?? 'text-white/50')}`}
-      title={title}
-      onClick={(e) => {
-        e.stopPropagation();
-        onClick();
-      }}
-    >
-      {children}
-    </button>
-  );
-}
-
-// ── Info row: status + pills ────────────────────────────────────────
-
-const EMPTY_TAGS: string[] = [];
-
-const NodeInfoRow = memo(function NodeInfoRow({ ptyId }: { ptyId: string }) {
-  const summaryType = useTerminalStore((s) => s.displayStates[ptyId]?.summaryType ?? 'ready');
-  const summary = useTerminalStore((s) => s.displayStates[ptyId]?.summary ?? '');
-  const taskId = useTerminalStore((s) => s.displayStates[ptyId]?.taskId ?? null);
-  const worktreeBranch = useTerminalStore((s) => s.displayStates[ptyId]?.worktreeBranch ?? null);
-  const tags = useTerminalStore((s) => s.displayStates[ptyId]?.tags) ?? EMPTY_TAGS;
-  const tasks = useProjectStore((s) => s.tasks);
-
-  const chainMap = taskId != null ? buildChainMap(tasks) : null;
-  const chainInfo = taskId != null && chainMap ? chainMap.get(taskId) : null;
-  const hasChain = isChainMember(chainInfo);
-
-  return (
-    <div className="flex items-center gap-1.5 min-w-0 flex-wrap">
-      <span
-        className={`w-1.5 h-1.5 rounded-full shrink-0 ${summaryType === 'thinking' ? 'bg-[#da77f2]' : 'bg-[#69db7c]'}`}
-        style={{
-          boxShadow:
-            summaryType === 'thinking' ? '0 0 4px rgba(218, 119, 242, 0.5)' : '0 0 4px rgba(105, 219, 124, 0.5)',
-          ...(summaryType === 'thinking' ? { animation: 'terminal-status-pulse 1s ease-in-out infinite' } : {}),
-        }}
-      />
-      {summary && <span className="font-mono text-[11px] text-white/40 truncate max-w-[200px]">{summary}</span>}
-      {worktreeBranch && (
-        <Pill>
-          <Icon name="git-branch" className="!w-3 !h-3 text-white/40" />
-          <span className="truncate max-w-[160px]">{worktreeBranch}</span>
-        </Pill>
-      )}
-      {hasChain && chainInfo && (
-        <Pill
-          style={{
-            color: getChainColor(chainInfo.rootTaskNumber, chainInfo.depth),
-            backgroundColor: getChainBgColor(chainInfo.rootTaskNumber, chainInfo.depth),
-          }}
-        >
-          {chainInfo.depth === 0
-            ? `root · ${chainInfo.childTaskNumbers.length} child${chainInfo.childTaskNumbers.length !== 1 ? 'ren' : ''}`
-            : `depth ${chainInfo.depth}`}
-        </Pill>
-      )}
-      {tags.map((tag) => (
-        <Pill key={tag}>
-          <Icon name="tag" className="!w-3 !h-3 text-white/30" />
-          {tag}
-        </Pill>
-      ))}
-    </div>
-  );
-});
-
-function Pill({ children, style }: { children: React.ReactNode; style?: React.CSSProperties }) {
-  return (
-    <span
-      className="inline-flex items-center gap-1 font-mono text-[11px] text-white/50 bg-white/[0.06] rounded-full px-2 py-0.5 shrink-0"
-      style={style}
-    >
-      {children}
-    </span>
-  );
-}

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -1,10 +1,14 @@
 import { memo, useCallback } from 'react';
 import { NodeResizer, Handle, Position, type NodeProps } from '@xyflow/react';
 import type { TerminalNode as TerminalNodeType } from '../../stores/canvasStore';
+import { useTerminalStore } from '../../stores/terminalStore';
+import { useProjectStore } from '../../stores/projectStore';
 import { useTerminalPanels } from '../terminal/useTerminalPanels';
 import { closeProjectTerminal } from '../terminal/terminalActions';
 import { TerminalHeader } from '../terminal/TerminalHeader';
 import { TerminalBody } from '../terminal/TerminalBody';
+import { Icon } from '../terminal/Icon';
+import { buildChainMap, getChainColor, getChainBgColor, isChainMember } from '../../utils/taskChain';
 
 export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeProps<TerminalNodeType>) {
   const { ptyId, projectPath } = data;
@@ -26,63 +30,177 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
   }, [ptyId]);
 
   // Only intercept canvas gestures when this node is selected.
-  // Unselected terminals let pan/zoom pass through to the canvas.
   const bodyClasses = selected ? 'nodrag nowheel nopan flex-1 min-h-0' : 'flex-1 min-h-0';
 
   return (
-    <div
-      className={`canvas-terminal-node rounded-[14px] border overflow-hidden flex flex-col ${
-        selected ? 'border-accent/40' : 'border-white/10'
-      }`}
-      style={{
-        width: '100%',
-        height: '100%',
-        background: 'var(--color-terminal-bg, #171717)',
-        boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
-      }}
-    >
-      <NodeResizer
-        minWidth={400}
-        minHeight={200}
-        maxWidth={2400}
-        maxHeight={1600}
-        isVisible={!!selected}
-        lineClassName="!border-accent/30"
-        handleClassName="!w-2 !h-2 !bg-accent/50 !border-none !rounded-sm"
-      />
-      {/* Handles on all 4 sides for dynamic closest-side edge routing */}
-      <Handle id="top" type="source" position={Position.Top} className="!bg-transparent !border-none !w-0 !h-0" />
-      <Handle id="top" type="target" position={Position.Top} className="!bg-transparent !border-none !w-0 !h-0" />
-      <Handle id="bottom" type="source" position={Position.Bottom} className="!bg-transparent !border-none !w-0 !h-0" />
-      <Handle id="bottom" type="target" position={Position.Bottom} className="!bg-transparent !border-none !w-0 !h-0" />
-      <Handle id="left" type="source" position={Position.Left} className="!bg-transparent !border-none !w-0 !h-0" />
-      <Handle id="left" type="target" position={Position.Left} className="!bg-transparent !border-none !w-0 !h-0" />
-      <Handle id="right" type="source" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
-      <Handle id="right" type="target" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
-
-      <div className="terminal-drag-handle">
-        <TerminalHeader
-          ptyId={ptyId}
-          isActive
-          onClose={handleClose}
-          onToggleDiffPanel={toggleDiffPanel}
-          onTogglePlanPanel={togglePlanPanel}
-          onToggleRunner={toggleRunner}
+    <>
+      <NodeTitle ptyId={ptyId} />
+      <div
+        className={`canvas-terminal-node rounded-[14px] border overflow-hidden flex flex-col ${
+          selected ? 'border-accent/40' : 'border-white/10'
+        }`}
+        style={{
+          width: '100%',
+          height: '100%',
+          background: 'var(--color-terminal-bg, #171717)',
+          boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+        }}
+      >
+        <NodeResizer
+          minWidth={400}
+          minHeight={200}
+          maxWidth={2400}
+          maxHeight={1600}
+          isVisible={!!selected}
+          lineClassName="!border-accent/30"
+          handleClassName="!w-2 !h-2 !bg-accent/50 !border-none !rounded-sm"
         />
-      </div>
-
-      <div className={bodyClasses} style={selected ? undefined : { pointerEvents: 'none' }}>
-        <TerminalBody
-          ptyId={ptyId}
-          projectPath={projectPath}
-          onCloseDiffPanel={closeDiffPanel}
-          onClosePlanPanel={closePlanPanel}
-          onChangePlanFile={changePlanFile}
-          onCollapseRunner={collapseRunner}
-          onKillRunner={killRunner}
-          onRestartRunner={restartRunner}
+        <Handle id="top" type="source" position={Position.Top} className="!bg-transparent !border-none !w-0 !h-0" />
+        <Handle id="top" type="target" position={Position.Top} className="!bg-transparent !border-none !w-0 !h-0" />
+        <Handle
+          id="bottom"
+          type="source"
+          position={Position.Bottom}
+          className="!bg-transparent !border-none !w-0 !h-0"
         />
+        <Handle
+          id="bottom"
+          type="target"
+          position={Position.Bottom}
+          className="!bg-transparent !border-none !w-0 !h-0"
+        />
+        <Handle id="left" type="source" position={Position.Left} className="!bg-transparent !border-none !w-0 !h-0" />
+        <Handle id="left" type="target" position={Position.Left} className="!bg-transparent !border-none !w-0 !h-0" />
+        <Handle id="right" type="source" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
+        <Handle id="right" type="target" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
+
+        <div className="terminal-drag-handle">
+          <TerminalHeader
+            ptyId={ptyId}
+            isActive
+            onClose={handleClose}
+            onToggleDiffPanel={toggleDiffPanel}
+            onTogglePlanPanel={togglePlanPanel}
+            onToggleRunner={toggleRunner}
+          />
+        </div>
+
+        <div className={bodyClasses} style={selected ? undefined : { pointerEvents: 'none' }}>
+          <TerminalBody
+            ptyId={ptyId}
+            projectPath={projectPath}
+            onCloseDiffPanel={closeDiffPanel}
+            onClosePlanPanel={closePlanPanel}
+            onChangePlanFile={changePlanFile}
+            onCollapseRunner={collapseRunner}
+            onKillRunner={killRunner}
+            onRestartRunner={restartRunner}
+          />
+        </div>
       </div>
+      <NodeMetadata ptyId={ptyId} />
+    </>
+  );
+});
+
+// ── Task name label above the card ──────────────────────────────────
+
+const NodeTitle = memo(function NodeTitle({ ptyId }: { ptyId: string }) {
+  const label = useTerminalStore((s) => s.displayStates[ptyId]?.label ?? '');
+  const taskId = useTerminalStore((s) => s.displayStates[ptyId]?.taskId ?? null);
+
+  if (!label) return null;
+
+  return (
+    <div className="px-1 pb-2" style={{ marginTop: -40 }}>
+      <span className="inline-flex items-center gap-2 text-xl font-semibold text-white/80 truncate max-w-full">
+        {taskId != null && <span className="text-white/30 font-mono text-base">T-{taskId}</span>}
+        {label}
+      </span>
     </div>
   );
 });
+
+// ── Peripheral metadata strip below the card ────────────────────────
+
+const EMPTY_TAGS: string[] = [];
+
+const NodeMetadata = memo(function NodeMetadata({ ptyId }: { ptyId: string }) {
+  const taskId = useTerminalStore((s) => s.displayStates[ptyId]?.taskId ?? null);
+  const worktreeBranch = useTerminalStore((s) => s.displayStates[ptyId]?.worktreeBranch ?? null);
+  const tags = useTerminalStore((s) => s.displayStates[ptyId]?.tags) ?? EMPTY_TAGS;
+  const summaryType = useTerminalStore((s) => s.displayStates[ptyId]?.summaryType ?? 'ready');
+  const tasks = useProjectStore((s) => s.tasks);
+
+  // Find the task for chain info
+  const task = taskId != null ? tasks.find((t) => t.taskNumber === taskId) : null;
+  const chainMap = taskId != null ? buildChainMap(tasks) : null;
+  const chainInfo = taskId != null && chainMap ? chainMap.get(taskId) : null;
+  const hasChain = isChainMember(chainInfo);
+
+  const hasPills = taskId != null || worktreeBranch || tags.length > 0;
+  if (!hasPills) return null;
+
+  return (
+    <div className="flex items-center gap-1.5 px-1 pt-2 pb-1 flex-wrap" style={{ maxWidth: '100%' }}>
+      {/* Task number */}
+      {taskId != null && (
+        <Pill>
+          <span
+            className="w-1.5 h-1.5 rounded-full shrink-0"
+            style={{
+              backgroundColor: summaryType === 'thinking' ? '#da77f2' : '#69db7c',
+              boxShadow:
+                summaryType === 'thinking' ? '0 0 4px rgba(218, 119, 242, 0.5)' : '0 0 4px rgba(105, 219, 124, 0.5)',
+            }}
+          />
+          T-{taskId}
+        </Pill>
+      )}
+
+      {/* Chain badge */}
+      {hasChain && chainInfo && (
+        <Pill
+          style={{
+            color: getChainColor(chainInfo.rootTaskNumber, chainInfo.depth),
+            backgroundColor: getChainBgColor(chainInfo.rootTaskNumber, chainInfo.depth),
+          }}
+        >
+          {chainInfo.depth === 0
+            ? `root · ${chainInfo.childTaskNumbers.length} child${chainInfo.childTaskNumbers.length !== 1 ? 'ren' : ''}`
+            : `depth ${chainInfo.depth}`}
+        </Pill>
+      )}
+
+      {/* Branch */}
+      {worktreeBranch && (
+        <Pill>
+          <Icon name="git-branch" className="!w-3 !h-3 text-white/40" />
+          <span className="truncate max-w-[180px]">{worktreeBranch}</span>
+        </Pill>
+      )}
+
+      {/* Tags */}
+      {tags.map((tag) => (
+        <Pill key={tag}>
+          <Icon name="tag" className="!w-3 !h-3 text-white/30" />
+          {tag}
+        </Pill>
+      ))}
+
+      {/* Task description preview */}
+      {task?.prompt && <span className="text-[11px] text-white/30 truncate max-w-[300px] ml-1">{task.prompt}</span>}
+    </div>
+  );
+});
+
+function Pill({ children, style }: { children: React.ReactNode; style?: React.CSSProperties }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1 font-mono text-[11px] text-white/50 bg-white/[0.06] rounded-full px-2 py-0.5 shrink-0"
+      style={style}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -38,6 +38,7 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
         width: '100%',
         height: '100%',
         background: 'var(--color-terminal-bg, #171717)',
+        boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
       }}
     >
       <NodeResizer

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -2,8 +2,7 @@ import { memo, useCallback } from 'react';
 import { NodeResizer, Handle, Position, type NodeProps } from '@xyflow/react';
 import type { TerminalNode as TerminalNodeType } from '../../stores/canvasStore';
 import { useTerminalPanels } from '../terminal/useTerminalPanels';
-import { terminalInstances } from '../terminal/terminalReact';
-import { useTerminalStore } from '../../stores/terminalStore';
+import { closeProjectTerminal } from '../terminal/terminalActions';
 import { TerminalHeader } from '../terminal/TerminalHeader';
 import { TerminalBody } from '../terminal/TerminalBody';
 
@@ -23,12 +22,12 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
   } = useTerminalPanels(ptyId);
 
   const handleClose = useCallback(() => {
-    const instance = terminalInstances.get(ptyId);
-    if (instance) {
-      instance.dispose();
-    }
-    useTerminalStore.getState().removeTerminal(ptyId);
+    closeProjectTerminal(ptyId);
   }, [ptyId]);
+
+  // Only intercept canvas gestures when this node is selected.
+  // Unselected terminals let pan/zoom pass through to the canvas.
+  const bodyClasses = selected ? 'nodrag nowheel nopan flex-1 min-h-0' : 'flex-1 min-h-0';
 
   return (
     <div
@@ -56,7 +55,7 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
       <div className="terminal-drag-handle">
         <TerminalHeader
           ptyId={ptyId}
-          isActive={!!selected}
+          isActive
           onClose={handleClose}
           onToggleDiffPanel={toggleDiffPanel}
           onTogglePlanPanel={togglePlanPanel}
@@ -64,7 +63,7 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
         />
       </div>
 
-      <div className="nodrag nowheel nopan flex-1 min-h-0">
+      <div className={bodyClasses} style={selected ? undefined : { pointerEvents: 'none' }}>
         <TerminalBody
           ptyId={ptyId}
           projectPath={projectPath}

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -1,0 +1,81 @@
+import { memo, useCallback } from 'react';
+import { NodeResizer, Handle, Position, type NodeProps } from '@xyflow/react';
+import type { TerminalNode as TerminalNodeType } from '../../stores/canvasStore';
+import { useTerminalPanels } from '../terminal/useTerminalPanels';
+import { terminalInstances } from '../terminal/terminalReact';
+import { useTerminalStore } from '../../stores/terminalStore';
+import { TerminalHeader } from '../terminal/TerminalHeader';
+import { TerminalBody } from '../terminal/TerminalBody';
+
+export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeProps<TerminalNodeType>) {
+  const { ptyId, projectPath } = data;
+
+  const {
+    toggleDiffPanel,
+    closeDiffPanel,
+    toggleRunner,
+    collapseRunner,
+    killRunner,
+    restartRunner,
+    togglePlanPanel,
+    closePlanPanel,
+    changePlanFile,
+  } = useTerminalPanels(ptyId);
+
+  const handleClose = useCallback(() => {
+    const instance = terminalInstances.get(ptyId);
+    if (instance) {
+      instance.dispose();
+    }
+    useTerminalStore.getState().removeTerminal(ptyId);
+  }, [ptyId]);
+
+  return (
+    <div
+      className={`canvas-terminal-node rounded-[14px] border overflow-hidden flex flex-col ${
+        selected ? 'border-accent/40' : 'border-white/10'
+      }`}
+      style={{
+        width: '100%',
+        height: '100%',
+        background: 'var(--color-terminal-bg, #171717)',
+      }}
+    >
+      <NodeResizer
+        minWidth={400}
+        minHeight={200}
+        maxWidth={2400}
+        maxHeight={1600}
+        isVisible={!!selected}
+        lineClassName="!border-accent/30"
+        handleClassName="!w-2 !h-2 !bg-accent/50 !border-none !rounded-sm"
+      />
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-none !w-0 !h-0" />
+
+      <div className="terminal-drag-handle">
+        <TerminalHeader
+          ptyId={ptyId}
+          isActive={!!selected}
+          onClose={handleClose}
+          onToggleDiffPanel={toggleDiffPanel}
+          onTogglePlanPanel={togglePlanPanel}
+          onToggleRunner={toggleRunner}
+        />
+      </div>
+
+      <div className="nodrag nowheel nopan flex-1 min-h-0">
+        <TerminalBody
+          ptyId={ptyId}
+          projectPath={projectPath}
+          onCloseDiffPanel={closeDiffPanel}
+          onClosePlanPanel={closePlanPanel}
+          onChangePlanFile={changePlanFile}
+          onCollapseRunner={collapseRunner}
+          onKillRunner={killRunner}
+          onRestartRunner={restartRunner}
+        />
+      </div>
+    </div>
+  );
+});

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -1,12 +1,13 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { NodeResizer, Handle, Position, type NodeProps } from '@xyflow/react';
-import type { TerminalNode as TerminalNodeType } from '../../stores/canvasStore';
+import { useCanvasStore, persistCanvas, type TerminalNode as TerminalNodeType } from '../../stores/canvasStore';
 import { useTerminalStore } from '../../stores/terminalStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useTerminalPanels } from '../terminal/useTerminalPanels';
-import { closeProjectTerminal } from '../terminal/terminalActions';
+import { addProjectTerminal, closeProjectTerminal } from '../terminal/terminalActions';
 import { TerminalBody } from '../terminal/TerminalBody';
 import { Icon } from '../terminal/Icon';
+import { BranchFromTaskDialog } from '../dialogs/BranchFromTaskDialog';
 import { buildChainMap, getChainColor, getChainBgColor, isChainMember } from '../../utils/taskChain';
 
 const INSET_TOP = 68;
@@ -14,6 +15,39 @@ const INSET_SIDE = 10;
 const INSET_BOTTOM = 8;
 
 export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeProps<TerminalNodeType>) {
+  if (data.loading) return <LoadingNode label={data.loadingLabel} />;
+  return <ActiveTerminalNode data={data} selected={selected} />;
+});
+
+function LoadingNode({ label }: { label?: string }) {
+  return (
+    <div
+      className="canvas-terminal-node absolute rounded-[14px] border border-white/10 overflow-hidden flex flex-col items-center justify-center gap-3"
+      style={{
+        top: INSET_TOP,
+        left: INSET_SIDE,
+        right: INSET_SIDE,
+        bottom: INSET_BOTTOM,
+        background: 'var(--color-terminal-bg, #171717)',
+        boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+      }}
+    >
+      <div
+        className="w-5 h-5 rounded-full border-2 border-white/20 border-t-accent"
+        style={{ animation: 'spin 0.8s linear infinite' }}
+      />
+      <span className="font-mono text-sm text-white/40">{label || 'Setting up workspace\u2026'}</span>
+    </div>
+  );
+}
+
+const ActiveTerminalNode = memo(function ActiveTerminalNode({
+  data,
+  selected,
+}: {
+  data: TerminalNodeType['data'];
+  selected?: boolean;
+}) {
   const { ptyId, projectPath } = data;
 
   const {
@@ -58,6 +92,7 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
       <div className="terminal-drag-handle absolute px-1" style={{ top: 2, left: INSET_SIDE, right: INSET_SIDE }}>
         <NodePeriphery
           ptyId={ptyId}
+          projectPath={projectPath}
           onClose={handleClose}
           onToggleDiffPanel={toggleDiffPanel}
           onTogglePlanPanel={togglePlanPanel}
@@ -100,6 +135,7 @@ const EMPTY_TAGS: string[] = [];
 
 interface PeripheryProps {
   ptyId: string;
+  projectPath: string;
   onClose: () => void;
   onToggleDiffPanel: () => void;
   onTogglePlanPanel: () => void;
@@ -108,6 +144,7 @@ interface PeripheryProps {
 
 const NodePeriphery = memo(function NodePeriphery({
   ptyId,
+  projectPath,
   onClose,
   onToggleDiffPanel,
   onTogglePlanPanel,
@@ -128,7 +165,11 @@ const NodePeriphery = memo(function NodePeriphery({
   const worktreeBranch = useTerminalStore((s) => s.displayStates[ptyId]?.worktreeBranch ?? null);
   const tasks = useProjectStore((s) => s.tasks);
 
+  const [forkDialogOpen, setForkDialogOpen] = useState(false);
+
   const isWorktree = taskId != null && !!worktreeBranch;
+  const task = taskId != null ? tasks.find((t) => t.taskNumber === taskId) : null;
+  const canFork = task != null && !!task.branch && task.status !== 'done';
   const dirtyFileCount = gitFileStatus?.uncommittedFiles.length ?? 0;
   const branchDiffCount = gitFileStatus?.branchDiffFiles.length ?? 0;
   const showDiff = dirtyFileCount > 0 || (isWorktree && branchDiffCount > 0);
@@ -208,6 +249,19 @@ const NodePeriphery = memo(function NodePeriphery({
           >
             {runText}
           </button>
+          {canFork && (
+            <button
+              className="flex items-center gap-1 px-2.5 py-1 rounded-full font-mono text-[13px] font-medium text-white/60 bg-white/[0.06] border-none transition-all duration-150 ease-out hover:bg-white/[0.12] hover:text-white/90"
+              title="Fork task"
+              onClick={(e) => {
+                e.stopPropagation();
+                setForkDialogOpen(true);
+              }}
+            >
+              <Icon name="git-fork" className="w-3.5 h-3.5" />
+              <span>Fork</span>
+            </button>
+          )}
           <button
             className="w-7 h-7 flex items-center justify-center bg-transparent border-none text-white/40 hover:text-white/90 transition-colors duration-150 ml-1 [&_svg]:w-4 [&_svg]:h-4"
             onClick={(e) => {
@@ -249,6 +303,76 @@ const NodePeriphery = memo(function NodePeriphery({
           </span>
         ))}
       </div>
+      {forkDialogOpen && task && (
+        <BranchFromTaskDialog
+          projectPath={projectPath}
+          parentTask={task}
+          onClose={async (created, taskNumber) => {
+            setForkDialogOpen(false);
+            if (!created || taskNumber == null) return;
+
+            // Show loading placeholder to the right of the parent node
+            const loadingId = `loading-${taskNumber}`;
+            const store = useCanvasStore.getState();
+            const parentNode = store.canvasByProject[projectPath]?.nodes.find((n) => n.id === ptyId);
+            const parentW = parentNode?.style?.width ? Number(parentNode.style.width) : 740;
+            const hintPos = parentNode
+              ? { x: parentNode.position.x + parentW + 60, y: parentNode.position.y }
+              : undefined;
+            store.addNode(projectPath, loadingId, hintPos, {
+              loading: true,
+              loadingLabel: `Starting T-${taskNumber}\u2026`,
+            });
+            persistCanvas(projectPath);
+
+            // Start the forked task (creates worktree, sets in_progress)
+            const result = await window.api.task.start(projectPath, taskNumber);
+
+            // Capture loading node position, then remove it
+            const loadingNode = useCanvasStore
+              .getState()
+              .canvasByProject[projectPath]?.nodes.find((n) => n.id === loadingId);
+            const forkPos = loadingNode ? { ...loadingNode.position } : undefined;
+            useCanvasStore.getState().removeNode(projectPath, loadingId);
+
+            // Reload tasks so chain edges hydrate
+            await useProjectStore.getState().loadTasks(projectPath);
+
+            if (!result.success || !result.task || !result.worktreePath) return;
+
+            // Track existing nodes so we can find the new one
+            const nodesBefore = new Set(
+              useCanvasStore.getState().canvasByProject[projectPath]?.nodes.map((n) => n.id) ?? [],
+            );
+
+            // Open a terminal for it on the canvas
+            await addProjectTerminal(projectPath, undefined, {
+              existingWorktree: {
+                path: result.worktreePath,
+                branch: result.task.branch || '',
+                createdAt: result.task.createdAt,
+              },
+              taskId: taskNumber,
+            });
+
+            // Move the new node to where the loading placeholder was
+            if (forkPos) {
+              const canvas = useCanvasStore.getState().canvasByProject[projectPath];
+              if (canvas) {
+                const newNode = canvas.nodes.find((n) => !nodesBefore.has(n.id));
+                if (newNode) {
+                  const updatedNodes = canvas.nodes.map((n) => (n.id === newNode.id ? { ...n, position: forkPos } : n));
+                  useCanvasStore.getState().loadCanvas(projectPath, {
+                    ...canvas,
+                    nodes: updatedNodes as TerminalNodeType[],
+                  });
+                  persistCanvas(projectPath);
+                }
+              }
+            }
+          }}
+        />
+      )}
     </div>
   );
 });

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -49,8 +49,15 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
         lineClassName="!border-accent/30"
         handleClassName="!w-2 !h-2 !bg-accent/50 !border-none !rounded-sm"
       />
-      <Handle type="target" position={Position.Top} className="!bg-transparent !border-none !w-0 !h-0" />
-      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-none !w-0 !h-0" />
+      {/* Handles on all 4 sides for dynamic closest-side edge routing */}
+      <Handle id="top" type="source" position={Position.Top} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="top" type="target" position={Position.Top} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="bottom" type="source" position={Position.Bottom} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="bottom" type="target" position={Position.Bottom} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="left" type="source" position={Position.Left} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="left" type="target" position={Position.Left} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="right" type="source" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
+      <Handle id="right" type="target" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
 
       <div className="terminal-drag-handle">
         <TerminalHeader

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -32,7 +32,7 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
     closeProjectTerminal(ptyId);
   }, [ptyId]);
 
-  const bodyClasses = selected ? 'nodrag nowheel nopan flex-1 min-h-0' : 'flex-1 min-h-0';
+  const bodyClasses = selected ? 'nodrag nowheel nopan flex flex-col flex-1 min-h-0' : 'flex flex-col flex-1 min-h-0';
 
   return (
     <>

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -5,10 +5,13 @@ import { useTerminalStore } from '../../stores/terminalStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useTerminalPanels } from '../terminal/useTerminalPanels';
 import { closeProjectTerminal } from '../terminal/terminalActions';
-import { TerminalHeader } from '../terminal/TerminalHeader';
 import { TerminalBody } from '../terminal/TerminalBody';
 import { Icon } from '../terminal/Icon';
 import { buildChainMap, getChainColor, getChainBgColor, isChainMember } from '../../utils/taskChain';
+
+const INSET_TOP = 68;
+const INSET_SIDE = 10;
+const INSET_BOTTOM = 8;
 
 export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeProps<TerminalNodeType>) {
   const { ptyId, projectPath } = data;
@@ -29,14 +32,7 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
     closeProjectTerminal(ptyId);
   }, [ptyId]);
 
-  // Only intercept canvas gestures when this node is selected.
   const bodyClasses = selected ? 'nodrag nowheel nopan flex-1 min-h-0' : 'flex-1 min-h-0';
-
-  // Insets: the card is inset within the node wrapper so the NodeResizer
-  // at the wrapper edges naturally wraps title + card + metadata.
-  const INSET_TOP = 40;
-  const INSET_SIDE = 10;
-  const INSET_BOTTOM = 36;
 
   return (
     <>
@@ -58,7 +54,22 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
       <Handle id="right" type="source" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
       <Handle id="right" type="target" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
 
-      <NodeTitle ptyId={ptyId} style={{ top: 4, left: INSET_SIDE, right: INSET_SIDE }} />
+      {/* ── Periphery above card: title + pills + actions ────────── */}
+      <div
+        className="terminal-drag-handle absolute flex flex-col gap-1 px-1"
+        style={{ top: 2, left: INSET_SIDE, right: INSET_SIDE }}
+      >
+        <NodeTitleRow
+          ptyId={ptyId}
+          onClose={handleClose}
+          onToggleDiffPanel={toggleDiffPanel}
+          onTogglePlanPanel={togglePlanPanel}
+          onToggleRunner={toggleRunner}
+        />
+        <NodeInfoRow ptyId={ptyId} />
+      </div>
+
+      {/* ── Card: terminal only ──────────────────────────────────── */}
       <div
         className="canvas-terminal-node absolute rounded-[14px] border border-white/10 overflow-hidden flex flex-col"
         style={{
@@ -70,17 +81,6 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
           boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
         }}
       >
-        <div className="terminal-drag-handle">
-          <TerminalHeader
-            ptyId={ptyId}
-            isActive
-            onClose={handleClose}
-            onToggleDiffPanel={toggleDiffPanel}
-            onTogglePlanPanel={togglePlanPanel}
-            onToggleRunner={toggleRunner}
-          />
-        </div>
-
         <div className={bodyClasses} style={selected ? undefined : { pointerEvents: 'none' }}>
           <TerminalBody
             ptyId={ptyId}
@@ -94,67 +94,153 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
           />
         </div>
       </div>
-      <NodeMetadata ptyId={ptyId} style={{ bottom: 4, left: INSET_SIDE, right: INSET_SIDE }} />
     </>
   );
 });
 
-// ── Task name label above the card ──────────────────────────────────
+// ── Title row: label + action buttons ───────────────────────────────
 
-const NodeTitle = memo(function NodeTitle({ ptyId, style }: { ptyId: string; style: React.CSSProperties }) {
+interface TitleRowProps {
+  ptyId: string;
+  onClose: () => void;
+  onToggleDiffPanel: () => void;
+  onTogglePlanPanel: () => void;
+  onToggleRunner: () => void;
+}
+
+const NodeTitleRow = memo(function NodeTitleRow({
+  ptyId,
+  onClose,
+  onToggleDiffPanel,
+  onTogglePlanPanel,
+  onToggleRunner,
+}: TitleRowProps) {
   const label = useTerminalStore((s) => s.displayStates[ptyId]?.label ?? '');
   const taskId = useTerminalStore((s) => s.displayStates[ptyId]?.taskId ?? null);
+  const planPath = useTerminalStore((s) => s.displayStates[ptyId]?.planPath ?? null);
+  const planPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.planPanelOpen ?? false);
+  const diffPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.diffPanelOpen ?? false);
+  const gitFileStatus = useTerminalStore((s) => s.displayStates[ptyId]?.gitFileStatus ?? null);
+  const runnerStatus = useTerminalStore((s) => s.displayStates[ptyId]?.runnerStatus ?? 'idle');
+  const runnerScriptName = useTerminalStore((s) => s.displayStates[ptyId]?.runnerScriptName ?? null);
+  const runnerPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.runnerPanelOpen ?? false);
+  const worktreeBranch = useTerminalStore((s) => s.displayStates[ptyId]?.worktreeBranch ?? null);
+  const isWorktree = taskId != null && !!worktreeBranch;
 
-  if (!label) return null;
+  const dirtyFileCount = gitFileStatus?.uncommittedFiles.length ?? 0;
+  const branchDiffCount = gitFileStatus?.branchDiffFiles.length ?? 0;
+  const showDiff = dirtyFileCount > 0 || (isWorktree && branchDiffCount > 0);
+
+  let runText = 'Run';
+  if (runnerStatus === 'running') runText = runnerScriptName ?? 'Running';
+  else if (runnerStatus === 'success') runText = 'Done';
+  else if (runnerStatus === 'error') runText = 'Failed';
+
+  const runColors =
+    runnerStatus === 'running' || runnerStatus === 'success'
+      ? 'text-[#69db7c]'
+      : runnerStatus === 'error'
+        ? 'text-[#ff6b6b]'
+        : 'text-white/50';
 
   return (
-    <div className="absolute px-1" style={style}>
-      <span className="inline-flex items-center gap-2 text-xl font-semibold text-white/80 truncate max-w-full">
-        {taskId != null && <span className="text-white/30 font-mono text-base">T-{taskId}</span>}
-        {label}
+    <div className="flex items-center justify-between min-w-0">
+      <span className="inline-flex items-center gap-2 text-lg font-semibold text-white/80 truncate min-w-0">
+        {taskId != null && <span className="text-white/30 font-mono text-sm">T-{taskId}</span>}
+        {label || 'Shell'}
       </span>
+      <div className="flex items-center gap-1.5 shrink-0 ml-3 nodrag">
+        {planPath && (
+          <ActionBtn active={planPanelOpen} onClick={onTogglePlanPanel} title="Plan">
+            <Icon name="list-checks" className="w-3 h-3" />
+          </ActionBtn>
+        )}
+        {showDiff && (
+          <ActionBtn
+            active={diffPanelOpen}
+            onClick={onToggleDiffPanel}
+            title={dirtyFileCount > 0 ? `${dirtyFileCount} files` : 'Compare'}
+          >
+            <span className="text-[11px] font-mono">{dirtyFileCount > 0 ? dirtyFileCount : '~'}</span>
+          </ActionBtn>
+        )}
+        <ActionBtn active={runnerPanelOpen} onClick={onToggleRunner} title={runText} className={runColors}>
+          <span className="text-[11px] font-medium">{runText}</span>
+        </ActionBtn>
+        <button
+          className="w-6 h-6 flex items-center justify-center bg-transparent border-none text-white/30 hover:text-white/70 transition-colors duration-150"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+        >
+          <Icon name="x" className="w-3.5 h-3.5" />
+        </button>
+      </div>
     </div>
   );
 });
 
-// ── Peripheral metadata strip below the card ────────────────────────
+function ActionBtn({
+  children,
+  active,
+  onClick,
+  title,
+  className,
+}: {
+  children: React.ReactNode;
+  active?: boolean;
+  onClick: () => void;
+  title: string;
+  className?: string;
+}) {
+  return (
+    <button
+      className={`flex items-center gap-1 px-2 py-0.5 rounded-full font-mono text-[11px] bg-white/[0.06] border-none transition-colors duration-150 hover:bg-white/[0.12] ${active ? '!bg-accent !text-white' : (className ?? 'text-white/50')}`}
+      title={title}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ── Info row: status + pills ────────────────────────────────────────
 
 const EMPTY_TAGS: string[] = [];
 
-const NodeMetadata = memo(function NodeMetadata({ ptyId, style }: { ptyId: string; style: React.CSSProperties }) {
+const NodeInfoRow = memo(function NodeInfoRow({ ptyId }: { ptyId: string }) {
+  const summaryType = useTerminalStore((s) => s.displayStates[ptyId]?.summaryType ?? 'ready');
+  const summary = useTerminalStore((s) => s.displayStates[ptyId]?.summary ?? '');
   const taskId = useTerminalStore((s) => s.displayStates[ptyId]?.taskId ?? null);
   const worktreeBranch = useTerminalStore((s) => s.displayStates[ptyId]?.worktreeBranch ?? null);
   const tags = useTerminalStore((s) => s.displayStates[ptyId]?.tags) ?? EMPTY_TAGS;
-  const summaryType = useTerminalStore((s) => s.displayStates[ptyId]?.summaryType ?? 'ready');
   const tasks = useProjectStore((s) => s.tasks);
 
-  // Find the task for chain info
-  const task = taskId != null ? tasks.find((t) => t.taskNumber === taskId) : null;
   const chainMap = taskId != null ? buildChainMap(tasks) : null;
   const chainInfo = taskId != null && chainMap ? chainMap.get(taskId) : null;
   const hasChain = isChainMember(chainInfo);
 
-  const hasPills = taskId != null || worktreeBranch || tags.length > 0;
-  if (!hasPills) return null;
-
   return (
-    <div className="absolute flex items-center gap-1.5 px-1 flex-wrap" style={style}>
-      {/* Task number */}
-      {taskId != null && (
+    <div className="flex items-center gap-1.5 min-w-0 flex-wrap">
+      <span
+        className={`w-1.5 h-1.5 rounded-full shrink-0 ${summaryType === 'thinking' ? 'bg-[#da77f2]' : 'bg-[#69db7c]'}`}
+        style={{
+          boxShadow:
+            summaryType === 'thinking' ? '0 0 4px rgba(218, 119, 242, 0.5)' : '0 0 4px rgba(105, 219, 124, 0.5)',
+          ...(summaryType === 'thinking' ? { animation: 'terminal-status-pulse 1s ease-in-out infinite' } : {}),
+        }}
+      />
+      {summary && <span className="font-mono text-[11px] text-white/40 truncate max-w-[200px]">{summary}</span>}
+      {worktreeBranch && (
         <Pill>
-          <span
-            className="w-1.5 h-1.5 rounded-full shrink-0"
-            style={{
-              backgroundColor: summaryType === 'thinking' ? '#da77f2' : '#69db7c',
-              boxShadow:
-                summaryType === 'thinking' ? '0 0 4px rgba(218, 119, 242, 0.5)' : '0 0 4px rgba(105, 219, 124, 0.5)',
-            }}
-          />
-          T-{taskId}
+          <Icon name="git-branch" className="!w-3 !h-3 text-white/40" />
+          <span className="truncate max-w-[160px]">{worktreeBranch}</span>
         </Pill>
       )}
-
-      {/* Chain badge */}
       {hasChain && chainInfo && (
         <Pill
           style={{
@@ -167,25 +253,12 @@ const NodeMetadata = memo(function NodeMetadata({ ptyId, style }: { ptyId: strin
             : `depth ${chainInfo.depth}`}
         </Pill>
       )}
-
-      {/* Branch */}
-      {worktreeBranch && (
-        <Pill>
-          <Icon name="git-branch" className="!w-3 !h-3 text-white/40" />
-          <span className="truncate max-w-[180px]">{worktreeBranch}</span>
-        </Pill>
-      )}
-
-      {/* Tags */}
       {tags.map((tag) => (
         <Pill key={tag}>
           <Icon name="tag" className="!w-3 !h-3 text-white/30" />
           {tag}
         </Pill>
       ))}
-
-      {/* Task description preview */}
-      {task?.prompt && <span className="text-[11px] text-white/30 truncate max-w-[300px] ml-1">{task.prompt}</span>}
     </div>
   );
 });

--- a/src/components/canvas/useChainEdges.ts
+++ b/src/components/canvas/useChainEdges.ts
@@ -1,9 +1,72 @@
 import { useEffect } from 'react';
-import { MarkerType, type Edge } from '@xyflow/react';
+import { Position, type Edge } from '@xyflow/react';
 import { useProjectStore } from '../../stores/projectStore';
 import { useTerminalStore } from '../../stores/terminalStore';
-import { useCanvasStore, persistCanvas } from '../../stores/canvasStore';
+import { useCanvasStore, persistCanvas, type TerminalNode } from '../../stores/canvasStore';
 import { buildChainMap, getChainColor } from '../../utils/taskChain';
+
+const DEFAULT_W = 720;
+const DEFAULT_H = 480;
+
+interface NodeRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  cx: number;
+  cy: number;
+}
+
+function getNodeRect(node: TerminalNode): NodeRect {
+  const w = node.measured?.width ?? (node.style?.width ? Number(node.style.width) : DEFAULT_W);
+  const h = node.measured?.height ?? (node.style?.height ? Number(node.style.height) : DEFAULT_H);
+  return {
+    x: node.position.x,
+    y: node.position.y,
+    w,
+    h,
+    cx: node.position.x + w / 2,
+    cy: node.position.y + h / 2,
+  };
+}
+
+/** Determine which side of each node to connect, based on relative position. */
+function getClosestSides(
+  source: NodeRect,
+  target: NodeRect,
+): { sourceHandle: string; targetHandle: string; sourcePosition: Position; targetPosition: Position } {
+  const dx = target.cx - source.cx;
+  const dy = target.cy - source.cy;
+
+  // Use the axis with the greater distance to pick sides
+  if (Math.abs(dx) > Math.abs(dy)) {
+    // Horizontal relationship
+    if (dx > 0) {
+      return {
+        sourceHandle: 'right',
+        targetHandle: 'left',
+        sourcePosition: Position.Right,
+        targetPosition: Position.Left,
+      };
+    }
+    return {
+      sourceHandle: 'left',
+      targetHandle: 'right',
+      sourcePosition: Position.Left,
+      targetPosition: Position.Right,
+    };
+  }
+  // Vertical relationship
+  if (dy > 0) {
+    return {
+      sourceHandle: 'bottom',
+      targetHandle: 'top',
+      sourcePosition: Position.Bottom,
+      targetPosition: Position.Top,
+    };
+  }
+  return { sourceHandle: 'top', targetHandle: 'bottom', sourcePosition: Position.Top, targetPosition: Position.Bottom };
+}
 
 /**
  * Computes react-flow edges from task chain relationships
@@ -20,13 +83,13 @@ export function useChainEdges(projectPath: string): void {
     // Build task chain map
     const chainMap = buildChainMap(tasks);
 
-    // Build taskNumber -> ptyId lookup from terminals on canvas
-    const taskToPtyId = new Map<number, string>();
+    // Build taskNumber -> node lookup from terminals on canvas
+    const taskToNode = new Map<number, TerminalNode>();
     for (const node of canvasNodes) {
       const ptyId = node.data.ptyId;
       const display = displayStates[ptyId];
       if (display?.taskId != null) {
-        taskToPtyId.set(display.taskId, ptyId);
+        taskToNode.set(display.taskId, node);
       }
     }
 
@@ -35,30 +98,40 @@ export function useChainEdges(projectPath: string): void {
     for (const task of tasks) {
       if (task.parentTaskNumber == null) continue;
 
-      const childPtyId = taskToPtyId.get(task.taskNumber);
-      const parentPtyId = taskToPtyId.get(task.parentTaskNumber);
-      if (!childPtyId || !parentPtyId) continue;
+      const childNode = taskToNode.get(task.taskNumber);
+      const parentNode = taskToNode.get(task.parentTaskNumber);
+      if (!childNode || !parentNode) continue;
 
       const chainInfo = chainMap.get(task.taskNumber);
       if (!chainInfo) continue;
 
       const color = getChainColor(chainInfo.rootTaskNumber, chainInfo.depth);
+      const sourceRect = getNodeRect(parentNode);
+      const targetRect = getNodeRect(childNode);
+      const { sourceHandle, targetHandle, sourcePosition, targetPosition } = getClosestSides(sourceRect, targetRect);
 
       edges.push({
-        id: `chain-${parentPtyId}-${childPtyId}`,
-        source: parentPtyId,
-        target: childPtyId,
+        id: `chain-${parentNode.id}-${childNode.id}`,
+        source: parentNode.id,
+        target: childNode.id,
+        sourceHandle,
+        targetHandle,
         type: 'chain',
-        markerEnd: { type: MarkerType.ArrowClosed, color, width: 16, height: 16 },
-        style: { stroke: color, strokeWidth: 2 },
+        data: { sourcePosition, targetPosition },
+        style: { stroke: color, strokeWidth: 2, strokeLinecap: 'round' },
       });
     }
 
-    // Only update if edges actually changed (avoid infinite loops)
+    // Only update if edges actually changed
     const current = useCanvasStore.getState().canvasByProject[projectPath]?.edges ?? [];
     const changed =
       edges.length !== current.length ||
-      edges.some((e, i) => e.id !== current[i]?.id || e.style?.stroke !== (current[i]?.style as any)?.stroke);
+      edges.some(
+        (e, i) =>
+          e.id !== current[i]?.id ||
+          e.sourceHandle !== current[i]?.sourceHandle ||
+          e.targetHandle !== current[i]?.targetHandle,
+      );
 
     if (changed) {
       useCanvasStore.getState().setEdges(projectPath, edges);

--- a/src/components/canvas/useChainEdges.ts
+++ b/src/components/canvas/useChainEdges.ts
@@ -1,0 +1,68 @@
+import { useEffect } from 'react';
+import { MarkerType, type Edge } from '@xyflow/react';
+import { useProjectStore } from '../../stores/projectStore';
+import { useTerminalStore } from '../../stores/terminalStore';
+import { useCanvasStore, persistCanvas } from '../../stores/canvasStore';
+import { buildChainMap, getChainColor } from '../../utils/taskChain';
+
+/**
+ * Computes react-flow edges from task chain relationships
+ * and syncs them into canvasStore whenever tasks or terminals change.
+ */
+export function useChainEdges(projectPath: string): void {
+  const tasks = useProjectStore((s) => s.tasks);
+  const displayStates = useTerminalStore((s) => s.displayStates);
+  const canvasNodes = useCanvasStore((s) => s.canvasByProject[projectPath]?.nodes);
+
+  useEffect(() => {
+    if (!canvasNodes || canvasNodes.length === 0) return;
+
+    // Build task chain map
+    const chainMap = buildChainMap(tasks);
+
+    // Build taskNumber -> ptyId lookup from terminals on canvas
+    const taskToPtyId = new Map<number, string>();
+    for (const node of canvasNodes) {
+      const ptyId = node.data.ptyId;
+      const display = displayStates[ptyId];
+      if (display?.taskId != null) {
+        taskToPtyId.set(display.taskId, ptyId);
+      }
+    }
+
+    // Compute edges for parent-child pairs where both have terminals on canvas
+    const edges: Edge[] = [];
+    for (const task of tasks) {
+      if (task.parentTaskNumber == null) continue;
+
+      const childPtyId = taskToPtyId.get(task.taskNumber);
+      const parentPtyId = taskToPtyId.get(task.parentTaskNumber);
+      if (!childPtyId || !parentPtyId) continue;
+
+      const chainInfo = chainMap.get(task.taskNumber);
+      if (!chainInfo) continue;
+
+      const color = getChainColor(chainInfo.rootTaskNumber, chainInfo.depth);
+
+      edges.push({
+        id: `chain-${parentPtyId}-${childPtyId}`,
+        source: parentPtyId,
+        target: childPtyId,
+        type: 'chain',
+        markerEnd: { type: MarkerType.ArrowClosed, color, width: 16, height: 16 },
+        style: { stroke: color, strokeWidth: 2 },
+      });
+    }
+
+    // Only update if edges actually changed (avoid infinite loops)
+    const current = useCanvasStore.getState().canvasByProject[projectPath]?.edges ?? [];
+    const changed =
+      edges.length !== current.length ||
+      edges.some((e, i) => e.id !== current[i]?.id || e.style?.stroke !== (current[i]?.style as any)?.stroke);
+
+    if (changed) {
+      useCanvasStore.getState().setEdges(projectPath, edges);
+      persistCanvas(projectPath);
+    }
+  }, [tasks, displayStates, canvasNodes, projectPath]);
+}

--- a/src/components/canvas/useChainEdges.ts
+++ b/src/components/canvas/useChainEdges.ts
@@ -5,8 +5,8 @@ import { useTerminalStore } from '../../stores/terminalStore';
 import { useCanvasStore, persistCanvas, type TerminalNode } from '../../stores/canvasStore';
 import { buildChainMap, getChainColor } from '../../utils/taskChain';
 
-const DEFAULT_W = 720;
-const DEFAULT_H = 480;
+const DEFAULT_W = 740;
+const DEFAULT_H = 556;
 
 interface NodeRect {
   x: number;

--- a/src/components/canvas/useChainEdges.ts
+++ b/src/components/canvas/useChainEdges.ts
@@ -83,37 +83,83 @@ export function useChainEdges(projectPath: string): void {
     // Build task chain map
     const chainMap = buildChainMap(tasks);
 
-    // Build taskNumber -> node lookup from terminals on canvas
-    const taskToNode = new Map<number, TerminalNode>();
+    // Build taskNumber -> nodes lookup (a task can have multiple terminals)
+    const taskToNodes = new Map<number, TerminalNode[]>();
     for (const node of canvasNodes) {
       const ptyId = node.data.ptyId;
       const display = displayStates[ptyId];
       if (display?.taskId != null) {
-        taskToNode.set(display.taskId, node);
+        const list = taskToNodes.get(display.taskId);
+        if (list) list.push(node);
+        else taskToNodes.set(display.taskId, [node]);
       }
     }
 
-    // Compute edges for parent-child pairs where both have terminals on canvas
     const edges: Edge[] = [];
+
+    // Connect same-task terminals to each other (sorted by x then y, chained)
+    for (const [taskId, nodes] of taskToNodes) {
+      if (nodes.length < 2) continue;
+      const chainInfo = chainMap.get(taskId);
+      if (!chainInfo) continue;
+
+      const color = getChainColor(chainInfo.rootTaskNumber, chainInfo.depth);
+      const sorted = [...nodes].sort((a, b) => a.position.x - b.position.x || a.position.y - b.position.y);
+      for (let i = 0; i < sorted.length - 1; i++) {
+        const sourceRect = getNodeRect(sorted[i]);
+        const targetRect = getNodeRect(sorted[i + 1]);
+        const { sourceHandle, targetHandle, sourcePosition, targetPosition } = getClosestSides(sourceRect, targetRect);
+        edges.push({
+          id: `task-${sorted[i].id}-${sorted[i + 1].id}`,
+          source: sorted[i].id,
+          target: sorted[i + 1].id,
+          sourceHandle,
+          targetHandle,
+          type: 'chain',
+          data: { sourcePosition, targetPosition },
+          style: { stroke: color, strokeWidth: 2, strokeLinecap: 'round' },
+        });
+      }
+    }
+
+    // Compute edges for parent-child chain pairs (closest terminal from each group)
     for (const task of tasks) {
       if (task.parentTaskNumber == null) continue;
 
-      const childNode = taskToNode.get(task.taskNumber);
-      const parentNode = taskToNode.get(task.parentTaskNumber);
-      if (!childNode || !parentNode) continue;
+      const childNodes = taskToNodes.get(task.taskNumber);
+      const parentNodes = taskToNodes.get(task.parentTaskNumber);
+      if (!childNodes || !parentNodes) continue;
 
       const chainInfo = chainMap.get(task.taskNumber);
       if (!chainInfo) continue;
 
+      // Find the closest pair between parent and child terminal groups
+      let bestDist = Infinity;
+      let bestParent: TerminalNode | undefined;
+      let bestChild: TerminalNode | undefined;
+      for (const pNode of parentNodes) {
+        const pr = getNodeRect(pNode);
+        for (const cNode of childNodes) {
+          const cr = getNodeRect(cNode);
+          const dist = (pr.cx - cr.cx) ** 2 + (pr.cy - cr.cy) ** 2;
+          if (dist < bestDist) {
+            bestDist = dist;
+            bestParent = pNode;
+            bestChild = cNode;
+          }
+        }
+      }
+      if (!bestParent || !bestChild) continue;
+
       const color = getChainColor(chainInfo.rootTaskNumber, chainInfo.depth);
-      const sourceRect = getNodeRect(parentNode);
-      const targetRect = getNodeRect(childNode);
+      const sourceRect = getNodeRect(bestParent);
+      const targetRect = getNodeRect(bestChild);
       const { sourceHandle, targetHandle, sourcePosition, targetPosition } = getClosestSides(sourceRect, targetRect);
 
       edges.push({
-        id: `chain-${parentNode.id}-${childNode.id}`,
-        source: parentNode.id,
-        target: childNode.id,
+        id: `chain-${bestParent.id}-${bestChild.id}`,
+        source: bestParent.id,
+        target: bestChild.id,
         sourceHandle,
         targetHandle,
         type: 'chain',

--- a/src/components/canvas/useSmartGuides.ts
+++ b/src/components/canvas/useSmartGuides.ts
@@ -1,0 +1,95 @@
+import { useState, useCallback } from 'react';
+import type { OnNodeDrag } from '@xyflow/react';
+import type { TerminalNode } from '../../stores/canvasStore';
+
+export interface GuideLine {
+  orientation: 'horizontal' | 'vertical';
+  position: number; // y for horizontal, x for vertical
+}
+
+const SNAP_THRESHOLD = 8;
+
+/**
+ * Computes smart alignment guides during node drag.
+ * Returns guide lines to render and drag event handlers.
+ */
+export function useSmartGuides(nodes: TerminalNode[]) {
+  const [guides, setGuides] = useState<GuideLine[]>([]);
+
+  const onNodeDrag: OnNodeDrag<TerminalNode> = useCallback(
+    (_event, draggedNode) => {
+      const newGuides: GuideLine[] = [];
+
+      const dLeft = draggedNode.position.x;
+      const dWidth = draggedNode.measured?.width ?? (draggedNode.style?.width ? Number(draggedNode.style.width) : 720);
+      const dHeight =
+        draggedNode.measured?.height ?? (draggedNode.style?.height ? Number(draggedNode.style.height) : 480);
+      const dRight = dLeft + dWidth;
+      const dTop = draggedNode.position.y;
+      const dBottom = dTop + dHeight;
+      const dCenterX = dLeft + dWidth / 2;
+      const dCenterY = dTop + dHeight / 2;
+
+      for (const node of nodes) {
+        if (node.id === draggedNode.id) continue;
+
+        const nLeft = node.position.x;
+        const nWidth = node.measured?.width ?? (node.style?.width ? Number(node.style.width) : 720);
+        const nHeight = node.measured?.height ?? (node.style?.height ? Number(node.style.height) : 480);
+        const nRight = nLeft + nWidth;
+        const nTop = node.position.y;
+        const nBottom = nTop + nHeight;
+        const nCenterX = nLeft + nWidth / 2;
+        const nCenterY = nTop + nHeight / 2;
+
+        // Vertical guides (x-axis alignment)
+        if (Math.abs(dLeft - nLeft) < SNAP_THRESHOLD) {
+          newGuides.push({ orientation: 'vertical', position: nLeft });
+        }
+        if (Math.abs(dRight - nRight) < SNAP_THRESHOLD) {
+          newGuides.push({ orientation: 'vertical', position: nRight });
+        }
+        if (Math.abs(dCenterX - nCenterX) < SNAP_THRESHOLD) {
+          newGuides.push({ orientation: 'vertical', position: nCenterX });
+        }
+        if (Math.abs(dLeft - nRight) < SNAP_THRESHOLD) {
+          newGuides.push({ orientation: 'vertical', position: nRight });
+        }
+        if (Math.abs(dRight - nLeft) < SNAP_THRESHOLD) {
+          newGuides.push({ orientation: 'vertical', position: nLeft });
+        }
+
+        // Horizontal guides (y-axis alignment)
+        if (Math.abs(dTop - nTop) < SNAP_THRESHOLD) {
+          newGuides.push({ orientation: 'horizontal', position: nTop });
+        }
+        if (Math.abs(dBottom - nBottom) < SNAP_THRESHOLD) {
+          newGuides.push({ orientation: 'horizontal', position: nBottom });
+        }
+        if (Math.abs(dCenterY - nCenterY) < SNAP_THRESHOLD) {
+          newGuides.push({ orientation: 'horizontal', position: nCenterY });
+        }
+        if (Math.abs(dTop - nBottom) < SNAP_THRESHOLD) {
+          newGuides.push({ orientation: 'horizontal', position: nBottom });
+        }
+        if (Math.abs(dBottom - nTop) < SNAP_THRESHOLD) {
+          newGuides.push({ orientation: 'horizontal', position: nTop });
+        }
+      }
+
+      // Deduplicate
+      const unique = newGuides.filter(
+        (g, i, arr) => arr.findIndex((o) => o.orientation === g.orientation && o.position === g.position) === i,
+      );
+
+      setGuides(unique);
+    },
+    [nodes],
+  );
+
+  const onNodeDragStop: OnNodeDrag<TerminalNode> = useCallback(() => {
+    setGuides([]);
+  }, []);
+
+  return { guides, onNodeDrag, onNodeDragStop };
+}

--- a/src/components/canvas/useSmartGuides.ts
+++ b/src/components/canvas/useSmartGuides.ts
@@ -1,29 +1,41 @@
 import { useState, useCallback } from 'react';
-import type { OnNodeDrag } from '@xyflow/react';
+import { useReactFlow, type OnNodeDrag } from '@xyflow/react';
 import type { TerminalNode } from '../../stores/canvasStore';
 
 export interface GuideLine {
   orientation: 'horizontal' | 'vertical';
-  position: number; // y for horizontal, x for vertical
+  /** Screen-space position (px from container edge) */
+  screenPos: number;
 }
 
 const SNAP_THRESHOLD = 8;
+const DEFAULT_W = 720;
+const DEFAULT_H = 480;
+
+function getW(node: { measured?: { width?: number }; style?: { width?: number | string } }): number {
+  return node.measured?.width ?? (node.style?.width ? Number(node.style.width) : DEFAULT_W);
+}
+
+function getH(node: { measured?: { height?: number }; style?: { height?: number | string } }): number {
+  return node.measured?.height ?? (node.style?.height ? Number(node.style.height) : DEFAULT_H);
+}
 
 /**
  * Computes smart alignment guides during node drag.
- * Returns guide lines to render and drag event handlers.
+ * Returns guide lines in screen-space and drag event handlers.
  */
 export function useSmartGuides(nodes: TerminalNode[]) {
   const [guides, setGuides] = useState<GuideLine[]>([]);
+  const { getViewport } = useReactFlow();
 
   const onNodeDrag: OnNodeDrag<TerminalNode> = useCallback(
     (_event, draggedNode) => {
-      const newGuides: GuideLine[] = [];
+      const { x: panX, y: panY, zoom } = getViewport();
+      const matches: { orientation: 'horizontal' | 'vertical'; canvasPos: number }[] = [];
 
       const dLeft = draggedNode.position.x;
-      const dWidth = draggedNode.measured?.width ?? (draggedNode.style?.width ? Number(draggedNode.style.width) : 720);
-      const dHeight =
-        draggedNode.measured?.height ?? (draggedNode.style?.height ? Number(draggedNode.style.height) : 480);
+      const dWidth = getW(draggedNode);
+      const dHeight = getH(draggedNode);
       const dRight = dLeft + dWidth;
       const dTop = draggedNode.position.y;
       const dBottom = dTop + dHeight;
@@ -34,8 +46,8 @@ export function useSmartGuides(nodes: TerminalNode[]) {
         if (node.id === draggedNode.id) continue;
 
         const nLeft = node.position.x;
-        const nWidth = node.measured?.width ?? (node.style?.width ? Number(node.style.width) : 720);
-        const nHeight = node.measured?.height ?? (node.style?.height ? Number(node.style.height) : 480);
+        const nWidth = getW(node);
+        const nHeight = getH(node);
         const nRight = nLeft + nWidth;
         const nTop = node.position.y;
         const nBottom = nTop + nHeight;
@@ -43,48 +55,37 @@ export function useSmartGuides(nodes: TerminalNode[]) {
         const nCenterY = nTop + nHeight / 2;
 
         // Vertical guides (x-axis alignment)
-        if (Math.abs(dLeft - nLeft) < SNAP_THRESHOLD) {
-          newGuides.push({ orientation: 'vertical', position: nLeft });
-        }
-        if (Math.abs(dRight - nRight) < SNAP_THRESHOLD) {
-          newGuides.push({ orientation: 'vertical', position: nRight });
-        }
-        if (Math.abs(dCenterX - nCenterX) < SNAP_THRESHOLD) {
-          newGuides.push({ orientation: 'vertical', position: nCenterX });
-        }
-        if (Math.abs(dLeft - nRight) < SNAP_THRESHOLD) {
-          newGuides.push({ orientation: 'vertical', position: nRight });
-        }
-        if (Math.abs(dRight - nLeft) < SNAP_THRESHOLD) {
-          newGuides.push({ orientation: 'vertical', position: nLeft });
-        }
+        if (Math.abs(dLeft - nLeft) < SNAP_THRESHOLD) matches.push({ orientation: 'vertical', canvasPos: nLeft });
+        if (Math.abs(dRight - nRight) < SNAP_THRESHOLD) matches.push({ orientation: 'vertical', canvasPos: nRight });
+        if (Math.abs(dCenterX - nCenterX) < SNAP_THRESHOLD)
+          matches.push({ orientation: 'vertical', canvasPos: nCenterX });
+        if (Math.abs(dLeft - nRight) < SNAP_THRESHOLD) matches.push({ orientation: 'vertical', canvasPos: nRight });
+        if (Math.abs(dRight - nLeft) < SNAP_THRESHOLD) matches.push({ orientation: 'vertical', canvasPos: nLeft });
 
         // Horizontal guides (y-axis alignment)
-        if (Math.abs(dTop - nTop) < SNAP_THRESHOLD) {
-          newGuides.push({ orientation: 'horizontal', position: nTop });
-        }
-        if (Math.abs(dBottom - nBottom) < SNAP_THRESHOLD) {
-          newGuides.push({ orientation: 'horizontal', position: nBottom });
-        }
-        if (Math.abs(dCenterY - nCenterY) < SNAP_THRESHOLD) {
-          newGuides.push({ orientation: 'horizontal', position: nCenterY });
-        }
-        if (Math.abs(dTop - nBottom) < SNAP_THRESHOLD) {
-          newGuides.push({ orientation: 'horizontal', position: nBottom });
-        }
-        if (Math.abs(dBottom - nTop) < SNAP_THRESHOLD) {
-          newGuides.push({ orientation: 'horizontal', position: nTop });
-        }
+        if (Math.abs(dTop - nTop) < SNAP_THRESHOLD) matches.push({ orientation: 'horizontal', canvasPos: nTop });
+        if (Math.abs(dBottom - nBottom) < SNAP_THRESHOLD)
+          matches.push({ orientation: 'horizontal', canvasPos: nBottom });
+        if (Math.abs(dCenterY - nCenterY) < SNAP_THRESHOLD)
+          matches.push({ orientation: 'horizontal', canvasPos: nCenterY });
+        if (Math.abs(dTop - nBottom) < SNAP_THRESHOLD) matches.push({ orientation: 'horizontal', canvasPos: nBottom });
+        if (Math.abs(dBottom - nTop) < SNAP_THRESHOLD) matches.push({ orientation: 'horizontal', canvasPos: nTop });
       }
 
-      // Deduplicate
-      const unique = newGuides.filter(
-        (g, i, arr) => arr.findIndex((o) => o.orientation === g.orientation && o.position === g.position) === i,
-      );
+      // Deduplicate and convert to screen space
+      const seen = new Set<string>();
+      const result: GuideLine[] = [];
+      for (const m of matches) {
+        const key = `${m.orientation}:${m.canvasPos}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const screenPos = m.orientation === 'vertical' ? m.canvasPos * zoom + panX : m.canvasPos * zoom + panY;
+        result.push({ orientation: m.orientation, screenPos });
+      }
 
-      setGuides(unique);
+      setGuides(result);
     },
-    [nodes],
+    [nodes, getViewport],
   );
 
   const onNodeDragStop: OnNodeDrag<TerminalNode> = useCallback(() => {

--- a/src/components/canvas/useSmartGuides.ts
+++ b/src/components/canvas/useSmartGuides.ts
@@ -9,8 +9,8 @@ export interface GuideLine {
 }
 
 const SNAP_THRESHOLD = 8;
-const DEFAULT_W = 720;
-const DEFAULT_H = 480;
+const DEFAULT_W = 740;
+const DEFAULT_H = 556;
 
 function getW(node: { measured?: { width?: number }; style?: { width?: number | string } }): number {
   return node.measured?.width ?? (node.style?.width ? Number(node.style.width) : DEFAULT_W);

--- a/src/components/dialogs/BranchFromTaskDialog.tsx
+++ b/src/components/dialogs/BranchFromTaskDialog.tsx
@@ -6,7 +6,7 @@ import { DialogOverlay } from './DialogOverlay';
 interface BranchFromTaskDialogProps {
   projectPath: string;
   parentTask: TaskWithWorkspace;
-  onClose: (created: boolean) => void;
+  onClose: (created: boolean, taskNumber?: number) => void;
 }
 
 export function BranchFromTaskDialog({ projectPath, parentTask, onClose }: BranchFromTaskDialogProps) {
@@ -28,10 +28,10 @@ export function BranchFromTaskDialog({ projectPath, parentTask, onClose }: Branc
   useEffect(() => () => clearTimeout(timerRef.current), []);
 
   const dismiss = useCallback(
-    (created: boolean) => {
+    (created: boolean, taskNumber?: number) => {
       setVisible(false);
       clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => onClose(created), 200);
+      timerRef.current = setTimeout(() => onClose(created, taskNumber), 200);
     },
     [onClose],
   );
@@ -42,7 +42,7 @@ export function BranchFromTaskDialog({ projectPath, parentTask, onClose }: Branc
     const result = await window.api.task.createFromTask(projectPath, parentTask.taskNumber, name || undefined);
     setSubmitting(false);
     if (result.success) {
-      dismiss(true);
+      dismiss(true, result.task?.taskNumber);
     } else {
       useProjectStore.getState().addToast(result.error || 'Failed to create task', 'error');
     }

--- a/src/components/terminal/terminalActions.ts
+++ b/src/components/terminal/terminalActions.ts
@@ -6,6 +6,7 @@
 
 import type { PtySpawnOptions, RunConfig, WorktreeInfo, ActiveSession, RunnerScript } from '../../types';
 import { useTerminalStore, type TerminalDisplayState } from '../../stores/terminalStore';
+import { useCanvasStore, persistCanvas } from '../../stores/canvasStore';
 import { useAppStore, staleGuard } from '../../stores/appStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { OuijitTerminal, terminalInstances, resolveTerminalLabel, type SummaryType } from './terminalReact';
@@ -45,6 +46,11 @@ function registerTerminal(
 
   // Add to Zustand store
   useTerminalStore.getState().addTerminal(projectPath, ptyId, initial);
+
+  // Add to canvas
+  useCanvasStore.getState().ensureProject(projectPath);
+  useCanvasStore.getState().addNode(projectPath, ptyId);
+  persistCanvas(projectPath);
 
   // Activate last unless background
   if (!background) {
@@ -260,10 +266,17 @@ export async function addProjectTerminal(
 
 export function closeProjectTerminal(ptyId: string): void {
   const instance = terminalInstances.get(ptyId);
+  const projectPath = instance?.projectPath;
   if (instance) {
     instance.dispose();
   }
   useTerminalStore.getState().removeTerminal(ptyId);
+
+  // Remove from canvas
+  if (projectPath) {
+    useCanvasStore.getState().removeNode(projectPath, ptyId);
+    persistCanvas(projectPath);
+  }
 }
 
 // ── Reconnect to an orphaned PTY ─────────────────────────────────────

--- a/src/index.css
+++ b/src/index.css
@@ -499,6 +499,13 @@ textarea,
   height: 100%;
 }
 
+/* Match the canvas background to the app background */
+.terminal-canvas .react-flow {
+  --xy-background-color-default: var(--color-background);
+  --xy-background-color: var(--color-background);
+  background-color: var(--color-background);
+}
+
 /* Remove default react-flow node styling — we own all node chrome */
 .terminal-canvas .react-flow__node-terminal {
   padding: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -527,9 +527,10 @@ textarea,
   background: rgba(10, 132, 255, 0.05);
 }
 
-/* Minimap dark mode */
+/* Minimap — styled to match controls bar */
 .terminal-canvas .react-flow__minimap {
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
   overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -491,3 +491,38 @@ textarea,
     transition-duration: 0.01ms !important;
   }
 }
+
+/* ── React Flow canvas overrides ──────────────────────────────────── */
+
+.terminal-canvas {
+  width: 100%;
+  height: 100%;
+}
+
+/* Remove default react-flow node styling — we own all node chrome */
+.terminal-canvas .react-flow__node-terminal {
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+}
+
+/* Hide default edge/handle visibility — we use invisible handles */
+.terminal-canvas .react-flow__handle {
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Selection box styling */
+.terminal-canvas .react-flow__selection {
+  border: 1px solid rgba(10, 132, 255, 0.3);
+  background: rgba(10, 132, 255, 0.05);
+}
+
+/* Minimap dark mode */
+.terminal-canvas .react-flow__minimap {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  overflow: hidden;
+}

--- a/src/ipc/handlers/settings.ts
+++ b/src/ipc/handlers/settings.ts
@@ -1,19 +1,21 @@
 import { typedHandle } from '../helpers';
 import { getGlobalSetting, setGlobalSetting } from '../../db';
 
-/** Only these keys are permitted through the IPC boundary */
-const ALLOWED_KEYS = new Set(['lastActiveView']);
+/** Check if a settings key is allowed through the IPC boundary */
+function isAllowedKey(key: string): boolean {
+  return key === 'lastActiveView' || key.startsWith('canvas:');
+}
 
 /** Maximum value length (bytes) to prevent abuse */
-const MAX_VALUE_LENGTH = 4096;
+const MAX_VALUE_LENGTH = 65536;
 
 export function registerSettingsHandlers(): void {
   typedHandle('settings:get-global', (key) => {
-    if (!ALLOWED_KEYS.has(key)) return undefined;
+    if (!isAllowedKey(key)) return undefined;
     return getGlobalSetting(key);
   });
   typedHandle('settings:set-global', (key, value) => {
-    if (!ALLOWED_KEYS.has(key)) return { success: false };
+    if (!isAllowedKey(key)) return { success: false };
     if (value.length > MAX_VALUE_LENGTH) return { success: false };
     return setGlobalSetting(key, value);
   });

--- a/src/stores/canvasStore.ts
+++ b/src/stores/canvasStore.ts
@@ -47,8 +47,8 @@ type CanvasStore = CanvasStoreState & CanvasStoreActions;
 
 // ── Constants ────────────────────────────────────────────────────────
 
-const DEFAULT_NODE_WIDTH = 720;
-const DEFAULT_NODE_HEIGHT = 480;
+const DEFAULT_NODE_WIDTH = 740;
+const DEFAULT_NODE_HEIGHT = 556;
 const NODE_SPACING = 60;
 
 function emptyProjectState(): CanvasProjectState {

--- a/src/stores/canvasStore.ts
+++ b/src/stores/canvasStore.ts
@@ -1,0 +1,406 @@
+import { create } from 'zustand';
+import {
+  applyNodeChanges,
+  applyEdgeChanges,
+  type Node,
+  type Edge,
+  type NodeChange,
+  type EdgeChange,
+  type Viewport,
+} from '@xyflow/react';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface TerminalNodeData extends Record<string, unknown> {
+  ptyId: string;
+  projectPath: string;
+}
+
+export type TerminalNode = Node<TerminalNodeData, 'terminal'>;
+
+export interface CanvasProjectState {
+  nodes: TerminalNode[];
+  edges: Edge[];
+  viewport: Viewport;
+  gridSnap: boolean;
+}
+
+interface CanvasStoreState {
+  canvasByProject: Record<string, CanvasProjectState>;
+}
+
+interface CanvasStoreActions {
+  onNodesChange: (projectPath: string, changes: NodeChange<TerminalNode>[]) => void;
+  onEdgesChange: (projectPath: string, changes: EdgeChange[]) => void;
+  addNode: (projectPath: string, ptyId: string, position?: { x: number; y: number }) => void;
+  removeNode: (projectPath: string, ptyId: string) => void;
+  setViewport: (projectPath: string, viewport: Viewport) => void;
+  setEdges: (projectPath: string, edges: Edge[]) => void;
+  setGridSnap: (projectPath: string, snap: boolean) => void;
+  groupSelected: (projectPath: string) => void;
+  ungroupSelected: (projectPath: string) => void;
+  loadCanvas: (projectPath: string, state: CanvasProjectState) => void;
+  ensureProject: (projectPath: string) => void;
+}
+
+type CanvasStore = CanvasStoreState & CanvasStoreActions;
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const DEFAULT_NODE_WIDTH = 720;
+const DEFAULT_NODE_HEIGHT = 480;
+const NODE_SPACING = 60;
+
+function emptyProjectState(): CanvasProjectState {
+  return {
+    nodes: [],
+    edges: [],
+    viewport: { x: 0, y: 0, zoom: 1 },
+    gridSnap: false,
+  };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Compute position for a new node, avoiding overlaps. */
+function computeNewNodePosition(
+  existing: TerminalNode[],
+  viewport: Viewport,
+  hint?: { x: number; y: number },
+): { x: number; y: number } {
+  if (hint) return hint;
+
+  // Find the selected node and place next to it
+  const selected = existing.find((n) => n.selected);
+  if (selected) {
+    const sx =
+      (selected.position.x ?? 0) +
+      (selected.style?.width ? Number(selected.style.width) : DEFAULT_NODE_WIDTH) +
+      NODE_SPACING;
+    const sy = selected.position.y ?? 0;
+    return cascadeIfOccupied(existing, sx, sy);
+  }
+
+  // No selection — place at viewport center
+  const cx = (-viewport.x + 400) / viewport.zoom;
+  const cy = (-viewport.y + 300) / viewport.zoom;
+  return cascadeIfOccupied(existing, cx, cy);
+}
+
+/** If a node already occupies the target position, cascade down-right. */
+function cascadeIfOccupied(existing: TerminalNode[], x: number, y: number): { x: number; y: number } {
+  const threshold = 40;
+  let pos = { x, y };
+  let attempts = 0;
+  while (attempts < 20) {
+    const overlap = existing.some(
+      (n) => Math.abs(n.position.x - pos.x) < threshold && Math.abs(n.position.y - pos.y) < threshold,
+    );
+    if (!overlap) break;
+    pos = { x: pos.x + NODE_SPACING, y: pos.y + NODE_SPACING };
+    attempts++;
+  }
+  return pos;
+}
+
+// ── Store ────────────────────────────────────────────────────────────
+
+export const useCanvasStore = create<CanvasStore>()((set, get) => ({
+  canvasByProject: {},
+
+  ensureProject: (projectPath) => {
+    const state = get();
+    if (state.canvasByProject[projectPath]) return;
+    set({
+      canvasByProject: {
+        ...state.canvasByProject,
+        [projectPath]: emptyProjectState(),
+      },
+    });
+  },
+
+  onNodesChange: (projectPath, changes) => {
+    const state = get();
+    const project = state.canvasByProject[projectPath];
+    if (!project) return;
+
+    // Filter out remove changes — we manage node removal ourselves via removeNode
+    const safeChanges = changes.filter((c) => c.type !== 'remove');
+
+    set({
+      canvasByProject: {
+        ...state.canvasByProject,
+        [projectPath]: {
+          ...project,
+          nodes: applyNodeChanges(safeChanges, project.nodes) as TerminalNode[],
+        },
+      },
+    });
+  },
+
+  onEdgesChange: (projectPath, changes) => {
+    const state = get();
+    const project = state.canvasByProject[projectPath];
+    if (!project) return;
+    set({
+      canvasByProject: {
+        ...state.canvasByProject,
+        [projectPath]: {
+          ...project,
+          edges: applyEdgeChanges(changes, project.edges),
+        },
+      },
+    });
+  },
+
+  addNode: (projectPath, ptyId, position) => {
+    const state = get();
+    const project = state.canvasByProject[projectPath] ?? emptyProjectState();
+
+    // Don't add duplicate nodes
+    if (project.nodes.some((n) => n.id === ptyId)) return;
+
+    const pos = computeNewNodePosition(project.nodes, project.viewport, position);
+
+    const node: TerminalNode = {
+      id: ptyId,
+      type: 'terminal',
+      position: pos,
+      data: { ptyId, projectPath },
+      dragHandle: '.terminal-drag-handle',
+      style: { width: DEFAULT_NODE_WIDTH, height: DEFAULT_NODE_HEIGHT },
+    };
+
+    set({
+      canvasByProject: {
+        ...state.canvasByProject,
+        [projectPath]: {
+          ...project,
+          nodes: [...project.nodes, node],
+        },
+      },
+    });
+  },
+
+  removeNode: (projectPath, ptyId) => {
+    const state = get();
+    const project = state.canvasByProject[projectPath];
+    if (!project) return;
+    set({
+      canvasByProject: {
+        ...state.canvasByProject,
+        [projectPath]: {
+          ...project,
+          nodes: project.nodes.filter((n) => n.id !== ptyId),
+          edges: project.edges.filter((e) => e.source !== ptyId && e.target !== ptyId),
+        },
+      },
+    });
+  },
+
+  setViewport: (projectPath, viewport) => {
+    const state = get();
+    const project = state.canvasByProject[projectPath];
+    if (!project) return;
+    set({
+      canvasByProject: {
+        ...state.canvasByProject,
+        [projectPath]: { ...project, viewport },
+      },
+    });
+  },
+
+  setEdges: (projectPath, edges) => {
+    const state = get();
+    const project = state.canvasByProject[projectPath];
+    if (!project) return;
+    set({
+      canvasByProject: {
+        ...state.canvasByProject,
+        [projectPath]: { ...project, edges },
+      },
+    });
+  },
+
+  setGridSnap: (projectPath, snap) => {
+    const state = get();
+    const project = state.canvasByProject[projectPath];
+    if (!project) return;
+    set({
+      canvasByProject: {
+        ...state.canvasByProject,
+        [projectPath]: { ...project, gridSnap: snap },
+      },
+    });
+  },
+
+  groupSelected: (projectPath) => {
+    const state = get();
+    const project = state.canvasByProject[projectPath];
+    if (!project) return;
+
+    const selected = project.nodes.filter((n) => n.selected && n.type === 'terminal');
+    if (selected.length < 2) return;
+
+    // Compute bounding box of selected nodes
+    const bounds = selected.reduce(
+      (acc, n) => {
+        const w = n.style?.width ? Number(n.style.width) : DEFAULT_NODE_WIDTH;
+        const h = n.style?.height ? Number(n.style.height) : DEFAULT_NODE_HEIGHT;
+        return {
+          minX: Math.min(acc.minX, n.position.x),
+          minY: Math.min(acc.minY, n.position.y),
+          maxX: Math.max(acc.maxX, n.position.x + w),
+          maxY: Math.max(acc.maxY, n.position.y + h),
+        };
+      },
+      { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
+    );
+
+    const padding = 20;
+    const groupId = `group-${Date.now()}`;
+
+    // Create group parent node
+    const groupNode: TerminalNode = {
+      id: groupId,
+      type: 'terminal',
+      position: { x: bounds.minX - padding, y: bounds.minY - padding },
+      data: { ptyId: groupId, projectPath },
+      style: {
+        width: bounds.maxX - bounds.minX + padding * 2,
+        height: bounds.maxY - bounds.minY + padding * 2,
+        background: 'rgba(255, 255, 255, 0.02)',
+        border: '1px dashed rgba(255, 255, 255, 0.1)',
+        borderRadius: 16,
+      },
+    } as TerminalNode;
+
+    // Reparent selected nodes under the group
+    const updatedNodes = project.nodes.map((n) => {
+      if (!n.selected || n.type !== 'terminal') return n;
+      return {
+        ...n,
+        parentId: groupId,
+        position: {
+          x: n.position.x - groupNode.position.x,
+          y: n.position.y - groupNode.position.y,
+        },
+        selected: false,
+      };
+    });
+
+    set({
+      canvasByProject: {
+        ...state.canvasByProject,
+        [projectPath]: {
+          ...project,
+          nodes: [groupNode, ...updatedNodes] as TerminalNode[],
+        },
+      },
+    });
+  },
+
+  ungroupSelected: (projectPath) => {
+    const state = get();
+    const project = state.canvasByProject[projectPath];
+    if (!project) return;
+
+    // Find selected group nodes (nodes that are parents of others)
+    const selectedIds = new Set(project.nodes.filter((n) => n.selected).map((n) => n.id));
+    const groupIds = new Set<string>();
+
+    // Find groups: any selected node that is a parentId of another node
+    for (const node of project.nodes) {
+      if (node.parentId && selectedIds.has(node.parentId)) {
+        groupIds.add(node.parentId);
+      }
+    }
+
+    // Also consider: if a selected node has a parentId, ungroup from its parent
+    for (const node of project.nodes) {
+      if (node.selected && node.parentId) {
+        groupIds.add(node.parentId);
+      }
+    }
+
+    if (groupIds.size === 0) return;
+
+    // Flatten children of groups back to root level
+    const updatedNodes: TerminalNode[] = [];
+    for (const node of project.nodes) {
+      if (groupIds.has(node.id) && node.id.startsWith('group-')) {
+        // Remove group node itself
+        continue;
+      }
+      if (node.parentId && groupIds.has(node.parentId)) {
+        // Move child to absolute position
+        const parent = project.nodes.find((n) => n.id === node.parentId);
+        const parentX = parent?.position.x ?? 0;
+        const parentY = parent?.position.y ?? 0;
+        updatedNodes.push({
+          ...node,
+          parentId: undefined,
+          position: {
+            x: node.position.x + parentX,
+            y: node.position.y + parentY,
+          },
+        } as TerminalNode);
+      } else {
+        updatedNodes.push(node);
+      }
+    }
+
+    set({
+      canvasByProject: {
+        ...state.canvasByProject,
+        [projectPath]: { ...project, nodes: updatedNodes },
+      },
+    });
+  },
+
+  loadCanvas: (projectPath, loaded) => {
+    const state = get();
+    set({
+      canvasByProject: {
+        ...state.canvasByProject,
+        [projectPath]: loaded,
+      },
+    });
+  },
+}));
+
+// ── Persistence ──────────────────────────────────────────────────────
+
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Debounced save of canvas state for a project. */
+export function persistCanvas(projectPath: string): void {
+  if (persistTimer) clearTimeout(persistTimer);
+  persistTimer = setTimeout(() => {
+    const project = useCanvasStore.getState().canvasByProject[projectPath];
+    if (!project) return;
+
+    // Strip transient properties before serializing
+    const nodes = project.nodes.map(({ selected: _s, dragging: _d, measured: _m, ...rest }) => rest) as TerminalNode[];
+    const edges = project.edges.map(({ selected: _sel, ...rest }) => rest);
+    const serializable: CanvasProjectState = {
+      nodes,
+      edges,
+      viewport: project.viewport,
+      gridSnap: project.gridSnap,
+    };
+
+    window.api.globalSettings.set('canvas:' + projectPath, JSON.stringify(serializable));
+  }, 300);
+}
+
+/** Load canvas state from persistence, returns null if none saved. */
+export async function loadPersistedCanvas(projectPath: string): Promise<CanvasProjectState | null> {
+  const json = await window.api.globalSettings.get('canvas:' + projectPath);
+  if (!json) return null;
+  try {
+    return JSON.parse(json) as CanvasProjectState;
+  } catch {
+    return null;
+  }
+}

--- a/src/stores/canvasStore.ts
+++ b/src/stores/canvasStore.ts
@@ -14,6 +14,8 @@ import {
 export interface TerminalNodeData extends Record<string, unknown> {
   ptyId: string;
   projectPath: string;
+  loading?: boolean;
+  loadingLabel?: string;
 }
 
 export type TerminalNode = Node<TerminalNodeData, 'terminal'>;
@@ -32,7 +34,12 @@ interface CanvasStoreState {
 interface CanvasStoreActions {
   onNodesChange: (projectPath: string, changes: NodeChange<TerminalNode>[]) => void;
   onEdgesChange: (projectPath: string, changes: EdgeChange[]) => void;
-  addNode: (projectPath: string, ptyId: string, position?: { x: number; y: number }) => void;
+  addNode: (
+    projectPath: string,
+    ptyId: string,
+    position?: { x: number; y: number },
+    extraData?: Partial<TerminalNodeData>,
+  ) => void;
   removeNode: (projectPath: string, ptyId: string) => void;
   setViewport: (projectPath: string, viewport: Viewport) => void;
   setEdges: (projectPath: string, edges: Edge[]) => void;
@@ -153,7 +160,7 @@ export const useCanvasStore = create<CanvasStore>()((set, get) => ({
     });
   },
 
-  addNode: (projectPath, ptyId, position) => {
+  addNode: (projectPath, ptyId, position, extraData) => {
     const state = get();
     const project = state.canvasByProject[projectPath] ?? emptyProjectState();
 
@@ -166,7 +173,7 @@ export const useCanvasStore = create<CanvasStore>()((set, get) => ({
       id: ptyId,
       type: 'terminal',
       position: pos,
-      data: { ptyId, projectPath },
+      data: { ptyId, projectPath, ...extraData },
       dragHandle: '.terminal-drag-handle',
       style: { width: DEFAULT_NODE_WIDTH, height: DEFAULT_NODE_HEIGHT },
     };

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1,9 +1,12 @@
 import { create } from 'zustand';
 import type { TaskWithWorkspace, Script } from '../types';
 
+export type TerminalLayout = 'stack' | 'canvas';
+
 interface ProjectStoreState {
   tasks: TaskWithWorkspace[];
   kanbanVisible: boolean;
+  terminalLayout: TerminalLayout;
   activePanel: 'terminals' | 'settings';
   scripts: Script[];
   taskVersion: number;
@@ -49,6 +52,8 @@ interface ProjectStoreActions {
   setBadgeDragOverTask: (taskNumber: number | null) => void;
   clearChainHighlights: () => void;
   resetBadgeDragState: () => void;
+  setTerminalLayout: (layout: TerminalLayout) => void;
+  toggleTerminalLayout: () => void;
   setActivePanel: (panel: 'terminals' | 'settings') => void;
   resetForProject: () => void;
 
@@ -68,6 +73,7 @@ let moveCounter = 0;
 export const useProjectStore = create<ProjectStore>()((set, get) => ({
   tasks: [],
   kanbanVisible: false,
+  terminalLayout: 'stack',
   activePanel: 'terminals',
   scripts: [],
   taskVersion: 0,
@@ -109,6 +115,10 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   resetBadgeDragState: () =>
     set({ activeBadgeDrag: null, badgeDragOverTask: null, highlightedChainTask: null, detachHoverParent: null }),
 
+  setTerminalLayout: (layout) => set({ terminalLayout: layout }),
+
+  toggleTerminalLayout: () => set((s) => ({ terminalLayout: s.terminalLayout === 'stack' ? 'canvas' : 'stack' })),
+
   setActivePanel: (panel) => set({ activePanel: panel }),
 
   showModal: (modal) => set({ activeModal: modal }),
@@ -140,6 +150,7 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
     set({
       tasks: [],
       kanbanVisible: false,
+      terminalLayout: 'stack',
       activePanel: 'terminals',
       scripts: [],
       taskVersion: 0,

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -39,6 +39,7 @@ import folderOpen from '@phosphor-icons/core/assets/regular/folder-open.svg?raw'
 import folderPlus from '@phosphor-icons/core/assets/regular/folder-plus.svg?raw';
 import gear from '@phosphor-icons/core/assets/regular/gear.svg?raw';
 import gitBranch from '@phosphor-icons/core/assets/regular/git-branch.svg?raw';
+import gitFork from '@phosphor-icons/core/assets/regular/git-fork.svg?raw';
 import gridFour from '@phosphor-icons/core/assets/regular/grid-four.svg?raw';
 import gitDiff from '@phosphor-icons/core/assets/regular/git-diff.svg?raw';
 import gitMerge from '@phosphor-icons/core/assets/regular/git-merge.svg?raw';
@@ -104,6 +105,7 @@ export const iconMap: Record<string, string> = {
   gear: gear,
   'git-branch': gitBranch,
   'git-diff': gitDiff,
+  'git-fork': gitFork,
   'grid-four': gridFour,
   'git-merge': gitMerge,
   info: info,

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -5,6 +5,12 @@
  * automatically converted to SVGs when added to the DOM.
  */
 
+import alignBottom from '@phosphor-icons/core/assets/regular/align-bottom.svg?raw';
+import alignCenterHorizontal from '@phosphor-icons/core/assets/regular/align-center-horizontal.svg?raw';
+import alignCenterVertical from '@phosphor-icons/core/assets/regular/align-center-vertical.svg?raw';
+import alignLeft from '@phosphor-icons/core/assets/regular/align-left.svg?raw';
+import alignRight from '@phosphor-icons/core/assets/regular/align-right.svg?raw';
+import alignTop from '@phosphor-icons/core/assets/regular/align-top.svg?raw';
 import archive from '@phosphor-icons/core/assets/regular/archive.svg?raw';
 import arrowCounterClockwise from '@phosphor-icons/core/assets/regular/arrow-counter-clockwise.svg?raw';
 import arrowLeft from '@phosphor-icons/core/assets/regular/arrow-left.svg?raw';
@@ -13,6 +19,7 @@ import arrowsClockwise from '@phosphor-icons/core/assets/regular/arrows-clockwis
 import arrowsIn from '@phosphor-icons/core/assets/regular/arrows-in.svg?raw';
 import arrowsOut from '@phosphor-icons/core/assets/regular/arrows-out.svg?raw';
 import arrowsOutLineHorizontal from '@phosphor-icons/core/assets/regular/arrows-out-line-horizontal.svg?raw';
+import arrowsOutLineVertical from '@phosphor-icons/core/assets/regular/arrows-out-line-vertical.svg?raw';
 import bug from '@phosphor-icons/core/assets/regular/bug.svg?raw';
 import caretDown from '@phosphor-icons/core/assets/regular/caret-down.svg?raw';
 import dotsSixVertical from '@phosphor-icons/core/assets/regular/dots-six-vertical.svg?raw';
@@ -32,6 +39,7 @@ import folderOpen from '@phosphor-icons/core/assets/regular/folder-open.svg?raw'
 import folderPlus from '@phosphor-icons/core/assets/regular/folder-plus.svg?raw';
 import gear from '@phosphor-icons/core/assets/regular/gear.svg?raw';
 import gitBranch from '@phosphor-icons/core/assets/regular/git-branch.svg?raw';
+import gridFour from '@phosphor-icons/core/assets/regular/grid-four.svg?raw';
 import gitDiff from '@phosphor-icons/core/assets/regular/git-diff.svg?raw';
 import gitMerge from '@phosphor-icons/core/assets/regular/git-merge.svg?raw';
 import info from '@phosphor-icons/core/assets/regular/info.svg?raw';
@@ -51,6 +59,7 @@ import star from '@phosphor-icons/core/assets/regular/star.svg?raw';
 import tag from '@phosphor-icons/core/assets/regular/tag.svg?raw';
 import terminal from '@phosphor-icons/core/assets/regular/terminal.svg?raw';
 import trash from '@phosphor-icons/core/assets/regular/trash.svg?raw';
+import treeStructure from '@phosphor-icons/core/assets/regular/tree-structure.svg?raw';
 import upload from '@phosphor-icons/core/assets/regular/upload.svg?raw';
 import webhooksLogo from '@phosphor-icons/core/assets/regular/webhooks-logo.svg?raw';
 import x from '@phosphor-icons/core/assets/regular/x.svg?raw';
@@ -60,6 +69,12 @@ const iconsLog = log.scope('icons');
 
 // Map of icon names (kebab-case) to SVG strings
 export const iconMap: Record<string, string> = {
+  'align-bottom': alignBottom,
+  'align-center-horizontal': alignCenterHorizontal,
+  'align-center-vertical': alignCenterVertical,
+  'align-left': alignLeft,
+  'align-right': alignRight,
+  'align-top': alignTop,
   archive: archive,
   'arrow-counter-clockwise': arrowCounterClockwise,
   'arrow-left': arrowLeft,
@@ -68,6 +83,7 @@ export const iconMap: Record<string, string> = {
   'arrows-in': arrowsIn,
   'arrows-out': arrowsOut,
   'arrows-out-line-horizontal': arrowsOutLineHorizontal,
+  'arrows-out-line-vertical': arrowsOutLineVertical,
   bug: bug,
   'caret-down': caretDown,
   'dots-six-vertical': dotsSixVertical,
@@ -88,6 +104,7 @@ export const iconMap: Record<string, string> = {
   gear: gear,
   'git-branch': gitBranch,
   'git-diff': gitDiff,
+  'grid-four': gridFour,
   'git-merge': gitMerge,
   info: info,
   kanban: kanban,
@@ -106,6 +123,7 @@ export const iconMap: Record<string, string> = {
   tag: tag,
   terminal: terminal,
   trash: trash,
+  'tree-structure': treeStructure,
   upload: upload,
   'webhooks-logo': webhooksLogo,
   x: x,


### PR DESCRIPTION
## Summary

- Add react-flow canvas view for terminal sessions with drag, resize, zoom, and smart guides
- Task chain edges connect parent/child terminals with auto-routing connectors
- Canvas periphery shows status light, label, branch, chain badges, and action buttons (Plan, Diff, Run, Fork, Close)
- Fork task directly from canvas with loading placeholder while worktree is created
- Grid and chain tree auto-layout via selection context menu
- Minimap with chain-colored nodes, collapsible into a toggle button
- Canvas state persisted per-project to global settings
- Task branching support for stacked PR workflows (parent/child task relationships)