### PR TITLE
Fix sandbox terminal collision on pre-bind placeholder id

### DIFF
--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -11,6 +11,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import type { PtyId, PtySpawnOptions, GitFileStatus } from '../../types';
 import { notifyReady, readyBody } from '../../utils/notifications';
+import { generateId } from '../../utils/ids';
 import { useTerminalStore } from '../../stores/terminalStore';
 
 // ── Idle fallback timer constants ────────────────────────────────────
@@ -261,7 +262,10 @@ export async function refreshAllTerminalGitStatus(projectPath: string): Promise<
 
 export class OuijitTerminal {
   // ── Identity ────────────────────────────────────────────────────────
-  ptyId: PtyId = '' as PtyId;
+  // Sandboxed terminals register in the store before their real PTY id is
+  // known. Use a unique placeholder per instance so concurrent pending
+  // terminals don't collide on the same key — bind() rekeys to the real id.
+  ptyId: PtyId = generateId('pty-pending') as PtyId;
   readonly projectPath: string;
   command: string | undefined;
   readonly isRunner: boolean;
@@ -455,11 +459,11 @@ export class OuijitTerminal {
     opts?: { onData?: (data: string) => void; onExit?: (exitCode: number) => void; skipSideEffects?: boolean },
   ): void {
     if (this.disposed) return;
-    // Sandbox terminals register under an empty ptyId before the real
-    // one is known (so the loading card can render while the VM spawns).
-    // Re-key the registry and Zustand store to the real id so downstream
-    // lookups — hook status updates, plan events, git-status refresh —
-    // can find us.
+    // Sandbox terminals register under a placeholder ptyId before the
+    // real one is known (so the loading card can render while the VM
+    // spawns). Re-key the registry and Zustand store to the real id so
+    // downstream lookups — hook status updates, plan events, git-status
+    // refresh — can find us.
     const prevPtyId = this.ptyId;
     if (prevPtyId !== ptyId) {
       if (terminalInstances.get(prevPtyId) === this) {

--- a/src/stores/terminalStore.ts
+++ b/src/stores/terminalStore.ts
@@ -77,9 +77,9 @@ interface TerminalStoreActions {
   updateDisplay: (ptyId: string, patch: Partial<TerminalDisplayState>) => void;
   /**
    * Swap a terminal's key from a placeholder id to the real PTY id. Sandbox
-   * terminals register under an empty id before the VM finishes spawning so
-   * the loading card can render; once the PTY exists we re-key all per-pty
-   * state to the real id.
+   * terminals register under a per-instance placeholder id before the VM
+   * finishes spawning so the loading card can render; once the PTY exists
+   * we re-key all per-pty state to the real id.
    */
   rekeyTerminal: (oldPtyId: string, newPtyId: string) => void;
   setActiveIndex: (projectPath: string, index: number) => void;


### PR DESCRIPTION
## Summary

- Sandboxed terminals registered in the store under an empty-string placeholder ptyId before their PTY spawned, so opening a VM Console and a sandbox task concurrently caused both to collide on the same key — rekey then mapped both array slots to one real id, orphaning the VM Console card (kanban showed 2, stack showed 1).
- Give each `OuijitTerminal` a unique per-instance placeholder via `generateId('pty-pending')` so concurrent pending terminals no longer stomp each other. `bind()` already rekeys placeholder → real id.