### PR TITLE
Add bulk task actions to kanban board

### DIFF
--- a/src/components/kanban/BulkActionBar.tsx
+++ b/src/components/kanban/BulkActionBar.tsx
@@ -1,0 +1,145 @@
+import { useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { useProjectStore } from '../../stores/projectStore';
+import type { TaskWithWorkspace, TaskStatus } from '../../types';
+import { Icon } from '../terminal/Icon';
+
+interface BulkActionBarProps {
+  projectPath: string;
+  onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
+}
+
+export function BulkActionBar({ projectPath, onOpenTerminal }: BulkActionBarProps) {
+  const selectedTaskNumbers = useProjectStore((s) => s.selectedTaskNumbers);
+  const tasks = useProjectStore((s) => s.tasks);
+  const count = selectedTaskNumbers.size;
+
+  const selectedTasks = tasks.filter((t) => selectedTaskNumbers.has(t.taskNumber));
+
+  // Determine which statuses ALL selected tasks share (to hide that button)
+  const allSameStatus =
+    selectedTasks.length > 0 && selectedTasks.every((t) => t.status === selectedTasks[0].status)
+      ? selectedTasks[0].status
+      : null;
+
+  const handleMoveToStatus = useCallback(
+    async (status: TaskStatus) => {
+      const selected = [...useProjectStore.getState().selectedTaskNumbers];
+      await Promise.allSettled(selected.map((n) => window.api.task.setStatus(projectPath, n, status)));
+      useProjectStore.getState().loadTasks(projectPath);
+      useProjectStore.getState().clearSelection();
+      const label = { todo: 'To Do', in_progress: 'In Progress', in_review: 'In Review', done: 'Done' }[status];
+      useProjectStore.getState().addToast(`Moved ${selected.length} tasks to ${label}`, 'success');
+    },
+    [projectPath],
+  );
+
+  const handleDelete = useCallback(async () => {
+    const store = useProjectStore.getState();
+    const selected = [...store.selectedTaskNumbers];
+    if (selected.length > 5) {
+      store.addToast(`Delete ${selected.length} tasks?`, {
+        type: 'info',
+        persistent: true,
+        actionLabel: 'Delete',
+        onAction: async () => {
+          const nums = [...useProjectStore.getState().selectedTaskNumbers];
+          await Promise.allSettled(nums.map((n) => window.api.task.trash(projectPath, n)));
+          useProjectStore.getState().loadTasks(projectPath);
+          useProjectStore.getState().clearSelection();
+          useProjectStore.getState().addToast(`Deleted ${nums.length} tasks`, 'success');
+        },
+      });
+      return;
+    }
+    await Promise.allSettled(selected.map((n) => window.api.task.trash(projectPath, n)));
+    useProjectStore.getState().loadTasks(projectPath);
+    useProjectStore.getState().clearSelection();
+    useProjectStore.getState().addToast(`Deleted ${selected.length} tasks`, 'success');
+  }, [projectPath]);
+
+  const handleOpenTerminals = useCallback(() => {
+    const store = useProjectStore.getState();
+    const selected = [...store.selectedTaskNumbers];
+    const tasksToOpen = store.tasks.filter((t) => selected.includes(t.taskNumber));
+
+    const doOpen = () => {
+      for (const t of tasksToOpen) onOpenTerminal(t);
+      useProjectStore.getState().clearSelection();
+    };
+
+    if (tasksToOpen.length > 3) {
+      store.addToast(`Open ${tasksToOpen.length} terminals?`, {
+        type: 'info',
+        persistent: true,
+        actionLabel: 'Open',
+        onAction: doOpen,
+      });
+      return;
+    }
+    doOpen();
+  }, [onOpenTerminal]);
+
+  const bar = (
+    <div
+      className="fixed z-[200] flex items-center gap-1 px-3 py-2 whitespace-nowrap"
+      style={{
+        bottom: 56,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        background: 'rgba(30, 30, 30, 0.95)',
+        backdropFilter: 'blur(20px)',
+        border: '1px solid rgba(255, 255, 255, 0.1)',
+        borderRadius: 10,
+        boxShadow: '0 8px 24px rgba(0, 0, 0, 0.4)',
+      }}
+    >
+      <span className="text-xs font-medium text-text-secondary px-2 whitespace-nowrap">{count} selected</span>
+      <Divider />
+      {allSameStatus !== 'todo' && <ActionButton label="To Do" onClick={() => handleMoveToStatus('todo')} />}
+      {allSameStatus !== 'in_progress' && (
+        <ActionButton label="In Progress" onClick={() => handleMoveToStatus('in_progress')} />
+      )}
+      {allSameStatus !== 'in_review' && (
+        <ActionButton label="In Review" onClick={() => handleMoveToStatus('in_review')} />
+      )}
+      {allSameStatus !== 'done' && <ActionButton label="Done" onClick={() => handleMoveToStatus('done')} />}
+      <Divider />
+      <ActionButton icon="terminal" label="Terminal" onClick={handleOpenTerminals} />
+      <Divider />
+      <ActionButton icon="trash" label="Delete" onClick={handleDelete} danger />
+    </div>
+  );
+
+  return createPortal(bar, document.body);
+}
+
+function Divider() {
+  return <div className="w-px h-4 mx-1" style={{ background: 'rgba(255, 255, 255, 0.1)' }} />;
+}
+
+function ActionButton({
+  icon,
+  label,
+  onClick,
+  danger,
+}: {
+  icon?: string;
+  label: string;
+  onClick: () => void;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border-none text-xs font-medium transition-colors duration-100 [&>svg]:w-3.5 [&>svg]:h-3.5 ${
+        danger
+          ? 'text-text-secondary bg-transparent hover:text-red-400 hover:bg-red-500/10'
+          : 'text-text-secondary bg-transparent hover:text-text-primary hover:bg-white/[0.08]'
+      }`}
+      onClick={onClick}
+    >
+      {icon && <Icon name={icon} />}
+      {label}
+    </button>
+  );
+}

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -19,6 +19,7 @@ import { useTerminalStore } from '../../stores/terminalStore';
 import type { TaskWithWorkspace, TaskStatus, HookType } from '../../types';
 import { addProjectTerminal, closeProjectTerminal } from '../terminal/terminalActions';
 import { KanbanColumn } from './KanbanColumn';
+import { BulkActionBar } from './BulkActionBar';
 import { focusKanbanAddInput } from './KanbanAddInput';
 import { HookConfigDialog } from '../dialogs/HookConfigDialog';
 import { CombinedHookConfigDialog } from '../dialogs/CombinedHookConfigDialog';
@@ -172,6 +173,12 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         if (hasOpenDialog) return; // Let the dialog handle Escape
+        const { selectedTaskNumbers, clearSelection } = useProjectStore.getState();
+        if (selectedTaskNumbers.size > 0) {
+          e.preventDefault();
+          clearSelection();
+          return; // First Escape deselects; second closes board
+        }
         e.preventDefault();
         onHide();
         return;
@@ -258,9 +265,13 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     return () => window.removeEventListener('pointermove', onMove);
   }, [activeTask, activeBadgeDrag]);
 
+  // Track multi-drag: task numbers being dragged together (null = single drag)
+  const multiDragRef = useRef<number[] | null>(null);
+
   const handleDragStart = useCallback((event: DragStartEvent) => {
     const data = event.active.data.current;
     if (data?.type === 'badge') {
+      multiDragRef.current = null;
       if (typeof data.taskNumber === 'number') useProjectStore.getState().setActiveBadgeDrag(data.taskNumber);
       setActiveTask(null);
     } else {
@@ -268,6 +279,15 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       setActiveTask(task ?? null);
       useProjectStore.getState().setActiveBadgeDrag(null);
       if (task) originalStatusRef.current = task.status;
+
+      // If dragged card is in the selection, enter multi-drag mode
+      const { selectedTaskNumbers } = useProjectStore.getState();
+      if (task && selectedTaskNumbers.has(task.taskNumber) && selectedTaskNumbers.size > 1) {
+        multiDragRef.current = [...selectedTaskNumbers];
+      } else {
+        multiDragRef.current = null;
+        if (selectedTaskNumbers.size > 0) useProjectStore.getState().clearSelection();
+      }
     }
   }, []);
 
@@ -353,7 +373,9 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       let draggedTask = activeTask;
       const origStatus = originalStatusRef.current;
       const droppedOnTrash = overTrashRef.current;
+      const multiDragTasks = multiDragRef.current;
       originalStatusRef.current = null;
+      multiDragRef.current = null;
 
       if (!draggedTask) {
         setActiveTask(null);
@@ -365,11 +387,19 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       // Handle trash drop — use pointer-based hit test for consistency with visual state
       if (droppedOnTrash) {
         setActiveTask(null);
-        const taskNum = parseInt(activeId.replace('task-', ''), 10);
-        await window.api.task.trash(projectPath, taskNum);
-        if (!mountedRef.current) return;
-        useProjectStore.getState().loadTasks(projectPath);
-        useProjectStore.getState().addToast('Task deleted', 'success');
+        if (multiDragTasks) {
+          await Promise.allSettled(multiDragTasks.map((n) => window.api.task.trash(projectPath, n)));
+          if (!mountedRef.current) return;
+          useProjectStore.getState().loadTasks(projectPath);
+          useProjectStore.getState().clearSelection();
+          useProjectStore.getState().addToast(`Deleted ${multiDragTasks.length} tasks`, 'success');
+        } else {
+          const taskNum = parseInt(activeId.replace('task-', ''), 10);
+          await window.api.task.trash(projectPath, taskNum);
+          if (!mountedRef.current) return;
+          useProjectStore.getState().loadTasks(projectPath);
+          useProjectStore.getState().addToast('Task deleted', 'success');
+        }
         return;
       }
 
@@ -388,6 +418,19 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
 
       const finalContainer = overContainer || activeContainer;
       const activeTaskNum = parseInt(activeId.replace('task-', ''), 10);
+
+      // ── Multi-drag: move all selected tasks to the target column ───
+      if (multiDragTasks && multiDragTasks.length > 1) {
+        setActiveTask(null);
+        const newStatus = finalContainer as TaskStatus;
+        await Promise.allSettled(multiDragTasks.map((n) => window.api.task.setStatus(projectPath, n, newStatus)));
+        if (!mountedRef.current) return;
+        useProjectStore.getState().loadTasks(projectPath);
+        useProjectStore.getState().clearSelection();
+        const label = { todo: 'To Do', in_progress: 'In Progress', in_review: 'In Review', done: 'Done' }[newStatus];
+        useProjectStore.getState().addToast(`Moved ${multiDragTasks.length} tasks to ${label}`, 'success');
+        return;
+      }
 
       // Handle reorder within same column
       let finalItems = items;
@@ -554,6 +597,22 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     [projectPath, onHide],
   );
 
+  const handleCardSelect = useCallback(
+    (taskNumber: number, event: React.MouseEvent) => {
+      const mod = isMac ? event.metaKey : event.ctrlKey;
+      const store = useProjectStore.getState();
+      if (event.shiftKey && store.selectionAnchor != null) {
+        const allOrdered = COLUMNS.flatMap((col) => (items[col.status] ?? []).map((t) => t.taskNumber));
+        store.selectTaskRange(taskNumber, allOrdered);
+      } else if (mod || event.shiftKey) {
+        store.toggleTaskSelection(taskNumber);
+      }
+    },
+    [items],
+  );
+
+  const selectedTaskCount = useProjectStore((s) => s.selectedTaskNumbers.size);
+
   const handleRunHookClose = useCallback(
     async (result: RunHookResult | null) => {
       const dialog = runHookDialog;
@@ -609,6 +668,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
         setActiveTask(null);
         useProjectStore.getState().resetBadgeDragState();
         originalStatusRef.current = null;
+        multiDragRef.current = null;
       }}
     >
       <div
@@ -673,6 +733,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
                 onUpdateDescription={handleUpdateDescription}
                 onOpenTerminal={handleOpenTerminal}
                 onSwitchToTerminal={handleSwitchToTerminal}
+                onSelect={handleCardSelect}
                 onConfigureHook={handleConfigureHook}
                 hasConfiguredHook={hookActive}
               />
@@ -681,12 +742,14 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
         </div>
       </div>
 
+      {selectedTaskCount > 0 && <BulkActionBar projectPath={projectPath} onOpenTerminal={handleOpenTerminal} />}
+
       <KanbanTrashZone ref={trashRef} visible={showTrash} isOver={overTrash} />
 
       <DragOverlay dropAnimation={null}>
         {activeTask && (
           <div
-            className="px-3 py-3.5"
+            className="px-3 py-3.5 relative"
             style={{
               background: '#111111',
               border: '1px solid rgba(255, 255, 255, 0.1)',
@@ -699,6 +762,14 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
                 {activeTask.name}
               </span>
             </div>
+            {selectedTaskCount > 1 && (
+              <span
+                className="absolute -top-2 -right-2 flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full text-[11px] font-semibold text-white"
+                style={{ background: '#0A84FF' }}
+              >
+                {selectedTaskCount}
+              </span>
+            )}
           </div>
         )}
         {activeBadgeDrag != null && (

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -13,16 +13,20 @@ import { Tooltip } from '../ui/Tooltip';
 import type { TaskChainInfo } from '../../utils/taskChain';
 import { getChainColor, getChainBgColor, isChainMember, isDescendantOf } from '../../utils/taskChain';
 
+const isMac = navigator.platform.toLowerCase().includes('mac');
+
 interface KanbanCardProps {
   task: TaskWithWorkspace;
   projectPath: string;
   chainInfo?: TaskChainInfo;
   chainMap?: Map<number, TaskChainInfo>;
   isSettingUp?: boolean;
+  isSelected?: boolean;
   onRename: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
   onSwitchToTerminal: (ptyId: string) => void;
+  onSelect: (taskNumber: number, event: React.MouseEvent) => void;
 }
 
 export const KanbanCard = memo(function KanbanCard({
@@ -31,10 +35,12 @@ export const KanbanCard = memo(function KanbanCard({
   chainInfo,
   chainMap,
   isSettingUp,
+  isSelected,
   onRename,
   onUpdateDescription,
   onOpenTerminal,
   onSwitchToTerminal,
+  onSelect,
 }: KanbanCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -162,7 +168,80 @@ export const KanbanCard = memo(function KanbanCard({
   }, [projectPath]);
 
   // Build context menu items
+  const selectedCount = useProjectStore((s) => s.selectedTaskNumbers.size);
   const contextMenuItems = useMemo((): ContextMenuEntry[] => {
+    // Bulk context menu when this card is part of a multi-selection
+    if (isSelected && selectedCount > 1) {
+      const items: ContextMenuEntry[] = [
+        {
+          label: 'Move to To Do',
+          onClick: async () => {
+            const selected = [...useProjectStore.getState().selectedTaskNumbers];
+            await Promise.allSettled(selected.map((n) => window.api.task.setStatus(projectPath, n, 'todo')));
+            useProjectStore.getState().loadTasks(projectPath);
+            useProjectStore.getState().clearSelection();
+            useProjectStore.getState().addToast(`Moved ${selected.length} tasks to To Do`, 'success');
+          },
+        },
+        {
+          label: 'Move to In Progress',
+          onClick: async () => {
+            const selected = [...useProjectStore.getState().selectedTaskNumbers];
+            await Promise.allSettled(selected.map((n) => window.api.task.setStatus(projectPath, n, 'in_progress')));
+            useProjectStore.getState().loadTasks(projectPath);
+            useProjectStore.getState().clearSelection();
+            useProjectStore.getState().addToast(`Moved ${selected.length} tasks to In Progress`, 'success');
+          },
+        },
+        {
+          label: 'Move to In Review',
+          onClick: async () => {
+            const selected = [...useProjectStore.getState().selectedTaskNumbers];
+            await Promise.allSettled(selected.map((n) => window.api.task.setStatus(projectPath, n, 'in_review')));
+            useProjectStore.getState().loadTasks(projectPath);
+            useProjectStore.getState().clearSelection();
+            useProjectStore.getState().addToast(`Moved ${selected.length} tasks to In Review`, 'success');
+          },
+        },
+        {
+          label: 'Move to Done',
+          onClick: async () => {
+            const selected = [...useProjectStore.getState().selectedTaskNumbers];
+            await Promise.allSettled(selected.map((n) => window.api.task.setStatus(projectPath, n, 'done')));
+            useProjectStore.getState().loadTasks(projectPath);
+            useProjectStore.getState().clearSelection();
+            useProjectStore.getState().addToast(`Moved ${selected.length} tasks to Done`, 'success');
+          },
+        },
+        { separator: true },
+        {
+          label: 'Open in Terminal',
+          icon: 'terminal',
+          onClick: () => {
+            const store = useProjectStore.getState();
+            const selected = [...store.selectedTaskNumbers];
+            const tasks = store.tasks.filter((t) => selected.includes(t.taskNumber));
+            for (const t of tasks) onOpenTerminal(t);
+            store.clearSelection();
+          },
+        },
+        { separator: true },
+        {
+          label: 'Delete',
+          icon: 'trash',
+          danger: true,
+          onClick: async () => {
+            const selected = [...useProjectStore.getState().selectedTaskNumbers];
+            await Promise.allSettled(selected.map((n) => window.api.task.trash(projectPath, n)));
+            useProjectStore.getState().loadTasks(projectPath);
+            useProjectStore.getState().clearSelection();
+            useProjectStore.getState().addToast(`Deleted ${selected.length} tasks`, 'success');
+          },
+        },
+      ];
+      return items;
+    }
+
     const items: ContextMenuEntry[] = [];
 
     // Connected terminals
@@ -284,6 +363,8 @@ export const KanbanCard = memo(function KanbanCard({
     isDone,
     sandboxAvailable,
     hasEditorHook,
+    isSelected,
+    selectedCount,
     startEditing,
     onSwitchToTerminal,
     onOpenTerminal,
@@ -293,12 +374,15 @@ export const KanbanCard = memo(function KanbanCard({
     <div
       className="kanban-card group px-3 py-3.5 ease-out [-webkit-app-region:no-drag] hover:bg-black/10 active:bg-black/[0.12]"
       style={{
-        background: isHoveredBadgeTarget
-          ? 'rgba(10, 132, 255, 0.08)'
-          : expanded
-            ? 'rgba(0, 0, 0, 0.15)'
-            : 'var(--color-terminal-bg)',
-        transition: 'background 150ms ease-out, opacity 150ms ease-out, outline-color 150ms ease-out',
+        background: isSelected
+          ? 'rgba(10, 132, 255, 0.06)'
+          : isHoveredBadgeTarget
+            ? 'rgba(10, 132, 255, 0.08)'
+            : expanded
+              ? 'rgba(0, 0, 0, 0.15)'
+              : 'var(--color-terminal-bg)',
+        transition:
+          'background 150ms ease-out, opacity 150ms ease-out, outline-color 150ms ease-out, box-shadow 150ms ease-out',
         borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
         outline: isHoveredBadgeTarget
           ? '1px solid rgba(10, 132, 255, 0.6)'
@@ -307,8 +391,25 @@ export const KanbanCard = memo(function KanbanCard({
             : 'none',
         outlineOffset: -1,
         ...(isInvalidBadgeTarget && { opacity: 0.4 }),
+        ...(isSelected && { boxShadow: 'inset 2px 0 0 0 #0A84FF' }),
       }}
       data-task-number={task.taskNumber}
+      onMouseDown={(e) => {
+        // Prevent browser text selection when shift-clicking to range-select
+        if (e.shiftKey) e.preventDefault();
+      }}
+      onClick={(e) => {
+        // Don't interfere with double-click (rename)
+        if (e.detail >= 2) return;
+        const mod = isMac ? e.metaKey : e.ctrlKey;
+        if (mod || e.shiftKey) {
+          e.stopPropagation();
+          onSelect(task.taskNumber, e);
+        } else if (useProjectStore.getState().selectedTaskNumbers.size > 0) {
+          // Plain click clears selection
+          useProjectStore.getState().clearSelection();
+        }
+      }}
       onContextMenu={(e) => {
         e.preventDefault();
         e.stopPropagation();

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
+import { useMemo, type MouseEvent } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { TaskWithWorkspace, HookType } from '../../types';
 import type { TaskChainInfo } from '../../utils/taskChain';
+import { useProjectStore } from '../../stores/projectStore';
 import { KanbanCard } from './KanbanCard';
 import { KanbanAddInput } from './KanbanAddInput';
 import { Icon } from '../terminal/Icon';
@@ -27,6 +28,7 @@ interface KanbanColumnProps {
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
   onSwitchToTerminal: (ptyId: string) => void;
+  onSelect: (taskNumber: number, event: MouseEvent) => void;
   onConfigureHook?: (hookTypes: HookType[]) => void;
   hasConfiguredHook?: boolean;
   chainMap?: Map<number, TaskChainInfo>;
@@ -43,6 +45,7 @@ export function KanbanColumn({
   onUpdateDescription,
   onOpenTerminal,
   onSwitchToTerminal,
+  onSelect,
   onConfigureHook,
   hasConfiguredHook,
   chainMap,
@@ -84,6 +87,9 @@ export function KanbanColumn({
           minHeight: 80,
           background: isOver && tasks.length === 0 ? 'rgba(10, 132, 255, 0.08)' : undefined,
         }}
+        onClick={(e) => {
+          if (e.target === e.currentTarget) useProjectStore.getState().clearSelection();
+        }}
       >
         <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
           {tasks.map((task) => (
@@ -97,6 +103,7 @@ export function KanbanColumn({
               onUpdateDescription={onUpdateDescription}
               onOpenTerminal={onOpenTerminal}
               onSwitchToTerminal={onSwitchToTerminal}
+              onSelect={onSelect}
             />
           ))}
         </SortableContext>
@@ -117,6 +124,7 @@ function SortableCard({
   onUpdateDescription,
   onOpenTerminal,
   onSwitchToTerminal,
+  onSelect,
 }: {
   task: TaskWithWorkspace;
   projectPath: string;
@@ -126,11 +134,13 @@ function SortableCard({
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
   onSwitchToTerminal: (ptyId: string) => void;
+  onSelect: (taskNumber: number, event: MouseEvent) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: `task-${task.taskNumber}`,
     data: { task, type: 'card' },
   });
+  const isSelected = useProjectStore((s) => s.selectedTaskNumbers.has(task.taskNumber));
 
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
@@ -166,10 +176,12 @@ function SortableCard({
         chainInfo={chainMap?.get(task.taskNumber)}
         chainMap={chainMap}
         isSettingUp={isSettingUp}
+        isSelected={isSelected}
         onRename={onRename}
         onUpdateDescription={onUpdateDescription}
         onOpenTerminal={onOpenTerminal}
         onSwitchToTerminal={onSwitchToTerminal}
+        onSelect={onSelect}
       />
     </div>
   );

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -16,6 +16,8 @@ interface ProjectStoreState {
   activeBadgeDrag: number | null;
   badgeDragOverTask: number | null;
   activeModal: string | null;
+  selectedTaskNumbers: Set<number>;
+  selectionAnchor: number | null;
   toasts: Array<{
     id: string;
     message: string;
@@ -57,6 +59,13 @@ interface ProjectStoreActions {
   setActivePanel: (panel: 'terminals' | 'settings') => void;
   resetForProject: () => void;
 
+  /** Toggle a single task's selection (Cmd/Ctrl+click) */
+  toggleTaskSelection: (taskNumber: number) => void;
+  /** Select a range of tasks from anchor to target (Shift+click) */
+  selectTaskRange: (taskNumber: number, orderedTaskNumbers: number[]) => void;
+  /** Clear all selection */
+  clearSelection: () => void;
+
   /** Load tasks from IPC with staleness check */
   loadTasks: (projectPath: string) => Promise<void>;
   /** Load scripts from IPC */
@@ -83,10 +92,23 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   activeBadgeDrag: null,
   badgeDragOverTask: null,
   activeModal: null,
+  selectedTaskNumbers: new Set<number>(),
+  selectionAnchor: null,
   toasts: [],
   _version: 0,
 
-  setTasks: (tasks) => set({ tasks }),
+  setTasks: (tasks) => {
+    const { selectedTaskNumbers } = get();
+    if (selectedTaskNumbers.size > 0) {
+      const validNumbers = new Set(tasks.map((t) => t.taskNumber));
+      const pruned = new Set([...selectedTaskNumbers].filter((n) => validNumbers.has(n)));
+      if (pruned.size !== selectedTaskNumbers.size) {
+        set({ tasks, selectedTaskNumbers: pruned, selectionAnchor: pruned.size > 0 ? get().selectionAnchor : null });
+        return;
+      }
+    }
+    set({ tasks });
+  },
 
   invalidateTaskList: () => set((s) => ({ taskVersion: s.taskVersion + 1 })),
 
@@ -160,8 +182,44 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
       activeBadgeDrag: null,
       badgeDragOverTask: null,
       activeModal: null,
+      selectedTaskNumbers: new Set<number>(),
+      selectionAnchor: null,
       _version: 0,
     });
+  },
+
+  toggleTaskSelection: (taskNumber) => {
+    const prev = get().selectedTaskNumbers;
+    const next = new Set(prev);
+    if (next.has(taskNumber)) {
+      next.delete(taskNumber);
+    } else {
+      next.add(taskNumber);
+    }
+    set({ selectedTaskNumbers: next, selectionAnchor: taskNumber });
+  },
+
+  selectTaskRange: (taskNumber, orderedTaskNumbers) => {
+    const { selectionAnchor } = get();
+    if (selectionAnchor == null) {
+      // No anchor — treat as toggle
+      const next = new Set(get().selectedTaskNumbers);
+      next.add(taskNumber);
+      set({ selectedTaskNumbers: next, selectionAnchor: taskNumber });
+      return;
+    }
+    const anchorIdx = orderedTaskNumbers.indexOf(selectionAnchor);
+    const targetIdx = orderedTaskNumbers.indexOf(taskNumber);
+    if (anchorIdx === -1 || targetIdx === -1) return;
+    const start = Math.min(anchorIdx, targetIdx);
+    const end = Math.max(anchorIdx, targetIdx);
+    const rangeNumbers = orderedTaskNumbers.slice(start, end + 1);
+    const next = new Set([...get().selectedTaskNumbers, ...rangeNumbers]);
+    set({ selectedTaskNumbers: next });
+  },
+
+  clearSelection: () => {
+    set({ selectedTaskNumbers: new Set<number>(), selectionAnchor: null });
   },
 
   loadTasks: async (projectPath) => {


### PR DESCRIPTION
## Summary
- Multi-select tasks on the kanban board with bulk action bar
- Multi-drag support: dragging a selected card moves the whole selection
- Escape clears selection before closing the board