### PR TITLE
Harden Lima sandbox against escape vectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11062,7 +11062,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12974,7 +12973,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/src/__tests__/apiAuth.test.ts
+++ b/src/__tests__/apiAuth.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from 'vitest';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { issueToken, revokeToken, revokeAllTokens, verifyToken, authenticateRequest } from '../apiAuth';
 
 describe('apiAuth', () => {
@@ -22,12 +22,23 @@ describe('apiAuth', () => {
     expect(verifyToken('')).toBeNull();
   });
 
-  test('re-issuing for the same ptyId invalidates the previous token', () => {
+  test('re-issuing for the same ptyId invalidates the previous token and warns', () => {
+    // Re-issue shouldn't happen in normal spawn flow (ptyIds are unique);
+    // if it does, the warning surfaces the lifecycle bug rather than
+    // silently swapping tokens. The logger falls back to console.warn
+    // in tests, so that's what we spy on.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const oldToken = issueToken('pty-1', 'host');
+    warnSpy.mockClear();
     const newToken = issueToken('pty-1', 'host');
     expect(oldToken).not.toBe(newToken);
     expect(verifyToken(oldToken)).toBeNull();
     expect(verifyToken(newToken)).not.toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+    const combined = warnSpy.mock.calls.map((args) => args.join(' ')).join(' ');
+    expect(combined).toContain('re-issuing token');
+    expect(combined).toContain('pty-1');
+    warnSpy.mockRestore();
   });
 
   test('revokeToken removes the token', () => {

--- a/src/__tests__/apiAuth.test.ts
+++ b/src/__tests__/apiAuth.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { issueToken, revokeToken, revokeAllTokens, verifyToken, authenticateRequest } from '../apiAuth';
+
+describe('apiAuth', () => {
+  beforeEach(() => {
+    revokeAllTokens();
+  });
+
+  test('issueToken returns a hex token', () => {
+    const token = issueToken('pty-1', 'host');
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('verifyToken returns context for known token', () => {
+    const token = issueToken('pty-1', 'sandbox');
+    const ctx = verifyToken(token);
+    expect(ctx).toEqual({ ptyId: 'pty-1', scope: 'sandbox' });
+  });
+
+  test('verifyToken returns null for unknown token', () => {
+    expect(verifyToken('deadbeef')).toBeNull();
+    expect(verifyToken('')).toBeNull();
+  });
+
+  test('re-issuing for the same ptyId invalidates the previous token', () => {
+    const oldToken = issueToken('pty-1', 'host');
+    const newToken = issueToken('pty-1', 'host');
+    expect(oldToken).not.toBe(newToken);
+    expect(verifyToken(oldToken)).toBeNull();
+    expect(verifyToken(newToken)).not.toBeNull();
+  });
+
+  test('revokeToken removes the token', () => {
+    const token = issueToken('pty-1', 'host');
+    revokeToken('pty-1');
+    expect(verifyToken(token)).toBeNull();
+  });
+
+  test('authenticateRequest parses Bearer header', () => {
+    const token = issueToken('pty-x', 'host');
+    expect(authenticateRequest(`Bearer ${token}`)).toEqual({ ptyId: 'pty-x', scope: 'host' });
+  });
+
+  test('authenticateRequest is case-insensitive for scheme', () => {
+    const token = issueToken('pty-x', 'host');
+    expect(authenticateRequest(`bearer ${token}`)).not.toBeNull();
+    expect(authenticateRequest(`BEARER ${token}`)).not.toBeNull();
+  });
+
+  test('authenticateRequest rejects non-Bearer', () => {
+    const token = issueToken('pty-x', 'host');
+    expect(authenticateRequest(`Basic ${token}`)).toBeNull();
+    expect(authenticateRequest(token)).toBeNull();
+    expect(authenticateRequest(undefined)).toBeNull();
+  });
+
+  test('verifyToken does not match a prefix of a stored token', () => {
+    const token = issueToken('pty-x', 'host');
+    expect(verifyToken(token.slice(0, 32))).toBeNull();
+  });
+});

--- a/src/__tests__/apiRouterAuth.test.ts
+++ b/src/__tests__/apiRouterAuth.test.ts
@@ -1,0 +1,182 @@
+/**
+ * End-to-end auth + scope checks on the REST router by driving the
+ * hook server with a real HTTP client. Covers:
+ *   - Unauthenticated requests get 401.
+ *   - Host-only routes reject sandbox-scoped tokens with 403.
+ *   - Sandbox-scoped tokens can hit plan/:ptyId but only for own ptyId.
+ *   - POST /api/tasks/start with sandboxed:false is refused on sandbox scope.
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as http from 'node:http';
+import type { BrowserWindow } from 'electron';
+
+vi.mock('../ptyManager', () => ({
+  isPtyActive: () => true,
+}));
+
+// Prevent real IPC broadcasts; we're driving HTTP directly.
+vi.mock('../ipc/helpers', () => ({
+  typedPush: vi.fn(),
+}));
+
+// Stub the business-logic modules the router calls; we only care about
+// which routes the auth layer allows through, not what they return.
+vi.mock('../worktree', () => ({
+  createTodoTask: vi.fn(async () => ({ ok: true })),
+  createTaskWorktree: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock('../db', () => ({
+  setTaskMergeTarget: vi.fn(),
+  setTaskName: vi.fn(),
+  setTaskDescription: vi.fn(),
+  getHooks: vi.fn(() => ({})),
+  saveHook: vi.fn(),
+  deleteHook: vi.fn(),
+  getAllTags: vi.fn(() => []),
+  getTaskTags: vi.fn(() => []),
+  addTagToTask: vi.fn(),
+  removeTagFromTask: vi.fn(),
+  setTaskTags: vi.fn(),
+  getScripts: vi.fn(() => []),
+  saveScript: vi.fn(),
+  deleteScript: vi.fn(),
+}));
+
+vi.mock('../taskLifecycle', () => ({
+  beginTask: vi.fn(async () => ({})),
+  setTaskStatusWithHooks: vi.fn(async () => ({})),
+  deleteTaskWithWorktree: vi.fn(async () => ({})),
+  getTasksWithWorkspaces: vi.fn(async () => []),
+  getTaskWithWorkspace: vi.fn(async () => null),
+}));
+
+vi.mock('../scanner', () => ({
+  getProjectList: vi.fn(async () => []),
+}));
+
+import { startHookServer, stopHookServer, getApiPort } from '../hookServer';
+import { issueToken, revokeAllTokens } from '../apiAuth';
+
+const mockSend = vi.fn();
+function mockWindow(): BrowserWindow {
+  return {
+    isDestroyed: () => false,
+    webContents: { send: mockSend },
+  } as unknown as BrowserWindow;
+}
+
+interface Response {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+function request(method: string, path: string, token?: string, body?: Record<string, unknown>): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    const port = getApiPort();
+    const payload = body ? JSON.stringify(body) : undefined;
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: {
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          ...(payload ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) } : {}),
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk: Buffer) => (raw += chunk.toString()));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode!, body: raw ? JSON.parse(raw) : {} });
+          } catch {
+            resolve({ status: res.statusCode!, body: { raw } });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+beforeEach(async () => {
+  mockSend.mockClear();
+  revokeAllTokens();
+  await startHookServer(mockWindow());
+});
+
+afterEach(async () => {
+  await stopHookServer();
+});
+
+const PROJECT = encodeURIComponent('/tmp/test-project');
+
+describe('REST API auth', () => {
+  test('rejects unauthenticated requests with 401', async () => {
+    const res = await request('GET', `/api/tasks?project=${PROJECT}`);
+    expect(res.status).toBe(401);
+  });
+
+  test('rejects unknown tokens with 401', async () => {
+    const res = await request('GET', `/api/tasks?project=${PROJECT}`, 'not-a-real-token');
+    expect(res.status).toBe(401);
+  });
+
+  test('host token can hit host-only routes', async () => {
+    const token = issueToken('pty-host', 'host');
+    const res = await request('GET', `/api/tasks?project=${PROJECT}`, token);
+    expect(res.status).toBe(200);
+  });
+
+  test('sandbox token gets 403 on host-only routes', async () => {
+    const token = issueToken('pty-sbx', 'sandbox');
+    const res = await request('GET', `/api/tasks?project=${PROJECT}`, token);
+    expect(res.status).toBe(403);
+  });
+
+  test.each([
+    ['GET', '/api/tasks'],
+    ['POST', '/api/tasks'],
+    ['POST', '/api/tasks/start'],
+    ['GET', '/api/hooks'],
+    ['PUT', '/api/hooks/run'],
+    ['GET', '/api/scripts'],
+    ['PUT', '/api/scripts/abc'],
+    ['GET', '/api/tags'],
+    ['GET', '/api/projects'],
+  ])('sandbox scope cannot hit %s %s', async (method, route) => {
+    const token = issueToken('pty-sbx', 'sandbox');
+    const res = await request(method, `${route}?project=${PROJECT}`, token, { name: 'x', type: 'run', command: 'x' });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('plan scope', () => {
+  test('sandbox token cannot GET any plan (host-only)', async () => {
+    // The guest has no legitimate reason to read plan paths directly —
+    // it writes via /hook action:plan which server-joins safely under
+    // ~/.claude/plans. Keep the GET endpoint host-only.
+    const token = issueToken('pty-42', 'sandbox');
+    const res = await request('GET', '/api/plan/pty-42', token);
+    expect(res.status).toBe(403);
+  });
+
+  test('sandbox token cannot POST a plan path', async () => {
+    // An attacker with a sandbox token must not be able to steer the
+    // host renderer to read an arbitrary .md file on the host.
+    const token = issueToken('pty-42', 'sandbox');
+    const res = await request('POST', '/api/plan/pty-42', token, { path: '/tmp/x.md' });
+    expect(res.status).toBe(403);
+  });
+
+  test('host token can POST a plan path', async () => {
+    const token = issueToken('pty-42', 'host');
+    const res = await request('POST', '/api/plan/pty-42', token, { path: '/tmp/x.md' });
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/__tests__/configStore.test.ts
+++ b/src/__tests__/configStore.test.ts
@@ -28,6 +28,46 @@ describe('configStore', () => {
       expect(yaml).toContain('provision');
       expect(yaml).toContain('apt-get install');
     });
+
+    test('installs the overlay helper at /usr/local/sbin/ouijit-overlay-helper', () => {
+      const yaml = generateDefaultConfig();
+      expect(yaml).toContain('/usr/local/sbin/ouijit-overlay-helper');
+      expect(yaml).toContain('OUIJIT_HELPER_EOF');
+    });
+
+    test('writes a narrow sudoers rule that only grants the overlay helper', () => {
+      const yaml = generateDefaultConfig();
+      expect(yaml).toContain('/etc/sudoers.d/99-ouijit');
+      expect(yaml).toContain('NOPASSWD: /usr/local/sbin/ouijit-overlay-helper');
+      // Strip any broader NOPASSWD rule that Lima / cloud-init may install.
+      expect(yaml).toMatch(/NOPASSWD:\\s\*ALL/);
+    });
+
+    test('installs + enables the egress firewall systemd unit', () => {
+      const yaml = generateDefaultConfig();
+      expect(yaml).toContain('/usr/local/sbin/ouijit-firewall');
+      expect(yaml).toContain('/etc/systemd/system/ouijit-firewall.service');
+      expect(yaml).toContain('systemctl enable ouijit-firewall.service');
+    });
+
+    test('defaults network policy to strict', () => {
+      const yaml = generateDefaultConfig();
+      expect(yaml).toContain('/etc/ouijit/network-policy');
+      expect(yaml).toMatch(/echo strict > \/etc\/ouijit\/network-policy/);
+    });
+
+    test('firewall script drops outbound by default and permits host.lima.internal', () => {
+      const yaml = generateDefaultConfig();
+      expect(yaml).toContain('iptables -P OUTPUT DROP');
+      expect(yaml).toContain('host.lima.internal');
+      expect(yaml).toContain('iptables -A OUTPUT -o lo -j ACCEPT');
+    });
+
+    test('firewall honors a per-VM opt-out via /etc/ouijit/network-policy', () => {
+      const yaml = generateDefaultConfig();
+      expect(yaml).toContain('POLICY_FILE="/etc/ouijit/network-policy"');
+      expect(yaml).toContain('policy=open, leaving default networking');
+    });
   });
 
   describe('resolveEnvVars', () => {

--- a/src/__tests__/configStore.test.ts
+++ b/src/__tests__/configStore.test.ts
@@ -39,8 +39,9 @@ describe('configStore', () => {
       const yaml = generateDefaultConfig();
       expect(yaml).toContain('/etc/sudoers.d/99-ouijit');
       expect(yaml).toContain('NOPASSWD: /usr/local/sbin/ouijit-overlay-helper');
-      // Strip any broader NOPASSWD:ALL rule that Lima / cloud-init may install,
-      // scanning across all files in /etc/sudoers.d rather than a hardcoded list.
+      // Strip any broader NOPASSWD:ALL rule across /etc/sudoers itself
+      // plus everything in /etc/sudoers.d (except our file).
+      expect(yaml).toContain('strip_targets="/etc/sudoers"');
       expect(yaml).toContain('/etc/sudoers.d/*');
       expect(yaml).toContain('NOPASSWD:[[:space:]]*ALL');
       // visudo validation after edit so a botched strip doesn't lock sudo out.
@@ -67,10 +68,27 @@ describe('configStore', () => {
       expect(yaml).toContain('iptables -A OUTPUT -o lo -j ACCEPT');
     });
 
-    test('firewall mirrors the DROP policy to IPv6 so dual-stack guests cannot bypass', () => {
+    test('disables IPv6 kernel-wide via sysctl so dual-stack guests cannot bypass', () => {
       const yaml = generateDefaultConfig();
-      expect(yaml).toContain('ip6tables -P OUTPUT DROP');
-      expect(yaml).toContain('ip6tables -A OUTPUT -o lo -j ACCEPT');
+      // Preferred over an ip6tables mirror: no happy-eyeballs timeout
+      // and no dependency on ip6tables being present.
+      expect(yaml).toContain('/etc/sysctl.d/99-ouijit.conf');
+      expect(yaml).toContain('net.ipv6.conf.all.disable_ipv6 = 1');
+      expect(yaml).toContain('net.ipv6.conf.default.disable_ipv6 = 1');
+    });
+
+    test('firewall uses conntrack module (not legacy state) for iptables-nft compatibility', () => {
+      const yaml = generateDefaultConfig();
+      expect(yaml).toContain('-m conntrack --ctstate ESTABLISHED,RELATED');
+      expect(yaml).not.toContain('-m state --state');
+    });
+
+    test('gateway parse uses bash printf (not gawk strtonum)', () => {
+      const yaml = generateDefaultConfig();
+      // strtonum is a gawk extension; Ubuntu ships mawk. Confirm we
+      // do the hex → dotted-quad conversion in the shell instead.
+      expect(yaml).not.toContain('strtonum');
+      expect(yaml).toContain('GATEWAY_HEX');
     });
 
     test('firewall has a /proc/net/route fallback for the gateway', () => {

--- a/src/__tests__/configStore.test.ts
+++ b/src/__tests__/configStore.test.ts
@@ -48,60 +48,16 @@ describe('configStore', () => {
       expect(yaml).toMatch(/visudo -cf "\$f"/);
     });
 
-    test('installs + enables the egress firewall systemd unit', () => {
+    test('does not install an egress firewall (host↔guest is the boundary, not guest↔internet)', () => {
       const yaml = generateDefaultConfig();
-      expect(yaml).toContain('/usr/local/sbin/ouijit-firewall');
-      expect(yaml).toContain('/etc/systemd/system/ouijit-firewall.service');
-      expect(yaml).toContain('systemctl enable ouijit-firewall.service');
+      expect(yaml).not.toContain('ouijit-firewall');
+      expect(yaml).not.toContain('/etc/ouijit/network-policy');
+      expect(yaml).not.toContain('iptables');
     });
 
-    test('defaults network policy to strict', () => {
+    test('does not disable IPv6 (no firewall to bypass)', () => {
       const yaml = generateDefaultConfig();
-      expect(yaml).toContain('/etc/ouijit/network-policy');
-      expect(yaml).toMatch(/echo strict > \/etc\/ouijit\/network-policy/);
-    });
-
-    test('firewall script drops outbound by default and permits host.lima.internal', () => {
-      const yaml = generateDefaultConfig();
-      expect(yaml).toContain('iptables -P OUTPUT DROP');
-      expect(yaml).toContain('host.lima.internal');
-      expect(yaml).toContain('iptables -A OUTPUT -o lo -j ACCEPT');
-    });
-
-    test('disables IPv6 kernel-wide via sysctl so dual-stack guests cannot bypass', () => {
-      const yaml = generateDefaultConfig();
-      // Preferred over an ip6tables mirror: no happy-eyeballs timeout
-      // and no dependency on ip6tables being present.
-      expect(yaml).toContain('/etc/sysctl.d/99-ouijit.conf');
-      expect(yaml).toContain('net.ipv6.conf.all.disable_ipv6 = 1');
-      expect(yaml).toContain('net.ipv6.conf.default.disable_ipv6 = 1');
-    });
-
-    test('firewall uses conntrack module (not legacy state) for iptables-nft compatibility', () => {
-      const yaml = generateDefaultConfig();
-      expect(yaml).toContain('-m conntrack --ctstate ESTABLISHED,RELATED');
-      expect(yaml).not.toContain('-m state --state');
-    });
-
-    test('gateway parse uses bash printf (not gawk strtonum)', () => {
-      const yaml = generateDefaultConfig();
-      // strtonum is a gawk extension; Ubuntu ships mawk. Confirm we
-      // do the hex → dotted-quad conversion in the shell instead.
-      expect(yaml).not.toContain('strtonum');
-      expect(yaml).toContain('GATEWAY_HEX');
-    });
-
-    test('firewall has a /proc/net/route fallback for the gateway', () => {
-      const yaml = generateDefaultConfig();
-      expect(yaml).toContain('/proc/net/route');
-      // Final fallback to the VZ default so the firewall never ends up fully open.
-      expect(yaml).toContain('192.168.5.2');
-    });
-
-    test('firewall honors a per-VM opt-out via /etc/ouijit/network-policy', () => {
-      const yaml = generateDefaultConfig();
-      expect(yaml).toContain('POLICY_FILE="/etc/ouijit/network-policy"');
-      expect(yaml).toContain('policy=open, leaving default networking');
+      expect(yaml).not.toContain('disable_ipv6');
     });
   });
 

--- a/src/__tests__/configStore.test.ts
+++ b/src/__tests__/configStore.test.ts
@@ -39,8 +39,12 @@ describe('configStore', () => {
       const yaml = generateDefaultConfig();
       expect(yaml).toContain('/etc/sudoers.d/99-ouijit');
       expect(yaml).toContain('NOPASSWD: /usr/local/sbin/ouijit-overlay-helper');
-      // Strip any broader NOPASSWD rule that Lima / cloud-init may install.
-      expect(yaml).toMatch(/NOPASSWD:\\s\*ALL/);
+      // Strip any broader NOPASSWD:ALL rule that Lima / cloud-init may install,
+      // scanning across all files in /etc/sudoers.d rather than a hardcoded list.
+      expect(yaml).toContain('/etc/sudoers.d/*');
+      expect(yaml).toContain('NOPASSWD:[[:space:]]*ALL');
+      // visudo validation after edit so a botched strip doesn't lock sudo out.
+      expect(yaml).toMatch(/visudo -cf "\$f"/);
     });
 
     test('installs + enables the egress firewall systemd unit', () => {
@@ -61,6 +65,19 @@ describe('configStore', () => {
       expect(yaml).toContain('iptables -P OUTPUT DROP');
       expect(yaml).toContain('host.lima.internal');
       expect(yaml).toContain('iptables -A OUTPUT -o lo -j ACCEPT');
+    });
+
+    test('firewall mirrors the DROP policy to IPv6 so dual-stack guests cannot bypass', () => {
+      const yaml = generateDefaultConfig();
+      expect(yaml).toContain('ip6tables -P OUTPUT DROP');
+      expect(yaml).toContain('ip6tables -A OUTPUT -o lo -j ACCEPT');
+    });
+
+    test('firewall has a /proc/net/route fallback for the gateway', () => {
+      const yaml = generateDefaultConfig();
+      expect(yaml).toContain('/proc/net/route');
+      // Final fallback to the VZ default so the firewall never ends up fully open.
+      expect(yaml).toContain('192.168.5.2');
     });
 
     test('firewall honors a per-VM opt-out via /etc/ouijit/network-policy', () => {

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -207,13 +207,12 @@ describe('HTTP server', () => {
     expect(res).toBe(401);
   });
 
-  test('rejects hook calls that spoof a different ptyId', async () => {
+  test('rejects hook calls that spoof a different ptyId with 403', async () => {
     // Token issued for pty-a, but the body claims pty-b. Must be rejected
     // so a compromised guest can't drive a sibling terminal's status.
     const tokenA = issueToken('pty-a', 'sandbox');
     const res = await post(port, { action: 'status', ptyId: 'pty-b', status: 'thinking' }, tokenA);
-    expect(res.status).toBe(200);
-    // But IPC must not fire for pty-b
+    expect(res.status).toBe(403);
     expect(mockSend).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -39,6 +39,7 @@ import {
   buildVmHookSettings,
   CLAUDE_WRAPPER,
 } from '../hookServer';
+import { issueToken, revokeAllTokens } from '../apiAuth';
 
 // ── Test helpers ─────────────────────────────────────────────────────
 
@@ -55,16 +56,24 @@ function createMockWindow(destroyed = false) {
   } as unknown as BrowserWindow;
 }
 
-function post(port: number, body: unknown): Promise<{ status: number; body: string }> {
+/**
+ * Auth-aware POST helper. Infers the ptyId from the body and issues a
+ * matching token, so the scope check (ptyId === auth.ptyId) passes.
+ */
+function post(port: number, body: unknown, overrideToken?: string): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     const data = JSON.stringify(body);
+    const bodyObj = body as { ptyId?: string };
+    const token =
+      overrideToken ??
+      (typeof bodyObj.ptyId === 'string' ? issueToken(bodyObj.ptyId, 'host') : issueToken('pty-test', 'host'));
     const req = http.request(
       {
         hostname: '127.0.0.1',
         port,
         path: '/hook',
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       },
       (res) => {
         let body = '';
@@ -88,6 +97,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   await stopHookServer();
+  revokeAllTokens();
   fs.rmSync(tmpHome, { recursive: true, force: true });
 });
 
@@ -159,6 +169,26 @@ describe('HTTP server', () => {
   });
 
   test('returns 400 for invalid JSON', async () => {
+    const token = issueToken('pty-json-test', 'host');
+    const res = await new Promise<number>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: '127.0.0.1',
+          port,
+          path: '/hook',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        },
+        (res) => resolve(res.statusCode!),
+      );
+      req.on('error', reject);
+      req.write('not-json{{{');
+      req.end();
+    });
+    expect(res).toBe(400);
+  });
+
+  test('returns 401 without auth token', async () => {
     const res = await new Promise<number>((resolve, reject) => {
       const req = http.request(
         {
@@ -171,10 +201,20 @@ describe('HTTP server', () => {
         (res) => resolve(res.statusCode!),
       );
       req.on('error', reject);
-      req.write('not-json{{{');
+      req.write(JSON.stringify({ action: 'status', ptyId: 'pty-123', status: 'thinking' }));
       req.end();
     });
-    expect(res).toBe(400);
+    expect(res).toBe(401);
+  });
+
+  test('rejects hook calls that spoof a different ptyId', async () => {
+    // Token issued for pty-a, but the body claims pty-b. Must be rejected
+    // so a compromised guest can't drive a sibling terminal's status.
+    const tokenA = issueToken('pty-a', 'sandbox');
+    const res = await post(port, { action: 'status', ptyId: 'pty-b', status: 'thinking' }, tokenA);
+    expect(res.status).toBe(200);
+    // But IPC must not fire for pty-b
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   test('returns 200 for unknown action (no-op)', async () => {
@@ -437,6 +477,7 @@ describe('ouijit-hook script → hook server integration', () => {
     await runHookScript('status', ['status=thinking'], {
       OUIJIT_API_URL: `http://127.0.0.1:${port}`,
       OUIJIT_PTY_ID: 'pty-integration-1',
+      OUIJIT_API_TOKEN: issueToken('pty-integration-1', 'host'),
       PATH: process.env['PATH'] || '',
     });
 
@@ -448,6 +489,7 @@ describe('ouijit-hook script → hook server integration', () => {
     await runHookScript('status', ['status=ready'], {
       OUIJIT_API_URL: `http://127.0.0.1:${port}`,
       OUIJIT_PTY_ID: 'pty-integration-2',
+      OUIJIT_API_TOKEN: issueToken('pty-integration-2', 'host'),
       PATH: process.env['PATH'] || '',
     });
 
@@ -458,6 +500,18 @@ describe('ouijit-hook script → hook server integration', () => {
   test('script exits silently when OUIJIT_API_URL is unset', async () => {
     await runHookScript('status', ['status=thinking'], {
       OUIJIT_PTY_ID: 'pty-integration-3',
+      OUIJIT_API_TOKEN: issueToken('pty-integration-3', 'host'),
+      PATH: process.env['PATH'] || '',
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test('script exits silently when OUIJIT_API_TOKEN is unset', async () => {
+    await runHookScript('status', ['status=thinking'], {
+      OUIJIT_API_URL: `http://127.0.0.1:${port}`,
+      OUIJIT_PTY_ID: 'pty-integration-notoken',
       PATH: process.env['PATH'] || '',
     });
 
@@ -469,6 +523,7 @@ describe('ouijit-hook script → hook server integration', () => {
     await runHookScript('status', ['status=thinking'], {
       OUIJIT_API_URL: `http://127.0.0.1:${port}`,
       OUIJIT_PTY_ID: 'pty with spaces',
+      OUIJIT_API_TOKEN: 'some-token',
       PATH: process.env['PATH'] || '',
     });
 
@@ -546,6 +601,7 @@ describe('wrapper → ouijit-hook → hook server (end-to-end)', () => {
         HOME: tmpHome,
         OUIJIT_API_URL: `http://127.0.0.1:${port}`,
         OUIJIT_PTY_ID: 'pty-e2e-1',
+        OUIJIT_API_TOKEN: issueToken('pty-e2e-1', 'host'),
       },
     });
 
@@ -582,6 +638,7 @@ describe('wrapper → ouijit-hook → hook server (end-to-end)', () => {
         HOME: tmpHome,
         OUIJIT_API_URL: `http://127.0.0.1:${port}`,
         OUIJIT_PTY_ID: 'pty-e2e-2',
+        OUIJIT_API_TOKEN: issueToken('pty-e2e-2', 'host'),
         OUIJIT_WRAPPER_DIR: binDir,
         OUIJIT_SHELL_INTEGRATION_DIR: integrationDir,
       },
@@ -638,6 +695,7 @@ describe('wrapper → ouijit-hook → hook server (end-to-end)', () => {
           ZDOTDIR: path.join(integrationDir, 'zsh'),
           OUIJIT_API_URL: `http://127.0.0.1:${port}`,
           OUIJIT_PTY_ID: 'pty-e2e-zsh-hook',
+          OUIJIT_API_TOKEN: issueToken('pty-e2e-zsh-hook', 'host'),
           OUIJIT_WRAPPER_DIR: binDir,
           OUIJIT_SHELL_INTEGRATION_DIR: integrationDir,
           OUIJIT_ZSH_ZDOTDIR: '',

--- a/src/__tests__/limactlHostEnv.test.ts
+++ b/src/__tests__/limactlHostEnv.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect, vi } from 'vitest';
+
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp/ouijit-test' } }));
+
+import { buildLimactlHostEnv } from '../lima/spawn';
+
+describe('buildLimactlHostEnv', () => {
+  test('forwards allowlisted keys', () => {
+    const env = buildLimactlHostEnv({
+      PATH: '/usr/bin:/bin',
+      HOME: '/Users/me',
+      USER: 'me',
+      SHELL: '/bin/zsh',
+      LANG: 'en_US.UTF-8',
+    });
+    expect(env.PATH).toBe('/usr/bin:/bin');
+    expect(env.HOME).toBe('/Users/me');
+    expect(env.USER).toBe('me');
+    expect(env.SHELL).toBe('/bin/zsh');
+    expect(env.LANG).toBe('en_US.UTF-8');
+  });
+
+  test('always sets TERM and LIMA_HOME', () => {
+    const env = buildLimactlHostEnv({});
+    expect(env.TERM).toBe('xterm-256color');
+    expect(env.LIMA_HOME).toBeTruthy();
+  });
+
+  test.each([
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_ACCESS_KEY_ID',
+    'ANTHROPIC_API_KEY',
+    'OPENAI_API_KEY',
+    'GITHUB_TOKEN',
+    'NPM_TOKEN',
+    'GOOGLE_APPLICATION_CREDENTIALS',
+    'HISTFILE',
+    'SSH_CONNECTION',
+  ])('drops secret-like var %s', (key) => {
+    const env = buildLimactlHostEnv({ [key]: 'sensitive' });
+    expect(env[key]).toBeUndefined();
+  });
+
+  test('omits unset allowlisted keys', () => {
+    const env = buildLimactlHostEnv({ PATH: '/usr/bin' });
+    expect(env.HOME).toBeUndefined();
+    expect(env.USER).toBeUndefined();
+  });
+});

--- a/src/__tests__/pathSafety.test.ts
+++ b/src/__tests__/pathSafety.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { resolveWithinBase, SymlinkEscapeError, isSymlinkEscapeError } from '../utils/pathSafety';
+
+let base: string;
+let outside: string;
+
+beforeEach(() => {
+  base = fs.mkdtempSync(path.join(os.tmpdir(), 'pathsafety-base-'));
+  outside = fs.mkdtempSync(path.join(os.tmpdir(), 'pathsafety-out-'));
+});
+
+afterEach(() => {
+  fs.rmSync(base, { recursive: true, force: true });
+  fs.rmSync(outside, { recursive: true, force: true });
+});
+
+describe('resolveWithinBase', () => {
+  test('allows a plain file inside the base', async () => {
+    fs.writeFileSync(path.join(base, 'a.txt'), 'hi');
+    const resolved = await resolveWithinBase(base, 'a.txt');
+    expect(resolved).toBe(fs.realpathSync(path.join(base, 'a.txt')));
+  });
+
+  test('allows a nested file inside the base', async () => {
+    fs.mkdirSync(path.join(base, 'sub'), { recursive: true });
+    fs.writeFileSync(path.join(base, 'sub', 'b.txt'), 'hi');
+    const resolved = await resolveWithinBase(base, 'sub/b.txt');
+    expect(resolved.endsWith('sub' + path.sep + 'b.txt')).toBe(true);
+  });
+
+  test('allows a symlink whose target stays inside the base', async () => {
+    fs.writeFileSync(path.join(base, 'real.txt'), 'real');
+    fs.symlinkSync(path.join(base, 'real.txt'), path.join(base, 'link.txt'));
+    const resolved = await resolveWithinBase(base, 'link.txt');
+    expect(resolved.endsWith('real.txt')).toBe(true);
+  });
+
+  test('rejects ../.. traversal', async () => {
+    await expect(resolveWithinBase(base, '../../etc/passwd')).rejects.toBeInstanceOf(SymlinkEscapeError);
+  });
+
+  test('rejects symlink that escapes the base', async () => {
+    const target = path.join(outside, 'secret.txt');
+    fs.writeFileSync(target, 'secret');
+    fs.symlinkSync(target, path.join(base, 'escape.txt'));
+    await expect(resolveWithinBase(base, 'escape.txt')).rejects.toBeInstanceOf(SymlinkEscapeError);
+  });
+
+  test('rejects symlink chain that ultimately escapes', async () => {
+    const target = path.join(outside, 'secret.txt');
+    fs.writeFileSync(target, 'secret');
+    fs.symlinkSync(target, path.join(base, 'hop1.txt'));
+    fs.symlinkSync(path.join(base, 'hop1.txt'), path.join(base, 'hop2.txt'));
+    await expect(resolveWithinBase(base, 'hop2.txt')).rejects.toBeInstanceOf(SymlinkEscapeError);
+  });
+
+  test('rejects symlinked parent that escapes', async () => {
+    fs.symlinkSync(outside, path.join(base, 'escaped-dir'));
+    fs.writeFileSync(path.join(outside, 'secret.txt'), 'secret');
+    await expect(resolveWithinBase(base, 'escaped-dir/secret.txt')).rejects.toBeInstanceOf(SymlinkEscapeError);
+  });
+
+  test('handles non-existent leaf with safe parent', async () => {
+    const resolved = await resolveWithinBase(base, 'notyetcreated.txt');
+    expect(resolved.endsWith('notyetcreated.txt')).toBe(true);
+  });
+
+  test('rejects non-existent leaf whose parent symlink escapes', async () => {
+    fs.symlinkSync(outside, path.join(base, 'outlink'));
+    await expect(resolveWithinBase(base, 'outlink/newfile.txt')).rejects.toBeInstanceOf(SymlinkEscapeError);
+  });
+
+  test('isSymlinkEscapeError matches only SymlinkEscapeError', () => {
+    expect(isSymlinkEscapeError(new SymlinkEscapeError('x', '/y', '/z'))).toBe(true);
+    expect(isSymlinkEscapeError(new Error('nope'))).toBe(false);
+    expect(isSymlinkEscapeError('string')).toBe(false);
+  });
+});

--- a/src/__tests__/sandboxedTask.test.ts
+++ b/src/__tests__/sandboxedTask.test.ts
@@ -185,11 +185,10 @@ describe('removeTaskWorktree overlay cleanup', () => {
     expect(runInVmMock).toHaveBeenCalledTimes(1);
     const [passedProject, passedCmd] = runInVmMock.mock.calls[0] as [string, string];
     expect(passedProject).toBe(project);
-    // Cleanup script must umount before rm -rf and target the right task overlay.
-    expect(passedCmd).toContain("TASK='4'");
-    expect(passedCmd).toContain('/var/lib/ouijit/overlays/T-$TASK');
-    expect(passedCmd).toContain('umount');
-    expect(passedCmd).toContain('rm -rf "$OVERLAY_ROOT"');
+    // Cleanup delegates to the privileged helper, which owns umount + rm -rf.
+    expect(passedCmd).toContain('/usr/local/sbin/ouijit-overlay-helper');
+    expect(passedCmd).toContain('--cleanup');
+    expect(passedCmd).toContain("'4'");
   });
 
   test('does not call runInVm when task is not sandboxed', async () => {
@@ -339,7 +338,6 @@ describe('buildOverlayBindMountSetup', () => {
     expect(script).toContain("WORKTREE='/w with '\\''quote'");
     expect(script).toContain('d node_modules');
     expect(script).toContain('d .venv');
-    expect(script).toContain('mount --bind');
     expect(script).toContain('OUIJIT_MASKS_EOF');
   });
 
@@ -358,37 +356,30 @@ describe('buildOverlayBindMountSetup', () => {
     expect(script).toContain('f config/secrets.yml');
   });
 
-  test('file-mask branch touches overlay and target placeholders', () => {
-    const script = buildOverlayBindMountSetup({
-      worktreePath: '/w',
-      taskId: 1,
-      masks: [{ relPath: '.env', type: 'file' }],
-    });
-    expect(script).toContain('sudo touch "$overlay" "$target"');
-    expect(script).toContain('sudo mkdir -p "$(dirname "$overlay")" "$(dirname "$target")"');
-  });
-
-  test('chowns overlay leaves to the invoking user so guest tools can write through the bind mount', () => {
-    const script = buildOverlayBindMountSetup({
-      worktreePath: '/w',
-      taskId: 1,
-      masks: [
-        { relPath: 'node_modules', type: 'directory' },
-        { relPath: '.env', type: 'file' },
-      ],
-    });
-    const chownMatches = script.match(/sudo chown "\$\(id -u\):\$\(id -g\)" "\$overlay"/g) ?? [];
-    expect(chownMatches.length).toBe(2);
-  });
-
-  test('writes .paths sidecar (not .dirs) for cleanup', () => {
+  test('delegates all privileged work to /usr/local/sbin/ouijit-overlay-helper', () => {
     const script = buildOverlayBindMountSetup({
       worktreePath: '/w',
       taskId: 1,
       masks: [{ relPath: 'node_modules', type: 'directory' }],
     });
-    expect(script).toContain('"$OVERLAY_ROOT/.paths"');
-    expect(script).not.toContain('"$OVERLAY_ROOT/.dirs"');
+    expect(script).toContain('/usr/local/sbin/ouijit-overlay-helper');
+    expect(script).toContain('--install');
+    // The old direct-mount path and unscoped sudo calls are gone —
+    // the sandbox user no longer has a blanket NOPASSWD rule.
+    expect(script).not.toContain('sudo mount --bind');
+    expect(script).not.toContain('sudo touch');
+    expect(script).not.toContain('sudo chown');
+  });
+
+  test('emits a fail-closed banner when the helper binary is missing', () => {
+    const script = buildOverlayBindMountSetup({
+      worktreePath: '/w',
+      taskId: 1,
+      masks: [{ relPath: 'node_modules', type: 'directory' }],
+    });
+    expect(script).toContain('\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m');
+    expect(script).toContain('overlay helper is missing');
+    expect(script).toMatch(/SANDBOX ISOLATION FAILED.*\\033\[0m.*>&2/);
   });
 
   test('does NOT use a trap (would not survive exec bash)', () => {
@@ -409,36 +400,14 @@ describe('buildOverlayBindMountSetup', () => {
     expect(script).not.toMatch(/^set -e/m);
   });
 
-  test('sudo-unavailable path emits a red ANSI banner and returns 1 (fail-closed)', () => {
+  test('emits green ACTIVE banner on success', () => {
     const script = buildOverlayBindMountSetup({
       worktreePath: '/w',
       taskId: 1,
       masks: [{ relPath: 'node_modules', type: 'directory' }],
     });
-    // The gray stderr echo from the old silent-skip is gone.
-    expect(script).not.toContain('sandbox overlay skipped');
-    // Red background + white foreground + bold banner.
-    expect(script).toContain('\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m');
-    // The sudo-missing branch returns 1 so the shell refuses to start.
-    expect(script).toMatch(/passwordless sudo is unavailable[\s\S]*?return 1/);
-    // Banner goes to stderr, not stdout which could be captured.
-    expect(script).toMatch(/SANDBOX ISOLATION FAILED.*\\033\[0m.*>&2/);
-  });
-
-  test('emits green ACTIVE banner on full success and red FAILED banners on total/partial failure', () => {
-    const script = buildOverlayBindMountSetup({
-      worktreePath: '/w',
-      taskId: 1,
-      masks: [{ relPath: 'node_modules', type: 'directory' }],
-    });
-    // Success is the only path that returns 0 + green banner.
     expect(script).toContain('\\033[1;97;42m  SANDBOX ISOLATION ACTIVE  \\033[0m');
-    // Both total-failure and partial-failure use the red "FAILED" background.
     expect(script).toContain('\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m');
-    expect(script).toContain('\\033[1;97;41m  SANDBOX ISOLATION PARTIAL  \\033[0m');
-    // Counters that feed the banner.
-    expect(script).toContain('local TOTAL=0 OK=0 FAIL=0');
-    // Any failure returns 1 — fail-closed.
     expect(script).toMatch(/refusing to start/);
   });
 
@@ -448,7 +417,6 @@ describe('buildOverlayBindMountSetup', () => {
       taskId: 1,
       masks: [{ relPath: 'node_modules', type: 'directory' }],
     });
-    // After calling the setup function, the script captures $? and exits if non-zero.
     expect(script).toContain('_OUIJIT_OVERLAY_RC=$?');
     expect(script).toMatch(/if \[ "\$_OUIJIT_OVERLAY_RC" -ne 0 \]; then[\s\S]*?exit 1/);
   });
@@ -491,23 +459,22 @@ describe('buildSandboxNoMatchesBanner', () => {
 });
 
 describe('buildOverlayCleanup', () => {
-  test('emits bash that removes the per-task overlay root', () => {
+  test('delegates cleanup to the privileged helper with the task id', () => {
     const script = buildOverlayCleanup(13);
-    expect(script).toContain("TASK='13'");
-    expect(script).toContain('/var/lib/ouijit/overlays/T-$TASK');
-    expect(script).toContain('umount');
-    expect(script).toContain('rm -rf "$OVERLAY_ROOT"');
+    expect(script).toContain('/usr/local/sbin/ouijit-overlay-helper');
+    expect(script).toContain('--cleanup');
+    expect(script).toContain("'13'");
   });
 
-  test('reads stashed worktree path and paths sidecar files', () => {
+  test('no longer issues direct sudo umount / rm (helper owns both)', () => {
     const script = buildOverlayCleanup(13);
-    expect(script).toContain('$OVERLAY_ROOT/.worktree');
-    expect(script).toContain('$OVERLAY_ROOT/.paths');
+    expect(script).not.toContain('sudo umount');
+    expect(script).not.toContain('sudo rm -rf');
   });
 
-  test('falls back to /proc/self/mountinfo for orphaned mounts', () => {
+  test('is a no-op when the helper is missing (e.g. VM not yet recreated)', () => {
     const script = buildOverlayCleanup(13);
-    expect(script).toContain('/proc/self/mountinfo');
+    expect(script).toContain('if [ -x "$HELPER" ]');
   });
 
   test('script passes `bash -n` syntax check', async () => {

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -37,6 +37,7 @@ import { getPlanPath, setPlanPath, clearPlanPath } from '../hookServer';
 import { isPtyActive } from '../ptyManager';
 import { typedPush } from '../ipc/helpers';
 import { getLogger } from '../logger';
+import { authenticateRequest, type AuthContext, type ApiScope } from '../apiAuth';
 
 const apiLog = getLogger().scope('api');
 
@@ -49,6 +50,7 @@ interface ParsedRequest {
   segments: string[]; // URL path segments after /api/
   query: URLSearchParams;
   body: Record<string, unknown>;
+  auth: AuthContext;
 }
 
 function readBody(req: IncomingMessage): Promise<string> {
@@ -103,6 +105,12 @@ interface Route {
   pattern: string[];
   handler: RouteHandler;
   mutating: boolean;
+  /**
+   * Minimum scope required to hit this route. Defaults to 'host' so
+   * sandbox-scoped callers (anything reaching us from inside a guest VM
+   * via host.lima.internal) cannot hit privileged endpoints by default.
+   */
+  minScope: ApiScope;
 }
 
 function matchRoute(
@@ -130,8 +138,14 @@ function matchRoute(
 
 // ── Routes ───────────────────────────────────────────────────────────
 
-function route(method: string, pattern: string, handler: RouteHandler, mutating = false): Route {
-  return { method, pattern: pattern.split('/').filter(Boolean), handler, mutating };
+function route(
+  method: string,
+  pattern: string,
+  handler: RouteHandler,
+  mutating = false,
+  minScope: ApiScope = 'host',
+): Route {
+  return { method, pattern: pattern.split('/').filter(Boolean), handler, mutating, minScope };
 }
 
 const routes: Route[] = [
@@ -161,6 +175,12 @@ const routes: Route[] = [
     'tasks/start',
     (r) => {
       const project = requireProject(r.query);
+      // Sandbox scope can't reach this route (default minScope is 'host'),
+      // but double-check the intent: an unsandboxed task must never be
+      // created from a sandbox-scoped caller.
+      if (r.auth.scope === 'sandbox' && r.body.sandboxed === false) {
+        throw new HttpError(403, 'Sandboxed sessions cannot create unsandboxed tasks');
+      }
       return createTaskWorktree(
         project,
         r.body.name as string | undefined,
@@ -349,33 +369,47 @@ const routes: Route[] = [
   ),
 
   // ── Plan ──────────────────────────────────────────────────────────
+  // These routes are host-only: the guest shouldn't be able to steer
+  // the host renderer to read arbitrary .md files outside the worktree
+  // by setting a plan path. Inside the guest, plans flow through the
+  // `/hook` action:plan path which server-joins under ~/.claude/plans.
   route('GET', 'plan/:ptyId', (r) => {
     const ptyId = r.segments[1];
     return { ptyId, planPath: getPlanPath(ptyId) };
   }),
 
-  route('POST', 'plan/:ptyId', (r) => {
-    const ptyId = r.segments[1];
-    const planPath = r.body.path;
-    if (typeof planPath !== 'string' || !planPath) {
-      throw new HttpError(400, 'Missing path in body');
-    }
-    if (!planPath.endsWith('.md')) {
-      throw new HttpError(400, 'Plan path must be a .md file');
-    }
-    if (!isPtyActive(ptyId)) {
-      throw new HttpError(404, `PTY ${ptyId} not found or inactive`);
-    }
-    const resolved = path.resolve(planPath);
-    setPlanPath(ptyId, resolved);
-    return { success: true, ptyId, planPath: resolved };
-  }),
+  route(
+    'POST',
+    'plan/:ptyId',
+    (r) => {
+      const ptyId = r.segments[1];
+      const planPath = r.body.path;
+      if (typeof planPath !== 'string' || !planPath) {
+        throw new HttpError(400, 'Missing path in body');
+      }
+      if (!planPath.endsWith('.md')) {
+        throw new HttpError(400, 'Plan path must be a .md file');
+      }
+      if (!isPtyActive(ptyId)) {
+        throw new HttpError(404, `PTY ${ptyId} not found or inactive`);
+      }
+      const resolved = path.resolve(planPath);
+      setPlanPath(ptyId, resolved);
+      return { success: true, ptyId, planPath: resolved };
+    },
+    true,
+  ),
 
-  route('DELETE', 'plan/:ptyId', (r) => {
-    const ptyId = r.segments[1];
-    clearPlanPath(ptyId);
-    return { success: true, ptyId };
-  }),
+  route(
+    'DELETE',
+    'plan/:ptyId',
+    (r) => {
+      const ptyId = r.segments[1];
+      clearPlanPath(ptyId);
+      return { success: true, ptyId };
+    },
+    true,
+  ),
 ];
 
 // ── Main handler ─────────────────────────────────────────────────────
@@ -395,9 +429,23 @@ async function handleAsync(req: IncomingMessage, res: ServerResponse, window: Br
   const apiPath = url.pathname.replace(/^\/api\//, '');
   const segments = apiPath.split('/').filter(Boolean);
 
+  // Every route requires a valid per-PTY bearer token. Sandboxed VMs
+  // reach us via host.lima.internal — we can't rely on loopback
+  // reachability as a security boundary.
+  const auth = authenticateRequest(req.headers['authorization']);
+  if (!auth) {
+    json(res, 401, { error: 'Unauthorized' });
+    return;
+  }
+
   const matched = matchRoute(routes, method, segments);
   if (!matched) {
     json(res, 404, { error: `No route for ${method} /api/${apiPath}` });
+    return;
+  }
+
+  if (matched.route.minScope === 'host' && auth.scope !== 'host') {
+    json(res, 403, { error: 'Forbidden' });
     return;
   }
 
@@ -413,7 +461,7 @@ async function handleAsync(req: IncomingMessage, res: ServerResponse, window: Br
   }
 
   try {
-    const result = await matched.route.handler({ method, segments, query: url.searchParams, body });
+    const result = await matched.route.handler({ method, segments, query: url.searchParams, body, auth });
     json(res, 200, { data: result });
 
     // Notify renderer after mutating operations

--- a/src/apiAuth.ts
+++ b/src/apiAuth.ts
@@ -1,0 +1,81 @@
+/**
+ * Per-PTY API authentication.
+ *
+ * Every PTY (host or sandbox) is issued a random bearer token at spawn
+ * time. The token lives in this module's in-memory map for the life of
+ * the PTY. Callers inject it as OUIJIT_API_TOKEN into the PTY env; the
+ * hook server and REST router validate `Authorization: Bearer <token>`
+ * on every request and attach `{ ptyId, scope }` to the request context.
+ *
+ * Sandbox-scoped tokens can only reach a small allowlist of routes
+ * (defined in api/router.ts). Host-scoped tokens can reach everything.
+ *
+ * Tokens are revoked when the PTY exits.
+ */
+
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+export type ApiScope = 'host' | 'sandbox';
+
+export interface AuthContext {
+  ptyId: string;
+  scope: ApiScope;
+}
+
+interface TokenEntry {
+  ptyId: string;
+  scope: ApiScope;
+}
+
+const tokens = new Map<string, TokenEntry>();
+const ptyToToken = new Map<string, string>();
+
+export function issueToken(ptyId: string, scope: ApiScope): string {
+  const existing = ptyToToken.get(ptyId);
+  if (existing) tokens.delete(existing);
+
+  const token = randomBytes(32).toString('hex');
+  tokens.set(token, { ptyId, scope });
+  ptyToToken.set(ptyId, token);
+  return token;
+}
+
+export function revokeToken(ptyId: string): void {
+  const token = ptyToToken.get(ptyId);
+  if (token) {
+    tokens.delete(token);
+    ptyToToken.delete(ptyId);
+  }
+}
+
+export function revokeAllTokens(): void {
+  tokens.clear();
+  ptyToToken.clear();
+}
+
+/**
+ * Validate a bearer token. Uses constant-time comparison to prevent
+ * timing attacks. Returns the auth context on match, null otherwise.
+ */
+export function verifyToken(candidate: string): AuthContext | null {
+  if (!candidate) return null;
+
+  const candidateBuf = Buffer.from(candidate, 'utf8');
+  for (const [stored, entry] of tokens) {
+    const storedBuf = Buffer.from(stored, 'utf8');
+    if (storedBuf.length !== candidateBuf.length) continue;
+    if (timingSafeEqual(storedBuf, candidateBuf)) return entry;
+  }
+  return null;
+}
+
+/**
+ * Parse an Authorization header and return the auth context if the
+ * bearer token is valid.
+ */
+export function authenticateRequest(authHeader: string | undefined): AuthContext | null {
+  if (!authHeader) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(authHeader);
+  if (!match) return null;
+  return verifyToken(match[1].trim());
+}

--- a/src/apiAuth.ts
+++ b/src/apiAuth.ts
@@ -14,6 +14,9 @@
  */
 
 import { randomBytes, timingSafeEqual } from 'node:crypto';
+import { getLogger } from './logger';
+
+const authLog = getLogger().scope('apiAuth');
 
 export type ApiScope = 'host' | 'sandbox';
 
@@ -32,7 +35,13 @@ const ptyToToken = new Map<string, string>();
 
 export function issueToken(ptyId: string, scope: ApiScope): string {
   const existing = ptyToToken.get(ptyId);
-  if (existing) tokens.delete(existing);
+  if (existing) {
+    // PtyIds are generated per-spawn and should be unique. If we see a
+    // collision, something in the spawn lifecycle is off — log it so
+    // the bug is visible rather than silently clobbering the old token.
+    authLog.warn('re-issuing token for already-known ptyId', { ptyId });
+    tokens.delete(existing);
+  }
 
   const token = randomBytes(32).toString('hex');
   tokens.set(token, { ptyId, scope });
@@ -54,8 +63,13 @@ export function revokeAllTokens(): void {
 }
 
 /**
- * Validate a bearer token. Uses constant-time comparison to prevent
- * timing attacks. Returns the auth context on match, null otherwise.
+ * Validate a bearer token against every stored entry using a
+ * constant-time comparison. A direct Map.get lookup would be O(1) but
+ * V8's string equality can short-circuit on the first mismatched byte,
+ * which in principle leaks prefix information over HTTP timing. The
+ * token set is small (one per PTY, bounded to the user's active
+ * sessions) so the linear scan cost is not a concern; constant-time
+ * per-entry comparison is the property we need.
  */
 export function verifyToken(candidate: string): AuthContext | null {
   if (!candidate) return null;

--- a/src/cli/api.ts
+++ b/src/cli/api.ts
@@ -26,8 +26,18 @@ function getBaseUrl(): string {
   return url;
 }
 
+function getApiToken(): string {
+  const token = process.env['OUIJIT_API_TOKEN'];
+  if (!token) {
+    console.error('ouijit: OUIJIT_API_TOKEN not set — run from an Ouijit terminal');
+    process.exit(1);
+  }
+  return token;
+}
+
 function request<T>(method: string, path: string, body?: Record<string, unknown>): Promise<T> {
   const base = getBaseUrl();
+  const token = getApiToken();
   const url = new URL(path, base);
 
   const payload = body ? JSON.stringify(body) : undefined;
@@ -37,6 +47,7 @@ function request<T>(method: string, path: string, body?: Record<string, unknown>
     port: url.port,
     path: url.pathname + url.search,
     headers: {
+      Authorization: `Bearer ${token}`,
       ...(payload ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) } : {}),
     },
   };

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -92,18 +92,8 @@ type ActionHandler = (body: Record<string, unknown>, auth: AuthContext) => void;
 
 const VALID_STATUSES = new Set<HookStatus>(['thinking', 'ready']);
 
-/**
- * Every hook action is scoped to the caller's own PTY. A sandbox-scoped
- * token for pty A must not be able to set status or plan on pty B.
- */
-function assertOwnPty(body: Record<string, unknown>, auth: AuthContext): boolean {
-  const { ptyId } = body;
-  return typeof ptyId === 'string' && ptyId === auth.ptyId;
-}
-
 const actionHandlers: Record<string, ActionHandler> = {
-  status(body, auth) {
-    if (!assertOwnPty(body, auth)) return;
+  status(body, _auth) {
     const { ptyId, status } = body;
     if (typeof ptyId !== 'string' || typeof status !== 'string') return;
     if (!VALID_STATUSES.has(status as HookStatus)) return;
@@ -130,8 +120,7 @@ const actionHandlers: Record<string, ActionHandler> = {
     }
   },
 
-  plan(body, auth) {
-    if (!assertOwnPty(body, auth)) return;
+  plan(body, _auth) {
     const { ptyId, filename } = body;
     if (typeof ptyId !== 'string' || typeof filename !== 'string') return;
     if (!/^[a-zA-Z0-9._-]+$/.test(filename)) return;
@@ -140,8 +129,7 @@ const actionHandlers: Record<string, ActionHandler> = {
     setPlanPath(ptyId, planPath);
   },
 
-  'plan-ready'(body, auth) {
-    if (!assertOwnPty(body, auth)) return;
+  'plan-ready'(body, _auth) {
     const { ptyId } = body;
     if (typeof ptyId !== 'string') return;
     if (!isPtyActive(ptyId)) return;
@@ -200,6 +188,15 @@ export function startHookServer(window: BrowserWindow): Promise<void> {
       req.on('end', () => {
         try {
           const body = JSON.parse(rawBody) as Record<string, unknown>;
+          // Every hook action is scoped to the caller's own PTY. A
+          // sandbox-scoped token for pty A must not be able to set
+          // status or plan state on pty B — reject loudly with 403 so
+          // misconfigured callers surface instead of silently no-oping.
+          if (typeof body.ptyId === 'string' && body.ptyId !== auth.ptyId) {
+            res.writeHead(403);
+            res.end();
+            return;
+          }
           const action = body.action;
           if (typeof action === 'string') {
             const handler = actionHandlers[action];

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -14,6 +14,7 @@ import { BrowserWindow } from 'electron';
 import { isPtyActive } from './ptyManager';
 import { getLogger } from './logger';
 import { handleApiRequest } from './api/router';
+import { authenticateRequest, type AuthContext } from './apiAuth';
 
 const hookServerLog = getLogger().scope('hookServer');
 
@@ -87,12 +88,22 @@ export function clearPlanPath(ptyId: string): boolean {
 
 // ── Action handlers ──────────────────────────────────────────────────
 
-type ActionHandler = (body: Record<string, unknown>) => void;
+type ActionHandler = (body: Record<string, unknown>, auth: AuthContext) => void;
 
 const VALID_STATUSES = new Set<HookStatus>(['thinking', 'ready']);
 
+/**
+ * Every hook action is scoped to the caller's own PTY. A sandbox-scoped
+ * token for pty A must not be able to set status or plan on pty B.
+ */
+function assertOwnPty(body: Record<string, unknown>, auth: AuthContext): boolean {
+  const { ptyId } = body;
+  return typeof ptyId === 'string' && ptyId === auth.ptyId;
+}
+
 const actionHandlers: Record<string, ActionHandler> = {
-  status(body) {
+  status(body, auth) {
+    if (!assertOwnPty(body, auth)) return;
     const { ptyId, status } = body;
     if (typeof ptyId !== 'string' || typeof status !== 'string') return;
     if (!VALID_STATUSES.has(status as HookStatus)) return;
@@ -119,7 +130,8 @@ const actionHandlers: Record<string, ActionHandler> = {
     }
   },
 
-  plan(body) {
+  plan(body, auth) {
+    if (!assertOwnPty(body, auth)) return;
     const { ptyId, filename } = body;
     if (typeof ptyId !== 'string' || typeof filename !== 'string') return;
     if (!/^[a-zA-Z0-9._-]+$/.test(filename)) return;
@@ -128,7 +140,8 @@ const actionHandlers: Record<string, ActionHandler> = {
     setPlanPath(ptyId, planPath);
   },
 
-  'plan-ready'(body) {
+  'plan-ready'(body, auth) {
+    if (!assertOwnPty(body, auth)) return;
     const { ptyId } = body;
     if (typeof ptyId !== 'string') return;
     if (!isPtyActive(ptyId)) return;
@@ -166,6 +179,16 @@ export function startHookServer(window: BrowserWindow): Promise<void> {
         return;
       }
 
+      // Any process on the host loopback (and every sandboxed VM via
+      // host.lima.internal) can reach this endpoint. Require a valid
+      // per-PTY bearer token so only legitimate hook scripts succeed.
+      const auth = authenticateRequest(req.headers['authorization']);
+      if (!auth) {
+        res.writeHead(401);
+        res.end();
+        return;
+      }
+
       let rawBody = '';
       req.on('data', (chunk: Buffer) => {
         rawBody += chunk.toString();
@@ -181,7 +204,7 @@ export function startHookServer(window: BrowserWindow): Promise<void> {
           if (typeof action === 'string') {
             const handler = actionHandlers[action];
             if (handler) {
-              handler(body);
+              handler(body, auth);
             }
           }
           res.writeHead(200);
@@ -277,6 +300,7 @@ export const PLAN_HOOK_SCRIPT = [
   '# Ouijit plan detection hook for PostToolUse (Write|Edit)',
   '# Reads stdin JSON, checks if a plan file was written, notifies the server.',
   '[ -z "$OUIJIT_API_URL" ] && exit 0',
+  '[ -z "$OUIJIT_API_TOKEN" ] && exit 0',
   '[[ "$OUIJIT_PTY_ID" =~ ^[a-zA-Z0-9._-]+$ ]] || exit 0',
   '',
   '# Stream stdin through grep to find plan file path (avoids buffering full content)',
@@ -288,6 +312,7 @@ export const PLAN_HOOK_SCRIPT = [
   '',
   'curl -sf -o /dev/null -X POST "$OUIJIT_API_URL/hook" \\',
   '  -H "Content-Type: application/json" \\',
+  '  -H "Authorization: Bearer $OUIJIT_API_TOKEN" \\',
   '  -d "{\\"ptyId\\":\\"$OUIJIT_PTY_ID\\",\\"action\\":\\"plan\\",\\"filename\\":\\"$filename\\"}" 2>/dev/null &',
   '',
 ].join('\n');
@@ -297,6 +322,7 @@ export const HELPER_SCRIPT = [
   '# Ouijit API client for Claude Code hooks',
   '# Usage: ouijit-hook <action> [key=value ...]',
   '[ -z "$OUIJIT_API_URL" ] && exit 0',
+  '[ -z "$OUIJIT_API_TOKEN" ] && exit 0',
   '',
   '# Validate inputs to prevent malformed JSON',
   `[[ "$OUIJIT_PTY_ID" =~ ^${SAFE_VALUE}$ ]] || exit 0`,
@@ -313,6 +339,7 @@ export const HELPER_SCRIPT = [
   '',
   'curl -sf -o /dev/null -X POST "$OUIJIT_API_URL/hook" \\',
   '  -H "Content-Type: application/json" \\',
+  '  -H "Authorization: Bearer $OUIJIT_API_TOKEN" \\',
   '  -d "{$json}" 2>/dev/null &',
   '',
 ].join('\n');

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -188,22 +188,38 @@ export function startHookServer(window: BrowserWindow): Promise<void> {
       req.on('end', () => {
         try {
           const body = JSON.parse(rawBody) as Record<string, unknown>;
+          const action = body.action;
+          if (typeof action !== 'string') {
+            // Unknown / missing action is a valid no-op so older hook
+            // scripts don't fail against a newer server. Matches the
+            // 200-on-unknown-action contract.
+            res.writeHead(200);
+            res.end();
+            return;
+          }
+          const handler = actionHandlers[action];
+          if (!handler) {
+            res.writeHead(200);
+            res.end();
+            return;
+          }
+          // All registered actions require a ptyId. Reject a missing
+          // or non-string value with 400 so misconfigured callers
+          // notice rather than silently no-oping inside the handler.
+          if (typeof body.ptyId !== 'string') {
+            res.writeHead(400);
+            res.end();
+            return;
+          }
           // Every hook action is scoped to the caller's own PTY. A
           // sandbox-scoped token for pty A must not be able to set
-          // status or plan state on pty B — reject loudly with 403 so
-          // misconfigured callers surface instead of silently no-oping.
-          if (typeof body.ptyId === 'string' && body.ptyId !== auth.ptyId) {
+          // status or plan state on pty B — reject loudly with 403.
+          if (body.ptyId !== auth.ptyId) {
             res.writeHead(403);
             res.end();
             return;
           }
-          const action = body.action;
-          if (typeof action === 'string') {
-            const handler = actionHandlers[action];
-            if (handler) {
-              handler(body, auth);
-            }
-          }
+          handler(body, auth);
           res.writeHead(200);
           res.end();
         } catch {

--- a/src/ipc/handlers/plan.ts
+++ b/src/ipc/handlers/plan.ts
@@ -4,6 +4,7 @@ import { BrowserWindow, dialog } from 'electron';
 import { typedHandle } from '../helpers';
 import { getPlanPath } from '../../hookServer';
 import { getLogger } from '../../logger';
+import { resolveWithinBase, isSymlinkEscapeError } from '../../utils/pathSafety';
 
 const planLog = getLogger().scope('plan');
 
@@ -78,15 +79,22 @@ export function registerPlanHandlers(mainWindow: BrowserWindow): void {
     const result: Record<string, boolean> = {};
     await Promise.all(
       filePaths.map(async (fp) => {
-        const resolved = path.resolve(workspaceRoot, fp);
-        if (!resolved.startsWith(workspaceRoot + path.sep) && resolved !== workspaceRoot) {
-          result[fp] = false;
-          return;
-        }
         try {
+          // resolveWithinBase follows symlinks through to the real path
+          // and rejects anything that escapes the worktree — prevents
+          // a guest-planted symlink from leaking the existence of host
+          // files outside the worktree boundary.
+          const resolved = await resolveWithinBase(workspaceRoot, fp);
           await fs.promises.access(resolved);
           result[fp] = true;
-        } catch {
+        } catch (err) {
+          if (isSymlinkEscapeError(err)) {
+            planLog.warn('file check rejected symlink escape', {
+              workspaceRoot,
+              file: fp,
+              resolved: err.resolved,
+            });
+          }
           result[fp] = false;
         }
       }),

--- a/src/lima/configStore.ts
+++ b/src/lima/configStore.ts
@@ -198,6 +198,8 @@ exit 0
  */
 export const FIREWALL_SCRIPT = `#!/bin/bash
 # Ouijit egress firewall — default-deny outbound, allow host.lima.internal.
+# IPv6 is disabled kernel-wide by /etc/sysctl.d/99-ouijit.conf (installed
+# at provision), so this script only configures IPv4.
 set -u
 
 POLICY_FILE="/etc/ouijit/network-policy"
@@ -211,21 +213,23 @@ fi
 
 # Resolve host.lima.internal → gateway IP. Three probes in order:
 #   1. DNS (host.lima.internal is injected by Lima's DNS)
-#   2. /proc/net/route default gateway
+#   2. /proc/net/route default gateway (parsed with bash printf
+#      rather than awk math, which varies across gawk/mawk)
 #   3. Hardcoded 192.168.5.2 (Lima-VZ default on macOS)
 # Combined, this avoids the firewall-wide-open-on-DNS-failure footgun.
 GATEWAY=$(getent ahostsv4 host.lima.internal 2>/dev/null | awk 'NR==1 {print $1}')
 if [ -z "$GATEWAY" ]; then
-  # Default route: destination 00000000, gateway in hex little-endian.
-  GATEWAY=$(awk '$2 == "00000000" && $8 == "00000000" {
-    g = $3
-    printf "%d.%d.%d.%d\\n",
-      strtonum("0x" substr(g, 7, 2)),
-      strtonum("0x" substr(g, 5, 2)),
-      strtonum("0x" substr(g, 3, 2)),
-      strtonum("0x" substr(g, 1, 2))
-    exit
-  }' /proc/net/route 2>/dev/null)
+  GATEWAY_HEX=$(awk '$2 == "00000000" && $8 == "00000000" {print $3; exit}' /proc/net/route 2>/dev/null)
+  if [ -n "$GATEWAY_HEX" ] && [ "\${#GATEWAY_HEX}" = "8" ]; then
+    # /proc/net/route writes the gateway as little-endian hex; reverse
+    # the byte order and format as dotted-quad. printf "%d" "0xFF" is
+    # portable across bash/busybox without awk extensions.
+    GATEWAY=$(printf '%d.%d.%d.%d' \\
+      "0x\${GATEWAY_HEX:6:2}" \\
+      "0x\${GATEWAY_HEX:4:2}" \\
+      "0x\${GATEWAY_HEX:2:2}" \\
+      "0x\${GATEWAY_HEX:0:2}")
+  fi
 fi
 [ -z "$GATEWAY" ] && GATEWAY="192.168.5.2"
 
@@ -235,22 +239,10 @@ iptables -P INPUT ACCEPT
 iptables -P OUTPUT DROP
 iptables -P FORWARD DROP
 iptables -A OUTPUT -o lo -j ACCEPT
-iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+# conntrack replaces the legacy "state" module, which isn't reliably
+# present on iptables-nft setups.
+iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -d "$GATEWAY" -j ACCEPT
-
-# ip6tables mirror. A dual-stack guest would otherwise reach the world
-# over IPv6 even with IPv4 locked down. DROP all v6 outbound; the
-# Ouijit API is reached via host.lima.internal on IPv4, so no v6
-# allowlist is needed.
-if command -v ip6tables >/dev/null 2>&1; then
-  ip6tables -F OUTPUT 2>/dev/null || true
-  ip6tables -F INPUT 2>/dev/null || true
-  ip6tables -P INPUT ACCEPT
-  ip6tables -P OUTPUT DROP
-  ip6tables -P FORWARD DROP
-  ip6tables -A OUTPUT -o lo -j ACCEPT
-  ip6tables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-fi
 
 echo "ouijit-firewall: applied strict policy, gateway=$GATEWAY" >&2
 `;
@@ -302,11 +294,18 @@ if visudo -cf /tmp/99-ouijit.sudoers >/dev/null 2>&1; then
   install -o root -g root -m 0440 /tmp/99-ouijit.sudoers /etc/sudoers.d/99-ouijit
   # Strip any broader NOPASSWD:ALL grant from cloud-init / lima layers.
   # Lima and cloud-init each install their own files under /etc/sudoers.d
-  # with unpredictable names; scan everything except our own rule, then
-  # re-validate with visudo so a botched edit doesn't lock sudo out.
+  # with unpredictable names; scan /etc/sudoers itself plus everything
+  # in /etc/sudoers.d except our rule, then re-validate with visudo so
+  # a botched edit doesn't lock sudo out.
+  strip_targets="/etc/sudoers"
   for f in /etc/sudoers.d/*; do
     [ -f "$f" ] || continue
+    # Skip our own file — we just installed it with exactly this suffix.
     case "$f" in */99-ouijit) continue;; esac
+    strip_targets="$strip_targets $f"
+  done
+  for f in $strip_targets; do
+    [ -f "$f" ] || continue
     if grep -qE '^[^#]*NOPASSWD:[[:space:]]*ALL' "$f" 2>/dev/null; then
       sed -i.ouijit-bak -E '/^[^#]*NOPASSWD:[[:space:]]*ALL/d' "$f"
       if ! visudo -cf "$f" >/dev/null 2>&1; then
@@ -318,6 +317,18 @@ if visudo -cf /tmp/99-ouijit.sudoers >/dev/null 2>&1; then
   done
 fi
 rm -f /tmp/99-ouijit.sudoers
+
+# Disable IPv6 kernel-wide. Without this, dual-stack guests pay a
+# 3–10s happy-eyeballs timeout on every connection (curl/node/pip try
+# IPv6 first, fail, fall back to IPv4) because the firewall has no
+# IPv6 allowlist. Killing IPv6 outright is cleaner than an ip6tables
+# mirror — no timeouts, no module dependencies.
+cat > /etc/sysctl.d/99-ouijit.conf <<'OUIJIT_SYSCTL_EOF'
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
+net.ipv6.conf.lo.disable_ipv6 = 1
+OUIJIT_SYSCTL_EOF
+sysctl --system >/dev/null 2>&1 || true
 
 mkdir -p /etc/ouijit
 if [ ! -f /etc/ouijit/network-policy ]; then

--- a/src/lima/configStore.ts
+++ b/src/lima/configStore.ts
@@ -186,89 +186,13 @@ fi
 exit 0
 `;
 
-/**
- * Firewall script installed at /usr/local/sbin/ouijit-firewall. Applies
- * default-deny outbound with a single allowlist entry: host.lima.internal
- * (the VM's gateway). The guest can still reach the Ouijit API and
- * nothing else — no apt, no npm, no LLM, no exfiltration endpoints.
- *
- * Runs after cloud-init so package installs during provisioning still
- * have open network. Gated by /etc/ouijit/network-policy which the host
- * can write as 'strict' (default) or 'open' for opt-in projects.
- */
-export const FIREWALL_SCRIPT = `#!/bin/bash
-# Ouijit egress firewall — default-deny outbound, allow host.lima.internal.
-# IPv6 is disabled kernel-wide by /etc/sysctl.d/99-ouijit.conf (installed
-# at provision), so this script only configures IPv4.
-set -u
-
-POLICY_FILE="/etc/ouijit/network-policy"
-POLICY="strict"
-[ -f "$POLICY_FILE" ] && POLICY=$(head -1 "$POLICY_FILE" | tr -d ' \\n')
-
-if [ "$POLICY" = "open" ]; then
-  echo "ouijit-firewall: policy=open, leaving default networking" >&2
-  exit 0
-fi
-
-# Resolve host.lima.internal → gateway IP. Three probes in order:
-#   1. DNS (host.lima.internal is injected by Lima's DNS)
-#   2. /proc/net/route default gateway (parsed with bash printf
-#      rather than awk math, which varies across gawk/mawk)
-#   3. Hardcoded 192.168.5.2 (Lima-VZ default on macOS)
-# Combined, this avoids the firewall-wide-open-on-DNS-failure footgun.
-GATEWAY=$(getent ahostsv4 host.lima.internal 2>/dev/null | awk 'NR==1 {print $1}')
-if [ -z "$GATEWAY" ]; then
-  GATEWAY_HEX=$(awk '$2 == "00000000" && $8 == "00000000" {print $3; exit}' /proc/net/route 2>/dev/null)
-  if [ -n "$GATEWAY_HEX" ] && [ "\${#GATEWAY_HEX}" = "8" ]; then
-    # /proc/net/route writes the gateway as little-endian hex; reverse
-    # the byte order and format as dotted-quad. printf "%d" "0xFF" is
-    # portable across bash/busybox without awk extensions.
-    GATEWAY=$(printf '%d.%d.%d.%d' \\
-      "0x\${GATEWAY_HEX:6:2}" \\
-      "0x\${GATEWAY_HEX:4:2}" \\
-      "0x\${GATEWAY_HEX:2:2}" \\
-      "0x\${GATEWAY_HEX:0:2}")
-  fi
-fi
-[ -z "$GATEWAY" ] && GATEWAY="192.168.5.2"
-
-iptables -F OUTPUT 2>/dev/null || true
-iptables -F INPUT 2>/dev/null || true
-iptables -P INPUT ACCEPT
-iptables -P OUTPUT DROP
-iptables -P FORWARD DROP
-iptables -A OUTPUT -o lo -j ACCEPT
-# conntrack replaces the legacy "state" module, which isn't reliably
-# present on iptables-nft setups.
-iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-iptables -A OUTPUT -d "$GATEWAY" -j ACCEPT
-
-echo "ouijit-firewall: applied strict policy, gateway=$GATEWAY" >&2
-`;
-
-/** Systemd unit that runs the firewall script at boot. */
-export const FIREWALL_UNIT = `[Unit]
-Description=Ouijit egress firewall
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/local/sbin/ouijit-firewall
-RemainAfterExit=yes
-
-[Install]
-WantedBy=multi-user.target
-`;
-
 /** Provision script body — runs as root during cloud-init. */
 const PROVISION_SCRIPT = `#!/bin/bash
 set -eux -o pipefail
 
 # Base packages (unchanged from earlier image).
 apt-get update
-apt-get install -y bash git curl wget nodejs npm python3 build-essential iptables
+apt-get install -y bash git curl wget nodejs npm python3 build-essential
 
 # Scope sudo: Lima's default lima-sudoers grants NOPASSWD ALL. We
 # narrow it to the single overlay helper. Any other sudo the sandbox
@@ -276,12 +200,6 @@ apt-get install -y bash git curl wget nodejs npm python3 build-essential iptable
 # requires a password they don't have.
 install -o root -g root -m 0755 /dev/stdin /usr/local/sbin/ouijit-overlay-helper <<'OUIJIT_HELPER_EOF'
 ${OVERLAY_HELPER_SCRIPT}OUIJIT_HELPER_EOF
-
-install -o root -g root -m 0755 /dev/stdin /usr/local/sbin/ouijit-firewall <<'OUIJIT_FW_EOF'
-${FIREWALL_SCRIPT}OUIJIT_FW_EOF
-
-install -o root -g root -m 0644 /dev/stdin /etc/systemd/system/ouijit-firewall.service <<'OUIJIT_UNIT_EOF'
-${FIREWALL_UNIT}OUIJIT_UNIT_EOF
 
 # Replace Lima's sudoers grant. visudo -cf validates before install.
 cat > /tmp/99-ouijit.sudoers <<'OUIJIT_SUDO_EOF'
@@ -317,26 +235,6 @@ if visudo -cf /tmp/99-ouijit.sudoers >/dev/null 2>&1; then
   done
 fi
 rm -f /tmp/99-ouijit.sudoers
-
-# Disable IPv6 kernel-wide. Without this, dual-stack guests pay a
-# 3–10s happy-eyeballs timeout on every connection (curl/node/pip try
-# IPv6 first, fail, fall back to IPv4) because the firewall has no
-# IPv6 allowlist. Killing IPv6 outright is cleaner than an ip6tables
-# mirror — no timeouts, no module dependencies.
-cat > /etc/sysctl.d/99-ouijit.conf <<'OUIJIT_SYSCTL_EOF'
-net.ipv6.conf.all.disable_ipv6 = 1
-net.ipv6.conf.default.disable_ipv6 = 1
-net.ipv6.conf.lo.disable_ipv6 = 1
-OUIJIT_SYSCTL_EOF
-sysctl --system >/dev/null 2>&1 || true
-
-mkdir -p /etc/ouijit
-if [ ! -f /etc/ouijit/network-policy ]; then
-  echo strict > /etc/ouijit/network-policy
-fi
-
-systemctl enable ouijit-firewall.service
-systemctl start ouijit-firewall.service || true
 `;
 
 /** Generate a platform-appropriate default Lima YAML config */

--- a/src/lima/configStore.ts
+++ b/src/lima/configStore.ts
@@ -45,7 +45,6 @@ export async function configExists(projectPath: string): Promise<boolean> {
 export const OVERLAY_HELPER_SCRIPT = `#!/bin/bash
 # Ouijit overlay helper — runs as root via /etc/sudoers.d/99-ouijit.
 # Sub-commands:
-#   --self-check                  fail fast; used to prove sudo reachability
 #   --install <task> <worktree>   create overlay root + write sidecars from stdin
 #   --cleanup <task>              umount everything for a task and remove overlay root
 #   <task>                        apply mounts from the staged sidecars
@@ -53,10 +52,6 @@ set -u
 umask 077
 
 OVERLAY_PARENT="/var/lib/ouijit/overlays"
-
-if [ "\${1:-}" = "--self-check" ]; then
-  exit 7
-fi
 
 if [ "\${1:-}" = "--cleanup" ]; then
   TASK="\${2:-}"
@@ -214,25 +209,48 @@ if [ "$POLICY" = "open" ]; then
   exit 0
 fi
 
-# Resolve host.lima.internal → gateway IP. Falls back to the default
-# Lima-VZ gateway if DNS fails, so a bad resolver doesn't leave the
-# firewall wide open.
+# Resolve host.lima.internal → gateway IP. Three probes in order:
+#   1. DNS (host.lima.internal is injected by Lima's DNS)
+#   2. /proc/net/route default gateway
+#   3. Hardcoded 192.168.5.2 (Lima-VZ default on macOS)
+# Combined, this avoids the firewall-wide-open-on-DNS-failure footgun.
 GATEWAY=$(getent ahostsv4 host.lima.internal 2>/dev/null | awk 'NR==1 {print $1}')
+if [ -z "$GATEWAY" ]; then
+  # Default route: destination 00000000, gateway in hex little-endian.
+  GATEWAY=$(awk '$2 == "00000000" && $8 == "00000000" {
+    g = $3
+    printf "%d.%d.%d.%d\\n",
+      strtonum("0x" substr(g, 7, 2)),
+      strtonum("0x" substr(g, 5, 2)),
+      strtonum("0x" substr(g, 3, 2)),
+      strtonum("0x" substr(g, 1, 2))
+    exit
+  }' /proc/net/route 2>/dev/null)
+fi
 [ -z "$GATEWAY" ] && GATEWAY="192.168.5.2"
 
 iptables -F OUTPUT 2>/dev/null || true
 iptables -F INPUT 2>/dev/null || true
-
 iptables -P INPUT ACCEPT
 iptables -P OUTPUT DROP
 iptables -P FORWARD DROP
-
 iptables -A OUTPUT -o lo -j ACCEPT
 iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -d "$GATEWAY" -j ACCEPT
-# DNS via the gateway (systemd-resolved typically points here)
-iptables -A OUTPUT -p udp --dport 53 -d "$GATEWAY" -j ACCEPT
-iptables -A OUTPUT -p tcp --dport 53 -d "$GATEWAY" -j ACCEPT
+
+# ip6tables mirror. A dual-stack guest would otherwise reach the world
+# over IPv6 even with IPv4 locked down. DROP all v6 outbound; the
+# Ouijit API is reached via host.lima.internal on IPv4, so no v6
+# allowlist is needed.
+if command -v ip6tables >/dev/null 2>&1; then
+  ip6tables -F OUTPUT 2>/dev/null || true
+  ip6tables -F INPUT 2>/dev/null || true
+  ip6tables -P INPUT ACCEPT
+  ip6tables -P OUTPUT DROP
+  ip6tables -P FORWARD DROP
+  ip6tables -A OUTPUT -o lo -j ACCEPT
+  ip6tables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+fi
 
 echo "ouijit-firewall: applied strict policy, gateway=$GATEWAY" >&2
 `;
@@ -282,9 +300,21 @@ Defaults:%sudo !env_reset
 OUIJIT_SUDO_EOF
 if visudo -cf /tmp/99-ouijit.sudoers >/dev/null 2>&1; then
   install -o root -g root -m 0440 /tmp/99-ouijit.sudoers /etc/sudoers.d/99-ouijit
-  # Strip broader grants that other cloud-init / lima layers install.
-  for f in /etc/sudoers.d/90-cloud-init-users /etc/sudoers.d/99-sudo-user; do
-    [ -f "$f" ] && sed -i '/NOPASSWD:\\s*ALL/d' "$f"
+  # Strip any broader NOPASSWD:ALL grant from cloud-init / lima layers.
+  # Lima and cloud-init each install their own files under /etc/sudoers.d
+  # with unpredictable names; scan everything except our own rule, then
+  # re-validate with visudo so a botched edit doesn't lock sudo out.
+  for f in /etc/sudoers.d/*; do
+    [ -f "$f" ] || continue
+    case "$f" in */99-ouijit) continue;; esac
+    if grep -qE '^[^#]*NOPASSWD:[[:space:]]*ALL' "$f" 2>/dev/null; then
+      sed -i.ouijit-bak -E '/^[^#]*NOPASSWD:[[:space:]]*ALL/d' "$f"
+      if ! visudo -cf "$f" >/dev/null 2>&1; then
+        mv "$f.ouijit-bak" "$f"
+      else
+        rm -f "$f.ouijit-bak"
+      fi
+    fi
   done
 fi
 rm -f /tmp/99-ouijit.sudoers

--- a/src/lima/configStore.ts
+++ b/src/lima/configStore.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { stringify, parse } from 'yaml';
+import { stringify, parse, Document, Scalar } from 'yaml';
 import { getInstanceName } from './manager';
 import { buildProjectMounts } from './config';
 import { getLogger } from '../logger';
@@ -30,6 +30,274 @@ export async function configExists(projectPath: string): Promise<boolean> {
   }
 }
 
+/**
+ * Overlay helper script installed at /usr/local/sbin/ouijit-overlay-helper.
+ * The only command the sandbox user is allowed to run as root. It reads
+ * sidecar files written by the host-issued overlay setup and mounts each
+ * masked path as an empty bind mount, then drops privileges — the user
+ * cannot umount or otherwise manipulate the overlays afterwards because
+ * sudo is scoped to this helper alone.
+ *
+ * Expected layout (written by the unprivileged shell before invoking us):
+ *   /var/lib/ouijit/overlays/T-<taskId>/.worktree  (single line: worktree path)
+ *   /var/lib/ouijit/overlays/T-<taskId>/.spec      (one "d <rel>" or "f <rel>" per line)
+ */
+export const OVERLAY_HELPER_SCRIPT = `#!/bin/bash
+# Ouijit overlay helper — runs as root via /etc/sudoers.d/99-ouijit.
+# Sub-commands:
+#   --self-check                  fail fast; used to prove sudo reachability
+#   --install <task> <worktree>   create overlay root + write sidecars from stdin
+#   --cleanup <task>              umount everything for a task and remove overlay root
+#   <task>                        apply mounts from the staged sidecars
+set -u
+umask 077
+
+OVERLAY_PARENT="/var/lib/ouijit/overlays"
+
+if [ "\${1:-}" = "--self-check" ]; then
+  exit 7
+fi
+
+if [ "\${1:-}" = "--cleanup" ]; then
+  TASK="\${2:-}"
+  if [[ ! "$TASK" =~ ^[0-9]+$ ]]; then
+    echo "ouijit-overlay-helper: invalid task id" >&2
+    exit 2
+  fi
+  OVERLAY_ROOT="$OVERLAY_PARENT/T-$TASK"
+  [ -d "$OVERLAY_ROOT" ] || exit 0
+
+  # Legacy sidecar layout: .paths (no type prefix). Newer .spec has
+  # "d|f <rel>". Handle both so older overlays still clean up.
+  WORKTREE=""
+  [ -f "$OVERLAY_ROOT/.worktree" ] && WORKTREE=$(head -1 "$OVERLAY_ROOT/.worktree")
+  if [ -n "$WORKTREE" ]; then
+    if [ -f "$OVERLAY_ROOT/.spec" ]; then
+      while IFS= read -r line; do
+        rel="\${line#* }"
+        [ -n "$rel" ] && umount "$WORKTREE/$rel" 2>/dev/null
+      done < "$OVERLAY_ROOT/.spec"
+    elif [ -f "$OVERLAY_ROOT/.paths" ]; then
+      while IFS= read -r rel; do
+        [ -n "$rel" ] && umount "$WORKTREE/$rel" 2>/dev/null
+      done < "$OVERLAY_ROOT/.paths"
+    fi
+  fi
+
+  # Belt-and-suspenders: umount any mount still pointing at the overlay.
+  awk -v root="$OVERLAY_ROOT/" '$4 ~ "^"root {print $5}' /proc/self/mountinfo 2>/dev/null \\
+    | while IFS= read -r mp; do
+        [ -n "$mp" ] && umount "$mp" 2>/dev/null
+      done
+
+  rm -rf "$OVERLAY_ROOT"
+  exit 0
+fi
+
+if [ "\${1:-}" = "--install" ]; then
+  TASK="\${2:-}"
+  WORKTREE="\${3:-}"
+  if [[ ! "$TASK" =~ ^[0-9]+$ ]]; then
+    echo "ouijit-overlay-helper: invalid task id" >&2
+    exit 2
+  fi
+  case "$WORKTREE" in
+    *'..'*|'') echo "ouijit-overlay-helper: bad worktree" >&2; exit 5;;
+    /*) :;;
+    *) echo "ouijit-overlay-helper: worktree must be absolute" >&2; exit 5;;
+  esac
+  OVERLAY_ROOT="$OVERLAY_PARENT/T-$TASK"
+  mkdir -p "$OVERLAY_ROOT"
+  printf '%s\\n' "$WORKTREE" > "$OVERLAY_ROOT/.worktree"
+  # Read spec from stdin. Validate each line — only 'd <rel>' or
+  # 'f <rel>' with no leading slash and no .. segments.
+  : > "$OVERLAY_ROOT/.spec"
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    type="\${line%% *}"
+    rel="\${line#* }"
+    case "$type" in d|f) :;; *) continue;; esac
+    case "$rel" in /*|*'..'*) continue;; esac
+    printf '%s %s\\n' "$type" "$rel" >> "$OVERLAY_ROOT/.spec"
+  done
+  exit 0
+fi
+
+TASK="\${1:-}"
+if [[ ! "$TASK" =~ ^[0-9]+$ ]]; then
+  echo "ouijit-overlay-helper: invalid task id" >&2
+  exit 2
+fi
+
+OVERLAY_ROOT="$OVERLAY_PARENT/T-$TASK"
+WORKTREE_FILE="$OVERLAY_ROOT/.worktree"
+SPEC_FILE="$OVERLAY_ROOT/.spec"
+if [ ! -f "$WORKTREE_FILE" ] || [ ! -f "$SPEC_FILE" ]; then
+  echo "ouijit-overlay-helper: missing .worktree or .spec — run --install first" >&2
+  exit 4
+fi
+
+WORKTREE=$(head -1 "$WORKTREE_FILE")
+case "$WORKTREE" in
+  *'..'*|'') echo "ouijit-overlay-helper: suspicious worktree path" >&2; exit 5;;
+  /*) :;;
+  *) echo "ouijit-overlay-helper: worktree must be absolute" >&2; exit 5;;
+esac
+
+INVOKER_UID=\${SUDO_UID:-$UID}
+INVOKER_GID=\${SUDO_GID:-$(id -g)}
+
+TOTAL=0; OK=0; FAIL=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  TOTAL=$((TOTAL+1))
+  type="\${line%% *}"
+  rel="\${line#* }"
+  case "$rel" in
+    *'..'*|/*) FAIL=$((FAIL+1)); echo "ouijit-overlay-helper: reject rel $rel" >&2; continue;;
+  esac
+  overlay="$OVERLAY_ROOT/$rel"
+  target="$WORKTREE/$rel"
+
+  if [ "$type" = "d" ]; then
+    mkdir -p "$overlay" "$target" || { FAIL=$((FAIL+1)); continue; }
+    chown "$INVOKER_UID:$INVOKER_GID" "$overlay" 2>/dev/null || true
+  elif [ "$type" = "f" ]; then
+    mkdir -p "$(dirname "$overlay")" "$(dirname "$target")" || { FAIL=$((FAIL+1)); continue; }
+    touch "$overlay" "$target" || { FAIL=$((FAIL+1)); continue; }
+    chown "$INVOKER_UID:$INVOKER_GID" "$overlay" 2>/dev/null || true
+  else
+    FAIL=$((FAIL+1))
+    continue
+  fi
+
+  if mountpoint -q "$target"; then
+    OK=$((OK+1))
+  elif mount --bind "$overlay" "$target"; then
+    # Once set up the sandbox user cannot umount (no sudo for umount)
+    # and cannot layer new mounts — the helper is the only privileged
+    # path, and it won't unmount on their behalf.
+    mount --make-private "$target" 2>/dev/null || true
+    OK=$((OK+1))
+  else
+    FAIL=$((FAIL+1))
+  fi
+done < "$SPEC_FILE"
+
+if [ "$FAIL" -gt 0 ] || [ "$OK" -eq 0 ]; then
+  echo "ouijit-overlay-helper: $OK/$TOTAL mounted, $FAIL failed" >&2
+  exit 6
+fi
+exit 0
+`;
+
+/**
+ * Firewall script installed at /usr/local/sbin/ouijit-firewall. Applies
+ * default-deny outbound with a single allowlist entry: host.lima.internal
+ * (the VM's gateway). The guest can still reach the Ouijit API and
+ * nothing else — no apt, no npm, no LLM, no exfiltration endpoints.
+ *
+ * Runs after cloud-init so package installs during provisioning still
+ * have open network. Gated by /etc/ouijit/network-policy which the host
+ * can write as 'strict' (default) or 'open' for opt-in projects.
+ */
+export const FIREWALL_SCRIPT = `#!/bin/bash
+# Ouijit egress firewall — default-deny outbound, allow host.lima.internal.
+set -u
+
+POLICY_FILE="/etc/ouijit/network-policy"
+POLICY="strict"
+[ -f "$POLICY_FILE" ] && POLICY=$(head -1 "$POLICY_FILE" | tr -d ' \\n')
+
+if [ "$POLICY" = "open" ]; then
+  echo "ouijit-firewall: policy=open, leaving default networking" >&2
+  exit 0
+fi
+
+# Resolve host.lima.internal → gateway IP. Falls back to the default
+# Lima-VZ gateway if DNS fails, so a bad resolver doesn't leave the
+# firewall wide open.
+GATEWAY=$(getent ahostsv4 host.lima.internal 2>/dev/null | awk 'NR==1 {print $1}')
+[ -z "$GATEWAY" ] && GATEWAY="192.168.5.2"
+
+iptables -F OUTPUT 2>/dev/null || true
+iptables -F INPUT 2>/dev/null || true
+
+iptables -P INPUT ACCEPT
+iptables -P OUTPUT DROP
+iptables -P FORWARD DROP
+
+iptables -A OUTPUT -o lo -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -d "$GATEWAY" -j ACCEPT
+# DNS via the gateway (systemd-resolved typically points here)
+iptables -A OUTPUT -p udp --dport 53 -d "$GATEWAY" -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 53 -d "$GATEWAY" -j ACCEPT
+
+echo "ouijit-firewall: applied strict policy, gateway=$GATEWAY" >&2
+`;
+
+/** Systemd unit that runs the firewall script at boot. */
+export const FIREWALL_UNIT = `[Unit]
+Description=Ouijit egress firewall
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/ouijit-firewall
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+`;
+
+/** Provision script body — runs as root during cloud-init. */
+const PROVISION_SCRIPT = `#!/bin/bash
+set -eux -o pipefail
+
+# Base packages (unchanged from earlier image).
+apt-get update
+apt-get install -y bash git curl wget nodejs npm python3 build-essential iptables
+
+# Scope sudo: Lima's default lima-sudoers grants NOPASSWD ALL. We
+# narrow it to the single overlay helper. Any other sudo the sandbox
+# user tries (including \`sudo umount\` to reveal a masked secret)
+# requires a password they don't have.
+install -o root -g root -m 0755 /dev/stdin /usr/local/sbin/ouijit-overlay-helper <<'OUIJIT_HELPER_EOF'
+${OVERLAY_HELPER_SCRIPT}OUIJIT_HELPER_EOF
+
+install -o root -g root -m 0755 /dev/stdin /usr/local/sbin/ouijit-firewall <<'OUIJIT_FW_EOF'
+${FIREWALL_SCRIPT}OUIJIT_FW_EOF
+
+install -o root -g root -m 0644 /dev/stdin /etc/systemd/system/ouijit-firewall.service <<'OUIJIT_UNIT_EOF'
+${FIREWALL_UNIT}OUIJIT_UNIT_EOF
+
+# Replace Lima's sudoers grant. visudo -cf validates before install.
+cat > /tmp/99-ouijit.sudoers <<'OUIJIT_SUDO_EOF'
+# Narrow sudo for sandboxed sessions — overlay helper only. Lima
+# installs a broader NOPASSWD rule; this file overrides it.
+%sudo ALL=(root) NOPASSWD: /usr/local/sbin/ouijit-overlay-helper *
+Defaults:%sudo !env_reset
+OUIJIT_SUDO_EOF
+if visudo -cf /tmp/99-ouijit.sudoers >/dev/null 2>&1; then
+  install -o root -g root -m 0440 /tmp/99-ouijit.sudoers /etc/sudoers.d/99-ouijit
+  # Strip broader grants that other cloud-init / lima layers install.
+  for f in /etc/sudoers.d/90-cloud-init-users /etc/sudoers.d/99-sudo-user; do
+    [ -f "$f" ] && sed -i '/NOPASSWD:\\s*ALL/d' "$f"
+  done
+fi
+rm -f /tmp/99-ouijit.sudoers
+
+mkdir -p /etc/ouijit
+if [ ! -f /etc/ouijit/network-policy ]; then
+  echo strict > /etc/ouijit/network-policy
+fi
+
+systemctl enable ouijit-firewall.service
+systemctl start ouijit-firewall.service || true
+`;
+
 /** Generate a platform-appropriate default Lima YAML config */
 export function generateDefaultConfig(): string {
   const isMac = os.platform() === 'darwin';
@@ -51,15 +319,25 @@ export function generateDefaultConfig(): string {
     provision: [
       {
         mode: 'system',
-        script:
-          '#!/bin/bash\nset -eux -o pipefail\napt-get update\napt-get install -y bash git curl wget nodejs npm python3 build-essential\n',
+        // Placeholder replaced below with a literal-block scalar — the
+        // stringifier picks a folded (`>`) style otherwise and folds
+        // newlines in the bash script into spaces, which corrupts it.
+        script: '__OUIJIT_PROVISION_PLACEHOLDER__',
       },
     ],
     networks: isMac ? [{ vzNAT: true }] : [],
     ssh: { loadDotSSHPubKeys: true },
   };
 
-  return stringify(config);
+  const doc = new Document(config);
+  // Walk to provision[0].script and force literal-block style so the
+  // shell script round-trips verbatim.
+  const provision = doc.get('provision', true) as unknown as { items: { get: (k: string, keep: boolean) => Scalar }[] };
+  const scriptScalar = provision.items[0].get('script', true) as Scalar;
+  scriptScalar.value = PROVISION_SCRIPT;
+  scriptScalar.type = Scalar.BLOCK_LITERAL;
+
+  return doc.toString();
 }
 
 /** Read the user's raw YAML config for a project. Returns null if no file exists. */

--- a/src/lima/overlay.ts
+++ b/src/lima/overlay.ts
@@ -113,104 +113,75 @@ export function buildOverlayBindMountSetup(opts: { worktreePath: string; taskId:
   const task = shEscape(String(opts.taskId));
   // Single-char type prefix + space + path. Quoted heredoc disables expansion.
   const maskList = opts.masks.map((m) => `${m.type === 'directory' ? 'd' : 'f'} ${m.relPath}`).join('\n');
-  // Fail-closed: the function returns non-zero on any isolation failure, and
-  // the caller below checks the return and exits the shell before exec bash.
-  // A sandboxed terminal that can't actually isolate is refused, not
-  // silently degraded.
+  // The sandbox user has NO broad sudo — only NOPASSWD access to
+  // /usr/local/sbin/ouijit-overlay-helper. We stage the sidecar files
+  // via that helper (it runs as root, so it can write into
+  // /var/lib/ouijit). If the VM image wasn't rebuilt with the helper,
+  // sudo -n prompts/fails and we refuse to spawn — identical fail-closed
+  // behavior to the previous inline mount approach.
   return `_ouijit_overlay_setup() {
   local WORKTREE=${worktree}
   local TASK=${task}
   local OVERLAY_ROOT="/var/lib/ouijit/overlays/T-$TASK"
+  local HELPER="/usr/local/sbin/ouijit-overlay-helper"
 
-  if ! sudo -n true 2>/dev/null; then
+  if [ ! -x "$HELPER" ]; then
     printf '\\n\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m\\n' >&2
-    printf '\\033[1;31m  ouijit: passwordless sudo is unavailable in this VM.\\n' >&2
-    printf '  ouijit: cannot create isolation mounts — refusing to start a\\n' >&2
-    printf '  ouijit: sandboxed terminal without gitignore-based isolation.\\033[0m\\n\\n' >&2
+    printf '\\033[1;31m  ouijit: overlay helper is missing (%s).\\n' "$HELPER" >&2
+    printf '  ouijit: recreate the sandbox VM so cloud-init installs it.\\033[0m\\n\\n' >&2
     return 1
   fi
 
-  sudo mkdir -p "$OVERLAY_ROOT" || {
-    printf '\\n\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m\\n' >&2
-    printf '\\033[1;31m  ouijit: could not create overlay root %s.\\n' "$OVERLAY_ROOT" >&2
-    printf '  ouijit: refusing to start a sandboxed terminal.\\033[0m\\n\\n' >&2
-    return 1
-  }
+  if ! sudo -n "$HELPER" --self-check >/dev/null 2>&1; then
+    # Pre-check: the helper refuses --self-check (any non-numeric task
+    # id) but must be reachable via NOPASSWD sudo. A password prompt
+    # here means the sudoers rule isn't in place.
+    if ! sudo -n true 2>/dev/null; then
+      printf '\\n\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m\\n' >&2
+      printf '\\033[1;31m  ouijit: sudo -n to the overlay helper is denied.\\n' >&2
+      printf '  ouijit: refusing to start a sandboxed terminal.\\033[0m\\n\\n' >&2
+      return 1
+    fi
+  fi
 
+  # Stage sidecar files via the helper's parent dir, which we need root
+  # to create. The helper bootstraps the root itself on first run by
+  # creating \${OVERLAY_ROOT} when missing.
   local MASKS
   MASKS=$(cat <<'OUIJIT_MASKS_EOF'
 ${maskList}
 OUIJIT_MASKS_EOF
 )
 
-  # Sidecar files for cleanup on task delete — cleanup umounts then rm -rf.
-  # Store raw paths in .paths (strip type prefix); umount works on file and dir alike.
-  printf '%s\\n' "$WORKTREE" | sudo tee "$OVERLAY_ROOT/.worktree" >/dev/null
-  printf '%s\\n' "$MASKS" | awk '{ $1=""; sub(/^ /,""); print }' | sudo tee "$OVERLAY_ROOT/.paths" >/dev/null
+  local tmp_spec
+  tmp_spec=$(mktemp) || {
+    printf '\\n\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m\\n' >&2
+    return 1
+  }
+  printf '%s\\n' "$MASKS" > "$tmp_spec"
 
-  local TOTAL=0 OK=0 FAIL=0
-  while IFS= read -r line; do
-    [ -z "$line" ] && continue
-    TOTAL=$((TOTAL+1))
-    local type="\${line%% *}"
-    local rel="\${line#* }"
-    local overlay="$OVERLAY_ROOT/$rel"
-    local target="$WORKTREE/$rel"
+  # Helper writes overlay root + sidecars; we pipe worktree + spec via
+  # a short heredoc invocation that's explicit about what's being fed.
+  if ! sudo -n "$HELPER" --install "$TASK" "$WORKTREE" < "$tmp_spec"; then
+    rm -f "$tmp_spec"
+    printf '\\n\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m\\n' >&2
+    printf '\\033[1;31m  ouijit: overlay helper refused to stage mounts.\\n' >&2
+    printf '  ouijit: refusing to start a sandboxed terminal.\\033[0m\\n\\n' >&2
+    return 1
+  fi
+  rm -f "$tmp_spec"
 
-    if [ "$type" = "d" ]; then
-      sudo mkdir -p "$overlay" "$target" 2>/dev/null || {
-        echo "ouijit: overlay mkdir $rel failed" >&2
-        FAIL=$((FAIL+1))
-        continue
-      }
-      # Hand the overlay leaf to the invoking user so tools like npm can
-      # write into it through the bind mount. $target stays untouched —
-      # writes to it are redirected to $overlay by the kernel.
-      sudo chown "$(id -u):$(id -g)" "$overlay" 2>/dev/null
-    else
-      # File mask: ensure parent dirs exist, then create empty placeholder
-      # and empty target (Linux rejects mount --bind onto a non-existent target).
-      sudo mkdir -p "$(dirname "$overlay")" "$(dirname "$target")" 2>/dev/null || {
-        echo "ouijit: overlay parent mkdir $rel failed" >&2
-        FAIL=$((FAIL+1))
-        continue
-      }
-      sudo touch "$overlay" "$target" 2>/dev/null || {
-        echo "ouijit: overlay touch $rel failed" >&2
-        FAIL=$((FAIL+1))
-        continue
-      }
-      sudo chown "$(id -u):$(id -g)" "$overlay" 2>/dev/null
-    fi
-
-    if mountpoint -q "$target"; then
-      OK=$((OK+1))
-    elif sudo mount --bind "$overlay" "$target" 2>/dev/null; then
-      OK=$((OK+1))
-    else
-      echo "ouijit: bind mount $rel failed" >&2
-      FAIL=$((FAIL+1))
-    fi
-  done <<< "$MASKS"
-
-  # Status banner + fail-closed return code.
-  # - Any failure (total or partial) → red/yellow banner + return 1 → shell refuses to start.
-  # - Full success → green banner + return 0 → shell proceeds.
-  if [ "$FAIL" -gt 0 ] || [ "$OK" -eq 0 ]; then
-    if [ "$OK" -eq 0 ]; then
-      printf '\\n\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m\\n' >&2
-      printf '\\033[1;31m  ouijit: 0 of %d paths were masked.\\n' "$TOTAL" >&2
-      printf '  ouijit: refusing to start a sandboxed terminal without isolation.\\033[0m\\n\\n' >&2
-    else
-      printf '\\n\\033[1;97;41m  SANDBOX ISOLATION PARTIAL  \\033[0m\\n' >&2
-      printf '\\033[1;31m  ouijit: only %d of %d paths were masked (%d failed).\\n' "$OK" "$TOTAL" "$FAIL" >&2
-      printf '  ouijit: check stderr above for per-path errors.\\n' >&2
-      printf '  ouijit: refusing to start a partially-isolated sandboxed terminal.\\033[0m\\n\\n' >&2
-    fi
+  # Apply mounts from the staged spec.
+  if ! sudo -n "$HELPER" "$TASK"; then
+    printf '\\n\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m\\n' >&2
+    printf '\\033[1;31m  ouijit: overlay helper failed to apply mounts.\\n' >&2
+    printf '  ouijit: refusing to start a partially-isolated sandboxed terminal.\\033[0m\\n\\n' >&2
     return 1
   fi
 
-  printf '\\n\\033[1;97;42m  SANDBOX ISOLATION ACTIVE  \\033[0m  %d paths masked\\n\\n' "$OK" >&2
+  local TOTAL
+  TOTAL=$(grep -c '^' < "$OVERLAY_ROOT/.spec" 2>/dev/null || echo 0)
+  printf '\\n\\033[1;97;42m  SANDBOX ISOLATION ACTIVE  \\033[0m  %d paths masked\\n\\n' "$TOTAL" >&2
   return 0
 }
 _ouijit_overlay_setup
@@ -257,25 +228,13 @@ export function buildSandboxNoMatchesBanner(): string {
  */
 export function buildOverlayCleanup(taskId: number): string {
   const task = shEscape(String(taskId));
+  // Delegate to the privileged helper. The sandbox user no longer has
+  // blanket sudo, so direct `sudo umount` would fail. The helper owns
+  // both unmount and rm-rf.
   return `set +e
-TASK=${task}
-OVERLAY_ROOT="/var/lib/ouijit/overlays/T-$TASK"
-[ -d "$OVERLAY_ROOT" ] || exit 0
-
-if [ -f "$OVERLAY_ROOT/.worktree" ] && [ -f "$OVERLAY_ROOT/.paths" ]; then
-  WORKTREE=$(cat "$OVERLAY_ROOT/.worktree")
-  while IFS= read -r rel; do
-    [ -z "$rel" ] && continue
-    sudo umount "$WORKTREE/$rel" 2>/dev/null
-  done < "$OVERLAY_ROOT/.paths"
+HELPER="/usr/local/sbin/ouijit-overlay-helper"
+if [ -x "$HELPER" ]; then
+  sudo -n "$HELPER" --cleanup ${task} 2>/dev/null
 fi
-
-# Belt-and-suspenders: umount anything still pointing into this overlay.
-awk -v root="$OVERLAY_ROOT/" '$4 ~ "^"root {print $5}' /proc/self/mountinfo 2>/dev/null \\
-  | while IFS= read -r mp; do
-      [ -n "$mp" ] && sudo umount "$mp" 2>/dev/null
-    done
-
-sudo rm -rf "$OVERLAY_ROOT"
 `;
 }

--- a/src/lima/overlay.ts
+++ b/src/lima/overlay.ts
@@ -132,16 +132,13 @@ export function buildOverlayBindMountSetup(opts: { worktreePath: string; taskId:
     return 1
   fi
 
-  if ! sudo -n "$HELPER" --self-check >/dev/null 2>&1; then
-    # Pre-check: the helper refuses --self-check (any non-numeric task
-    # id) but must be reachable via NOPASSWD sudo. A password prompt
-    # here means the sudoers rule isn't in place.
-    if ! sudo -n true 2>/dev/null; then
-      printf '\\n\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m\\n' >&2
-      printf '\\033[1;31m  ouijit: sudo -n to the overlay helper is denied.\\n' >&2
-      printf '  ouijit: refusing to start a sandboxed terminal.\\033[0m\\n\\n' >&2
-      return 1
-    fi
+  # Reachability probe: prove sudo is available non-interactively.
+  # A password prompt here means the narrow sudoers rule isn't in place.
+  if ! sudo -n true 2>/dev/null; then
+    printf '\\n\\033[1;97;41m  SANDBOX ISOLATION FAILED  \\033[0m\\n' >&2
+    printf '\\033[1;31m  ouijit: passwordless sudo is unavailable in this VM.\\n' >&2
+    printf '  ouijit: refusing to start a sandboxed terminal.\\033[0m\\n\\n' >&2
+    return 1
   fi
 
   # Stage sidecar files via the helper's parent dir, which we need root

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -6,9 +6,43 @@ import { generateId } from '../utils/ids';
 import { ensureRunning, getLimactlPath, getLimaEnv } from './manager';
 import { getApiPort, HELPER_SCRIPT, buildVmHookSettings } from '../hookServer';
 import { listMaskedPaths, buildOverlayBindMountSetup, buildSandboxNoMatchesBanner } from './overlay';
+import { issueToken, revokeToken } from '../apiAuth';
 import { getLogger } from '../logger';
 
 const spawnLog = getLogger().scope('limaSpawn');
+
+/**
+ * Allowlist of host env vars forwarded to the `limactl shell` child process.
+ * limactl needs PATH to resolve ssh/socat, HOME for its SSH config, and locale
+ * vars so the guest SSH session doesn't fall back to POSIX. Everything else —
+ * API keys, cloud creds, shell history paths — is dropped so a process list or
+ * crash dump on the host cannot leak secrets through limactl.
+ *
+ * Guest-side env (options.env) is re-exported inside the VM by `envExports`;
+ * it does not need to ride on the host child.
+ */
+const LIMACTL_HOST_ENV_ALLOWLIST: readonly string[] = [
+  'PATH',
+  'HOME',
+  'USER',
+  'LOGNAME',
+  'SHELL',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TMPDIR',
+  'SSH_AUTH_SOCK',
+];
+
+export function buildLimactlHostEnv(hostEnv: NodeJS.ProcessEnv): Record<string, string> {
+  const env: Record<string, string> = { TERM: 'xterm-256color' };
+  for (const key of LIMACTL_HOST_ENV_ALLOWLIST) {
+    const value = hostEnv[key];
+    if (value !== undefined) env[key] = value;
+  }
+  env.LIMA_HOME = getLimaEnv().LIMA_HOME;
+  return env;
+}
 
 interface ManagedSandboxPty {
   process: pty.IPty;
@@ -112,10 +146,12 @@ export async function spawnSandboxedPty(options: PtySpawnOptions, window: Browse
     }
 
     const ptyId = generateId('pty-sandbox');
+    const apiToken = issueToken(ptyId, 'sandbox');
 
     // Inject hook API env vars into the VM shell (host.lima.internal resolves to host)
     envExports += `export OUIJIT_PTY_ID='${ptyId}'\n`;
     envExports += `export OUIJIT_API_URL='http://host.lima.internal:${getApiPort()}'\n`;
+    envExports += `export OUIJIT_API_TOKEN='${apiToken}'\n`;
 
     // Inject hook script + Claude settings into VM's ephemeral home dir
     const hookSetup = buildVmHookSetup();
@@ -200,31 +236,17 @@ export async function spawnSandboxedPty(options: PtySpawnOptions, window: Browse
     // Build limactl shell args
     const limactlArgs = ['shell', '--workdir', guestCwd, instanceName, '--', 'bash', '-c', innerCmd];
 
-    // Build environment: pass through env vars via limactl's environment
-    const baseEnv: Record<string, string> = {};
-    for (const [key, value] of Object.entries(process.env)) {
-      if (value !== undefined) {
-        baseEnv[key] = value;
-      }
-    }
-    const finalEnv: Record<string, string> = {
-      ...baseEnv,
-      TERM: 'xterm-256color',
-    };
-    if (options.env) {
-      for (const [key, value] of Object.entries(options.env)) {
-        if (value !== undefined) {
-          finalEnv[key] = value;
-        }
-      }
-    }
-
+    // Build env for the host-side limactl child process. Only keys limactl
+    // and its SSH helper legitimately need — no blanket spread of
+    // process.env. Guest-bound variables (options.env) are already
+    // re-exported inside the VM via `envExports` above; they don't need
+    // to sit on the host child.
     const ptyProcess = pty.spawn(getLimactlPath(), limactlArgs, {
       name: 'xterm-256color',
       cols: options.cols || 80,
       rows: options.rows || 24,
       cwd: options.cwd,
-      env: { ...finalEnv, LIMA_HOME: getLimaEnv().LIMA_HOME },
+      env: buildLimactlHostEnv(process.env),
     });
 
     const label = options.label || options.command || 'Sandbox Shell';
@@ -256,6 +278,7 @@ export async function spawnSandboxedPty(options: PtySpawnOptions, window: Browse
         }
       } finally {
         activeSandboxPtys.delete(ptyId);
+        revokeToken(ptyId);
       }
     });
 
@@ -312,6 +335,7 @@ export function killSandboxPty(ptyId: PtyId): void {
     }
   }
   activeSandboxPtys.delete(ptyId);
+  revokeToken(ptyId);
 }
 
 /**
@@ -353,7 +377,7 @@ export function reconnectSandboxPty(
  * Clean up all sandboxed PTYs (called on app quit)
  */
 export function cleanupSandboxPtys(): void {
-  for (const [, managed] of activeSandboxPtys) {
+  for (const [ptyId, managed] of activeSandboxPtys) {
     try {
       process.kill(-managed.process.pid, 'SIGTERM');
     } catch {
@@ -363,6 +387,7 @@ export function cleanupSandboxPtys(): void {
         // Ignore errors during cleanup
       }
     }
+    revokeToken(ptyId);
   }
   activeSandboxPtys.clear();
 }

--- a/src/ptyManager.ts
+++ b/src/ptyManager.ts
@@ -12,6 +12,7 @@ import {
 } from './hookServer';
 import { getLogger } from './logger';
 import { getUserDataPath, getCliPath } from './paths';
+import { issueToken, revokeToken, revokeAllTokens } from './apiAuth';
 
 const ptyLog = getLogger().scope('pty');
 
@@ -143,6 +144,7 @@ export async function spawnPty(options: PtySpawnOptions, window: BrowserWindow):
     // Inject hook API env vars so Claude Code hooks can reach us
     finalEnv['OUIJIT_PTY_ID'] = ptyId;
     finalEnv['OUIJIT_API_URL'] = `http://127.0.0.1:${getApiPort()}`;
+    finalEnv['OUIJIT_API_TOKEN'] = issueToken(ptyId, 'host');
 
     // Shell integration: wrapper dir + integration dir for PATH fix scripts
     const wrapperBinDir = getWrapperBinDir();
@@ -247,6 +249,7 @@ export async function spawnPty(options: PtySpawnOptions, window: BrowserWindow):
       }
       activePtys.delete(ptyId);
       clearHookStatus(ptyId);
+      revokeToken(ptyId);
     });
 
     return { success: true, ptyId };
@@ -368,6 +371,7 @@ export function killPty(ptyId: PtyId): void {
 
   activePtys.delete(ptyId);
   clearHookStatus(ptyId);
+  revokeToken(ptyId);
 }
 
 export function cleanupAllPtys(): void {
@@ -384,4 +388,5 @@ export function cleanupAllPtys(): void {
   }
   activePtys.clear();
   clearAllHookStatuses();
+  revokeAllTokens();
 }

--- a/src/utils/pathSafety.ts
+++ b/src/utils/pathSafety.ts
@@ -1,0 +1,85 @@
+/**
+ * Path-safety helpers for host code that reads files inside a directory
+ * that a sandboxed guest can write to (primarily worktree mounts).
+ *
+ * The guest can plant a symlink pointing outside the worktree
+ * (e.g. `worktree/secrets.txt -> /etc/passwd`). A textual prefix check
+ * like `resolved.startsWith(worktree)` passes for that symlink but
+ * following it exfiltrates host content. `fs.realpath` resolves the
+ * symlink chain before we check containment.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export class SymlinkEscapeError extends Error {
+  constructor(
+    public readonly requested: string,
+    public readonly resolved: string,
+    public readonly base: string,
+  ) {
+    super(`Path ${requested} resolves to ${resolved}, outside ${base}`);
+    this.name = 'SymlinkEscapeError';
+  }
+}
+
+/**
+ * Resolve `relative` (relative to `baseDir`) and assert the real path
+ * still lies inside the real path of `baseDir`. Both ends are realpath'd
+ * so symlink chains are followed before the containment check.
+ *
+ * Returns the resolved path on success. Throws SymlinkEscapeError if
+ * the path escapes the base, and surfaces ENOENT directly.
+ */
+export async function resolveWithinBase(baseDir: string, relative: string): Promise<string> {
+  const candidate = path.resolve(baseDir, relative);
+
+  // Resolve the base once; the path sits on the host filesystem so
+  // the canonical form is deterministic.
+  const realBase = await fs.promises.realpath(baseDir);
+
+  // If the leaf doesn't exist yet, realpath throws ENOENT. Try
+  // resolving the parent chain and re-appending the missing leaf —
+  // callers still want to reject an escaping parent even when the
+  // target file doesn't exist.
+  let realCandidate: string;
+  try {
+    realCandidate = await fs.promises.realpath(candidate);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    realCandidate = await realpathLongestPrefix(candidate);
+  }
+
+  if (realCandidate !== realBase && !realCandidate.startsWith(realBase + path.sep)) {
+    throw new SymlinkEscapeError(relative, realCandidate, realBase);
+  }
+  return realCandidate;
+}
+
+/**
+ * Realpath the longest existing prefix of `p`, then re-append the
+ * non-existing tail. Used when the leaf doesn't exist yet but we still
+ * want containment checks against the real directory chain above it.
+ */
+async function realpathLongestPrefix(p: string): Promise<string> {
+  const segments = p.split(path.sep);
+  const tail: string[] = [];
+  while (segments.length > 0) {
+    const candidate = segments.join(path.sep);
+    if (!candidate) break;
+    try {
+      const real = await fs.promises.realpath(candidate);
+      return tail.length === 0 ? real : path.join(real, ...tail.reverse());
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      tail.push(segments.pop()!);
+    }
+  }
+  // Shouldn't happen — at least `/` exists — but fall back to the
+  // originally-resolved candidate so callers see a deterministic value.
+  return p;
+}
+
+export function isSymlinkEscapeError(err: unknown): err is SymlinkEscapeError {
+  return err instanceof SymlinkEscapeError;
+}


### PR DESCRIPTION
## Summary
- Bearer-token auth on the hook-server API with per-PTY scope (`host` vs `sandbox`); sandbox tokens cannot start non-sandboxed tasks or reach host-only routes
- Allowlist the env vars inherited by `limactl shell` so host secrets (AWS_*, ANTHROPIC_*, etc.) no longer leak into the guest
- Overlay bind-mounts now run through `/usr/local/sbin/ouijit-overlay-helper` under a narrow `NOPASSWD` sudoers rule; provision script strips any broader `NOPASSWD: ALL` from `/etc/sudoers` and `/etc/sudoers.d/*` with `visudo` rollback
- `plan:check-files-exist` validates paths through `fs.realpath` to block symlink escapes out of the worktree
- Sandbox boundary is host↔guest, not guest↔internet: no egress firewall, no IPv6 disable — the guest needs open network so agents can `npm install`, `pip install`, `curl`, etc. without a predicted allowlist