### PR TITLE
Add web preview panel for embedded dev server URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11062,7 +11062,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12974,7 +12973,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/src/__tests__/webPreviewUrlHelpers.test.ts
+++ b/src/__tests__/webPreviewUrlHelpers.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { detectDevServerUrl, normalizeUrl } from '../components/webPreview/urlHelpers';
+
+describe('normalizeUrl', () => {
+  it('returns empty string for blank input', () => {
+    expect(normalizeUrl('')).toBe('');
+    expect(normalizeUrl('   ')).toBe('');
+  });
+
+  it('passes through URLs with http scheme', () => {
+    expect(normalizeUrl('http://localhost:3000')).toBe('http://localhost:3000');
+  });
+
+  it('passes through URLs with https scheme', () => {
+    expect(normalizeUrl('https://example.com')).toBe('https://example.com');
+  });
+
+  it('treats the scheme check as case-insensitive', () => {
+    expect(normalizeUrl('HTTP://example.com')).toBe('HTTP://example.com');
+    expect(normalizeUrl('HTTPS://example.com')).toBe('HTTPS://example.com');
+  });
+
+  it('prepends http:// to bare host:port', () => {
+    expect(normalizeUrl('localhost:3000')).toBe('http://localhost:3000');
+  });
+
+  it('prepends http:// to a bare host', () => {
+    expect(normalizeUrl('example.com')).toBe('http://example.com');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeUrl('  localhost:3000  ')).toBe('http://localhost:3000');
+    expect(normalizeUrl('  http://foo  ')).toBe('http://foo');
+  });
+});
+
+describe('detectDevServerUrl', () => {
+  it('finds a bare localhost URL', () => {
+    expect(detectDevServerUrl('Listening on http://localhost:3000')).toBe('http://localhost:3000');
+  });
+
+  it('finds a 127.0.0.1 URL', () => {
+    expect(detectDevServerUrl('server: http://127.0.0.1:8080')).toBe('http://127.0.0.1:8080');
+  });
+
+  it('captures an explicit path', () => {
+    expect(detectDevServerUrl('Ready at http://localhost:5173/admin')).toBe('http://localhost:5173/admin');
+  });
+
+  it('requires a port to avoid false positives on bare "localhost"', () => {
+    expect(detectDevServerUrl('Use localhost for local development.')).toBeNull();
+  });
+
+  it('returns null when no loopback URL is present', () => {
+    expect(detectDevServerUrl('Fetching https://api.github.com/repos')).toBeNull();
+  });
+
+  it('ignores 0.0.0.0 (not browsable)', () => {
+    expect(detectDevServerUrl('listening on http://0.0.0.0:3000')).toBeNull();
+  });
+
+  it('strips trailing punctuation printed by loggers', () => {
+    expect(detectDevServerUrl('Server started at http://localhost:3000.')).toBe('http://localhost:3000');
+    expect(detectDevServerUrl('Visit (http://localhost:3000)')).toBe('http://localhost:3000');
+    expect(detectDevServerUrl('See http://localhost:3000,')).toBe('http://localhost:3000');
+  });
+
+  it('strips ANSI CSI color escapes wrapping the URL', () => {
+    const ansiWrapped = 'Local:   \x1b[36mhttp://localhost:5173/\x1b[0m';
+    expect(detectDevServerUrl(ansiWrapped)).toBe('http://localhost:5173/');
+  });
+
+  it('strips ANSI OSC sequences', () => {
+    const chunk = '\x1b]0;title\x07Ready at http://localhost:3000';
+    expect(detectDevServerUrl(chunk)).toBe('http://localhost:3000');
+  });
+
+  it('returns the first URL when multiple are present', () => {
+    const chunk = 'Local: http://localhost:3000\nNetwork: http://127.0.0.1:3000';
+    expect(detectDevServerUrl(chunk)).toBe('http://localhost:3000');
+  });
+
+  it('handles https dev servers', () => {
+    expect(detectDevServerUrl('serving https://localhost:3443')).toBe('https://localhost:3443');
+  });
+});

