### PR TITLE
Bump deps to patch security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@xyflow/react": "^12.10.2",
         "better-sqlite3": "^12.6.2",
         "commander": "^14.0.3",
-        "dompurify": "^3.3.3",
+        "dompurify": "^3.4.0",
         "electron-log": "^5.4.3",
         "electron-squirrel-startup": "^1.0.1",
         "fix-path": "^5.0.0",
@@ -59,7 +59,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react-swc": "^4.3.0",
-        "electron": "39.2.7",
+        "electron": "39.8.8",
         "esbuild": "^0.25.12",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
@@ -73,7 +73,7 @@
         "tailwindcss": "^4.1.18",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.56.1",
-        "vite": "^6.4.1",
+        "vite": "^6.4.2",
         "vitest": "^4.0.18"
       }
     },
@@ -5235,13 +5235,13 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
+      "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/@xterm/addon-fit": {
@@ -6669,9 +6669,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -6685,9 +6685,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "39.2.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.2.7.tgz",
-      "integrity": "sha512-KU0uFS6LSTh4aOIC3miolcbizOFP7N1M46VTYVfqIgFiuA2ilfNaOHLDS9tCMvwwHRowAsvqBrh9NgMXcTOHCQ==",
+      "version": "39.8.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.8.tgz",
+      "integrity": "sha512-24MMLdwCg8xwlWzDxC1XZU2MqW0Xx2UPxt9EU15vMDoRSMHPqmi/BgRCEINXZaBLfFSeXEKGpg+QlBRdL5uwaw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -9530,9 +9530,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -13172,9 +13172,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.3.0",
-    "electron": "39.2.7",
+    "electron": "39.8.8",
     "esbuild": "^0.25.12",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
@@ -71,7 +71,7 @@
     "tailwindcss": "^4.1.18",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.56.1",
-    "vite": "^6.4.1",
+    "vite": "^6.4.2",
     "vitest": "^4.0.18"
   },
   "dependencies": {
@@ -83,7 +83,7 @@
     "@xyflow/react": "^12.10.2",
     "better-sqlite3": "^12.6.2",
     "commander": "^14.0.3",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.0",
     "electron-log": "^5.4.3",
     "electron-squirrel-startup": "^1.0.1",
     "fix-path": "^5.0.0",
@@ -101,6 +101,8 @@
   },
   "overrides": {
     "tar": "^7.5.7",
-    "tmp": "^0.2.5"
+    "tmp": "^0.2.5",
+    "@xmldom/xmldom": "^0.9.9",
+    "lodash": "^4.18.1"
   }
 }


### PR DESCRIPTION
## Summary

- Bump `electron` 39.2.7 → 39.8.8 (18 CVEs)
- Bump `vite` ^6.4.1 → ^6.4.2 (path traversal, WS file read)
- Bump `dompurify` ^3.3.3 → ^3.4.0 (FORBID_TAGS bypass)
- Add overrides for `@xmldom/xmldom` ^0.9.9 and `lodash` ^4.18.1
- 23 low-severity advisories remain in the `@tootallnate/once` → `@electron-forge/*` chain; no non-downgrading fix published upstream