### PR TITLE
Gate canvas layout behind experimental project setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Component, useCallback, useEffect, useState, type ErrorInfo, type ReactNode } from 'react';
 import { useIPCListeners } from './hooks/useIPCListeners';
 import { useAppStore } from './stores/appStore';
+import { useExperimentalStore } from './stores/experimentalStore';
 import { TitleBar } from './components/TitleBarReact';
 import { Sidebar } from './components/SidebarReact';
 import { HomeView } from './components/HomeViewReact';
@@ -53,9 +54,17 @@ export function App() {
   useIPCListeners();
 
   const activeView = useAppStore((s) => s.activeView);
+  const activeProjectPath = useAppStore((s) => s.activeProjectPath);
   const whatsNew = useAppStore((s) => s.whatsNew);
   const [showNewProject, setShowNewProject] = useState(false);
   const [initialized, setInitialized] = useState(false);
+
+  // Hydrate experimental flags whenever the active project changes
+  useEffect(() => {
+    if (activeProjectPath) {
+      useExperimentalStore.getState().loadFor(activeProjectPath);
+    }
+  }, [activeProjectPath]);
 
   // Prevent Electron drag/drop navigation
   useEffect(() => {

--- a/src/components/ProjectViewReact.tsx
+++ b/src/components/ProjectViewReact.tsx
@@ -3,6 +3,7 @@ import { useAppStore } from '../stores/appStore';
 import { useProjectStore } from '../stores/projectStore';
 import { useTerminalStore, getTerminalIndexByStackPosition, STACK_PAGE_SIZE } from '../stores/terminalStore';
 import { useCanvasStore, persistCanvas } from '../stores/canvasStore';
+import { useExperimentalStore } from '../stores/experimentalStore';
 import { TerminalCardStack } from './terminal/TerminalCardStack';
 import { TerminalCanvas, syncCanvasWithTerminals } from './canvas/TerminalCanvas';
 import { KanbanBoard } from './kanban/KanbanBoard';
@@ -47,6 +48,9 @@ export function ProjectView() {
   const kanbanVisible = useProjectStore((s) => s.kanbanVisible);
   const activePanel = useProjectStore((s) => s.activePanel);
   const terminalLayout = useProjectStore((s) => s.terminalLayout);
+  const canvasEnabled = useExperimentalStore((s) =>
+    projectPath ? (s.flagsByProject[projectPath]?.canvas ?? false) : false,
+  );
 
   const activeIndex = useTerminalStore((s) => (projectPath ? (s.activeIndices[projectPath] ?? 0) : 0));
   const terminalList = useTerminalStore((s) => (projectPath ? s.terminalsByProject[projectPath] : undefined));
@@ -102,8 +106,8 @@ export function ProjectView() {
         return;
       }
 
-      // Cmd+L — toggle terminal layout (stack / canvas)
-      if (key === 'l') {
+      // Cmd+L — toggle terminal layout (stack / canvas) — only when canvas is enabled
+      if (key === 'l' && canvasEnabled) {
         e.preventDefault();
         e.stopPropagation();
         useProjectStore.getState().toggleTerminalLayout();
@@ -111,7 +115,7 @@ export function ProjectView() {
       }
 
       // Cmd+G / Cmd+Shift+G — group/ungroup (canvas mode only)
-      if (key === 'g' && useProjectStore.getState().terminalLayout === 'canvas') {
+      if (key === 'g' && canvasEnabled && useProjectStore.getState().terminalLayout === 'canvas') {
         e.preventDefault();
         e.stopPropagation();
         if (e.shiftKey) {
@@ -221,7 +225,14 @@ export function ProjectView() {
 
     document.addEventListener('keydown', handler, true);
     return () => document.removeEventListener('keydown', handler, true);
-  }, [projectPath]);
+  }, [projectPath, canvasEnabled]);
+
+  // Force layout back to stack if the canvas flag gets disabled while active
+  useEffect(() => {
+    if (!canvasEnabled && terminalLayout === 'canvas') {
+      useProjectStore.getState().setTerminalLayout('stack');
+    }
+  }, [canvasEnabled, terminalLayout]);
 
   // Reconnect orphaned sessions, or show kanban if none exist
   useEffect(() => {
@@ -343,7 +354,7 @@ export function ProjectView() {
   }
 
   const renderTerminals = () => {
-    if (terminalLayout === 'canvas') {
+    if (canvasEnabled && terminalLayout === 'canvas') {
       return <TerminalCanvas projectPath={projectPath} />;
     }
     return <TerminalCardStack projectPath={projectPath} />;

--- a/src/components/TitleBarReact.tsx
+++ b/src/components/TitleBarReact.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAppStore } from '../stores/appStore';
 import { useProjectStore, type TerminalLayout } from '../stores/projectStore';
+import { useExperimentalStore } from '../stores/experimentalStore';
 import { useUIStore } from '../stores/uiStore';
 import { stringToColor, getInitials } from '../utils/projectIcon';
 import { Icon } from './terminal/Icon';
@@ -23,6 +24,9 @@ export function TitleBar({ mode }: TitleBarProps) {
   const kanbanVisible = useProjectStore((s) => s.kanbanVisible);
   const terminalLayout = useProjectStore((s) => s.terminalLayout);
   const activePanel = useProjectStore((s) => s.activePanel);
+  const canvasEnabled = useExperimentalStore((s) =>
+    activeProjectPath ? (s.flagsByProject[activeProjectPath]?.canvas ?? false) : false,
+  );
   const homeGroupMode = useUIStore((s) => s.homeGroupMode);
   const [username, setUsername] = useState('');
 
@@ -138,13 +142,15 @@ export function TitleBar({ mode }: TitleBarProps) {
               >
                 <Icon name="cards-three" />
               </TooltipButton>
-              <TooltipButton
-                text="Canvas"
-                className={`w-9 h-full flex items-center justify-center text-text-secondary transition-all duration-150 ease-out hover:text-text-primary hover:bg-background-tertiary [&>svg]:w-5 [&>svg]:h-5${activePanel !== 'settings' && !kanbanVisible && terminalLayout === 'canvas' ? ' text-text-primary bg-background-tertiary' : ''}`}
-                onClick={() => handleToggleView('canvas')}
-              >
-                <CanvasIcon />
-              </TooltipButton>
+              {canvasEnabled && (
+                <TooltipButton
+                  text="Canvas"
+                  className={`w-9 h-full flex items-center justify-center text-text-secondary transition-all duration-150 ease-out hover:text-text-primary hover:bg-background-tertiary [&>svg]:w-5 [&>svg]:h-5${activePanel !== 'settings' && !kanbanVisible && terminalLayout === 'canvas' ? ' text-text-primary bg-background-tertiary' : ''}`}
+                  onClick={() => handleToggleView('canvas')}
+                >
+                  <CanvasIcon />
+                </TooltipButton>
+              )}
               <TooltipButton
                 text="Settings"
                 className={`w-9 h-full flex items-center justify-center text-text-secondary transition-all duration-150 ease-out hover:text-text-primary hover:bg-background-tertiary [&>svg]:w-5 [&>svg]:h-5${activePanel === 'settings' ? ' text-text-primary bg-background-tertiary' : ''}`}

--- a/src/components/scripts/ExperimentalFeaturesSection.tsx
+++ b/src/components/scripts/ExperimentalFeaturesSection.tsx
@@ -1,0 +1,63 @@
+import { useExperimentalStore } from '../../stores/experimentalStore';
+import { useProjectStore } from '../../stores/projectStore';
+
+interface ExperimentalFeaturesSectionProps {
+  projectPath: string;
+}
+
+export function ExperimentalFeaturesSection({ projectPath }: ExperimentalFeaturesSectionProps) {
+  const flags = useExperimentalStore((s) => s.flagsByProject[projectPath]);
+  const canvasEnabled = flags?.canvas ?? false;
+
+  const handleToggleCanvas = async () => {
+    const next = !canvasEnabled;
+    await useExperimentalStore.getState().setFlag(projectPath, 'canvas', next);
+    if (!next && useProjectStore.getState().terminalLayout === 'canvas') {
+      useProjectStore.getState().setTerminalLayout('stack');
+    }
+  };
+
+  return (
+    <div className="border border-white/10 rounded-[14px] overflow-hidden divide-y divide-white/[0.06] bg-[var(--color-terminal-bg,#171717)]">
+      <ToggleRow
+        label="Canvas layout"
+        description="React-flow based free-form terminal canvas with grouping and chain edges."
+        checked={canvasEnabled}
+        onChange={handleToggleCanvas}
+      />
+    </div>
+  );
+}
+
+interface ToggleRowProps {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: () => void;
+}
+
+function ToggleRow({ label, description, checked, onChange }: ToggleRowProps) {
+  return (
+    <label className="flex items-center gap-4 px-4 py-3 hover:bg-white/[0.02]">
+      <div className="flex-1 min-w-0">
+        <div className="text-sm text-text-primary">{label}</div>
+        <div className="text-xs text-text-tertiary mt-0.5">{description}</div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={onChange}
+        className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-150 ${
+          checked ? 'bg-blue-500' : 'bg-white/15'
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-150 ${
+            checked ? 'translate-x-[18px]' : 'translate-x-[2px]'
+          }`}
+        />
+      </button>
+    </label>
+  );
+}

--- a/src/components/scripts/ProjectSettingsPanel.tsx
+++ b/src/components/scripts/ProjectSettingsPanel.tsx
@@ -5,6 +5,7 @@ import { ScriptList } from './ScriptList';
 import { HookList } from './HookList';
 import type { HookEntry } from './HookList';
 import { SandboxSection } from './SandboxSection';
+import { ExperimentalFeaturesSection } from './ExperimentalFeaturesSection';
 
 const LIFECYCLE_HOOKS: HookEntry[] = [
   { type: 'start', label: 'Start', description: 'Runs when a task moves to In Progress' },
@@ -90,6 +91,13 @@ export function ProjectSettingsPanel({ projectPath }: ProjectSettingsPanelProps)
               <SandboxSection projectPath={projectPath} />
             </section>
           )}
+          <section>
+            <h2 className="text-sm font-semibold text-text-primary mb-2">Experimental</h2>
+            <p className="text-xs text-text-tertiary mb-4">
+              Unstable features that may change or be removed in future releases.
+            </p>
+            <ExperimentalFeaturesSection projectPath={projectPath} />
+          </section>
         </div>
       </div>
     </div>

--- a/src/ipc/handlers/settings.ts
+++ b/src/ipc/handlers/settings.ts
@@ -3,7 +3,7 @@ import { getGlobalSetting, setGlobalSetting } from '../../db';
 
 /** Check if a settings key is allowed through the IPC boundary */
 function isAllowedKey(key: string): boolean {
-  return key === 'lastActiveView' || key.startsWith('canvas:');
+  return key === 'lastActiveView' || key.startsWith('canvas:') || key.startsWith('experimental:');
 }
 
 /** Maximum value length (bytes) to prevent abuse */

--- a/src/stores/experimentalStore.ts
+++ b/src/stores/experimentalStore.ts
@@ -1,0 +1,76 @@
+import { create } from 'zustand';
+import log from 'electron-log/renderer';
+
+const experimentalLog = log.scope('experimental');
+
+export interface ExperimentalFlags {
+  canvas: boolean;
+}
+
+const DEFAULT_FLAGS: ExperimentalFlags = {
+  canvas: false,
+};
+
+interface ExperimentalStoreState {
+  flagsByProject: Record<string, ExperimentalFlags>;
+}
+
+interface ExperimentalStoreActions {
+  loadFor: (projectPath: string) => Promise<void>;
+  setFlag: <K extends keyof ExperimentalFlags>(
+    projectPath: string,
+    name: K,
+    value: ExperimentalFlags[K],
+  ) => Promise<void>;
+  getFlags: (projectPath: string) => ExperimentalFlags;
+}
+
+type ExperimentalStore = ExperimentalStoreState & ExperimentalStoreActions;
+
+function storageKey(projectPath: string): string {
+  return 'experimental:' + projectPath;
+}
+
+export const useExperimentalStore = create<ExperimentalStore>()((set, get) => ({
+  flagsByProject: {},
+
+  getFlags: (projectPath) => get().flagsByProject[projectPath] ?? DEFAULT_FLAGS,
+
+  loadFor: async (projectPath) => {
+    try {
+      const json = await window.api.globalSettings.get(storageKey(projectPath));
+      const parsed = json ? (JSON.parse(json) as Partial<ExperimentalFlags>) : {};
+      set((s) => ({
+        flagsByProject: {
+          ...s.flagsByProject,
+          [projectPath]: { ...DEFAULT_FLAGS, ...parsed },
+        },
+      }));
+    } catch (error) {
+      experimentalLog.error('failed to load flags', {
+        projectPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      set((s) => ({
+        flagsByProject: { ...s.flagsByProject, [projectPath]: { ...DEFAULT_FLAGS } },
+      }));
+    }
+  },
+
+  setFlag: async (projectPath, name, value) => {
+    const current = get().flagsByProject[projectPath] ?? DEFAULT_FLAGS;
+    const next = { ...current, [name]: value };
+    set((s) => ({
+      flagsByProject: { ...s.flagsByProject, [projectPath]: next },
+    }));
+    try {
+      await window.api.globalSettings.set(storageKey(projectPath), JSON.stringify(next));
+    } catch (error) {
+      experimentalLog.error('failed to persist flag', {
+        projectPath,
+        name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  },
+}));


### PR DESCRIPTION
## Summary

- New "Experimental" section in Project Settings with a per-project Canvas toggle (default off).
- When the flag is off, the canvas titlebar button, Cmd+L layout toggle, and Cmd+G grouping shortcuts are inert and the layout falls back to the terminal stack. If the flag is flipped off while the canvas is active, the layout snaps back to stack immediately.
- Flag is persisted in the existing `globalSettings` KV store under `experimental:<projectPath>` as a JSON blob, so future experimental flags can be added without further IPC allowlist changes — no DB migration, no `project_settings` schema changes.