--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -277,6 +277,8 @@ export function HomeView() {
     restartRunner,
     closePlanPanel,
     changePlanFile,
+    closeWebPreviewPanel,
+    changeWebPreviewUrl,
   } = useTerminalPanels(activePtyId);
 
   if (allPtyIds.length === 0) {
@@ -355,6 +357,8 @@ export function HomeView() {
                 onCloseDiffPanel={closeDiffPanel}
                 onClosePlanPanel={closePlanPanel}
                 onChangePlanFile={changePlanFile}
+                onCloseWebPreviewPanel={closeWebPreviewPanel}
+                onChangeWebPreviewUrl={changeWebPreviewUrl}
                 onCollapseRunner={collapseRunner}
                 onKillRunner={killRunner}
                 onRestartRunner={restartRunner}

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -60,6 +60,9 @@ const ActiveTerminalNode = memo(function ActiveTerminalNode({
     togglePlanPanel,
     closePlanPanel,
     changePlanFile,
+    toggleWebPreviewPanel,
+    closeWebPreviewPanel,
+    changeWebPreviewUrl,
   } = useTerminalPanels(ptyId);
 
   const handleClose = useCallback(() => {
@@ -96,6 +99,7 @@ const ActiveTerminalNode = memo(function ActiveTerminalNode({
           onClose={handleClose}
           onToggleDiffPanel={toggleDiffPanel}
           onTogglePlanPanel={togglePlanPanel}
+          onToggleWebPreviewPanel={toggleWebPreviewPanel}
           onToggleRunner={toggleRunner}
         />
       </div>
@@ -119,6 +123,8 @@ const ActiveTerminalNode = memo(function ActiveTerminalNode({
             onCloseDiffPanel={closeDiffPanel}
             onClosePlanPanel={closePlanPanel}
             onChangePlanFile={changePlanFile}
+            onCloseWebPreviewPanel={closeWebPreviewPanel}
+            onChangeWebPreviewUrl={changeWebPreviewUrl}
             onCollapseRunner={collapseRunner}
             onKillRunner={killRunner}
             onRestartRunner={restartRunner}
@@ -139,6 +145,7 @@ interface PeripheryProps {
   onClose: () => void;
   onToggleDiffPanel: () => void;
   onTogglePlanPanel: () => void;
+  onToggleWebPreviewPanel: () => void;
   onToggleRunner: () => void;
 }
 
@@ -148,6 +155,7 @@ const NodePeriphery = memo(function NodePeriphery({
   onClose,
   onToggleDiffPanel,
   onTogglePlanPanel,
+  onToggleWebPreviewPanel,
   onToggleRunner,
 }: PeripheryProps) {
   const label = useTerminalStore((s) => s.displayStates[ptyId]?.label ?? '');
@@ -162,6 +170,8 @@ const NodePeriphery = memo(function NodePeriphery({
   const diffPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.diffPanelOpen ?? false);
   const planPath = useTerminalStore((s) => s.displayStates[ptyId]?.planPath ?? null);
   const planPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.planPanelOpen ?? false);
+  const webPreviewUrl = useTerminalStore((s) => s.displayStates[ptyId]?.webPreviewUrl ?? null);
+  const webPreviewPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.webPreviewPanelOpen ?? false);
   const worktreeBranch = useTerminalStore((s) => s.displayStates[ptyId]?.worktreeBranch ?? null);
   const tasks = useProjectStore((s) => s.tasks);
 
@@ -224,6 +234,19 @@ const NodePeriphery = memo(function NodePeriphery({
             >
               <Icon name="list-checks" className="w-3.5 h-3.5" />
               <span>Plan</span>
+            </button>
+          )}
+          {webPreviewUrl && (
+            <button
+              className={`flex items-center gap-1 px-2.5 py-1 rounded-full font-mono text-[13px] font-medium text-white/60 bg-white/[0.06] border-none transition-all duration-150 ease-out hover:bg-white/[0.12] hover:text-white/90 ${webPreviewPanelOpen ? '!bg-accent !text-white' : ''}`}
+              title={`Preview ${webPreviewUrl}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleWebPreviewPanel();
+              }}
+            >
+              <Icon name="globe-simple" className="w-3.5 h-3.5" />
+              <span>Preview</span>
             </button>
           )}
           {showDiff && (

--- a/src/components/terminal/TerminalBody.tsx
+++ b/src/components/terminal/TerminalBody.tsx
@@ -3,6 +3,7 @@ import { XTermContainer } from './XTermContainer';
 import { RunnerPanel } from './RunnerPanel';
 import { DiffPanel } from '../diff/DiffPanel';
 import { PlanPanel } from '../plan/PlanPanel';
+import { WebPreviewPanel } from '../webPreview/WebPreviewPanel';
 
 interface TerminalBodyProps {
   ptyId: string;
@@ -10,6 +11,8 @@ interface TerminalBodyProps {
   onCloseDiffPanel: () => void;
   onClosePlanPanel: () => void;
   onChangePlanFile: (newPath: string) => void;
+  onCloseWebPreviewPanel: () => void;
+  onChangeWebPreviewUrl: (newUrl: string) => void;
   onCollapseRunner: () => void;
   onKillRunner: () => void;
   onRestartRunner: () => void;
@@ -21,6 +24,8 @@ export function TerminalBody({
   onCloseDiffPanel,
   onClosePlanPanel,
   onChangePlanFile,
+  onCloseWebPreviewPanel,
+  onChangeWebPreviewUrl,
   onCollapseRunner,
   onKillRunner,
   onRestartRunner,
@@ -29,12 +34,35 @@ export function TerminalBody({
   const planPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.planPanelOpen ?? false);
   const planPath = useTerminalStore((s) => s.displayStates[ptyId]?.planPath ?? null);
   const planFullWidth = useTerminalStore((s) => s.displayStates[ptyId]?.planFullWidth ?? true);
+  const webPreviewPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.webPreviewPanelOpen ?? false);
+  const webPreviewUrl = useTerminalStore((s) => s.displayStates[ptyId]?.webPreviewUrl ?? null);
+  const webPreviewFullWidth = useTerminalStore((s) => s.displayStates[ptyId]?.webPreviewFullWidth ?? true);
   const runnerPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.runnerPanelOpen ?? false);
   const runnerFullWidth = useTerminalStore((s) => s.displayStates[ptyId]?.runnerFullWidth ?? true);
 
   return (
     <div className="relative flex-1 flex flex-row min-h-0 overflow-hidden">
-      {planPanelOpen && planPath ? (
+      {webPreviewPanelOpen && webPreviewUrl ? (
+        <>
+          {!webPreviewFullWidth && (
+            <XTermContainer
+              ptyId={ptyId}
+              className="terminal-xterm-container flex-1 min-h-0 min-w-0 rounded-none border-none pt-4 pl-4 pr-2 pb-2 overflow-hidden"
+              style={{
+                transition: 'flex 0.25s ease',
+                minWidth: 200,
+                background: 'var(--color-terminal-bg, #171717)',
+              }}
+            />
+          )}
+          <WebPreviewPanel
+            ptyId={ptyId}
+            url={webPreviewUrl}
+            onClose={onCloseWebPreviewPanel}
+            onChangeUrl={onChangeWebPreviewUrl}
+          />
+        </>
+      ) : planPanelOpen && planPath ? (
         <>
           {!planFullWidth && (
             <XTermContainer

--- a/src/components/terminal/TerminalBody.tsx
+++ b/src/components/terminal/TerminalBody.tsx
@@ -42,7 +42,7 @@ export function TerminalBody({
 
   return (
     <div className="relative flex-1 flex flex-row min-h-0 overflow-hidden">
-      {webPreviewPanelOpen && webPreviewUrl ? (
+      {webPreviewPanelOpen ? (
         <>
           {!webPreviewFullWidth && (
             <XTermContainer
@@ -57,7 +57,7 @@ export function TerminalBody({
           )}
           <WebPreviewPanel
             ptyId={ptyId}
-            url={webPreviewUrl}
+            url={webPreviewUrl ?? ''}
             onClose={onCloseWebPreviewPanel}
             onChangeUrl={onChangeWebPreviewUrl}
           />

--- a/src/components/terminal/TerminalCard.tsx
+++ b/src/components/terminal/TerminalCard.tsx
@@ -150,7 +150,6 @@ export const TerminalCard = memo(function TerminalCard({ ptyId, projectPath }: T
         onToggleDiffPanel={toggleDiffPanel}
         onTogglePlanPanel={togglePlanPanel}
         onToggleWebPreviewPanel={toggleWebPreviewPanel}
-        onChangeWebPreviewUrl={changeWebPreviewUrl}
         onToggleRunner={toggleRunner}
       />
       <TerminalBody

--- a/src/components/terminal/TerminalCard.tsx
+++ b/src/components/terminal/TerminalCard.tsx
@@ -70,6 +70,9 @@ export const TerminalCard = memo(function TerminalCard({ ptyId, projectPath }: T
     togglePlanPanel,
     closePlanPanel,
     changePlanFile,
+    toggleWebPreviewPanel,
+    closeWebPreviewPanel,
+    changeWebPreviewUrl,
   } = useTerminalPanels(ptyId);
 
   const backDepth = useMemo(() => {
@@ -146,6 +149,8 @@ export const TerminalCard = memo(function TerminalCard({ ptyId, projectPath }: T
         onClose={handleClose}
         onToggleDiffPanel={toggleDiffPanel}
         onTogglePlanPanel={togglePlanPanel}
+        onToggleWebPreviewPanel={toggleWebPreviewPanel}
+        onChangeWebPreviewUrl={changeWebPreviewUrl}
         onToggleRunner={toggleRunner}
       />
       <TerminalBody
@@ -154,6 +159,8 @@ export const TerminalCard = memo(function TerminalCard({ ptyId, projectPath }: T
         onCloseDiffPanel={closeDiffPanel}
         onClosePlanPanel={closePlanPanel}
         onChangePlanFile={changePlanFile}
+        onCloseWebPreviewPanel={closeWebPreviewPanel}
+        onChangeWebPreviewUrl={changeWebPreviewUrl}
         onCollapseRunner={collapseRunner}
         onKillRunner={killRunner}
         onRestartRunner={restartRunner}

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -25,7 +25,6 @@ interface TerminalHeaderProps {
   onToggleDiffPanel?: () => void;
   onTogglePlanPanel?: () => void;
   onToggleWebPreviewPanel?: () => void;
-  onChangeWebPreviewUrl?: (newUrl: string) => void;
   onToggleRunner?: (script?: RunnerScript) => void;
 }
 
@@ -39,7 +38,6 @@ export const TerminalHeader = memo(function TerminalHeader({
   onToggleDiffPanel,
   onTogglePlanPanel,
   onToggleWebPreviewPanel,
-  onChangeWebPreviewUrl,
   onToggleRunner,
 }: TerminalHeaderProps) {
   const label = useTerminalStore((s) => s.displayStates[ptyId]?.label ?? '');
@@ -171,17 +169,12 @@ export const TerminalHeader = memo(function TerminalHeader({
     });
 
     items.push({
-      label: webPreviewUrl ? 'Change Preview URL' : 'Set Preview URL',
+      label: webPreviewUrl ? 'Open Web Preview' : 'Set Preview URL',
       icon: 'globe-simple',
       onClick: () => {
-        const input = window.prompt('Web preview URL:', webPreviewUrl ?? 'http://localhost:3000');
-        if (input == null) return;
-        const trimmed = input.trim();
-        if (!trimmed) return;
-        const normalized = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
-        onChangeWebPreviewUrl?.(normalized);
-        // Open the panel on first set
-        if (!webPreviewUrl) onToggleWebPreviewPanel?.();
+        // Open the panel. When no URL is set yet, the panel auto-focuses its
+        // inline URL editor so the user can type one directly.
+        if (!webPreviewPanelOpen) onToggleWebPreviewPanel?.();
       },
     });
 
@@ -215,7 +208,7 @@ export const TerminalHeader = memo(function TerminalHeader({
     hasEditorHook,
     onClose,
     webPreviewUrl,
-    onChangeWebPreviewUrl,
+    webPreviewPanelOpen,
     onToggleWebPreviewPanel,
   ]);
 

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -24,6 +24,8 @@ interface TerminalHeaderProps {
   onClose: () => void;
   onToggleDiffPanel?: () => void;
   onTogglePlanPanel?: () => void;
+  onToggleWebPreviewPanel?: () => void;
+  onChangeWebPreviewUrl?: (newUrl: string) => void;
   onToggleRunner?: (script?: RunnerScript) => void;
 }
 
@@ -36,6 +38,8 @@ export const TerminalHeader = memo(function TerminalHeader({
   onClose,
   onToggleDiffPanel,
   onTogglePlanPanel,
+  onToggleWebPreviewPanel,
+  onChangeWebPreviewUrl,
   onToggleRunner,
 }: TerminalHeaderProps) {
   const label = useTerminalStore((s) => s.displayStates[ptyId]?.label ?? '');
@@ -51,6 +55,8 @@ export const TerminalHeader = memo(function TerminalHeader({
   const diffPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.diffPanelOpen ?? false);
   const planPath = useTerminalStore((s) => s.displayStates[ptyId]?.planPath ?? null);
   const planPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.planPanelOpen ?? false);
+  const webPreviewUrl = useTerminalStore((s) => s.displayStates[ptyId]?.webPreviewUrl ?? null);
+  const webPreviewPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.webPreviewPanelOpen ?? false);
   const taskId = useTerminalStore((s) => s.displayStates[ptyId]?.taskId ?? null);
   const worktreeBranch = useTerminalStore((s) => s.displayStates[ptyId]?.worktreeBranch ?? null);
 
@@ -152,13 +158,30 @@ export const TerminalHeader = memo(function TerminalHeader({
           instance.planPanelOpen = true;
           instance.diffPanelOpen = false;
           instance.runnerPanelOpen = false;
+          instance.webPreviewPanelOpen = false;
           instance.pushDisplayState({
             planPath: result.filePath,
             planPanelOpen: true,
             diffPanelOpen: false,
             runnerPanelOpen: false,
+            webPreviewPanelOpen: false,
           });
         }
+      },
+    });
+
+    items.push({
+      label: webPreviewUrl ? 'Change Preview URL' : 'Set Preview URL',
+      icon: 'globe-simple',
+      onClick: () => {
+        const input = window.prompt('Web preview URL:', webPreviewUrl ?? 'http://localhost:3000');
+        if (input == null) return;
+        const trimmed = input.trim();
+        if (!trimmed) return;
+        const normalized = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+        onChangeWebPreviewUrl?.(normalized);
+        // Open the panel on first set
+        if (!webPreviewUrl) onToggleWebPreviewPanel?.();
       },
     });
 
@@ -183,7 +206,18 @@ export const TerminalHeader = memo(function TerminalHeader({
     }
 
     return items;
-  }, [isTaskTerminal, instance, projectPath, taskId, sandboxAvailable, hasEditorHook, onClose]);
+  }, [
+    isTaskTerminal,
+    instance,
+    projectPath,
+    taskId,
+    sandboxAvailable,
+    hasEditorHook,
+    onClose,
+    webPreviewUrl,
+    onChangeWebPreviewUrl,
+    onToggleWebPreviewPanel,
+  ]);
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -283,6 +317,14 @@ export const TerminalHeader = memo(function TerminalHeader({
       onTogglePlanPanel?.();
     },
     [onTogglePlanPanel],
+  );
+
+  const handleWebPreviewClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onToggleWebPreviewPanel?.();
+    },
+    [onToggleWebPreviewPanel],
   );
 
   const displayText = summary ? `${label} \u2014 ${summary}` : label;
@@ -398,6 +440,16 @@ export const TerminalHeader = memo(function TerminalHeader({
           >
             <Icon name="list-checks" className="w-3.5 h-3.5" />
             <span>Plan</span>
+          </button>
+        )}
+        {!compact && isActive && webPreviewUrl && (
+          <button
+            className={`flex items-center gap-1 px-2.5 py-1 rounded-full font-mono text-[13px] font-medium text-white/60 bg-white/[0.06] transition-all duration-150 ease-out hover:bg-white/[0.12] hover:text-white/90 active:bg-white/[0.10] active:text-white/80 ${webPreviewPanelOpen ? '!bg-accent !text-white' : ''}`}
+            title={`Preview ${webPreviewUrl}`}
+            onClick={handleWebPreviewClick}
+          >
+            <Icon name="globe-simple" className="w-3.5 h-3.5" />
+            <span>Preview</span>
           </button>
         )}
         {!compact && isActive && (

--- a/src/components/terminal/terminalActions.ts
+++ b/src/components/terminal/terminalActions.ts
@@ -10,29 +10,20 @@ import { useCanvasStore, persistCanvas } from '../../stores/canvasStore';
 import { useAppStore, staleGuard } from '../../stores/appStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { OuijitTerminal, terminalInstances, resolveTerminalLabel, type SummaryType } from './terminalReact';
+import { detectDevServerUrl } from '../webPreview/urlHelpers';
 import log from 'electron-log/renderer';
 
 const actionsLog = log.scope('terminalActions');
 
 // ── Dev server URL detection ─────────────────────────────────────────
 
-// Strip ANSI CSI and OSC sequences so URLs split by color codes still match.
-const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07/g;
-// Match http[s]://localhost or loopback IP with required port. Requiring a port
-// avoids false positives on documentation URLs that mention "localhost".
-const DEV_SERVER_URL_RE = /https?:\/\/(?:localhost|127\.0\.0\.1):\d+(?:\/[^\s]*)?/;
-
-function detectDevServerUrl(chunk: string): string | null {
-  const stripped = chunk.replace(ANSI_RE, '');
-  const match = DEV_SERVER_URL_RE.exec(stripped);
-  if (!match) return null;
-  // Trim common trailing punctuation printed by loggers.
-  return match[0].replace(/[.,;:!?)\]]+$/, '');
-}
-
-function setWebPreviewUrlIfUnset(parent: OuijitTerminal, url: string): void {
-  if (parent.webPreviewUrl) return;
+function applyDetectedWebPreviewUrl(parent: OuijitTerminal, url: string): void {
+  // Respect manual edits: only overwrite if unset or the previous value was
+  // itself auto-detected (e.g. Vite bumped to a new port).
+  if (parent.webPreviewUrl && !parent.webPreviewUrlAutoDetected) return;
+  if (parent.webPreviewUrl === url) return;
   parent.webPreviewUrl = url;
+  parent.webPreviewUrlAutoDetected = true;
   parent.pushDisplayState({ webPreviewUrl: url });
 }
 
@@ -468,7 +459,7 @@ async function _spawnRunnerInner(instance: OuijitTerminal, script?: RunnerScript
           }
         }
         const detected = detectDevServerUrl(data);
-        if (detected) setWebPreviewUrlIfUnset(instance, detected);
+        if (detected) applyDetectedWebPreviewUrl(instance, detected);
       },
       onExit: (exitCode) => {
         instance.runnerStatus = exitCode === 0 ? 'success' : 'error';
@@ -587,7 +578,7 @@ export async function reconnectOrphanedSessions(projectPath: string): Promise<vo
           }
         }
         const detected = detectDevServerUrl(data);
-        if (detected) setWebPreviewUrlIfUnset(parentTerminal, detected);
+        if (detected) applyDetectedWebPreviewUrl(parentTerminal, detected);
       },
       onExit: (exitCode) => {
         parentTerminal.runnerStatus = exitCode === 0 ? 'success' : 'error';

--- a/src/components/terminal/terminalActions.ts
+++ b/src/components/terminal/terminalActions.ts
@@ -14,6 +14,28 @@ import log from 'electron-log/renderer';
 
 const actionsLog = log.scope('terminalActions');
 
+// ── Dev server URL detection ─────────────────────────────────────────
+
+// Strip ANSI CSI and OSC sequences so URLs split by color codes still match.
+const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07/g;
+// Match http[s]://localhost or loopback IP with required port. Requiring a port
+// avoids false positives on documentation URLs that mention "localhost".
+const DEV_SERVER_URL_RE = /https?:\/\/(?:localhost|127\.0\.0\.1):\d+(?:\/[^\s]*)?/;
+
+function detectDevServerUrl(chunk: string): string | null {
+  const stripped = chunk.replace(ANSI_RE, '');
+  const match = DEV_SERVER_URL_RE.exec(stripped);
+  if (!match) return null;
+  // Trim common trailing punctuation printed by loggers.
+  return match[0].replace(/[.,;:!?)\]]+$/, '');
+}
+
+function setWebPreviewUrlIfUnset(parent: OuijitTerminal, url: string): void {
+  if (parent.webPreviewUrl) return;
+  parent.webPreviewUrl = url;
+  parent.pushDisplayState({ webPreviewUrl: url });
+}
+
 // ── Types ────────────────────────────────────────────────────────────
 
 export interface AddProjectTerminalOptions {
@@ -445,6 +467,8 @@ async function _spawnRunnerInner(instance: OuijitTerminal, script?: RunnerScript
             instance.pushDisplayState({ runnerStatus: instance.runnerStatus });
           }
         }
+        const detected = detectDevServerUrl(data);
+        if (detected) setWebPreviewUrlIfUnset(instance, detected);
       },
       onExit: (exitCode) => {
         instance.runnerStatus = exitCode === 0 ? 'success' : 'error';
@@ -562,6 +586,8 @@ export async function reconnectOrphanedSessions(projectPath: string): Promise<vo
             parentTerminal.pushDisplayState({ runnerStatus: parentTerminal.runnerStatus });
           }
         }
+        const detected = detectDevServerUrl(data);
+        if (detected) setWebPreviewUrlIfUnset(parentTerminal, detected);
       },
       onExit: (exitCode) => {
         parentTerminal.runnerStatus = exitCode === 0 ? 'success' : 'error';

--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -302,6 +302,12 @@ export class OuijitTerminal {
   planFullWidth = true;
   planSplitRatio = 0.5;
 
+  // ── Per-terminal web preview panel state ──────────────────────────
+  webPreviewUrl: string | null = null;
+  webPreviewPanelOpen = false;
+  webPreviewFullWidth = true;
+  webPreviewSplitRatio = 0.5;
+
   // ── Runner (child OuijitTerminal) ──────────────────────────────────
   runner: OuijitTerminal | null = null;
   runnerPanelOpen = false;

--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -304,6 +304,7 @@ export class OuijitTerminal {
 
   // ── Per-terminal web preview panel state ──────────────────────────
   webPreviewUrl: string | null = null;
+  webPreviewUrlAutoDetected = false;
   webPreviewPanelOpen = false;
   webPreviewFullWidth = true;
   webPreviewSplitRatio = 0.5;
@@ -659,11 +660,23 @@ export class OuijitTerminal {
     this.runnerStatus = 'idle';
     this.runnerFullWidth = true;
 
-    this.pushDisplayState({
+    const patch: Record<string, unknown> = {
       runnerPanelOpen: false,
       runnerStatus: 'idle',
       runnerScriptName: null,
-    });
+    };
+
+    // Clear auto-detected preview URL so the next runner can publish a fresh one
+    // (e.g. Vite bumps ports when its default is busy). Manual URLs are preserved.
+    if (this.webPreviewUrlAutoDetected) {
+      this.webPreviewUrl = null;
+      this.webPreviewUrlAutoDetected = false;
+      this.webPreviewPanelOpen = false;
+      patch.webPreviewUrl = null;
+      patch.webPreviewPanelOpen = false;
+    }
+
+    this.pushDisplayState(patch);
   }
 
   // ── Hook status handling ────────────────────────────────────────────

--- a/src/components/terminal/useTerminalPanels.ts
+++ b/src/components/terminal/useTerminalPanels.ts
@@ -1,7 +1,22 @@
 import { useCallback } from 'react';
-import { terminalInstances } from './terminalReact';
+import { terminalInstances, type OuijitTerminal } from './terminalReact';
 import { spawnRunner } from './terminalActions';
 import type { RunnerScript } from '../../types';
+
+type PanelKey = 'diffPanelOpen' | 'runnerPanelOpen' | 'planPanelOpen' | 'webPreviewPanelOpen';
+
+const ALL_PANELS: PanelKey[] = ['diffPanelOpen', 'runnerPanelOpen', 'planPanelOpen', 'webPreviewPanelOpen'];
+
+/** Close every panel except the one being opened, and push the patch to the store. */
+function closeOtherPanels(instance: OuijitTerminal, keep: PanelKey): void {
+  const patch: Record<string, boolean> = { [keep]: true };
+  for (const panel of ALL_PANELS) {
+    if (panel === keep) continue;
+    instance[panel] = false;
+    patch[panel] = false;
+  }
+  instance.pushDisplayState(patch);
+}
 
 export function useTerminalPanels(ptyId: string | null) {
   const toggleDiffPanel = useCallback(() => {
@@ -10,19 +25,9 @@ export function useTerminalPanels(ptyId: string | null) {
     if (!instance) return;
     instance.diffPanelOpen = !instance.diffPanelOpen;
     if (instance.diffPanelOpen) {
-      instance.runnerPanelOpen = false;
-      instance.planPanelOpen = false;
-      instance.webPreviewPanelOpen = false;
-      instance.pushDisplayState({
-        diffPanelOpen: true,
-        runnerPanelOpen: false,
-        planPanelOpen: false,
-        webPreviewPanelOpen: false,
-      });
+      closeOtherPanels(instance, 'diffPanelOpen');
     } else {
       instance.pushDisplayState({ diffPanelOpen: false });
-    }
-    if (!instance.diffPanelOpen) {
       requestAnimationFrame(() => instance.fit());
     }
   }, [ptyId]);
@@ -44,15 +49,7 @@ export function useTerminalPanels(ptyId: string | null) {
       if (instance.runner?.ptyId && !script) {
         instance.runnerPanelOpen = !instance.runnerPanelOpen;
         if (instance.runnerPanelOpen) {
-          instance.diffPanelOpen = false;
-          instance.planPanelOpen = false;
-          instance.webPreviewPanelOpen = false;
-          instance.pushDisplayState({
-            runnerPanelOpen: true,
-            diffPanelOpen: false,
-            planPanelOpen: false,
-            webPreviewPanelOpen: false,
-          });
+          closeOtherPanels(instance, 'runnerPanelOpen');
         } else {
           instance.pushDisplayState({ runnerPanelOpen: false });
         }
@@ -101,15 +98,7 @@ export function useTerminalPanels(ptyId: string | null) {
     if (!instance) return;
     instance.planPanelOpen = !instance.planPanelOpen;
     if (instance.planPanelOpen) {
-      instance.diffPanelOpen = false;
-      instance.runnerPanelOpen = false;
-      instance.webPreviewPanelOpen = false;
-      instance.pushDisplayState({
-        planPanelOpen: true,
-        diffPanelOpen: false,
-        runnerPanelOpen: false,
-        webPreviewPanelOpen: false,
-      });
+      closeOtherPanels(instance, 'planPanelOpen');
     } else {
       instance.pushDisplayState({ planPanelOpen: false });
       requestAnimationFrame(() => instance.fit());
@@ -142,15 +131,7 @@ export function useTerminalPanels(ptyId: string | null) {
     if (!instance) return;
     instance.webPreviewPanelOpen = !instance.webPreviewPanelOpen;
     if (instance.webPreviewPanelOpen) {
-      instance.diffPanelOpen = false;
-      instance.runnerPanelOpen = false;
-      instance.planPanelOpen = false;
-      instance.pushDisplayState({
-        webPreviewPanelOpen: true,
-        diffPanelOpen: false,
-        runnerPanelOpen: false,
-        planPanelOpen: false,
-      });
+      closeOtherPanels(instance, 'webPreviewPanelOpen');
     } else {
       instance.pushDisplayState({ webPreviewPanelOpen: false });
       requestAnimationFrame(() => instance.fit());
@@ -172,6 +153,8 @@ export function useTerminalPanels(ptyId: string | null) {
       const instance = terminalInstances.get(ptyId);
       if (!instance) return;
       instance.webPreviewUrl = newUrl;
+      // A manual edit locks out future auto-detections.
+      instance.webPreviewUrlAutoDetected = false;
       instance.pushDisplayState({ webPreviewUrl: newUrl });
     },
     [ptyId],

--- a/src/components/terminal/useTerminalPanels.ts
+++ b/src/components/terminal/useTerminalPanels.ts
@@ -12,7 +12,13 @@ export function useTerminalPanels(ptyId: string | null) {
     if (instance.diffPanelOpen) {
       instance.runnerPanelOpen = false;
       instance.planPanelOpen = false;
-      instance.pushDisplayState({ diffPanelOpen: true, runnerPanelOpen: false, planPanelOpen: false });
+      instance.webPreviewPanelOpen = false;
+      instance.pushDisplayState({
+        diffPanelOpen: true,
+        runnerPanelOpen: false,
+        planPanelOpen: false,
+        webPreviewPanelOpen: false,
+      });
     } else {
       instance.pushDisplayState({ diffPanelOpen: false });
     }
@@ -40,7 +46,13 @@ export function useTerminalPanels(ptyId: string | null) {
         if (instance.runnerPanelOpen) {
           instance.diffPanelOpen = false;
           instance.planPanelOpen = false;
-          instance.pushDisplayState({ runnerPanelOpen: true, diffPanelOpen: false, planPanelOpen: false });
+          instance.webPreviewPanelOpen = false;
+          instance.pushDisplayState({
+            runnerPanelOpen: true,
+            diffPanelOpen: false,
+            planPanelOpen: false,
+            webPreviewPanelOpen: false,
+          });
         } else {
           instance.pushDisplayState({ runnerPanelOpen: false });
         }
@@ -91,7 +103,13 @@ export function useTerminalPanels(ptyId: string | null) {
     if (instance.planPanelOpen) {
       instance.diffPanelOpen = false;
       instance.runnerPanelOpen = false;
-      instance.pushDisplayState({ planPanelOpen: true, diffPanelOpen: false, runnerPanelOpen: false });
+      instance.webPreviewPanelOpen = false;
+      instance.pushDisplayState({
+        planPanelOpen: true,
+        diffPanelOpen: false,
+        runnerPanelOpen: false,
+        webPreviewPanelOpen: false,
+      });
     } else {
       instance.pushDisplayState({ planPanelOpen: false });
       requestAnimationFrame(() => instance.fit());
@@ -118,6 +136,47 @@ export function useTerminalPanels(ptyId: string | null) {
     [ptyId],
   );
 
+  const toggleWebPreviewPanel = useCallback(() => {
+    if (!ptyId) return;
+    const instance = terminalInstances.get(ptyId);
+    if (!instance) return;
+    instance.webPreviewPanelOpen = !instance.webPreviewPanelOpen;
+    if (instance.webPreviewPanelOpen) {
+      instance.diffPanelOpen = false;
+      instance.runnerPanelOpen = false;
+      instance.planPanelOpen = false;
+      instance.pushDisplayState({
+        webPreviewPanelOpen: true,
+        diffPanelOpen: false,
+        runnerPanelOpen: false,
+        planPanelOpen: false,
+      });
+    } else {
+      instance.pushDisplayState({ webPreviewPanelOpen: false });
+      requestAnimationFrame(() => instance.fit());
+    }
+  }, [ptyId]);
+
+  const closeWebPreviewPanel = useCallback(() => {
+    if (!ptyId) return;
+    const instance = terminalInstances.get(ptyId);
+    if (!instance) return;
+    instance.webPreviewPanelOpen = false;
+    instance.pushDisplayState({ webPreviewPanelOpen: false });
+    requestAnimationFrame(() => instance.fit());
+  }, [ptyId]);
+
+  const changeWebPreviewUrl = useCallback(
+    (newUrl: string) => {
+      if (!ptyId) return;
+      const instance = terminalInstances.get(ptyId);
+      if (!instance) return;
+      instance.webPreviewUrl = newUrl;
+      instance.pushDisplayState({ webPreviewUrl: newUrl });
+    },
+    [ptyId],
+  );
+
   return {
     toggleDiffPanel,
     closeDiffPanel,
@@ -128,5 +187,8 @@ export function useTerminalPanels(ptyId: string | null) {
     togglePlanPanel,
     closePlanPanel,
     changePlanFile,
+    toggleWebPreviewPanel,
+    closeWebPreviewPanel,
+    changeWebPreviewUrl,
   };
 }

--- a/src/components/ui/TooltipButton.tsx
+++ b/src/components/ui/TooltipButton.tsx
@@ -19,6 +19,7 @@ interface TooltipButtonProps {
   placement?: Placement;
   className?: string;
   onClick?: (e: React.MouseEvent) => void;
+  disabled?: boolean;
   children: ReactNode;
 }
 
@@ -26,7 +27,14 @@ interface TooltipButtonProps {
  * A button with a floating tooltip — no wrapper element.
  * Use this when the button must be a direct flex child (e.g. inside .project-view-toggle).
  */
-export function TooltipButton({ text, placement = 'bottom', className, onClick, children }: TooltipButtonProps) {
+export function TooltipButton({
+  text,
+  placement = 'bottom',
+  className,
+  onClick,
+  disabled,
+  children,
+}: TooltipButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const { refs, floatingStyles, context } = useFloating({
@@ -47,7 +55,13 @@ export function TooltipButton({ text, placement = 'bottom', className, onClick, 
 
   return (
     <>
-      <button ref={refs.setReference} className={className} onClick={onClick} {...getReferenceProps()}>
+      <button
+        ref={refs.setReference}
+        className={className}
+        onClick={onClick}
+        disabled={disabled}
+        {...getReferenceProps()}
+      >
         {children}
       </button>
       {isOpen &&

--- a/src/components/webPreview/WebPreviewPanel.tsx
+++ b/src/components/webPreview/WebPreviewPanel.tsx
@@ -1,0 +1,366 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { terminalInstances } from '../terminal/terminalReact';
+import { Icon } from '../terminal/Icon';
+import { TooltipButton } from '../ui/TooltipButton';
+
+interface WebPreviewPanelProps {
+  ptyId: string;
+  url: string;
+  onClose: () => void;
+  onChangeUrl: (newUrl: string) => void;
+}
+
+// Electron <webview> is a custom element. Declare the minimal API surface we use.
+interface ElectronWebviewElement extends HTMLElement {
+  src: string;
+  loadURL(url: string): Promise<void>;
+  reload(): void;
+  stop(): void;
+  goBack(): void;
+  goForward(): void;
+  canGoBack(): boolean;
+  canGoForward(): boolean;
+  getURL(): string;
+  openDevTools(): void;
+}
+
+function normalizeUrl(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return '';
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  // Bare host:port or host — assume http for dev servers
+  return `http://${trimmed}`;
+}
+
+export function WebPreviewPanel({ ptyId, url, onClose, onChangeUrl }: WebPreviewPanelProps) {
+  const instance = terminalInstances.get(ptyId);
+  const [fullWidth, setFullWidth] = useState(instance?.webPreviewFullWidth ?? true);
+  const [splitRatio, setSplitRatio] = useState(instance?.webPreviewSplitRatio ?? 0.5);
+
+  const [loading, setLoading] = useState(false);
+  const [canGoBack, setCanGoBack] = useState(false);
+  const [canGoForward, setCanGoForward] = useState(false);
+  const [currentUrl, setCurrentUrl] = useState(url);
+  const [editingUrl, setEditingUrl] = useState(false);
+  const [urlDraft, setUrlDraft] = useState(url);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  const handleRef = useRef<HTMLDivElement>(null);
+  const webviewRef = useRef<ElectronWebviewElement | null>(null);
+  const urlInputRef = useRef<HTMLInputElement>(null);
+
+  // Wire webview events
+  useEffect(() => {
+    const webview = webviewRef.current;
+    if (!webview) return;
+
+    // allowpopups is a boolean attribute Electron reads before attach; setting
+    // it via React props fights the type defs, so set it imperatively.
+    webview.setAttribute('allowpopups', '');
+
+    const handleStart = () => {
+      setLoading(true);
+      setLoadError(null);
+    };
+    const handleStop = () => {
+      setLoading(false);
+      try {
+        setCanGoBack(webview.canGoBack());
+        setCanGoForward(webview.canGoForward());
+      } catch {
+        // webview not yet attached
+      }
+    };
+    const handleNavigate = (e: Event) => {
+      const navEvent = e as Event & { url?: string };
+      if (navEvent.url) setCurrentUrl(navEvent.url);
+      try {
+        setCanGoBack(webview.canGoBack());
+        setCanGoForward(webview.canGoForward());
+      } catch {
+        // ignore
+      }
+    };
+    const handleFailLoad = (e: Event) => {
+      const failEvent = e as Event & { errorCode?: number; errorDescription?: string; validatedURL?: string };
+      // -3 is ERR_ABORTED (usually user navigation away); ignore it.
+      if (failEvent.errorCode === -3) return;
+      setLoading(false);
+      setLoadError(failEvent.errorDescription || 'Failed to load page');
+    };
+
+    webview.addEventListener('did-start-loading', handleStart);
+    webview.addEventListener('did-stop-loading', handleStop);
+    webview.addEventListener('did-navigate', handleNavigate);
+    webview.addEventListener('did-navigate-in-page', handleNavigate);
+    webview.addEventListener('did-fail-load', handleFailLoad);
+
+    return () => {
+      webview.removeEventListener('did-start-loading', handleStart);
+      webview.removeEventListener('did-stop-loading', handleStop);
+      webview.removeEventListener('did-navigate', handleNavigate);
+      webview.removeEventListener('did-navigate-in-page', handleNavigate);
+      webview.removeEventListener('did-fail-load', handleFailLoad);
+    };
+  }, []);
+
+  // Sync external url prop changes into the webview (e.g. user edits URL)
+  useEffect(() => {
+    const webview = webviewRef.current;
+    if (!webview) return;
+    if (!url) return;
+    try {
+      if (webview.getURL() !== url) {
+        webview.loadURL(url).catch(() => {
+          // Errors surface through did-fail-load
+        });
+      }
+    } catch {
+      // Not yet attached — initial src attribute handles it
+    }
+    setCurrentUrl(url);
+    setUrlDraft(url);
+  }, [url]);
+
+  const handleReload = useCallback(() => {
+    webviewRef.current?.reload();
+  }, []);
+
+  const handleBack = useCallback(() => {
+    const w = webviewRef.current;
+    if (w?.canGoBack()) w.goBack();
+  }, []);
+
+  const handleForward = useCallback(() => {
+    const w = webviewRef.current;
+    if (w?.canGoForward()) w.goForward();
+  }, []);
+
+  const commitUrl = useCallback(() => {
+    const normalized = normalizeUrl(urlDraft);
+    setEditingUrl(false);
+    if (normalized && normalized !== url) {
+      onChangeUrl(normalized);
+    } else {
+      setUrlDraft(url);
+    }
+  }, [urlDraft, url, onChangeUrl]);
+
+  const startEditingUrl = useCallback(() => {
+    setUrlDraft(currentUrl || url);
+    setEditingUrl(true);
+    requestAnimationFrame(() => {
+      urlInputRef.current?.focus();
+      urlInputRef.current?.select();
+    });
+  }, [currentUrl, url]);
+
+  const toggleFullWidth = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!instance) return;
+      const newFullWidth = !fullWidth;
+      instance.webPreviewFullWidth = newFullWidth;
+      setFullWidth(newFullWidth);
+      instance.pushDisplayState({ webPreviewFullWidth: newFullWidth });
+
+      requestAnimationFrame(() => {
+        if (!newFullWidth) instance.fit();
+      });
+    },
+    [fullWidth, instance],
+  );
+
+  // Resize handle drag
+  useEffect(() => {
+    const handle = handleRef.current;
+    const panel = panelRef.current;
+    if (!handle || !panel || !instance) return;
+
+    const cardBody = panel.parentElement;
+    if (!cardBody) return;
+
+    let dragging = false;
+
+    const onMouseDown = (e: MouseEvent) => {
+      e.preventDefault();
+      dragging = true;
+      panel.style.transition = 'none';
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (!dragging) return;
+      const rect = cardBody.getBoundingClientRect();
+      const handleWidth = handle.offsetWidth;
+      const totalWidth = rect.width - handleWidth;
+      const mouseX = e.clientX - rect.left;
+      let ratio = 1 - mouseX / totalWidth;
+      ratio = Math.max(0.15, Math.min(0.85, ratio));
+      instance.webPreviewSplitRatio = ratio;
+      panel.style.flexBasis = `${ratio * 100}%`;
+    };
+
+    const onMouseUp = () => {
+      if (!dragging) return;
+      dragging = false;
+      setSplitRatio(instance.webPreviewSplitRatio ?? 0.5);
+      panel.style.transition = '';
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    handle.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+
+    return () => {
+      handle.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+  }, [instance, fullWidth]);
+
+  // Set initial flex-basis
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    if (fullWidth) {
+      panel.style.flexBasis = '100%';
+    } else {
+      panel.style.flexBasis = `${splitRatio * 100}%`;
+    }
+
+    requestAnimationFrame(() => {
+      if (!fullWidth) instance?.fit();
+    });
+  }, [fullWidth, splitRatio, instance]);
+
+  const splitIcon = fullWidth ? 'square-split-horizontal' : 'arrows-out-line-horizontal';
+  const splitTitle = fullWidth ? 'Split view' : 'Full width';
+
+  return (
+    <>
+      {!fullWidth && (
+        <div
+          ref={handleRef}
+          className="shrink-0 relative hover:bg-white/15 active:bg-white/15 after:content-[''] after:absolute after:top-0 after:bottom-0 after:-left-2 after:-right-2"
+          style={{ width: 4, cursor: 'col-resize', background: 'transparent', transition: 'background 0.15s ease' }}
+        />
+      )}
+      <div
+        ref={panelRef}
+        className="rounded-none border-0 border-l border-t border-solid border-white/10 shadow-none flex flex-col overflow-hidden"
+        style={{
+          flexBasis: 0,
+          background: 'var(--color-terminal-bg, #171717)',
+          transition: 'flex-basis 0.25s ease',
+          ...(fullWidth ? { flex: '1 0 100%', borderLeft: 'none' } : { minWidth: 200 }),
+        }}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-1 px-2 py-1.5 bg-white/[0.03] border-b border-white/10 shrink-0">
+          <TooltipButton
+            text="Back"
+            placement="bottom"
+            className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/60 shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90 disabled:text-white/20 disabled:hover:bg-transparent [&>svg]:w-3.5 [&>svg]:h-3.5"
+            onClick={handleBack}
+            disabled={!canGoBack}
+          >
+            <Icon name="arrow-left" />
+          </TooltipButton>
+          <TooltipButton
+            text="Forward"
+            placement="bottom"
+            className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/60 shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90 disabled:text-white/20 disabled:hover:bg-transparent [&>svg]:w-3.5 [&>svg]:h-3.5"
+            onClick={handleForward}
+            disabled={!canGoForward}
+          >
+            <Icon name="arrow-right" />
+          </TooltipButton>
+          <TooltipButton
+            text={loading ? 'Stop' : 'Reload'}
+            placement="bottom"
+            className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/60 shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90 [&>svg]:w-3.5 [&>svg]:h-3.5"
+            onClick={loading ? () => webviewRef.current?.stop() : handleReload}
+          >
+            <Icon name={loading ? 'x' : 'arrows-clockwise'} />
+          </TooltipButton>
+          {editingUrl ? (
+            <input
+              ref={urlInputRef}
+              value={urlDraft}
+              onChange={(e) => setUrlDraft(e.target.value)}
+              onBlur={commitUrl}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') commitUrl();
+                if (e.key === 'Escape') {
+                  setUrlDraft(url);
+                  setEditingUrl(false);
+                }
+              }}
+              className="text-[13px] text-white/80 flex-1 min-w-0 font-mono bg-white/5 border border-white/10 rounded px-2 py-0.5 outline-none focus:border-accent [-webkit-app-region:no-drag]"
+            />
+          ) : (
+            <button
+              className="text-[13px] text-white/60 truncate flex-1 min-w-0 font-mono bg-transparent border-none py-0.5 px-2 text-left transition-colors duration-150 hover:text-white/90 rounded"
+              title={currentUrl}
+              onClick={startEditingUrl}
+            >
+              {currentUrl || 'Enter URL…'}
+            </button>
+          )}
+          <TooltipButton
+            text={splitTitle}
+            placement="bottom"
+            className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/60 shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90 [&>svg]:w-3.5 [&>svg]:h-3.5"
+            onClick={toggleFullWidth}
+          >
+            <Icon name={splitIcon} />
+          </TooltipButton>
+          <TooltipButton
+            text="Minimize"
+            placement="bottom"
+            className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/60 shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90 [&>svg]:w-4 [&>svg]:h-4"
+            onClick={onClose}
+          >
+            <Icon name="minus" />
+          </TooltipButton>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 relative bg-white">
+          {url ? (
+            <webview
+              ref={webviewRef as unknown as React.Ref<HTMLWebViewElement>}
+              src={url}
+              style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 'none' }}
+            />
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center text-sm text-white/40 bg-[var(--color-terminal-bg,#171717)]">
+              No URL set
+            </div>
+          )}
+          {loadError && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-sm text-white/70 bg-[var(--color-terminal-bg,#171717)] p-6 text-center">
+              <Icon name="globe-simple" className="w-8 h-8 text-white/30" />
+              <div className="font-mono text-white/80">{loadError}</div>
+              <div className="font-mono text-[11px] text-white/40 break-all">{currentUrl}</div>
+              <button
+                className="mt-2 px-3 py-1 rounded-md bg-white/10 hover:bg-white/15 text-white/80 text-xs border-none transition-colors"
+                onClick={handleReload}
+              >
+                Retry
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/webPreview/WebPreviewPanel.tsx
+++ b/src/components/webPreview/WebPreviewPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { terminalInstances } from '../terminal/terminalReact';
 import { Icon } from '../terminal/Icon';
 import { TooltipButton } from '../ui/TooltipButton';
+import { normalizeUrl } from './urlHelpers';
 
 interface WebPreviewPanelProps {
   ptyId: string;
@@ -24,14 +25,6 @@ interface ElectronWebviewElement extends HTMLElement {
   openDevTools(): void;
 }
 
-function normalizeUrl(input: string): string {
-  const trimmed = input.trim();
-  if (!trimmed) return '';
-  if (/^https?:\/\//i.test(trimmed)) return trimmed;
-  // Bare host:port or host — assume http for dev servers
-  return `http://${trimmed}`;
-}
-
 export function WebPreviewPanel({ ptyId, url, onClose, onChangeUrl }: WebPreviewPanelProps) {
   const instance = terminalInstances.get(ptyId);
   const [fullWidth, setFullWidth] = useState(instance?.webPreviewFullWidth ?? true);
@@ -41,23 +34,34 @@ export function WebPreviewPanel({ ptyId, url, onClose, onChangeUrl }: WebPreview
   const [canGoBack, setCanGoBack] = useState(false);
   const [canGoForward, setCanGoForward] = useState(false);
   const [currentUrl, setCurrentUrl] = useState(url);
-  const [editingUrl, setEditingUrl] = useState(false);
+  // When opened without a URL, drop straight into the editor so users can type
+  // one instead of seeing a dead-end "No URL set" panel.
+  const [editingUrl, setEditingUrl] = useState(!url);
   const [urlDraft, setUrlDraft] = useState(url);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [dragging, setDragging] = useState(false);
 
   const panelRef = useRef<HTMLDivElement>(null);
   const handleRef = useRef<HTMLDivElement>(null);
   const webviewRef = useRef<ElectronWebviewElement | null>(null);
   const urlInputRef = useRef<HTMLInputElement>(null);
 
-  // Wire webview events
-  useEffect(() => {
-    const webview = webviewRef.current;
-    if (!webview) return;
+  // Attach webview event listeners via a callback ref so they rewire if the
+  // <webview> remounts (e.g. url cleared and set again).
+  const setWebviewNode = useCallback((node: ElectronWebviewElement | null) => {
+    // Tear down listeners on the previous node.
+    const prev = webviewRef.current;
+    if (prev && prev !== node) {
+      const cleanup = (prev as HTMLElement & { __ouijitCleanup?: () => void }).__ouijitCleanup;
+      cleanup?.();
+    }
+
+    webviewRef.current = node;
+    if (!node) return;
 
     // allowpopups is a boolean attribute Electron reads before attach; setting
     // it via React props fights the type defs, so set it imperatively.
-    webview.setAttribute('allowpopups', '');
+    node.setAttribute('allowpopups', '');
 
     const handleStart = () => {
       setLoading(true);
@@ -66,18 +70,18 @@ export function WebPreviewPanel({ ptyId, url, onClose, onChangeUrl }: WebPreview
     const handleStop = () => {
       setLoading(false);
       try {
-        setCanGoBack(webview.canGoBack());
-        setCanGoForward(webview.canGoForward());
+        setCanGoBack(node.canGoBack());
+        setCanGoForward(node.canGoForward());
       } catch {
-        // webview not yet attached
+        // not yet attached
       }
     };
     const handleNavigate = (e: Event) => {
       const navEvent = e as Event & { url?: string };
       if (navEvent.url) setCurrentUrl(navEvent.url);
       try {
-        setCanGoBack(webview.canGoBack());
-        setCanGoForward(webview.canGoForward());
+        setCanGoBack(node.canGoBack());
+        setCanGoForward(node.canGoForward());
       } catch {
         // ignore
       }
@@ -90,32 +94,37 @@ export function WebPreviewPanel({ ptyId, url, onClose, onChangeUrl }: WebPreview
       setLoadError(failEvent.errorDescription || 'Failed to load page');
     };
 
-    webview.addEventListener('did-start-loading', handleStart);
-    webview.addEventListener('did-stop-loading', handleStop);
-    webview.addEventListener('did-navigate', handleNavigate);
-    webview.addEventListener('did-navigate-in-page', handleNavigate);
-    webview.addEventListener('did-fail-load', handleFailLoad);
+    node.addEventListener('did-start-loading', handleStart);
+    node.addEventListener('did-stop-loading', handleStop);
+    node.addEventListener('did-navigate', handleNavigate);
+    node.addEventListener('did-navigate-in-page', handleNavigate);
+    node.addEventListener('did-fail-load', handleFailLoad);
 
-    return () => {
-      webview.removeEventListener('did-start-loading', handleStart);
-      webview.removeEventListener('did-stop-loading', handleStop);
-      webview.removeEventListener('did-navigate', handleNavigate);
-      webview.removeEventListener('did-navigate-in-page', handleNavigate);
-      webview.removeEventListener('did-fail-load', handleFailLoad);
+    (node as HTMLElement & { __ouijitCleanup?: () => void }).__ouijitCleanup = () => {
+      node.removeEventListener('did-start-loading', handleStart);
+      node.removeEventListener('did-stop-loading', handleStop);
+      node.removeEventListener('did-navigate', handleNavigate);
+      node.removeEventListener('did-navigate-in-page', handleNavigate);
+      node.removeEventListener('did-fail-load', handleFailLoad);
     };
   }, []);
 
-  // Sync external url prop changes into the webview (e.g. user edits URL)
+  // Sync external url prop changes into the webview. Skip the initial render
+  // because `src={url}` already loads it — otherwise we'd double-load.
+  const lastLoadedUrlRef = useRef<string>(url);
   useEffect(() => {
     const webview = webviewRef.current;
-    if (!webview) return;
+    if (!webview) {
+      lastLoadedUrlRef.current = url;
+      return;
+    }
     if (!url) return;
+    if (lastLoadedUrlRef.current === url) return;
+    lastLoadedUrlRef.current = url;
     try {
-      if (webview.getURL() !== url) {
-        webview.loadURL(url).catch(() => {
-          // Errors surface through did-fail-load
-        });
-      }
+      webview.loadURL(url).catch(() => {
+        // Errors surface through did-fail-load
+      });
     } catch {
       // Not yet attached — initial src attribute handles it
     }
@@ -156,6 +165,11 @@ export function WebPreviewPanel({ ptyId, url, onClose, onChangeUrl }: WebPreview
     });
   }, [currentUrl, url]);
 
+  // Focus the input when it auto-opens (panel opened without a URL).
+  useEffect(() => {
+    if (editingUrl) urlInputRef.current?.focus();
+  }, [editingUrl]);
+
   const toggleFullWidth = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -172,7 +186,9 @@ export function WebPreviewPanel({ ptyId, url, onClose, onChangeUrl }: WebPreview
     [fullWidth, instance],
   );
 
-  // Resize handle drag
+  // Resize handle drag. The webview captures pointer events for its own
+  // webContents, so while dragging we flip pointer-events off on it and
+  // listen for mousemove on document to keep getting coordinates.
   useEffect(() => {
     const handle = handleRef.current;
     const panel = panelRef.current;
@@ -181,18 +197,19 @@ export function WebPreviewPanel({ ptyId, url, onClose, onChangeUrl }: WebPreview
     const cardBody = panel.parentElement;
     if (!cardBody) return;
 
-    let dragging = false;
+    let isDragging = false;
 
     const onMouseDown = (e: MouseEvent) => {
       e.preventDefault();
-      dragging = true;
+      isDragging = true;
+      setDragging(true);
       panel.style.transition = 'none';
       document.body.style.cursor = 'col-resize';
       document.body.style.userSelect = 'none';
     };
 
     const onMouseMove = (e: MouseEvent) => {
-      if (!dragging) return;
+      if (!isDragging) return;
       const rect = cardBody.getBoundingClientRect();
       const handleWidth = handle.offsetWidth;
       const totalWidth = rect.width - handleWidth;
@@ -204,8 +221,9 @@ export function WebPreviewPanel({ ptyId, url, onClose, onChangeUrl }: WebPreview
     };
 
     const onMouseUp = () => {
-      if (!dragging) return;
-      dragging = false;
+      if (!isDragging) return;
+      isDragging = false;
+      setDragging(false);
       setSplitRatio(instance.webPreviewSplitRatio ?? 0.5);
       panel.style.transition = '';
       document.body.style.cursor = '';
@@ -304,6 +322,7 @@ export function WebPreviewPanel({ ptyId, url, onClose, onChangeUrl }: WebPreview
                   setEditingUrl(false);
                 }
               }}
+              placeholder="http://localhost:3000"
               className="text-[13px] text-white/80 flex-1 min-w-0 font-mono bg-white/5 border border-white/10 rounded px-2 py-0.5 outline-none focus:border-accent [-webkit-app-region:no-drag]"
             />
           ) : (
@@ -337,13 +356,20 @@ export function WebPreviewPanel({ ptyId, url, onClose, onChangeUrl }: WebPreview
         <div className="flex-1 relative bg-white">
           {url ? (
             <webview
-              ref={webviewRef as unknown as React.Ref<HTMLWebViewElement>}
+              ref={setWebviewNode as unknown as React.Ref<HTMLWebViewElement>}
               src={url}
-              style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', border: 'none' }}
+              style={{
+                position: 'absolute',
+                inset: 0,
+                width: '100%',
+                height: '100%',
+                border: 'none',
+                pointerEvents: dragging ? 'none' : 'auto',
+              }}
             />
           ) : (
             <div className="absolute inset-0 flex items-center justify-center text-sm text-white/40 bg-[var(--color-terminal-bg,#171717)]">
-              No URL set
+              Enter a URL above to preview it
             </div>
           )}
           {loadError && (

--- a/src/components/webPreview/urlHelpers.ts
+++ b/src/components/webPreview/urlHelpers.ts
@@ -1,0 +1,34 @@
+/**
+ * URL utilities for the web preview panel.
+ *
+ * Kept separate so they can be unit-tested without pulling in React or
+ * the Electron <webview> element.
+ */
+
+/** Normalize user-entered URL input: add http:// when a scheme is missing. */
+export function normalizeUrl(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return '';
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  // Bare host:port or host — assume http for dev servers.
+  return `http://${trimmed}`;
+}
+
+// Strip ANSI CSI and OSC sequences so URLs split by color codes still match.
+const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07/g;
+
+// Match http[s]://localhost or loopback IP with required port. Requiring a
+// port avoids false positives on documentation URLs that mention "localhost".
+const DEV_SERVER_URL_RE = /https?:\/\/(?:localhost|127\.0\.0\.1):\d+(?:\/[^\s]*)?/;
+
+/**
+ * Scan a runner-terminal output chunk for a dev server URL. Returns the first
+ * match, stripped of ANSI escapes and trailing punctuation.
+ */
+export function detectDevServerUrl(chunk: string): string | null {
+  const stripped = chunk.replace(ANSI_RE, '');
+  const match = DEV_SERVER_URL_RE.exec(stripped);
+  if (!match) return null;
+  // Trim trailing punctuation commonly printed by loggers (e.g. ".", ")").
+  return match[0].replace(/[.,;:!?)\]]+$/, '');
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,6 +99,7 @@ const createWindow = (): BrowserWindow => {
     backgroundColor,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
+      webviewTag: true,
     },
   });
 
@@ -120,6 +121,21 @@ const createWindow = (): BrowserWindow => {
   window.webContents.setWindowOpenHandler(({ url }) => {
     if (/^https?:\/\//i.test(url)) shell.openExternal(url);
     return { action: 'deny' };
+  });
+
+  // Lock down <webview> elements used for web preview panels. We strip node
+  // integration, disable the preload script, and prevent new window spawns so
+  // an embedded dev server page can't escape the sandbox.
+  window.webContents.on('will-attach-webview', (_event, webPreferences, params) => {
+    delete webPreferences.preload;
+    webPreferences.nodeIntegration = false;
+    webPreferences.contextIsolation = true;
+    webPreferences.sandbox = true;
+
+    // Only allow http(s) URLs. A bad src attribute can't ship us to a file:// page.
+    if (!/^https?:\/\//i.test(params.src || '')) {
+      params.src = 'about:blank';
+    }
   });
 
   // Prevent the main window from navigating away to an external URL.

--- a/src/stores/terminalStore.ts
+++ b/src/stores/terminalStore.ts
@@ -21,6 +21,9 @@ export interface TerminalDisplayState {
   planPath: string | null;
   planPanelOpen: boolean;
   planFullWidth: boolean;
+  webPreviewUrl: string | null;
+  webPreviewPanelOpen: boolean;
+  webPreviewFullWidth: boolean;
   sandboxed: boolean;
   taskId: number | null;
   worktreeBranch: string | null;
@@ -46,6 +49,9 @@ export const DEFAULT_DISPLAY_STATE: Omit<TerminalDisplayState, 'ptyId' | 'projec
   planPath: null,
   planPanelOpen: false,
   planFullWidth: true,
+  webPreviewUrl: null,
+  webPreviewPanelOpen: false,
+  webPreviewFullWidth: true,
   sandboxed: false,
   taskId: null,
   worktreeBranch: null,

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -38,6 +38,7 @@ import fileText from '@phosphor-icons/core/assets/regular/file-text.svg?raw';
 import folderOpen from '@phosphor-icons/core/assets/regular/folder-open.svg?raw';
 import folderPlus from '@phosphor-icons/core/assets/regular/folder-plus.svg?raw';
 import gear from '@phosphor-icons/core/assets/regular/gear.svg?raw';
+import globeSimple from '@phosphor-icons/core/assets/regular/globe-simple.svg?raw';
 import gitBranch from '@phosphor-icons/core/assets/regular/git-branch.svg?raw';
 import gitFork from '@phosphor-icons/core/assets/regular/git-fork.svg?raw';
 import gridFour from '@phosphor-icons/core/assets/regular/grid-four.svg?raw';
@@ -103,6 +104,7 @@ export const iconMap: Record<string, string> = {
   'folder-open': folderOpen,
   'folder-plus': folderPlus,
   gear: gear,
+  'globe-simple': globeSimple,
   'git-branch': gitBranch,
   'git-diff': gitDiff,
   'git-fork': gitFork,


### PR DESCRIPTION
## Summary
- Adds a slide-in Web Preview panel next to each terminal card that renders a URL via Electron `<webview>`
- Auto-detects `http://localhost:PORT` and `http://127.0.0.1:PORT` in runner output; auto-detected URLs update on port bump but never overwrite manual edits; cleared when the runner is killed
- Locks down `<webview>` at attach time (no preload, sandboxed, http(s)-only) via `will-attach-webview`
- Panel supports split/full-width, back/forward/reload/stop, inline URL editor, load-error retry; pointer events are shimmed off during split-drag so coordinates keep flowing over the webview
- "Preview" pill appears on the terminal header and canvas node periphery whenever a URL is known
- Factors `closeOtherPanels` helper to dedupe panel mutual-exclusion code; adds 18 unit tests for `detectDevServerUrl` / `normalizeUrl`