### PR TITLE
Chown sandbox overlay leaves so guest tools can write

### DIFF
--- a/src/__tests__/sandboxedTask.test.ts
+++ b/src/__tests__/sandboxedTask.test.ts
@@ -368,6 +368,19 @@ describe('buildOverlayBindMountSetup', () => {
     expect(script).toContain('sudo mkdir -p "$(dirname "$overlay")" "$(dirname "$target")"');
   });
 
+  test('chowns overlay leaves to the invoking user so guest tools can write through the bind mount', () => {
+    const script = buildOverlayBindMountSetup({
+      worktreePath: '/w',
+      taskId: 1,
+      masks: [
+        { relPath: 'node_modules', type: 'directory' },
+        { relPath: '.env', type: 'file' },
+      ],
+    });
+    const chownMatches = script.match(/sudo chown "\$\(id -u\):\$\(id -g\)" "\$overlay"/g) ?? [];
+    expect(chownMatches.length).toBe(2);
+  });
+
   test('writes .paths sidecar (not .dirs) for cleanup', () => {
     const script = buildOverlayBindMountSetup({
       worktreePath: '/w',

--- a/src/lima/overlay.ts
+++ b/src/lima/overlay.ts
@@ -163,6 +163,10 @@ OUIJIT_MASKS_EOF
         FAIL=$((FAIL+1))
         continue
       }
+      # Hand the overlay leaf to the invoking user so tools like npm can
+      # write into it through the bind mount. $target stays untouched —
+      # writes to it are redirected to $overlay by the kernel.
+      sudo chown "$(id -u):$(id -g)" "$overlay" 2>/dev/null
     else
       # File mask: ensure parent dirs exist, then create empty placeholder
       # and empty target (Linux rejects mount --bind onto a non-existent target).
@@ -176,6 +180,7 @@ OUIJIT_MASKS_EOF
         FAIL=$((FAIL+1))
         continue
       }
+      sudo chown "$(id -u):$(id -g)" "$overlay" 2>/dev/null
     fi
 
     if mountpoint -q "$target"; then


### PR DESCRIPTION
## Summary
- `buildOverlayBindMountSetup` created each overlay leaf with `sudo mkdir`/`sudo touch`, so `node_modules` (and file masks like `.env`) landed root-owned inside the bind mount; running `npm i` in a sandboxed terminal failed with EACCES
- Chown each overlay leaf to `$(id -u):$(id -g)` after creation so the invoking guest user can write through the bind mount — writes still land on the VM's ext4 and stay isolated from the host worktree
- Test asserts both the directory and file branches emit the chown