### PR TITLE
Fix macOS build: downgrade @xmldom/xmldom override to ^0.8.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5234,16 +5234,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
-      "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.6"
-      }
-    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -10784,6 +10774,16 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/plist/node_modules/@xmldom/xmldom": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "overrides": {
     "tar": "^7.5.7",
     "tmp": "^0.2.5",
-    "@xmldom/xmldom": "^0.9.9",
+    "@xmldom/xmldom": "^0.8.11",
     "lodash": "^4.18.1"
   }
 }


### PR DESCRIPTION
## Summary
- The `^0.9.9` override added in #128 crashed `@electron/packager` on macOS during `MacApp.loadPlist` with `DOMParser.parseFromString: the provided mimeType "undefined" is not valid`
- xmldom 0.9.x made the `mimeType` arg to `parseFromString` required, but `plist/lib/parse.js` calls it without one
- Downgrade the override to `^0.8.11`, which keeps the pre-breaking-change API and still carries the CVE fixes the override was added for