### PR TITLE
Isolate gitignored dirs in Lima sandbox via bind-mount overlay

### DIFF
--- a/src/__tests__/sandboxedTask.test.ts
+++ b/src/__tests__/sandboxedTask.test.ts
@@ -1,0 +1,267 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as realFs from 'node:fs';
+import { createTask, getTaskByNumber } from '../db';
+
+// Mock child_process so git commands don't actually run.
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+  exec: vi.fn((_cmd: string, _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+    cb(null, { stdout: 'main\n', stderr: '' });
+  }),
+  execFile: vi.fn(
+    (
+      _file: string,
+      args: string[],
+      _opts: unknown,
+      cb: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      if (Array.isArray(args) && args.includes('--verify')) {
+        cb(new Error('not found'), '', '');
+      } else {
+        cb(null, '', '');
+      }
+    },
+  ),
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    mkdir: vi.fn(async () => undefined),
+    access: vi.fn(async () => {
+      throw new Error('ENOENT');
+    }),
+    cp: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock('koffi', () => ({
+  default: { load: vi.fn() },
+}));
+
+// Mock runInVm so it doesn't try to reach limactl during tests.
+const { runInVmMock } = vi.hoisted(() => ({ runInVmMock: vi.fn(async () => undefined) }));
+vi.mock('../lima/manager', () => ({
+  runInVm: runInVmMock,
+}));
+
+import { createTaskWorktree, startTask, recoverTaskWorktree, removeTaskWorktree } from '../worktree';
+import { beginTask, createBranchFromTask } from '../taskLifecycle';
+import { parseIgnoredDirs, buildOverlayBindMountSetup } from '../lima/overlay';
+import { exec as execMockedRaw } from 'node:child_process';
+
+const execMocked = vi.mocked(execMockedRaw);
+
+function findLsFilesCall(): unknown[] | undefined {
+  return execMocked.mock.calls.find(
+    (call) => typeof call[0] === 'string' && (call[0] as string).includes('git ls-files'),
+  ) as unknown[] | undefined;
+}
+
+beforeEach(() => {
+  runInVmMock.mockClear();
+  execMocked.mockClear();
+});
+
+describe('createTaskWorktree sandboxed behavior', () => {
+  test('persists sandboxed=true on the task row', async () => {
+    const project = '/test/sandboxed-create-persists';
+    const result = await createTaskWorktree(project, 'Sandboxed task', undefined, undefined, true);
+    expect(result.success).toBe(true);
+    const task = await getTaskByNumber(project, result.task!.taskNumber);
+    expect(task!.sandboxed).toBe(true);
+  });
+
+  test('skips git ls-files (and copyGitIgnoredFiles) when sandboxed', async () => {
+    const project = '/test/sandboxed-create-skip';
+    const result = await createTaskWorktree(project, 'Sandboxed', undefined, undefined, true);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeUndefined();
+  });
+
+  test('still calls git ls-files when not sandboxed (regression guard)', async () => {
+    const project = '/test/sandboxed-create-regression';
+    const result = await createTaskWorktree(project, 'Normal', undefined, undefined, false);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeDefined();
+  });
+});
+
+describe('beginTask sandbox propagation', () => {
+  test('forwards task.sandboxed into startTask (skips copy)', async () => {
+    const project = '/test/sandboxed-begin';
+    await createTask(project, 1, 'Sandboxed todo', { status: 'todo', sandboxed: true });
+
+    const result = await beginTask(project, 1);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeUndefined();
+  });
+
+  test('non-sandboxed begin still copies', async () => {
+    const project = '/test/nonsandboxed-begin';
+    await createTask(project, 1, 'Regular todo', { status: 'todo' });
+
+    const result = await beginTask(project, 1);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeDefined();
+  });
+});
+
+describe('recoverTaskWorktree sandbox behavior', () => {
+  test('skips copyGitIgnoredFiles when task is sandboxed', async () => {
+    const project = '/test/sandboxed-recover';
+    await createTask(project, 7, 'Sandbox recovered', {
+      branch: 'feat/sandbox-recover',
+      status: 'in_progress',
+      sandboxed: true,
+      worktreePath: '/old/path',
+    });
+
+    const result = await recoverTaskWorktree(project, 7);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeUndefined();
+  });
+});
+
+describe('createBranchFromTask sandbox inheritance', () => {
+  test('child inherits sandboxed flag from sandboxed parent', async () => {
+    const project = '/test/sandbox-inherit';
+    await createTask(project, 1, 'Sandbox parent', {
+      branch: 'feat/parent',
+      status: 'in_progress',
+      sandboxed: true,
+    });
+
+    const result = await createBranchFromTask(project, 1, 'Child');
+    expect(result.success).toBe(true);
+    expect(result.task!.sandboxed).toBe(true);
+  });
+
+  test('child of non-sandboxed parent is not sandboxed', async () => {
+    const project = '/test/sandbox-inherit-none';
+    await createTask(project, 1, 'Regular parent', { branch: 'feat/parent', status: 'in_progress' });
+
+    const result = await createBranchFromTask(project, 1, 'Child');
+    expect(result.success).toBe(true);
+    expect(result.task!.sandboxed).toBeUndefined();
+  });
+});
+
+describe('removeTaskWorktree overlay cleanup', () => {
+  test('calls runInVm with the expected overlay path when task is sandboxed', async () => {
+    const project = '/test/sandbox-remove';
+    await createTask(project, 4, 'Sandbox delete', {
+      branch: 'feat/del',
+      worktreePath: '/worktrees/T-4',
+      sandboxed: true,
+    });
+
+    const result = await removeTaskWorktree(project, '/worktrees/T-4', 4);
+    expect(result.success).toBe(true);
+    expect(runInVmMock).toHaveBeenCalledTimes(1);
+    const [passedProject, passedCmd] = runInVmMock.mock.calls[0] as [string, string];
+    expect(passedProject).toBe(project);
+    expect(passedCmd).toBe('rm -rf /var/lib/ouijit/overlays/T-4');
+  });
+
+  test('does not call runInVm when task is not sandboxed', async () => {
+    const project = '/test/regular-remove';
+    await createTask(project, 4, 'Regular delete', {
+      branch: 'feat/reg',
+      worktreePath: '/worktrees/T-4',
+    });
+
+    const result = await removeTaskWorktree(project, '/worktrees/T-4', 4);
+    expect(result.success).toBe(true);
+    expect(runInVmMock).not.toHaveBeenCalled();
+  });
+
+  test('swallows runInVm errors', async () => {
+    runInVmMock.mockRejectedValueOnce(new Error('VM not running'));
+    const project = '/test/sandbox-remove-error';
+    await createTask(project, 9, 'Sandbox delete err', {
+      branch: 'feat/err',
+      worktreePath: '/worktrees/T-9',
+      sandboxed: true,
+    });
+
+    const result = await removeTaskWorktree(project, '/worktrees/T-9', 9);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('startTask sandbox flag', () => {
+  test('sandboxed=true skips ls-files', async () => {
+    const project = '/test/start-sandbox';
+    await createTask(project, 1, 'Sandbox todo', { status: 'todo' });
+
+    const result = await startTask(project, 1, undefined, undefined, true);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeUndefined();
+  });
+});
+
+describe('parseIgnoredDirs', () => {
+  const tmpRoot = realFs.mkdtempSync(path.join(os.tmpdir(), 'ouijit-parse-'));
+
+  function writeGitignore(name: string, contents: string): string {
+    const dir = path.join(tmpRoot, name);
+    realFs.mkdirSync(dir, { recursive: true });
+    realFs.writeFileSync(path.join(dir, '.gitignore'), contents);
+    return dir;
+  }
+
+  test('returns [] when .gitignore is missing', async () => {
+    const dir = path.join(tmpRoot, 'no-gitignore');
+    realFs.mkdirSync(dir, { recursive: true });
+    expect(await parseIgnoredDirs(dir)).toEqual([]);
+  });
+
+  test('returns [] for an empty .gitignore', async () => {
+    const dir = writeGitignore('empty', '');
+    expect(await parseIgnoredDirs(dir)).toEqual([]);
+  });
+
+  test('accepts common bare directories', async () => {
+    const dir = writeGitignore('common', ['node_modules', 'target', 'dist/', '/.venv', ''].join('\n'));
+    const result = await parseIgnoredDirs(dir);
+    expect(result).toEqual(['node_modules', 'target', 'dist', '.venv']);
+  });
+
+  test('rejects globs, negations, nested paths, comments', async () => {
+    const dir = writeGitignore(
+      'unsupported',
+      ['# a comment', '', '*.log', '**/build', 'build-*', '!keep', 'src/generated/', 'node_modules'].join('\n'),
+    );
+    expect(await parseIgnoredDirs(dir)).toEqual(['node_modules']);
+  });
+
+  test('dedupes repeated entries (node_modules and node_modules/)', async () => {
+    const dir = writeGitignore('dedupe', ['node_modules', 'node_modules/'].join('\n'));
+    expect(await parseIgnoredDirs(dir)).toEqual(['node_modules']);
+  });
+});
+
+describe('buildOverlayBindMountSetup', () => {
+  test('returns empty string when dirs is empty', () => {
+    expect(buildOverlayBindMountSetup({ worktreePath: '/w', taskId: 1, dirs: [] })).toBe('');
+  });
+
+  test('emits bash with taskId and worktree quoted', () => {
+    const script = buildOverlayBindMountSetup({
+      worktreePath: "/w with 'quote",
+      taskId: 42,
+      dirs: ['node_modules', '.venv'],
+    });
+    expect(script).toContain("TASK='42'");
+    expect(script).toContain("WORKTREE='/w with '\\''quote'");
+    expect(script).toContain('node_modules');
+    expect(script).toContain('.venv');
+    expect(script).toContain('mount --bind');
+    expect(script).toContain('trap _ouijit_overlay_cleanup EXIT');
+    expect(script).toContain('OUIJIT_IGNORED_DIRS_EOF');
+  });
+});

--- a/src/__tests__/sandboxedTask.test.ts
+++ b/src/__tests__/sandboxedTask.test.ts
@@ -50,7 +50,7 @@ vi.mock('../lima/manager', () => ({
 
 import { createTaskWorktree, startTask, recoverTaskWorktree, removeTaskWorktree } from '../worktree';
 import { beginTask, createBranchFromTask } from '../taskLifecycle';
-import { parseIgnoredDirs, buildOverlayBindMountSetup } from '../lima/overlay';
+import { parseIgnoredDirs, buildOverlayBindMountSetup, buildOverlayCleanup } from '../lima/overlay';
 import { exec as execMockedRaw } from 'node:child_process';
 
 const execMocked = vi.mocked(execMockedRaw);
@@ -151,7 +151,7 @@ describe('createBranchFromTask sandbox inheritance', () => {
 });
 
 describe('removeTaskWorktree overlay cleanup', () => {
-  test('calls runInVm with the expected overlay path when task is sandboxed', async () => {
+  test('runs the cleanup script in the VM when task is sandboxed', async () => {
     const project = '/test/sandbox-remove';
     await createTask(project, 4, 'Sandbox delete', {
       branch: 'feat/del',
@@ -164,7 +164,11 @@ describe('removeTaskWorktree overlay cleanup', () => {
     expect(runInVmMock).toHaveBeenCalledTimes(1);
     const [passedProject, passedCmd] = runInVmMock.mock.calls[0] as [string, string];
     expect(passedProject).toBe(project);
-    expect(passedCmd).toBe('rm -rf /var/lib/ouijit/overlays/T-4');
+    // Cleanup script must umount before rm -rf and target the right task overlay.
+    expect(passedCmd).toContain("TASK='4'");
+    expect(passedCmd).toContain('/var/lib/ouijit/overlays/T-$TASK');
+    expect(passedCmd).toContain('umount');
+    expect(passedCmd).toContain('rm -rf "$OVERLAY_ROOT"');
   });
 
   test('does not call runInVm when task is not sandboxed', async () => {
@@ -234,13 +238,18 @@ describe('parseIgnoredDirs', () => {
   test('rejects globs, negations, nested paths, comments', async () => {
     const dir = writeGitignore(
       'unsupported',
-      ['# a comment', '', '*.log', '**/build', 'build-*', '!keep', 'src/generated/', 'node_modules'].join('\n'),
+      ['# a comment', '', '*.log', 'build-*', '!keep', 'src/generated/', 'node_modules'].join('\n'),
     );
     expect(await parseIgnoredDirs(dir)).toEqual(['node_modules']);
   });
 
-  test('dedupes repeated entries (node_modules and node_modules/)', async () => {
-    const dir = writeGitignore('dedupe', ['node_modules', 'node_modules/'].join('\n'));
+  test('accepts **/<name> shorthand for a single bare dir', async () => {
+    const dir = writeGitignore('recursive', ['**/build', '**/node_modules', '**/nested/dir'].join('\n'));
+    expect(await parseIgnoredDirs(dir)).toEqual(['build', 'node_modules']);
+  });
+
+  test('dedupes across plain, trailing slash, and **/ forms', async () => {
+    const dir = writeGitignore('dedupe', ['node_modules', 'node_modules/', '**/node_modules'].join('\n'));
     expect(await parseIgnoredDirs(dir)).toEqual(['node_modules']);
   });
 });
@@ -261,7 +270,53 @@ describe('buildOverlayBindMountSetup', () => {
     expect(script).toContain('node_modules');
     expect(script).toContain('.venv');
     expect(script).toContain('mount --bind');
-    expect(script).toContain('trap _ouijit_overlay_cleanup EXIT');
     expect(script).toContain('OUIJIT_IGNORED_DIRS_EOF');
+  });
+
+  test('does NOT use a trap (would not survive exec bash)', () => {
+    const script = buildOverlayBindMountSetup({ worktreePath: '/w', taskId: 1, dirs: ['node_modules'] });
+    expect(script).not.toContain('trap ');
+  });
+
+  test('does NOT use set -e (overlay setup must be best-effort)', () => {
+    const script = buildOverlayBindMountSetup({ worktreePath: '/w', taskId: 1, dirs: ['node_modules'] });
+    expect(script).not.toMatch(/^set -e/m);
+  });
+
+  test('script passes `bash -n` syntax check', async () => {
+    const realCp = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+    const script = buildOverlayBindMountSetup({
+      worktreePath: "/w with 'quote and $danger",
+      taskId: 7,
+      dirs: ['node_modules', '.venv', 'target'],
+    });
+    expect(() => realCp.execSync('bash -n', { input: script })).not.toThrow();
+  });
+});
+
+describe('buildOverlayCleanup', () => {
+  test('emits bash that removes the per-task overlay root', () => {
+    const script = buildOverlayCleanup(13);
+    expect(script).toContain("TASK='13'");
+    expect(script).toContain('/var/lib/ouijit/overlays/T-$TASK');
+    expect(script).toContain('umount');
+    expect(script).toContain('rm -rf "$OVERLAY_ROOT"');
+  });
+
+  test('reads stashed worktree path and dirs sidecar files', () => {
+    const script = buildOverlayCleanup(13);
+    expect(script).toContain('$OVERLAY_ROOT/.worktree');
+    expect(script).toContain('$OVERLAY_ROOT/.dirs');
+  });
+
+  test('falls back to /proc/self/mountinfo for orphaned mounts', () => {
+    const script = buildOverlayCleanup(13);
+    expect(script).toContain('/proc/self/mountinfo');
+  });
+
+  test('script passes `bash -n` syntax check', async () => {
+    const realCp = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+    const script = buildOverlayCleanup(99);
+    expect(() => realCp.execSync('bash -n', { input: script })).not.toThrow();
   });
 });

--- a/src/__tests__/sandboxedTask.test.ts
+++ b/src/__tests__/sandboxedTask.test.ts
@@ -66,7 +66,12 @@ vi.mock('../lima/manager', () => ({
 
 import { createTaskWorktree, startTask, recoverTaskWorktree, removeTaskWorktree } from '../worktree';
 import { beginTask, createBranchFromTask } from '../taskLifecycle';
-import { listMaskedPaths, buildOverlayBindMountSetup, buildOverlayCleanup } from '../lima/overlay';
+import {
+  listMaskedPaths,
+  buildOverlayBindMountSetup,
+  buildOverlayCleanup,
+  buildSandboxNoMatchesBanner,
+} from '../lima/overlay';
 import { exec as execMockedRaw } from 'node:child_process';
 
 const execMocked = vi.mocked(execMockedRaw);
@@ -246,10 +251,10 @@ describe('listMaskedPaths', () => {
     return dir;
   }
 
-  test('returns [] for a non-repo directory', async () => {
+  test('throws for a non-repo directory (enumeration failure is not silent)', async () => {
     const dir = path.join(tmpRoot, 'not-a-repo');
     realFs.mkdirSync(dir, { recursive: true });
-    expect(await listMaskedPaths(dir)).toEqual([]);
+    await expect(listMaskedPaths(dir)).rejects.toThrow(/git ls-files failed/);
   });
 
   test('returns [] when .gitignore matches nothing on disk', async () => {
@@ -391,6 +396,50 @@ describe('buildOverlayBindMountSetup', () => {
     expect(script).not.toMatch(/^set -e/m);
   });
 
+  test('sudo-unavailable path emits a red ANSI banner and returns 1 (fail-closed)', () => {
+    const script = buildOverlayBindMountSetup({
+      worktreePath: '/w',
+      taskId: 1,
+      masks: [{ relPath: 'node_modules', type: 'directory' }],
+    });
+    // The gray stderr echo from the old silent-skip is gone.
+    expect(script).not.toContain('sandbox overlay skipped');
+    // Red background + white foreground + bold banner.
+    expect(script).toContain('\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m');
+    // The sudo-missing branch returns 1 so the shell refuses to start.
+    expect(script).toMatch(/passwordless sudo is unavailable[\s\S]*?return 1/);
+    // Banner goes to stderr, not stdout which could be captured.
+    expect(script).toMatch(/SANDBOX ISOLATION FAILED.*\\033\[0m.*>&2/);
+  });
+
+  test('emits green ACTIVE banner on full success and red FAILED banners on total/partial failure', () => {
+    const script = buildOverlayBindMountSetup({
+      worktreePath: '/w',
+      taskId: 1,
+      masks: [{ relPath: 'node_modules', type: 'directory' }],
+    });
+    // Success is the only path that returns 0 + green banner.
+    expect(script).toContain('\\033[1;97;42m  SANDBOX ISOLATION ACTIVE  \\033[0m');
+    // Both total-failure and partial-failure use the red "FAILED" background.
+    expect(script).toContain('\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m');
+    expect(script).toContain('\\033[1;97;41m  SANDBOX ISOLATION PARTIAL  \\033[0m');
+    // Counters that feed the banner.
+    expect(script).toContain('local TOTAL=0 OK=0 FAIL=0');
+    // Any failure returns 1 — fail-closed.
+    expect(script).toMatch(/refusing to start/);
+  });
+
+  test('caller checks the function return code and exits before exec bash (fail-closed)', () => {
+    const script = buildOverlayBindMountSetup({
+      worktreePath: '/w',
+      taskId: 1,
+      masks: [{ relPath: 'node_modules', type: 'directory' }],
+    });
+    // After calling the setup function, the script captures $? and exits if non-zero.
+    expect(script).toContain('_OUIJIT_OVERLAY_RC=$?');
+    expect(script).toMatch(/if \[ "\$_OUIJIT_OVERLAY_RC" -ne 0 \]; then[\s\S]*?exit 1/);
+  });
+
   test('script passes `bash -n` with mixed file + dir masks', async () => {
     const realCp = await vi.importActual<typeof import('node:child_process')>('node:child_process');
     const script = buildOverlayBindMountSetup({
@@ -405,6 +454,26 @@ describe('buildOverlayBindMountSetup', () => {
       ],
     });
     expect(() => realCp.execSync('bash -n', { input: script })).not.toThrow();
+  });
+});
+
+describe('buildSandboxNoMatchesBanner', () => {
+  test('emits a yellow warning banner to stderr', () => {
+    const banner = buildSandboxNoMatchesBanner();
+    expect(banner).toContain('\\033[1;30;43m  SANDBOX NO PATHS TO ISOLATE  \\033[0m');
+    expect(banner).toContain('no gitignored paths were found');
+    expect(banner).toContain('>&2');
+  });
+
+  test('does NOT return or exit non-zero — zero-matches is proceed-with-warning', () => {
+    const banner = buildSandboxNoMatchesBanner();
+    expect(banner).not.toMatch(/\breturn 1\b/);
+    expect(banner).not.toMatch(/\bexit 1\b/);
+  });
+
+  test('banner passes `bash -n`', async () => {
+    const realCp = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+    expect(() => realCp.execSync('bash -n', { input: buildSandboxNoMatchesBanner() })).not.toThrow();
   });
 });
 

--- a/src/__tests__/sandboxedTask.test.ts
+++ b/src/__tests__/sandboxedTask.test.ts
@@ -4,27 +4,43 @@ import * as path from 'node:path';
 import * as realFs from 'node:fs';
 import { createTask, getTaskByNumber } from '../db';
 
-// Mock child_process so git commands don't actually run.
-vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
-  exec: vi.fn((_cmd: string, _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
-    cb(null, { stdout: 'main\n', stderr: '' });
-  }),
-  execFile: vi.fn(
-    (
-      _file: string,
-      args: string[],
-      _opts: unknown,
-      cb: (err: Error | null, stdout: string, stderr: string) => void,
-    ) => {
-      if (Array.isArray(args) && args.includes('--verify')) {
-        cb(new Error('not found'), '', '');
-      } else {
-        cb(null, '', '');
-      }
-    },
-  ),
-}));
+// Mock child_process so git commands don't actually run — except for
+// `git ls-files -o -i` calls from listMaskedPaths, which delegate to the
+// real execFile so tests can enumerate gitignored paths in real temp repos.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execSync: vi.fn(),
+    exec: vi.fn((_cmd: string, _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+      cb(null, { stdout: 'main\n', stderr: '' });
+    }),
+    execFile: vi.fn(
+      (
+        file: string,
+        args: string[],
+        opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        // Delegate listMaskedPaths' git ls-files call to the real binary.
+        if (
+          file === 'git' &&
+          Array.isArray(args) &&
+          args.includes('ls-files') &&
+          args.includes('-i') &&
+          args.includes('--exclude-standard')
+        ) {
+          return actual.execFile(file, args, opts as Parameters<typeof actual.execFile>[2], cb);
+        }
+        if (Array.isArray(args) && args.includes('--verify')) {
+          cb(new Error('not found'), '', '');
+        } else {
+          cb(null, '', '');
+        }
+      },
+    ),
+  };
+});
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>();
@@ -50,7 +66,7 @@ vi.mock('../lima/manager', () => ({
 
 import { createTaskWorktree, startTask, recoverTaskWorktree, removeTaskWorktree } from '../worktree';
 import { beginTask, createBranchFromTask } from '../taskLifecycle';
-import { parseIgnoredDirs, buildOverlayBindMountSetup, buildOverlayCleanup } from '../lima/overlay';
+import { listMaskedPaths, buildOverlayBindMountSetup, buildOverlayCleanup } from '../lima/overlay';
 import { exec as execMockedRaw } from 'node:child_process';
 
 const execMocked = vi.mocked(execMockedRaw);
@@ -208,87 +224,185 @@ describe('startTask sandbox flag', () => {
   });
 });
 
-describe('parseIgnoredDirs', () => {
-  const tmpRoot = realFs.mkdtempSync(path.join(os.tmpdir(), 'ouijit-parse-'));
+describe('listMaskedPaths', () => {
+  const tmpRoot = realFs.mkdtempSync(path.join(os.tmpdir(), 'ouijit-mask-'));
 
-  function writeGitignore(name: string, contents: string): string {
+  async function loadRealCp(): Promise<typeof import('node:child_process')> {
+    return await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  }
+
+  async function initRepo(name: string, files: Record<string, string>): Promise<string> {
     const dir = path.join(tmpRoot, name);
     realFs.mkdirSync(dir, { recursive: true });
-    realFs.writeFileSync(path.join(dir, '.gitignore'), contents);
+    const realCp = await loadRealCp();
+    realCp.execSync('git init -q', { cwd: dir });
+    realCp.execSync('git config user.email test@test.example', { cwd: dir });
+    realCp.execSync('git config user.name test', { cwd: dir });
+    for (const [rel, contents] of Object.entries(files)) {
+      const full = path.join(dir, rel);
+      realFs.mkdirSync(path.dirname(full), { recursive: true });
+      realFs.writeFileSync(full, contents);
+    }
     return dir;
   }
 
-  test('returns [] when .gitignore is missing', async () => {
-    const dir = path.join(tmpRoot, 'no-gitignore');
+  test('returns [] for a non-repo directory', async () => {
+    const dir = path.join(tmpRoot, 'not-a-repo');
     realFs.mkdirSync(dir, { recursive: true });
-    expect(await parseIgnoredDirs(dir)).toEqual([]);
+    expect(await listMaskedPaths(dir)).toEqual([]);
   });
 
-  test('returns [] for an empty .gitignore', async () => {
-    const dir = writeGitignore('empty', '');
-    expect(await parseIgnoredDirs(dir)).toEqual([]);
+  test('returns [] when .gitignore matches nothing on disk', async () => {
+    const dir = await initRepo('empty-matches', { '.gitignore': 'node_modules\n' });
+    expect(await listMaskedPaths(dir)).toEqual([]);
   });
 
-  test('accepts common bare directories', async () => {
-    const dir = writeGitignore('common', ['node_modules', 'target', 'dist/', '/.venv', ''].join('\n'));
-    const result = await parseIgnoredDirs(dir);
-    expect(result).toEqual(['node_modules', 'target', 'dist', '.venv']);
+  test('collapses a populated ignored directory to a single dir entry', async () => {
+    const dir = await initRepo('dir-collapse', {
+      '.gitignore': 'node_modules\n',
+      'node_modules/a/index.js': '',
+      'node_modules/b/index.js': '',
+    });
+    expect(await listMaskedPaths(dir)).toEqual([{ relPath: 'node_modules', type: 'directory' }]);
   });
 
-  test('rejects globs, negations, nested paths, comments', async () => {
-    const dir = writeGitignore(
-      'unsupported',
-      ['# a comment', '', '*.log', 'build-*', '!keep', 'src/generated/', 'node_modules'].join('\n'),
-    );
-    expect(await parseIgnoredDirs(dir)).toEqual(['node_modules']);
+  test('detects a gitignored file at the repo root', async () => {
+    const dir = await initRepo('file-root', { '.gitignore': '.env\n', '.env': 'SECRET=1' });
+    expect(await listMaskedPaths(dir)).toEqual([{ relPath: '.env', type: 'file' }]);
   });
 
-  test('accepts **/<name> shorthand for a single bare dir', async () => {
-    const dir = writeGitignore('recursive', ['**/build', '**/node_modules', '**/nested/dir'].join('\n'));
-    expect(await parseIgnoredDirs(dir)).toEqual(['build', 'node_modules']);
+  test('detects a gitignored file at a nested path', async () => {
+    const dir = await initRepo('file-nested', {
+      '.gitignore': 'config/secrets.yml\n',
+      'config/secrets.yml': 'token: abc',
+      'config/keep.yml': 'ok: true',
+    });
+    const result = await listMaskedPaths(dir);
+    expect(result).toContainEqual({ relPath: 'config/secrets.yml', type: 'file' });
+    expect(result.find((m) => m.relPath === 'config/keep.yml')).toBeUndefined();
   });
 
-  test('dedupes across plain, trailing slash, and **/ forms', async () => {
-    const dir = writeGitignore('dedupe', ['node_modules', 'node_modules/', '**/node_modules'].join('\n'));
-    expect(await parseIgnoredDirs(dir)).toEqual(['node_modules']);
+  test('honors negations (!keep.env is excluded from masks)', async () => {
+    const dir = await initRepo('negation', {
+      '.gitignore': '*.env\n!keep.env\n',
+      'secret.env': 'x',
+      'keep.env': 'y',
+    });
+    const result = await listMaskedPaths(dir);
+    expect(result).toContainEqual({ relPath: 'secret.env', type: 'file' });
+    expect(result.find((m) => m.relPath === 'keep.env')).toBeUndefined();
+  });
+
+  test('honors nested .gitignore files', async () => {
+    const dir = await initRepo('nested-gitignore', {
+      '.gitignore': '',
+      'sub/.gitignore': 'local.log\n',
+      'sub/local.log': 'logs',
+    });
+    const result = await listMaskedPaths(dir);
+    expect(result).toContainEqual({ relPath: 'sub/local.log', type: 'file' });
+  });
+
+  test('expands globs (*.pem)', async () => {
+    const dir = await initRepo('glob', {
+      '.gitignore': '*.pem\n',
+      'a.pem': '',
+      'b.pem': '',
+    });
+    const result = await listMaskedPaths(dir);
+    const pems = result.filter((m) => m.relPath.endsWith('.pem'));
+    expect(pems.map((m) => m.relPath).sort()).toEqual(['a.pem', 'b.pem']);
+    expect(pems.every((m) => m.type === 'file')).toBe(true);
   });
 });
 
 describe('buildOverlayBindMountSetup', () => {
-  test('returns empty string when dirs is empty', () => {
-    expect(buildOverlayBindMountSetup({ worktreePath: '/w', taskId: 1, dirs: [] })).toBe('');
+  test('returns empty string when masks is empty', () => {
+    expect(buildOverlayBindMountSetup({ worktreePath: '/w', taskId: 1, masks: [] })).toBe('');
   });
 
   test('emits bash with taskId and worktree quoted', () => {
     const script = buildOverlayBindMountSetup({
       worktreePath: "/w with 'quote",
       taskId: 42,
-      dirs: ['node_modules', '.venv'],
+      masks: [
+        { relPath: 'node_modules', type: 'directory' },
+        { relPath: '.venv', type: 'directory' },
+      ],
     });
     expect(script).toContain("TASK='42'");
     expect(script).toContain("WORKTREE='/w with '\\''quote'");
-    expect(script).toContain('node_modules');
-    expect(script).toContain('.venv');
+    expect(script).toContain('d node_modules');
+    expect(script).toContain('d .venv');
     expect(script).toContain('mount --bind');
-    expect(script).toContain('OUIJIT_IGNORED_DIRS_EOF');
+    expect(script).toContain('OUIJIT_MASKS_EOF');
+  });
+
+  test('emits both d and f prefixes in the mask heredoc', () => {
+    const script = buildOverlayBindMountSetup({
+      worktreePath: '/w',
+      taskId: 1,
+      masks: [
+        { relPath: 'node_modules', type: 'directory' },
+        { relPath: '.env', type: 'file' },
+        { relPath: 'config/secrets.yml', type: 'file' },
+      ],
+    });
+    expect(script).toContain('d node_modules');
+    expect(script).toContain('f .env');
+    expect(script).toContain('f config/secrets.yml');
+  });
+
+  test('file-mask branch touches overlay and target placeholders', () => {
+    const script = buildOverlayBindMountSetup({
+      worktreePath: '/w',
+      taskId: 1,
+      masks: [{ relPath: '.env', type: 'file' }],
+    });
+    expect(script).toContain('sudo touch "$overlay" "$target"');
+    expect(script).toContain('sudo mkdir -p "$(dirname "$overlay")" "$(dirname "$target")"');
+  });
+
+  test('writes .paths sidecar (not .dirs) for cleanup', () => {
+    const script = buildOverlayBindMountSetup({
+      worktreePath: '/w',
+      taskId: 1,
+      masks: [{ relPath: 'node_modules', type: 'directory' }],
+    });
+    expect(script).toContain('"$OVERLAY_ROOT/.paths"');
+    expect(script).not.toContain('"$OVERLAY_ROOT/.dirs"');
   });
 
   test('does NOT use a trap (would not survive exec bash)', () => {
-    const script = buildOverlayBindMountSetup({ worktreePath: '/w', taskId: 1, dirs: ['node_modules'] });
+    const script = buildOverlayBindMountSetup({
+      worktreePath: '/w',
+      taskId: 1,
+      masks: [{ relPath: 'node_modules', type: 'directory' }],
+    });
     expect(script).not.toContain('trap ');
   });
 
   test('does NOT use set -e (overlay setup must be best-effort)', () => {
-    const script = buildOverlayBindMountSetup({ worktreePath: '/w', taskId: 1, dirs: ['node_modules'] });
+    const script = buildOverlayBindMountSetup({
+      worktreePath: '/w',
+      taskId: 1,
+      masks: [{ relPath: 'node_modules', type: 'directory' }],
+    });
     expect(script).not.toMatch(/^set -e/m);
   });
 
-  test('script passes `bash -n` syntax check', async () => {
+  test('script passes `bash -n` with mixed file + dir masks', async () => {
     const realCp = await vi.importActual<typeof import('node:child_process')>('node:child_process');
     const script = buildOverlayBindMountSetup({
       worktreePath: "/w with 'quote and $danger",
       taskId: 7,
-      dirs: ['node_modules', '.venv', 'target'],
+      masks: [
+        { relPath: 'node_modules', type: 'directory' },
+        { relPath: '.venv', type: 'directory' },
+        { relPath: 'target', type: 'directory' },
+        { relPath: '.env', type: 'file' },
+        { relPath: 'config/secrets.yml', type: 'file' },
+      ],
     });
     expect(() => realCp.execSync('bash -n', { input: script })).not.toThrow();
   });
@@ -303,10 +417,10 @@ describe('buildOverlayCleanup', () => {
     expect(script).toContain('rm -rf "$OVERLAY_ROOT"');
   });
 
-  test('reads stashed worktree path and dirs sidecar files', () => {
+  test('reads stashed worktree path and paths sidecar files', () => {
     const script = buildOverlayCleanup(13);
     expect(script).toContain('$OVERLAY_ROOT/.worktree');
-    expect(script).toContain('$OVERLAY_ROOT/.dirs');
+    expect(script).toContain('$OVERLAY_ROOT/.paths');
   });
 
   test('falls back to /proc/self/mountinfo for orphaned mounts', () => {

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -166,6 +166,7 @@ const routes: Route[] = [
         r.body.name as string | undefined,
         r.body.prompt as string | undefined,
         r.body.branchName as string | undefined,
+        r.body.sandboxed as boolean | undefined,
       );
     },
     true,

--- a/src/components/terminal/terminalActions.ts
+++ b/src/components/terminal/terminalActions.ts
@@ -82,6 +82,7 @@ export async function addProjectTerminal(
       options.worktreeName,
       options.worktreePrompt,
       options.worktreeBranchName,
+      options.sandboxed,
     );
 
     useTerminalStore.getState().setLoadingLabel(null);
@@ -100,9 +101,6 @@ export async function addProjectTerminal(
     };
     taskPrompt = options.worktreePrompt;
 
-    if (options?.sandboxed !== undefined) {
-      await window.api.task.setSandboxed(projectPath, result.task.taskNumber, options.sandboxed);
-    }
     if (!options) options = {};
     options.taskId = result.task.taskNumber;
     useProjectStore.getState().invalidateTaskList();

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -81,7 +81,7 @@ export interface IpcInvokeContract {
   // ── Task ─────────────────────────────────────────────────────────────
   'task:create': { args: [projectPath: string, name?: string, prompt?: string]; return: TaskWorktreeResult };
   'task:create-and-start': {
-    args: [projectPath: string, name?: string, prompt?: string, branchName?: string];
+    args: [projectPath: string, name?: string, prompt?: string, branchName?: string, sandboxed?: boolean];
     return: TaskWorktreeResult;
   };
   'task:start': { args: [projectPath: string, taskNumber: number, branchName?: string]; return: TaskWorktreeResult };

--- a/src/ipc/handlers/task.ts
+++ b/src/ipc/handlers/task.ts
@@ -15,8 +15,8 @@ import {
 export function registerTaskHandlers(): void {
   typedHandle('task:create', (projectPath, name, prompt) => createTodoTask(projectPath, name, prompt));
 
-  typedHandle('task:create-and-start', (projectPath, name, prompt, branchName) =>
-    createTaskWorktree(projectPath, name, prompt, branchName),
+  typedHandle('task:create-and-start', (projectPath, name, prompt, branchName, sandboxed) =>
+    createTaskWorktree(projectPath, name, prompt, branchName, sandboxed),
   );
 
   typedHandle('task:start', (projectPath, taskNumber, branchName) => beginTask(projectPath, taskNumber, branchName));

--- a/src/lima/manager.ts
+++ b/src/lima/manager.ts
@@ -506,6 +506,19 @@ export async function deleteWithCleanup(projectPath: string): Promise<{ success:
 }
 
 /**
+ * Run a bash command inside a project's Lima VM via `limactl shell`.
+ * Used for best-effort maintenance operations (e.g. overlay cleanup on task delete).
+ * Callers should wrap in try/catch — the VM may not be running.
+ */
+export async function runInVm(projectPath: string, command: string): Promise<void> {
+  const instanceName = getInstanceName(projectPath);
+  await execFileAsync(getLimactlPath(), ['shell', instanceName, '--', 'bash', '-c', command], {
+    timeout: 15_000,
+    env: getLimaEnv(),
+  });
+}
+
+/**
  * Stop all running ouijit-* instances. Synchronous — safe to call during app quit.
  */
 export function stopAllInstances(): void {

--- a/src/lima/overlay.ts
+++ b/src/lima/overlay.ts
@@ -57,9 +57,13 @@ export interface MaskEntry {
  * null-delimits output so spaces and newlines in filenames are safe.
  *
  * Delegates all gitignore semantics — negations, nested `.gitignore`,
- * `core.excludesFile`, globs — to git itself. Returns [] on any failure
- * (missing git, not a repo, perms); the caller treats empty as "nothing
- * to mask" and logs a warning.
+ * `core.excludesFile`, globs — to git itself.
+ *
+ * **Throws on hard failures** (git missing, path not a repo, permissions,
+ * maxBuffer overflow). An empty return means git succeeded and found
+ * nothing to ignore — that's a legitimate state the caller should still
+ * surface loudly, but it's semantically different from "enumeration
+ * failed" and the caller needs to distinguish them.
  */
 export async function listMaskedPaths(projectPath: string): Promise<MaskEntry[]> {
   let stdout: string;
@@ -71,11 +75,9 @@ export async function listMaskedPaths(projectPath: string): Promise<MaskEntry[]>
     );
     stdout = result.stdout;
   } catch (error) {
-    overlayLog.warn('git ls-files failed — no sandbox masks applied', {
-      projectPath,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return [];
+    const message = error instanceof Error ? error.message : String(error);
+    overlayLog.error('git ls-files failed — sandbox masking cannot run', { projectPath, error: message });
+    throw new Error(`listMaskedPaths: git ls-files failed for ${projectPath}: ${message}`);
   }
 
   const masks: MaskEntry[] = [];
@@ -111,17 +113,29 @@ export function buildOverlayBindMountSetup(opts: { worktreePath: string; taskId:
   const task = shEscape(String(opts.taskId));
   // Single-char type prefix + space + path. Quoted heredoc disables expansion.
   const maskList = opts.masks.map((m) => `${m.type === 'directory' ? 'd' : 'f'} ${m.relPath}`).join('\n');
+  // Fail-closed: the function returns non-zero on any isolation failure, and
+  // the caller below checks the return and exits the shell before exec bash.
+  // A sandboxed terminal that can't actually isolate is refused, not
+  // silently degraded.
   return `_ouijit_overlay_setup() {
   local WORKTREE=${worktree}
   local TASK=${task}
   local OVERLAY_ROOT="/var/lib/ouijit/overlays/T-$TASK"
 
   if ! sudo -n true 2>/dev/null; then
-    echo "ouijit: sandbox overlay skipped (passwordless sudo unavailable)" >&2
-    return 0
+    printf '\\n\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m\\n' >&2
+    printf '\\033[1;31m  ouijit: passwordless sudo is unavailable in this VM.\\n' >&2
+    printf '  ouijit: cannot create isolation mounts — refusing to start a\\n' >&2
+    printf '  ouijit: sandboxed terminal without gitignore-based isolation.\\033[0m\\n\\n' >&2
+    return 1
   fi
 
-  sudo mkdir -p "$OVERLAY_ROOT" || { echo "ouijit: overlay mkdir failed" >&2; return 0; }
+  sudo mkdir -p "$OVERLAY_ROOT" || {
+    printf '\\n\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m\\n' >&2
+    printf '\\033[1;31m  ouijit: could not create overlay root %s.\\n' "$OVERLAY_ROOT" >&2
+    printf '  ouijit: refusing to start a sandboxed terminal.\\033[0m\\n\\n' >&2
+    return 1
+  }
 
   local MASKS
   MASKS=$(cat <<'OUIJIT_MASKS_EOF'
@@ -134,8 +148,10 @@ OUIJIT_MASKS_EOF
   printf '%s\\n' "$WORKTREE" | sudo tee "$OVERLAY_ROOT/.worktree" >/dev/null
   printf '%s\\n' "$MASKS" | awk '{ $1=""; sub(/^ /,""); print }' | sudo tee "$OVERLAY_ROOT/.paths" >/dev/null
 
+  local TOTAL=0 OK=0 FAIL=0
   while IFS= read -r line; do
     [ -z "$line" ] && continue
+    TOTAL=$((TOTAL+1))
     local type="\${line%% *}"
     local rel="\${line#* }"
     local overlay="$OVERLAY_ROOT/$rel"
@@ -144,6 +160,7 @@ OUIJIT_MASKS_EOF
     if [ "$type" = "d" ]; then
       sudo mkdir -p "$overlay" "$target" 2>/dev/null || {
         echo "ouijit: overlay mkdir $rel failed" >&2
+        FAIL=$((FAIL+1))
         continue
       }
     else
@@ -151,22 +168,78 @@ OUIJIT_MASKS_EOF
       # and empty target (Linux rejects mount --bind onto a non-existent target).
       sudo mkdir -p "$(dirname "$overlay")" "$(dirname "$target")" 2>/dev/null || {
         echo "ouijit: overlay parent mkdir $rel failed" >&2
+        FAIL=$((FAIL+1))
         continue
       }
       sudo touch "$overlay" "$target" 2>/dev/null || {
         echo "ouijit: overlay touch $rel failed" >&2
+        FAIL=$((FAIL+1))
         continue
       }
     fi
 
-    if ! mountpoint -q "$target"; then
-      sudo mount --bind "$overlay" "$target" 2>/dev/null || echo "ouijit: bind mount $rel failed" >&2
+    if mountpoint -q "$target"; then
+      OK=$((OK+1))
+    elif sudo mount --bind "$overlay" "$target" 2>/dev/null; then
+      OK=$((OK+1))
+    else
+      echo "ouijit: bind mount $rel failed" >&2
+      FAIL=$((FAIL+1))
     fi
   done <<< "$MASKS"
+
+  # Status banner + fail-closed return code.
+  # - Any failure (total or partial) → red/yellow banner + return 1 → shell refuses to start.
+  # - Full success → green banner + return 0 → shell proceeds.
+  if [ "$FAIL" -gt 0 ] || [ "$OK" -eq 0 ]; then
+    if [ "$OK" -eq 0 ]; then
+      printf '\\n\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m\\n' >&2
+      printf '\\033[1;31m  ouijit: 0 of %d paths were masked.\\n' "$TOTAL" >&2
+      printf '  ouijit: refusing to start a sandboxed terminal without isolation.\\033[0m\\n\\n' >&2
+    else
+      printf '\\n\\033[1;97;41m  SANDBOX ISOLATION PARTIAL  \\033[0m\\n' >&2
+      printf '\\033[1;31m  ouijit: only %d of %d paths were masked (%d failed).\\n' "$OK" "$TOTAL" "$FAIL" >&2
+      printf '  ouijit: check stderr above for per-path errors.\\n' >&2
+      printf '  ouijit: refusing to start a partially-isolated sandboxed terminal.\\033[0m\\n\\n' >&2
+    fi
+    return 1
+  fi
+
+  printf '\\n\\033[1;97;42m  SANDBOX ISOLATION ACTIVE  \\033[0m  %d paths masked\\n\\n' "$OK" >&2
+  return 0
 }
 _ouijit_overlay_setup
+_OUIJIT_OVERLAY_RC=$?
 unset -f _ouijit_overlay_setup
+if [ "$_OUIJIT_OVERLAY_RC" -ne 0 ]; then
+  unset _OUIJIT_OVERLAY_RC
+  exit 1
+fi
+unset _OUIJIT_OVERLAY_RC
 `;
+}
+
+/**
+ * Build a yellow ANSI banner that prints to stderr when git ls-files
+ * succeeded but returned zero gitignored paths. This is the one
+ * proceed-with-warning state: the worktree has no secrets/artifacts to
+ * isolate, so running the sandbox shell is legitimate, but the user
+ * should see that nothing was masked in case their .gitignore is
+ * incomplete. Consumed by spawn.ts and prepended to the shell's
+ * innerCmd so the user sees the warning immediately at terminal start.
+ *
+ * Hard enumeration failures (git missing, not a repo, etc.) are
+ * handled in spawn.ts: the spawn returns {success: false} and the
+ * shell never starts. There's no banner for that case because there's
+ * no terminal to print it into.
+ */
+export function buildSandboxNoMatchesBanner(): string {
+  return [
+    `printf '\\n\\033[1;30;43m  SANDBOX NO PATHS TO ISOLATE  \\033[0m\\n' >&2`,
+    `printf '\\033[1;33m  ouijit: no gitignored paths were found in this worktree.\\n' >&2`,
+    `printf '  ouijit: verify your .gitignore covers the files you want hidden.\\033[0m\\n\\n' >&2`,
+    '',
+  ].join('\n');
 }
 
 /**

--- a/src/lima/overlay.ts
+++ b/src/lima/overlay.ts
@@ -17,8 +17,10 @@ function shEscape(str: string): string {
 
 /**
  * Parse the repo-root `.gitignore` and return the list of bare directory
- * names to bind-mount. Rejects globs, negations, nested paths, and
- * comments. Order-preserving dedupe.
+ * names to bind-mount. Accepts plain entries (`node_modules`, `target/`,
+ * `/.venv`) and recursive-glob shorthand for a single dir name
+ * (`**​/node_modules`). Rejects negations, comments, other globs, and
+ * nested paths. Order-preserving dedupe.
  */
 export async function parseIgnoredDirs(projectPath: string): Promise<string[]> {
   const gitignorePath = path.join(projectPath, '.gitignore');
@@ -34,10 +36,14 @@ export async function parseIgnoredDirs(projectPath: string): Promise<string[]> {
     if (!line) continue;
     if (line.startsWith('#')) continue;
     if (line.startsWith('!')) continue;
-    if (/[*?[\]]/.test(line)) continue;
-    const entry = line.replace(/^\//, '').replace(/\/$/, '');
+    let entry = line.replace(/^\//, '').replace(/\/$/, '');
     if (!entry) continue;
-    if (entry.includes('/')) continue;
+    // Accept `**/<name>` as `<name>` (only meaningful glob form for a bare dir).
+    if (entry.startsWith('**/')) {
+      entry = entry.slice(3);
+    }
+    if (/[*?[\]]/.test(entry)) continue;
+    if (!entry || entry.includes('/')) continue;
     dirs.push(entry);
   }
   return Array.from(new Set(dirs));
@@ -45,9 +51,12 @@ export async function parseIgnoredDirs(projectPath: string): Promise<string[]> {
 
 /**
  * Build bash that creates a per-task overlay directory on the guest's
- * local ext4, bind-mounts each gitignored directory from the worktree
- * onto it, and installs a trap to unmount on shell exit. Refcount lives
- * under flock on the guest so concurrent PTYs share mounts.
+ * local ext4 and bind-mounts each gitignored directory from the worktree
+ * onto it. Idempotent: re-running for an existing task is a no-op.
+ *
+ * Best-effort by design — any failure logs to stderr and continues so
+ * the user still gets a working shell. Mounts persist for the life of
+ * the task and are reclaimed by `buildOverlayCleanup` on task delete.
  *
  * Returns an empty string when there are no directories to isolate.
  */
@@ -57,51 +66,73 @@ export function buildOverlayBindMountSetup(opts: { worktreePath: string; taskId:
   const task = shEscape(String(opts.taskId));
   // Quoted heredoc disables shell expansion — entries are safe even with $, `, quotes.
   const dirList = opts.dirs.join('\n');
-  return `set -e
-WORKTREE=${worktree}
-TASK=${task}
-OVERLAY_ROOT="/var/lib/ouijit/overlays/T-$TASK"
-LOCK="$OVERLAY_ROOT/.lock"
-COUNT="$OVERLAY_ROOT/.count"
+  return `_ouijit_overlay_setup() {
+  local WORKTREE=${worktree}
+  local TASK=${task}
+  local OVERLAY_ROOT="/var/lib/ouijit/overlays/T-$TASK"
 
-# Sudo must be non-interactive or the rest of this script would hang.
-sudo -n true 2>/dev/null || { echo "ouijit: sandbox requires passwordless sudo" >&2; exit 1; }
+  if ! sudo -n true 2>/dev/null; then
+    echo "ouijit: sandbox overlay skipped (passwordless sudo unavailable)" >&2
+    return 0
+  fi
 
-sudo mkdir -p "$OVERLAY_ROOT"
-sudo touch "$LOCK" "$COUNT"
+  sudo mkdir -p "$OVERLAY_ROOT" || { echo "ouijit: overlay mkdir failed" >&2; return 0; }
 
-IGNORED_DIRS=$(cat <<'OUIJIT_IGNORED_DIRS_EOF'
+  local IGNORED_DIRS
+  IGNORED_DIRS=$(cat <<'OUIJIT_IGNORED_DIRS_EOF'
 ${dirList}
 OUIJIT_IGNORED_DIRS_EOF
 )
 
-(
-  flock -x 9
-  N=$(cat "$COUNT" 2>/dev/null || echo 0)
-  echo $((N+1)) | sudo tee "$COUNT" >/dev/null
+  # Stash worktree path + dir list so cleanup on task delete can umount
+  # before rm -rf, even after the host worktree directory is gone.
+  printf '%s\\n' "$WORKTREE" | sudo tee "$OVERLAY_ROOT/.worktree" >/dev/null
+  printf '%s\\n' "$IGNORED_DIRS" | sudo tee "$OVERLAY_ROOT/.dirs" >/dev/null
+
   while IFS= read -r dir; do
     [ -z "$dir" ] && continue
-    overlay="$OVERLAY_ROOT/$dir"
-    target="$WORKTREE/$dir"
-    sudo mkdir -p "$overlay" "$target"
-    mountpoint -q "$target" || sudo mount --bind "$overlay" "$target"
-  done <<< "$IGNORED_DIRS"
-) 9<"$LOCK"
-
-_ouijit_overlay_cleanup() {
-  (
-    flock -x 9
-    N=$(cat "$COUNT" 2>/dev/null || echo 0)
-    N=$((N-1))
-    echo $N | sudo tee "$COUNT" >/dev/null
-    if [ "$N" -le 0 ]; then
-      while IFS= read -r dir; do
-        [ -z "$dir" ] && continue
-        sudo umount "$WORKTREE/$dir" 2>/dev/null || true
-      done <<< "$IGNORED_DIRS"
+    local overlay="$OVERLAY_ROOT/$dir"
+    local target="$WORKTREE/$dir"
+    sudo mkdir -p "$overlay" "$target" 2>/dev/null || { echo "ouijit: overlay mkdir $dir failed" >&2; continue; }
+    if ! mountpoint -q "$target"; then
+      sudo mount --bind "$overlay" "$target" 2>/dev/null || echo "ouijit: bind mount $dir failed" >&2
     fi
-  ) 9<"$LOCK"
+  done <<< "$IGNORED_DIRS"
 }
-trap _ouijit_overlay_cleanup EXIT
+_ouijit_overlay_setup
+unset -f _ouijit_overlay_setup
+`;
+}
+
+/**
+ * Build bash that umounts every bind mount belonging to a task overlay
+ * and removes the overlay directory. Reads the worktree path and dir
+ * list from sidecar files written by `buildOverlayBindMountSetup`, then
+ * falls back to scanning `/proc/self/mountinfo` for any mounts whose
+ * source still references the overlay (handles older overlays without
+ * sidecars or partial state).
+ */
+export function buildOverlayCleanup(taskId: number): string {
+  const task = shEscape(String(taskId));
+  return `set +e
+TASK=${task}
+OVERLAY_ROOT="/var/lib/ouijit/overlays/T-$TASK"
+[ -d "$OVERLAY_ROOT" ] || exit 0
+
+if [ -f "$OVERLAY_ROOT/.worktree" ] && [ -f "$OVERLAY_ROOT/.dirs" ]; then
+  WORKTREE=$(cat "$OVERLAY_ROOT/.worktree")
+  while IFS= read -r dir; do
+    [ -z "$dir" ] && continue
+    sudo umount "$WORKTREE/$dir" 2>/dev/null
+  done < "$OVERLAY_ROOT/.dirs"
+fi
+
+# Belt-and-suspenders: umount anything still pointing into this overlay.
+awk -v root="$OVERLAY_ROOT/" '$4 ~ "^"root {print $5}' /proc/self/mountinfo 2>/dev/null \
+  | while IFS= read -r mp; do
+      [ -n "$mp" ] && sudo umount "$mp" 2>/dev/null
+    done
+
+sudo rm -rf "$OVERLAY_ROOT"
 `;
 }

--- a/src/lima/overlay.ts
+++ b/src/lima/overlay.ts
@@ -1,71 +1,116 @@
 /**
  * Per-task bind-mount overlay for sandboxed Lima tasks.
  *
- * Parses the project's `.gitignore` to find bare directory entries and
+ * Enumerates every gitignored path in the project via `git ls-files` and
  * emits guest-side bash that creates an overlay directory on the VM's
- * local ext4 and bind-mounts each ignored directory onto an empty
- * overlay. This isolates darwin-arm64 host `node_modules` / `target` /
- * `.venv` from the linux guest, avoiding native-module ABI mismatches
- * and slow-start copies.
+ * local ext4 and bind-mounts an empty placeholder over each path. Both
+ * directory and file masks are supported — directories mask whole trees
+ * (darwin-arm64 `node_modules` / `target` / `.venv`), files mask secrets
+ * like `.env`, `.npmrc`, `config/secrets.yml`.
  */
-import * as fs from 'node:fs/promises';
-import * as path from 'node:path';
+import { execFile, type ExecFileOptions } from 'node:child_process';
+import { getLogger } from '../logger';
+
+const overlayLog = getLogger().scope('overlay');
+
+/**
+ * Promise wrapper around `execFile` that always resolves to
+ * `{ stdout, stderr }` strings. Written manually (rather than using
+ * `util.promisify`) so tests can mock `execFile` with a plain
+ * callback-style function without needing to preserve
+ * `util.promisify.custom`.
+ */
+function execFileAsync(
+  file: string,
+  args: string[],
+  opts: ExecFileOptions,
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, opts, (err, stdout, stderr) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve({
+        stdout: typeof stdout === 'string' ? stdout : stdout.toString('utf8'),
+        stderr: typeof stderr === 'string' ? stderr : stderr.toString('utf8'),
+      });
+    });
+  });
+}
 
 function shEscape(str: string): string {
   return `'${str.replace(/'/g, "'\\''")}'`;
 }
 
-/**
- * Parse the repo-root `.gitignore` and return the list of bare directory
- * names to bind-mount. Accepts plain entries (`node_modules`, `target/`,
- * `/.venv`) and recursive-glob shorthand for a single dir name
- * (`**​/node_modules`). Rejects negations, comments, other globs, and
- * nested paths. Order-preserving dedupe.
- */
-export async function parseIgnoredDirs(projectPath: string): Promise<string[]> {
-  const gitignorePath = path.join(projectPath, '.gitignore');
-  let contents: string;
-  try {
-    contents = await fs.readFile(gitignorePath, 'utf8');
-  } catch {
-    return [];
-  }
-  const dirs: string[] = [];
-  for (const rawLine of contents.split('\n')) {
-    const line = rawLine.trim();
-    if (!line) continue;
-    if (line.startsWith('#')) continue;
-    if (line.startsWith('!')) continue;
-    let entry = line.replace(/^\//, '').replace(/\/$/, '');
-    if (!entry) continue;
-    // Accept `**/<name>` as `<name>` (only meaningful glob form for a bare dir).
-    if (entry.startsWith('**/')) {
-      entry = entry.slice(3);
-    }
-    if (/[*?[\]]/.test(entry)) continue;
-    if (!entry || entry.includes('/')) continue;
-    dirs.push(entry);
-  }
-  return Array.from(new Set(dirs));
+export interface MaskEntry {
+  /** Repo-root-relative, forward-slash. Never starts with `/`, never contains `..`. */
+  relPath: string;
+  type: 'file' | 'directory';
 }
 
 /**
- * Build bash that creates a per-task overlay directory on the guest's
- * local ext4 and bind-mounts each gitignored directory from the worktree
- * onto it. Idempotent: re-running for an existing task is a no-op.
+ * Enumerate every gitignored path in the project using git's own matcher.
+ *
+ * `--directory` collapses fully-ignored directories to just the dir name
+ * (trailing slash) so we don't descend into `node_modules` etc. `-z`
+ * null-delimits output so spaces and newlines in filenames are safe.
+ *
+ * Delegates all gitignore semantics — negations, nested `.gitignore`,
+ * `core.excludesFile`, globs — to git itself. Returns [] on any failure
+ * (missing git, not a repo, perms); the caller treats empty as "nothing
+ * to mask" and logs a warning.
+ */
+export async function listMaskedPaths(projectPath: string): Promise<MaskEntry[]> {
+  let stdout: string;
+  try {
+    const result = await execFileAsync(
+      'git',
+      ['-C', projectPath, 'ls-files', '-o', '-i', '--exclude-standard', '--directory', '-z'],
+      { maxBuffer: 32 * 1024 * 1024 },
+    );
+    stdout = result.stdout;
+  } catch (error) {
+    overlayLog.warn('git ls-files failed — no sandbox masks applied', {
+      projectPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+
+  const masks: MaskEntry[] = [];
+  for (const raw of stdout.split('\0')) {
+    if (!raw) continue;
+    if (raw.startsWith('/') || raw.includes('..')) continue;
+
+    if (raw.endsWith('/')) {
+      masks.push({ relPath: raw.slice(0, -1), type: 'directory' });
+    } else {
+      masks.push({ relPath: raw, type: 'file' });
+    }
+  }
+  return masks;
+}
+
+/**
+ * Build bash that creates a per-task overlay on the guest's local ext4
+ * and bind-mounts an empty placeholder over each masked path in the
+ * worktree. Supports both directory masks (mkdir + bind) and file masks
+ * (touch empty placeholder + bind). Idempotent: re-running for an
+ * existing task is a no-op.
  *
  * Best-effort by design — any failure logs to stderr and continues so
  * the user still gets a working shell. Mounts persist for the life of
  * the task and are reclaimed by `buildOverlayCleanup` on task delete.
  *
- * Returns an empty string when there are no directories to isolate.
+ * Returns an empty string when there are no masks.
  */
-export function buildOverlayBindMountSetup(opts: { worktreePath: string; taskId: number; dirs: string[] }): string {
-  if (opts.dirs.length === 0) return '';
+export function buildOverlayBindMountSetup(opts: { worktreePath: string; taskId: number; masks: MaskEntry[] }): string {
+  if (opts.masks.length === 0) return '';
   const worktree = shEscape(opts.worktreePath);
   const task = shEscape(String(opts.taskId));
-  // Quoted heredoc disables shell expansion — entries are safe even with $, `, quotes.
-  const dirList = opts.dirs.join('\n');
+  // Single-char type prefix + space + path. Quoted heredoc disables expansion.
+  const maskList = opts.masks.map((m) => `${m.type === 'directory' ? 'd' : 'f'} ${m.relPath}`).join('\n');
   return `_ouijit_overlay_setup() {
   local WORKTREE=${worktree}
   local TASK=${task}
@@ -78,26 +123,46 @@ export function buildOverlayBindMountSetup(opts: { worktreePath: string; taskId:
 
   sudo mkdir -p "$OVERLAY_ROOT" || { echo "ouijit: overlay mkdir failed" >&2; return 0; }
 
-  local IGNORED_DIRS
-  IGNORED_DIRS=$(cat <<'OUIJIT_IGNORED_DIRS_EOF'
-${dirList}
-OUIJIT_IGNORED_DIRS_EOF
+  local MASKS
+  MASKS=$(cat <<'OUIJIT_MASKS_EOF'
+${maskList}
+OUIJIT_MASKS_EOF
 )
 
-  # Stash worktree path + dir list so cleanup on task delete can umount
-  # before rm -rf, even after the host worktree directory is gone.
+  # Sidecar files for cleanup on task delete — cleanup umounts then rm -rf.
+  # Store raw paths in .paths (strip type prefix); umount works on file and dir alike.
   printf '%s\\n' "$WORKTREE" | sudo tee "$OVERLAY_ROOT/.worktree" >/dev/null
-  printf '%s\\n' "$IGNORED_DIRS" | sudo tee "$OVERLAY_ROOT/.dirs" >/dev/null
+  printf '%s\\n' "$MASKS" | awk '{ $1=""; sub(/^ /,""); print }' | sudo tee "$OVERLAY_ROOT/.paths" >/dev/null
 
-  while IFS= read -r dir; do
-    [ -z "$dir" ] && continue
-    local overlay="$OVERLAY_ROOT/$dir"
-    local target="$WORKTREE/$dir"
-    sudo mkdir -p "$overlay" "$target" 2>/dev/null || { echo "ouijit: overlay mkdir $dir failed" >&2; continue; }
-    if ! mountpoint -q "$target"; then
-      sudo mount --bind "$overlay" "$target" 2>/dev/null || echo "ouijit: bind mount $dir failed" >&2
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    local type="\${line%% *}"
+    local rel="\${line#* }"
+    local overlay="$OVERLAY_ROOT/$rel"
+    local target="$WORKTREE/$rel"
+
+    if [ "$type" = "d" ]; then
+      sudo mkdir -p "$overlay" "$target" 2>/dev/null || {
+        echo "ouijit: overlay mkdir $rel failed" >&2
+        continue
+      }
+    else
+      # File mask: ensure parent dirs exist, then create empty placeholder
+      # and empty target (Linux rejects mount --bind onto a non-existent target).
+      sudo mkdir -p "$(dirname "$overlay")" "$(dirname "$target")" 2>/dev/null || {
+        echo "ouijit: overlay parent mkdir $rel failed" >&2
+        continue
+      }
+      sudo touch "$overlay" "$target" 2>/dev/null || {
+        echo "ouijit: overlay touch $rel failed" >&2
+        continue
+      }
     fi
-  done <<< "$IGNORED_DIRS"
+
+    if ! mountpoint -q "$target"; then
+      sudo mount --bind "$overlay" "$target" 2>/dev/null || echo "ouijit: bind mount $rel failed" >&2
+    fi
+  done <<< "$MASKS"
 }
 _ouijit_overlay_setup
 unset -f _ouijit_overlay_setup
@@ -106,7 +171,7 @@ unset -f _ouijit_overlay_setup
 
 /**
  * Build bash that umounts every bind mount belonging to a task overlay
- * and removes the overlay directory. Reads the worktree path and dir
+ * and removes the overlay directory. Reads the worktree path and path
  * list from sidecar files written by `buildOverlayBindMountSetup`, then
  * falls back to scanning `/proc/self/mountinfo` for any mounts whose
  * source still references the overlay (handles older overlays without
@@ -119,16 +184,16 @@ TASK=${task}
 OVERLAY_ROOT="/var/lib/ouijit/overlays/T-$TASK"
 [ -d "$OVERLAY_ROOT" ] || exit 0
 
-if [ -f "$OVERLAY_ROOT/.worktree" ] && [ -f "$OVERLAY_ROOT/.dirs" ]; then
+if [ -f "$OVERLAY_ROOT/.worktree" ] && [ -f "$OVERLAY_ROOT/.paths" ]; then
   WORKTREE=$(cat "$OVERLAY_ROOT/.worktree")
-  while IFS= read -r dir; do
-    [ -z "$dir" ] && continue
-    sudo umount "$WORKTREE/$dir" 2>/dev/null
-  done < "$OVERLAY_ROOT/.dirs"
+  while IFS= read -r rel; do
+    [ -z "$rel" ] && continue
+    sudo umount "$WORKTREE/$rel" 2>/dev/null
+  done < "$OVERLAY_ROOT/.paths"
 fi
 
 # Belt-and-suspenders: umount anything still pointing into this overlay.
-awk -v root="$OVERLAY_ROOT/" '$4 ~ "^"root {print $5}' /proc/self/mountinfo 2>/dev/null \
+awk -v root="$OVERLAY_ROOT/" '$4 ~ "^"root {print $5}' /proc/self/mountinfo 2>/dev/null \\
   | while IFS= read -r mp; do
       [ -n "$mp" ] && sudo umount "$mp" 2>/dev/null
     done

--- a/src/lima/overlay.ts
+++ b/src/lima/overlay.ts
@@ -1,0 +1,107 @@
+/**
+ * Per-task bind-mount overlay for sandboxed Lima tasks.
+ *
+ * Parses the project's `.gitignore` to find bare directory entries and
+ * emits guest-side bash that creates an overlay directory on the VM's
+ * local ext4 and bind-mounts each ignored directory onto an empty
+ * overlay. This isolates darwin-arm64 host `node_modules` / `target` /
+ * `.venv` from the linux guest, avoiding native-module ABI mismatches
+ * and slow-start copies.
+ */
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+function shEscape(str: string): string {
+  return `'${str.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Parse the repo-root `.gitignore` and return the list of bare directory
+ * names to bind-mount. Rejects globs, negations, nested paths, and
+ * comments. Order-preserving dedupe.
+ */
+export async function parseIgnoredDirs(projectPath: string): Promise<string[]> {
+  const gitignorePath = path.join(projectPath, '.gitignore');
+  let contents: string;
+  try {
+    contents = await fs.readFile(gitignorePath, 'utf8');
+  } catch {
+    return [];
+  }
+  const dirs: string[] = [];
+  for (const rawLine of contents.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith('#')) continue;
+    if (line.startsWith('!')) continue;
+    if (/[*?[\]]/.test(line)) continue;
+    const entry = line.replace(/^\//, '').replace(/\/$/, '');
+    if (!entry) continue;
+    if (entry.includes('/')) continue;
+    dirs.push(entry);
+  }
+  return Array.from(new Set(dirs));
+}
+
+/**
+ * Build bash that creates a per-task overlay directory on the guest's
+ * local ext4, bind-mounts each gitignored directory from the worktree
+ * onto it, and installs a trap to unmount on shell exit. Refcount lives
+ * under flock on the guest so concurrent PTYs share mounts.
+ *
+ * Returns an empty string when there are no directories to isolate.
+ */
+export function buildOverlayBindMountSetup(opts: { worktreePath: string; taskId: number; dirs: string[] }): string {
+  if (opts.dirs.length === 0) return '';
+  const worktree = shEscape(opts.worktreePath);
+  const task = shEscape(String(opts.taskId));
+  // Quoted heredoc disables shell expansion — entries are safe even with $, `, quotes.
+  const dirList = opts.dirs.join('\n');
+  return `set -e
+WORKTREE=${worktree}
+TASK=${task}
+OVERLAY_ROOT="/var/lib/ouijit/overlays/T-$TASK"
+LOCK="$OVERLAY_ROOT/.lock"
+COUNT="$OVERLAY_ROOT/.count"
+
+# Sudo must be non-interactive or the rest of this script would hang.
+sudo -n true 2>/dev/null || { echo "ouijit: sandbox requires passwordless sudo" >&2; exit 1; }
+
+sudo mkdir -p "$OVERLAY_ROOT"
+sudo touch "$LOCK" "$COUNT"
+
+IGNORED_DIRS=$(cat <<'OUIJIT_IGNORED_DIRS_EOF'
+${dirList}
+OUIJIT_IGNORED_DIRS_EOF
+)
+
+(
+  flock -x 9
+  N=$(cat "$COUNT" 2>/dev/null || echo 0)
+  echo $((N+1)) | sudo tee "$COUNT" >/dev/null
+  while IFS= read -r dir; do
+    [ -z "$dir" ] && continue
+    overlay="$OVERLAY_ROOT/$dir"
+    target="$WORKTREE/$dir"
+    sudo mkdir -p "$overlay" "$target"
+    mountpoint -q "$target" || sudo mount --bind "$overlay" "$target"
+  done <<< "$IGNORED_DIRS"
+) 9<"$LOCK"
+
+_ouijit_overlay_cleanup() {
+  (
+    flock -x 9
+    N=$(cat "$COUNT" 2>/dev/null || echo 0)
+    N=$((N-1))
+    echo $N | sudo tee "$COUNT" >/dev/null
+    if [ "$N" -le 0 ]; then
+      while IFS= read -r dir; do
+        [ -z "$dir" ] && continue
+        sudo umount "$WORKTREE/$dir" 2>/dev/null || true
+      done <<< "$IGNORED_DIRS"
+    fi
+  ) 9<"$LOCK"
+}
+trap _ouijit_overlay_cleanup EXIT
+`;
+}

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -5,7 +5,7 @@ import type { ActiveSession } from '../ptyManager';
 import { generateId } from '../utils/ids';
 import { ensureRunning, getLimactlPath, getLimaEnv } from './manager';
 import { getApiPort, HELPER_SCRIPT, buildVmHookSettings } from '../hookServer';
-import { parseIgnoredDirs, buildOverlayBindMountSetup } from './overlay';
+import { listMaskedPaths, buildOverlayBindMountSetup } from './overlay';
 import { getLogger } from '../logger';
 
 const spawnLog = getLogger().scope('limaSpawn');
@@ -115,22 +115,35 @@ export async function spawnSandboxedPty(options: PtySpawnOptions, window: Browse
     // Inject hook script + Claude settings into VM's ephemeral home dir
     const hookSetup = buildVmHookSetup();
 
-    // Per-task bind-mount overlay for gitignored directories on the guest's
-    // local ext4. Only runs for sandboxed tasks whose .gitignore lists bare
-    // directory entries. Runs before hookSetup so mounts are live for hooks.
+    // Per-task bind-mount overlay for every gitignored path (files + dirs)
+    // on the guest's local ext4. Runs before hookSetup so mounts are live
+    // for hooks.
     let overlaySetup = '';
     if (options.taskId != null && options.worktreePath) {
-      const dirs = await parseIgnoredDirs(projectPath);
-      if (dirs.length === 0) {
-        spawnLog.warn('sandboxed task has no parsable .gitignore dirs to isolate', {
+      const masks = await listMaskedPaths(projectPath);
+      if (masks.length === 0) {
+        spawnLog.warn('sandboxed task has no gitignored paths to mask', {
           taskId: options.taskId,
           projectPath,
         });
       } else {
+        const fileCount = masks.filter((m) => m.type === 'file').length;
+        const dirCount = masks.length - fileCount;
+        spawnLog.info('sandbox masking paths', {
+          taskId: options.taskId,
+          total: masks.length,
+          files: fileCount,
+          dirs: dirCount,
+        });
+        sendStep({
+          id: 'mask',
+          label: `Isolating ${masks.length} path${masks.length === 1 ? '' : 's'} (${dirCount} dir, ${fileCount} file)…`,
+          status: 'done',
+        });
         overlaySetup = buildOverlayBindMountSetup({
           worktreePath: options.worktreePath,
           taskId: options.taskId,
-          dirs,
+          masks,
         });
       }
     }

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -4,7 +4,7 @@ import type { PtySpawnOptions, PtySpawnResult, PtyId } from '../types';
 import type { ActiveSession } from '../ptyManager';
 import { generateId } from '../utils/ids';
 import { ensureRunning, getLimactlPath, getLimaEnv } from './manager';
-import { getApiPort, HELPER_SCRIPT, CLI_REFERENCE, buildVmHookSettings } from '../hookServer';
+import { getApiPort, HELPER_SCRIPT, buildVmHookSettings } from '../hookServer';
 import { listMaskedPaths, buildOverlayBindMountSetup, buildSandboxNoMatchesBanner } from './overlay';
 import { getLogger } from '../logger';
 
@@ -50,6 +50,11 @@ function handleOutput(ptyId: PtyId, channel: string, data: string): void {
  * Build bash commands that inject the ouijit-hook script and Claude settings
  * into the VM's ephemeral home directory. Runs once per shell spawn so hooks
  * are always fresh (never stale).
+ *
+ * The ouijit CLI reference file is deliberately not written into the
+ * sandbox VM. The CLI would give an agent inside the VM task-management
+ * powers (create non-sandboxed tasks, install hooks, change merge
+ * targets) that amount to a lateral-movement path from VM to host.
  */
 function buildVmHookSetup(): string {
   const hookScript = HELPER_SCRIPT;
@@ -65,11 +70,6 @@ function buildVmHookSetup(): string {
     `cat > ~/.claude/settings.json <<'OUIJIT_SETTINGS_EOF'`,
     hookSettings,
     'OUIJIT_SETTINGS_EOF',
-    // Write CLI reference file for --append-system-prompt-file
-    'mkdir -p ~/.config/Ouijit',
-    `cat > ~/.config/Ouijit/ouijit-cli-reference.md <<'OUIJIT_REF_EOF'`,
-    CLI_REFERENCE.trimEnd(),
-    'OUIJIT_REF_EOF',
     '',
   ].join('\n');
 }

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -5,7 +5,7 @@ import type { ActiveSession } from '../ptyManager';
 import { generateId } from '../utils/ids';
 import { ensureRunning, getLimactlPath, getLimaEnv } from './manager';
 import { getApiPort, HELPER_SCRIPT, buildVmHookSettings } from '../hookServer';
-import { listMaskedPaths, buildOverlayBindMountSetup } from './overlay';
+import { listMaskedPaths, buildOverlayBindMountSetup, buildSandboxNoMatchesBanner } from './overlay';
 import { getLogger } from '../logger';
 
 const spawnLog = getLogger().scope('limaSpawn');
@@ -121,33 +121,64 @@ export async function spawnSandboxedPty(options: PtySpawnOptions, window: Browse
     // gitignored files created inside the worktree (e.g. a .env.secrets the
     // user just dropped in) and any worktree-local .gitignore edits are
     // honored.
+    //
+    // Fail-closed: if we can't enumerate the mask list at all (git errored,
+    // path isn't a repo, etc.), refuse to spawn the PTY. A sandboxed task
+    // without working isolation is a broken sandbox; we'd rather the user
+    // see a spawn error and fix their setup than run an agent against an
+    // unmasked worktree. Failures that happen guest-side (no passwordless
+    // sudo, mount errors) are handled by buildOverlayBindMountSetup, which
+    // prints a red banner and exits the shell before `exec bash`.
+    //
+    // The one non-fatal path is "no gitignored files in this worktree" —
+    // that's a legitimate empty state, so we proceed with a yellow warning
+    // banner instead of failing.
     let overlaySetup = '';
     if (options.taskId != null && options.worktreePath) {
-      const masks = await listMaskedPaths(options.worktreePath);
-      if (masks.length === 0) {
-        spawnLog.warn('sandboxed task has no gitignored paths to mask', {
+      try {
+        const masks = await listMaskedPaths(options.worktreePath);
+        if (masks.length === 0) {
+          spawnLog.warn('sandboxed task has no gitignored paths to mask', {
+            taskId: options.taskId,
+            worktreePath: options.worktreePath,
+          });
+          sendStep({
+            id: 'mask',
+            label: 'No gitignored paths to isolate',
+            status: 'done',
+          });
+          overlaySetup = buildSandboxNoMatchesBanner();
+        } else {
+          const fileCount = masks.filter((m) => m.type === 'file').length;
+          const dirCount = masks.length - fileCount;
+          spawnLog.info('sandbox masking paths', {
+            taskId: options.taskId,
+            total: masks.length,
+            files: fileCount,
+            dirs: dirCount,
+          });
+          sendStep({
+            id: 'mask',
+            label: `Isolating ${masks.length} path${masks.length === 1 ? '' : 's'} (${dirCount} dir, ${fileCount} file)…`,
+            status: 'done',
+          });
+          overlaySetup = buildOverlayBindMountSetup({
+            worktreePath: options.worktreePath,
+            taskId: options.taskId,
+            masks,
+          });
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        spawnLog.error('listMaskedPaths failed — refusing to spawn sandboxed terminal', {
           taskId: options.taskId,
           worktreePath: options.worktreePath,
+          error: message,
         });
-      } else {
-        const fileCount = masks.filter((m) => m.type === 'file').length;
-        const dirCount = masks.length - fileCount;
-        spawnLog.info('sandbox masking paths', {
-          taskId: options.taskId,
-          total: masks.length,
-          files: fileCount,
-          dirs: dirCount,
-        });
-        sendStep({
-          id: 'mask',
-          label: `Isolating ${masks.length} path${masks.length === 1 ? '' : 's'} (${dirCount} dir, ${fileCount} file)…`,
-          status: 'done',
-        });
-        overlaySetup = buildOverlayBindMountSetup({
-          worktreePath: options.worktreePath,
-          taskId: options.taskId,
-          masks,
-        });
+        return {
+          success: false,
+          error: `Sandbox isolation could not be computed (${message}). Refusing to start a sandboxed terminal without gitignore-based masking.`,
+        };
       }
     }
 

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -117,14 +117,17 @@ export async function spawnSandboxedPty(options: PtySpawnOptions, window: Browse
 
     // Per-task bind-mount overlay for every gitignored path (files + dirs)
     // on the guest's local ext4. Runs before hookSetup so mounts are live
-    // for hooks.
+    // for hooks. Enumerate from the worktree — not the project — so that
+    // gitignored files created inside the worktree (e.g. a .env.secrets the
+    // user just dropped in) and any worktree-local .gitignore edits are
+    // honored.
     let overlaySetup = '';
     if (options.taskId != null && options.worktreePath) {
-      const masks = await listMaskedPaths(projectPath);
+      const masks = await listMaskedPaths(options.worktreePath);
       if (masks.length === 0) {
         spawnLog.warn('sandboxed task has no gitignored paths to mask', {
           taskId: options.taskId,
-          projectPath,
+          worktreePath: options.worktreePath,
         });
       } else {
         const fileCount = masks.filter((m) => m.type === 'file').length;

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -5,6 +5,7 @@ import type { ActiveSession } from '../ptyManager';
 import { generateId } from '../utils/ids';
 import { ensureRunning, getLimactlPath, getLimaEnv } from './manager';
 import { getApiPort, HELPER_SCRIPT, buildVmHookSettings } from '../hookServer';
+import { parseIgnoredDirs, buildOverlayBindMountSetup } from './overlay';
 
 interface ManagedSandboxPty {
   process: pty.IPty;
@@ -111,14 +112,27 @@ export async function spawnSandboxedPty(options: PtySpawnOptions, window: Browse
     // Inject hook script + Claude settings into VM's ephemeral home dir
     const hookSetup = buildVmHookSetup();
 
+    // Per-task bind-mount overlay for gitignored directories on the guest's
+    // local ext4. Only runs for sandboxed tasks whose .gitignore lists bare
+    // directory entries. Runs before hookSetup so mounts are live for hooks.
+    let overlaySetup = '';
+    if (options.taskId != null && options.worktreePath) {
+      const dirs = await parseIgnoredDirs(projectPath);
+      overlaySetup = buildOverlayBindMountSetup({
+        worktreePath: options.worktreePath,
+        taskId: options.taskId,
+        dirs,
+      });
+    }
+
     // Build the command to run inside the VM
     let innerCmd: string;
     if (options.command) {
       // Run command then drop to interactive bash
       const escapedCmd = options.command.replace(/'/g, "'\\''");
-      innerCmd = `${envExports}${hookSetup}${escapedCmd}; exec bash`;
+      innerCmd = `${envExports}${overlaySetup}${hookSetup}${escapedCmd}; exec bash`;
     } else {
-      innerCmd = `${envExports}${hookSetup}exec bash`;
+      innerCmd = `${envExports}${overlaySetup}${hookSetup}exec bash`;
     }
 
     // Build limactl shell args

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -6,6 +6,9 @@ import { generateId } from '../utils/ids';
 import { ensureRunning, getLimactlPath, getLimaEnv } from './manager';
 import { getApiPort, HELPER_SCRIPT, buildVmHookSettings } from '../hookServer';
 import { parseIgnoredDirs, buildOverlayBindMountSetup } from './overlay';
+import { getLogger } from '../logger';
+
+const spawnLog = getLogger().scope('limaSpawn');
 
 interface ManagedSandboxPty {
   process: pty.IPty;
@@ -118,11 +121,18 @@ export async function spawnSandboxedPty(options: PtySpawnOptions, window: Browse
     let overlaySetup = '';
     if (options.taskId != null && options.worktreePath) {
       const dirs = await parseIgnoredDirs(projectPath);
-      overlaySetup = buildOverlayBindMountSetup({
-        worktreePath: options.worktreePath,
-        taskId: options.taskId,
-        dirs,
-      });
+      if (dirs.length === 0) {
+        spawnLog.warn('sandboxed task has no parsable .gitignore dirs to isolate', {
+          taskId: options.taskId,
+          projectPath,
+        });
+      } else {
+        overlaySetup = buildOverlayBindMountSetup({
+          worktreePath: options.worktreePath,
+          taskId: options.taskId,
+          dirs,
+        });
+      }
     }
 
     // Build the command to run inside the VM

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -112,8 +112,8 @@ contextBridge.exposeInMainWorld('api', {
   task: {
     create: (projectPath: string, name?: string, prompt?: string) =>
       typedInvoke('task:create', projectPath, name, prompt),
-    createAndStart: (projectPath: string, name?: string, prompt?: string, branchName?: string) =>
-      typedInvoke('task:create-and-start', projectPath, name, prompt, branchName),
+    createAndStart: (projectPath: string, name?: string, prompt?: string, branchName?: string, sandboxed?: boolean) =>
+      typedInvoke('task:create-and-start', projectPath, name, prompt, branchName, sandboxed),
     start: (projectPath: string, taskNumber: number, branchName?: string) =>
       typedInvoke('task:start', projectPath, taskNumber, branchName),
     getAll: (projectPath: string) => typedInvoke('task:get-all', projectPath),

--- a/src/taskLifecycle.ts
+++ b/src/taskLifecycle.ts
@@ -50,7 +50,7 @@ export async function beginTask(
     }
   }
 
-  const result = await startTask(projectPath, taskNumber, branchName, baseBranch);
+  const result = await startTask(projectPath, taskNumber, branchName, baseBranch, task?.sandboxed ?? false);
   if (!result.success) return result;
 
   // Move to in_progress if currently todo (startTask doesn't change status)
@@ -82,6 +82,7 @@ export async function createBranchFromTask(
     status: 'todo',
     parentTaskNumber,
     mergeTarget: parent.branch,
+    sandboxed: parent.sandboxed,
   });
   return { success: true, task };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -282,7 +282,13 @@ export interface ScriptsAPI {
 
 export interface TaskAPI {
   create(projectPath: string, name?: string, prompt?: string): Promise<TaskWorktreeResult>;
-  createAndStart(projectPath: string, name?: string, prompt?: string, branchName?: string): Promise<TaskWorktreeResult>;
+  createAndStart(
+    projectPath: string,
+    name?: string,
+    prompt?: string,
+    branchName?: string,
+    sandboxed?: boolean,
+  ): Promise<TaskWorktreeResult>;
   start(projectPath: string, taskNumber: number, branchName?: string): Promise<TaskWorktreeResult>;
   getAll(projectPath: string): Promise<TaskWithWorkspace[]>;
   getByNumber(projectPath: string, taskNumber: number): Promise<TaskWithWorkspace | null>;

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -23,6 +23,7 @@ import {
 } from './db';
 import { mergeWorktreeBranch } from './git';
 import { runInVm } from './lima/manager';
+import { buildOverlayCleanup } from './lima/overlay';
 
 const worktreeLog = getLogger().scope('worktree');
 
@@ -482,6 +483,20 @@ export async function removeTaskWorktree(
     const task = await getTaskByNumber(projectPath, taskNumber);
     const branchName = task?.branch;
 
+    // Best-effort: umount and reclaim the per-task overlay BEFORE removing
+    // the host worktree, while the bind mount targets still resolve.
+    // Swallow errors — the VM may not be running.
+    if (task?.sandboxed && !Number.isNaN(taskNumber)) {
+      try {
+        await runInVm(projectPath, buildOverlayCleanup(taskNumber));
+      } catch (error) {
+        worktreeLog.warn('overlay cleanup failed', {
+          taskNumber,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
     // Remove the worktree
     await execFileAsync('git', ['worktree', 'remove', worktreePath, '--force'], {
       cwd: projectPath,
@@ -501,21 +516,8 @@ export async function removeTaskWorktree(
     }
 
     // Delete task metadata
-    if (!isNaN(taskNumber)) {
+    if (!Number.isNaN(taskNumber)) {
       await deleteTaskByNumber(projectPath, taskNumber);
-    }
-
-    // Best-effort: reclaim per-task overlay directory inside the sandbox VM.
-    // Swallow errors — the VM may not be running.
-    if (task?.sandboxed && !isNaN(taskNumber)) {
-      try {
-        await runInVm(projectPath, `rm -rf /var/lib/ouijit/overlays/T-${taskNumber}`);
-      } catch (error) {
-        worktreeLog.warn('overlay cleanup failed', {
-          taskNumber,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
     }
 
     return { success: true };

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -22,6 +22,7 @@ import {
   type TaskMetadata,
 } from './db';
 import { mergeWorktreeBranch } from './git';
+import { runInVm } from './lima/manager';
 
 const worktreeLog = getLogger().scope('worktree');
 
@@ -286,6 +287,7 @@ export async function startTask(
   taskNumber: number,
   branchName?: string,
   baseBranch?: string,
+  sandboxed: boolean = false,
 ): Promise<TaskWorktreeResult> {
   try {
     const task = await getTaskByNumber(projectPath, taskNumber);
@@ -347,7 +349,7 @@ export async function startTask(
 
     const [, ignoredFiles] = await Promise.all([
       execFileAsync('git', wtAddArgs, { cwd: projectPath }),
-      fetchIgnoredFiles(projectPath),
+      sandboxed ? Promise.resolve<string[]>([]) : fetchIgnoredFiles(projectPath),
     ]);
 
     await Promise.all([
@@ -359,7 +361,9 @@ export async function startTask(
       await setTaskMergeTarget(projectPath, taskNumber, mergeTarget);
     }
 
-    await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
+    if (!sandboxed) {
+      await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
+    }
 
     worktreeLog.info('started task', { taskNumber, worktreePath, branch });
     const updated = await getTaskByNumber(projectPath, taskNumber);
@@ -378,6 +382,7 @@ export async function createTaskWorktree(
   name?: string,
   prompt?: string,
   branchName?: string,
+  sandboxed: boolean = false,
 ): Promise<TaskWorktreeResult> {
   try {
     const [hasHead, branchResult, taskNumber] = await Promise.all([
@@ -436,7 +441,7 @@ export async function createTaskWorktree(
     // ls-files reads from source dir, doesn't need the worktree to exist
     const [, ignoredFiles] = await Promise.all([
       execFileAsync('git', wtAddArgs, { cwd: projectPath }),
-      fetchIgnoredFiles(projectPath),
+      sandboxed ? Promise.resolve<string[]>([]) : fetchIgnoredFiles(projectPath),
     ]);
 
     const task = await createTask(projectPath, currentTaskNumber, displayName, {
@@ -444,9 +449,12 @@ export async function createTaskWorktree(
       mergeTarget,
       prompt,
       worktreePath,
+      sandboxed,
     });
 
-    await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
+    if (!sandboxed) {
+      await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
+    }
 
     return {
       success: true,
@@ -495,6 +503,19 @@ export async function removeTaskWorktree(
     // Delete task metadata
     if (!isNaN(taskNumber)) {
       await deleteTaskByNumber(projectPath, taskNumber);
+    }
+
+    // Best-effort: reclaim per-task overlay directory inside the sandbox VM.
+    // Swallow errors — the VM may not be running.
+    if (task?.sandboxed && !isNaN(taskNumber)) {
+      try {
+        await runInVm(projectPath, `rm -rf /var/lib/ouijit/overlays/T-${taskNumber}`);
+      } catch (error) {
+        worktreeLog.warn('overlay cleanup failed', {
+          taskNumber,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
     return { success: true };
@@ -650,13 +671,15 @@ export async function recoverTaskWorktree(projectPath: string, taskNumber: numbe
     // Re-create worktree from the existing branch (no -b flag)
     const [, ignoredFiles] = await Promise.all([
       execAsync(`git worktree add ${shellEscape(worktreePath)} ${shellEscape(task.branch)}`, { cwd: projectPath }),
-      fetchIgnoredFiles(projectPath),
+      task.sandboxed ? Promise.resolve<string[]>([]) : fetchIgnoredFiles(projectPath),
     ]);
 
     // Update metadata with new path
     await setTaskWorktreePath(projectPath, taskNumber, worktreePath);
 
-    await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
+    if (!task.sandboxed) {
+      await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
+    }
 
     worktreeLog.info('recovered', { taskNumber, worktreePath });
     const updated = await getTaskByNumber(projectPath, taskNumber);

--- a/website/docs/vm-sandbox.html
+++ b/website/docs/vm-sandbox.html
@@ -23,14 +23,15 @@
 
     <h2>Why sandbox?</h2>
     <p>Git worktrees isolate your code, but a terminal session still has full access to your host &mdash; your home directory, credentials, system binaries, network. When CLI agents run arbitrary commands, that's a lot of trust.</p>
-    <p>The VM sandbox wraps each terminal in a <a href="https://lima-vm.io" target="_blank" rel="noopener">Lima</a> virtual machine. Your project worktree is mounted into the VM (read-write), but the rest of your filesystem is walled off. The agent can install packages, run builds, and execute code without risk to your host.</p>
+    <p>The VM sandbox wraps each terminal in a <a href="https://lima-vm.io" target="_blank" rel="noopener">Lima</a> virtual machine. Your project worktree is mounted into the VM (read-write), but the rest of your filesystem is walled off. Inside the worktree, every path your <code>.gitignore</code> matches &mdash; <code>.env</code> files, <code>secrets/</code>, <code>node_modules</code>, build artifacts &mdash; is masked with an empty placeholder so the agent only sees what git would track. The agent can install packages, run builds, and execute code without risk to your host or your host-only secrets.</p>
 
     <h2>How it works</h2>
     <ol>
-      <li><strong>Enable sandbox</strong> &mdash; Click the cube icon in the terminal toolbar to open the sandbox dropdown. Toggle it on.</li>
-      <li><strong>First terminal</strong> &mdash; Ouijit creates an Ubuntu 24.04 VM via Lima, starts it, and waits for SSH. This takes a minute or two on first boot; subsequent starts are faster.</li>
+      <li><strong>Enable sandbox on a task</strong> &mdash; Sandboxing is per-task, not per-project. When you start or continue a task, the run dialog has a <strong>Sandbox</strong> toggle. Flip it on and the task's terminal will spawn inside the VM.</li>
+      <li><strong>First terminal</strong> &mdash; Ouijit lazily creates an Ubuntu 24.04 VM via Lima on the first sandboxed spawn for a project. One VM per project, shared across that project's sandboxed tasks. Subsequent terminals reuse the running VM.</li>
+      <li><strong>Spawn progress</strong> &mdash; The spawn dialog shows each step: checking VM status, creating / starting, SSH connect, provisioning, isolating gitignored paths, launching shell. First boot takes a minute or two; later spawns are fast.</li>
       <li><strong>Shell sessions</strong> &mdash; Terminals run inside the VM via <code>limactl shell</code>. Your worktree is mounted at the same path as on the host, so relative paths and git operations work normally.</li>
-      <li><strong>VM lifecycle</strong> &mdash; The sandbox dropdown gives you direct control: Start, Stop, Recreate, or Delete the VM. When you open a sandboxed terminal, Ouijit starts the VM if it's stopped, or creates one if it doesn't exist yet.</li>
+      <li><strong>VM lifecycle &amp; resources</strong> &mdash; Manage the VM from <strong>Project Settings &rarr; Sandbox</strong>. You can see the VM status (Running / Stopped / Broken / Not created), create, start, stop, or recreate it, open a VM console, and edit the merged Lima YAML config (memory, CPU, disk, mounts). Changing resources prompts you to recreate the VM.</li>
     </ol>
 
     <h2>What's isolated</h2>
@@ -48,22 +49,39 @@
       </tbody>
     </table>
 
-    <h2>Setup hook</h2>
-    <p>VMs start from a clean Ubuntu image with <code>bash</code>, <code>git</code>, <code>curl</code>, <code>wget</code>, <code>nodejs</code>, <code>npm</code>, <code>python3</code>, and <code>build-essential</code> pre-installed. If your project needs more, use the <strong>sandbox-setup</strong> hook.</p>
-    <p>The setup hook runs once per VM session (not per terminal). If you edit the hook script, it re-runs automatically on the next terminal open.</p>
-    <p>Configure it from the sandbox dropdown &mdash; click the gear icon next to "Setup Hook", or create a new one if none exists.</p>
-    <pre><code># Example: install project dependencies inside the VM
-cd /path/to/your/worktree
-npm install</code></pre>
+    <h2>Gitignored paths are masked</h2>
+    <p>When a sandboxed terminal starts, every path your <code>.gitignore</code> matches is replaced with an empty placeholder inside the VM. Host-only secrets like <code>.env</code> or <code>config/secrets.yml</code> aren't visible to the agent, and platform-specific artifacts like macOS <code>node_modules</code> don't leak into the Linux guest.</p>
+    <p>There's no config file or allowlist to maintain. Ouijit runs <code>git ls-files</code> against the worktree and honors whatever git says is ignored &mdash; negations (<code>!keep.env</code>), nested <code>.gitignore</code> files, globs, and <code>core.excludesFile</code> all work. The terminal startup banner reports what was hidden, e.g. <em>&ldquo;Isolating 12 paths (7 dir, 5 file)&rdquo;</em>.</p>
 
-    <h2>Resource configuration</h2>
-    <p>Each project's VM can be configured with custom resource limits from the sandbox dropdown:</p>
+    <h3>What this buys you</h3>
     <ul>
-      <li><strong>Memory</strong> &mdash; default 4 GiB</li>
-      <li><strong>Disk</strong> &mdash; default 10 GiB</li>
-      <li><strong>CPUs</strong> &mdash; default 2</li>
+      <li><strong>Secret isolation</strong> &mdash; gitignored <code>.env</code>, <code>.npmrc</code>, <code>secrets/</code>, and similar files stay on the host.</li>
+      <li><strong>No ABI mismatches</strong> &mdash; darwin-arm64 <code>node_modules</code>, Rust <code>target/</code>, and Python <code>.venv</code> never collide with the Linux guest's toolchain.</li>
+      <li><strong>Per-task isolation</strong> &mdash; two parallel sandboxed tasks on the same project can't stomp each other's installs.</li>
     </ul>
-    <p>Changes to resources require recreating the VM (the dropdown has a "Recreate VM" option for this).</p>
+
+    <h3>Caveats</h3>
+    <ul>
+      <li><strong>Committed files are always visible.</strong> <code>.gitignore</code> only affects files git considers untracked. If you committed a secret and then gitignored it, the agent still sees it &mdash; run <code>git rm --cached &lt;file&gt;</code> and rotate the secret. Don't commit what you don't want an agent to read.</li>
+      <li><strong>Masking is a snapshot at terminal start.</strong> New gitignored files created while a terminal is already open aren't masked in that terminal. Close and reopen to re-enumerate.</li>
+      <li><strong>Filenames aren't hidden, only contents.</strong> <code>ls</code> still shows <code>.env.secrets</code> as a 0-byte file. Don't rely on this to hide secret-sounding paths.</li>
+      <li><strong>The worktree is read-write.</strong> The VM has no git credentials, so a compromised agent can't push &mdash; but it can stage commits that a human on the host could unknowingly push later. Review diffs before pushing.</li>
+      <li><strong>Scope is the worktree.</strong> Files in the VM's own <code>$HOME</code> (e.g. <code>~/.netrc</code>, <code>~/.git-credentials</code>) aren't covered. Lima ships a clean home; don't copy host auth into it.</li>
+    </ul>
+
+    <h3>Startup banners</h3>
+    <p>Masking is fail-closed: if isolation can't be delivered, the terminal refuses to start. Every spawn resolves to one of three banners, printed to the terminal before the interactive shell:</p>
+    <ul>
+      <li><strong>SANDBOX ISOLATION ACTIVE</strong> &mdash; green. Masks applied. Shell starts.</li>
+      <li><strong>SANDBOX NO PATHS TO ISOLATE</strong> &mdash; yellow. Nothing was gitignored in the worktree. Shell still starts &mdash; double-check your <code>.gitignore</code> before running anything sensitive.</li>
+      <li><strong>SANDBOX ISOLATION FAILED</strong> &mdash; red. Enumeration error, missing sudo, mount failure, or any partial failure. The shell exits immediately; fix the cause and reopen. Partial failures are treated as total failures.</li>
+    </ul>
+    <p>Errors that happen before the VM side runs (e.g. <code>git ls-files</code> throws) come back as a failed terminal-open in Ouijit, not as a banner.</p>
+
+    <h2>Customizing the VM</h2>
+    <p>VMs start from a clean Ubuntu 24.04 image with <code>bash</code>, <code>git</code>, <code>curl</code>, <code>wget</code>, <code>nodejs</code>, <code>npm</code>, <code>python3</code>, and <code>build-essential</code> pre-installed. Defaults are 4 GiB memory, 2 CPUs, 10 GiB disk.</p>
+    <p>Everything else &mdash; resource limits, extra packages, additional mounts, provisioning scripts &mdash; is controlled by the Lima YAML config in <strong>Project Settings &rarr; Sandbox</strong>. The editor shows the merged effective config and lets you write overrides; Ouijit prompts you to recreate the VM when changes require it.</p>
+    <p>See the <a href="https://lima-vm.io/docs/config/" target="_blank" rel="noopener">Lima configuration reference</a> for the available keys.</p>
 
     <h2>Claude Code integration</h2>
     <p>Ouijit automatically injects its hook helper script and Claude Code settings into each sandboxed shell. This means Claude Code's hook status events (thinking, tool use, idle) work inside the VM just like they do on the host &mdash; the VM shell communicates back to Ouijit via <code>host.lima.internal</code>.</p>


### PR DESCRIPTION
## Summary
- Add a `sandboxed` boolean to the `task:create-and-start` IPC and plumb it through `preload`, `types`, `api/router`, `ipc/handlers/task`, and `terminalActions` (which no longer makes a separate `setSandboxed` round-trip after creation)
- `createTaskWorktree`, `startTask`, and `recoverTaskWorktree` skip `fetchIgnoredFiles` / `copyGitIgnoredFiles` when sandboxed; `beginTask` forwards `task.sandboxed` into `startTask`; `createBranchFromTask` inherits the flag from the parent
- New `src/lima/overlay.ts` parses the project `.gitignore` for bare directory entries (rejecting globs, negations, nested paths, comments) and emits guest bash that bind-mounts each one over an empty `/var/lib/ouijit/overlays/T-<n>/<dir>` on the VM's local ext4, with a flock-refcounted `EXIT` trap so concurrent PTYs share mounts and only the last one unmounts
- `spawnSandboxedPty` runs the overlay setup before the hook setup so mounts are live for hooks; `removeTaskWorktree` best-effort `rm -rf`s the overlay root via a new `runInVm` helper in `lima/manager` and swallows VM-not-running errors
- `src/__tests__/sandboxedTask.test.ts` covers the sandboxed-vs-regular branching in worktree lifecycle, the parent→child sandbox inheritance, the overlay cleanup call, plus unit tests for `parseIgnoredDirs` and `buildOverlayBindMountSetup`