### PR TITLE
Add `ouijit task current` CLI command

### DIFF
--- a/src/__tests__/apiRouterAuth.test.ts
+++ b/src/__tests__/apiRouterAuth.test.ts
@@ -12,6 +12,7 @@ import type { BrowserWindow } from 'electron';
 
 vi.mock('../ptyManager', () => ({
   isPtyActive: () => true,
+  getPtyTaskContext: () => null,
 }));
 
 // Prevent real IPC broadcasts; we're driving HTTP directly.

--- a/src/__tests__/cli/commands/task.test.ts
+++ b/src/__tests__/cli/commands/task.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Command } from 'commander';
 import { registerTaskCommands } from '../../../cli/commands/task';
 
@@ -57,6 +57,41 @@ describe('task commands', () => {
     const result = output.getJson();
     expect(get).toHaveBeenCalledWith(`/api/tasks/1?project=${encodeURIComponent(PROJECT)}`);
     expect(result.name).toBe('My task');
+  });
+
+  describe('current', () => {
+    const ORIGINAL_PTY_ID = process.env['OUIJIT_PTY_ID'];
+
+    afterEach(() => {
+      if (ORIGINAL_PTY_ID === undefined) delete process.env['OUIJIT_PTY_ID'];
+      else process.env['OUIJIT_PTY_ID'] = ORIGINAL_PTY_ID;
+    });
+
+    test('calls GET /api/tasks/current with no project query', async () => {
+      process.env['OUIJIT_PTY_ID'] = 'pty-123';
+      vi.mocked(get).mockResolvedValue({ taskNumber: 7, name: 'Owned task' });
+      const output = captureOutput();
+      await createProgram().parseAsync(['task', 'current'], { from: 'user' });
+      const result = output.getJson();
+      expect(get).toHaveBeenCalledWith('/api/tasks/current');
+      expect(result.taskNumber).toBe(7);
+    });
+
+    test('errors and exits non-zero when OUIJIT_PTY_ID is unset', async () => {
+      delete process.env['OUIJIT_PTY_ID'];
+      const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`exit:${code}`);
+      }) as never);
+      try {
+        await expect(createProgram().parseAsync(['task', 'current'], { from: 'user' })).rejects.toThrow(/exit:1/);
+        expect(get).not.toHaveBeenCalled();
+        expect(errSpy).toHaveBeenCalled();
+      } finally {
+        errSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+    });
   });
 
   test('create calls POST /api/tasks', async () => {

--- a/src/__tests__/getPtyTaskContext.test.ts
+++ b/src/__tests__/getPtyTaskContext.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Verifies getPtyTaskContext sees PTYs registered via the sandbox bridge.
+ * The sandbox spawn path doesn't enter `activePtys`; it registers its
+ * { projectPath, taskId } via registerSandboxPty. This is the bit task
+ * 326 will eventually unify — until then, the helper has to cover both maps.
+ */
+import { describe, test, expect } from 'vitest';
+import { getPtyTaskContext, registerSandboxPty, unregisterSandboxPty, isPtyActive } from '../ptyManager';
+
+describe('getPtyTaskContext', () => {
+  test('returns null for unknown ptyId', () => {
+    expect(getPtyTaskContext('pty-does-not-exist')).toBeNull();
+  });
+
+  test('resolves task context for a registered sandbox PTY', () => {
+    registerSandboxPty('pty-sb-1', { projectPath: '/p', taskId: 42 });
+    try {
+      expect(isPtyActive('pty-sb-1')).toBe(true);
+      expect(getPtyTaskContext('pty-sb-1')).toEqual({ projectPath: '/p', taskId: 42 });
+    } finally {
+      unregisterSandboxPty('pty-sb-1');
+    }
+    expect(isPtyActive('pty-sb-1')).toBe(false);
+    expect(getPtyTaskContext('pty-sb-1')).toBeNull();
+  });
+
+  test('returns null for sandbox PTYs without a taskId (e.g. project-mode shells)', () => {
+    registerSandboxPty('pty-sb-2', { projectPath: '/p' });
+    try {
+      expect(isPtyActive('pty-sb-2')).toBe(true);
+      expect(getPtyTaskContext('pty-sb-2')).toBeNull();
+    } finally {
+      unregisterSandboxPty('pty-sb-2');
+    }
+  });
+});

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -34,7 +34,7 @@ import {
 } from '../taskLifecycle';
 import { getProjectList } from '../scanner';
 import { getPlanPath, setPlanPath, clearPlanPath } from '../hookServer';
-import { isPtyActive } from '../ptyManager';
+import { isPtyActive, getPtyTaskContext } from '../ptyManager';
 import { typedPush } from '../ipc/helpers';
 import { getLogger } from '../logger';
 import { authenticateRequest, type AuthContext, type ApiScope } from '../apiAuth';
@@ -154,6 +154,18 @@ const routes: Route[] = [
   // ── Tasks ────────────────────────────────────────────────────────
   route('GET', 'tasks', (r) => {
     return getTasksWithWorkspaces(requireProject(r.query));
+  }),
+
+  // Resolves the task owning the calling PTY. The project is derived from
+  // the pty's record, so this route deliberately does not take ?project=.
+  // Order matters: must come before 'tasks/:number' so the literal segment
+  // wins the match against a numeric :number.
+  route('GET', 'tasks/current', async (r) => {
+    const ctx = getPtyTaskContext(r.auth.ptyId);
+    if (!ctx) throw new HttpError(404, 'Current PTY is not associated with a task');
+    const task = await getTaskWithWorkspace(ctx.projectPath, ctx.taskId);
+    if (!task) throw new HttpError(404, `Task ${ctx.taskId} not found`);
+    return task;
   }),
 
   route('GET', 'tasks/:number', (r) => {

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -26,6 +26,7 @@ Examples:
   ouijit task create "Fix login bug"
   ouijit task create "Refactor auth" --prompt "Extract auth middleware"
   ouijit task list
+  ouijit task current
   ouijit task start 5
   ouijit task set-status 5 in_review
   ouijit task set-name 5 "Better name"
@@ -51,6 +52,18 @@ Examples:
       const project = requireProject();
       const t = await get(`/api/tasks/${num}${projectQuery(project)}`);
       if (!t) return printError(`Task ${num} not found`);
+      printJson(t);
+    });
+
+  task
+    .command('current')
+    .description('Get the task owning this terminal (uses OUIJIT_PTY_ID)')
+    .action(async () => {
+      if (!process.env['OUIJIT_PTY_ID']) {
+        return printError('OUIJIT_PTY_ID not set — run from an Ouijit terminal');
+      }
+      const t = await get('/api/tasks/current');
+      if (!t) return printError('Current terminal is not associated with a task');
       printJson(t);
     });
 

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -369,6 +369,7 @@ You are running inside an Ouijit terminal. The \`ouijit\` CLI manages tasks, tag
 ## Task Commands (most common)
 ouijit task list                              # → [{taskNumber, name, status, branch, worktreePath, prompt, ...}]
 ouijit task get <number>                      # → single task object
+ouijit task current                           # → task owning this terminal (resolves via OUIJIT_PTY_ID)
 ouijit task create "<name>"                   # → {success, task: {taskNumber, ...}}
 ouijit task create "<name>" --prompt "<text>" # set description at creation
 ouijit task start <number>                    # creates git worktree, sets in_progress
@@ -417,9 +418,9 @@ ouijit project list                           # → all registered projects
 - Always prefer ouijit over editing task files directly.
 
 ## Common Workflows
-# Check what tasks exist, then update yours:
-ouijit task list
-ouijit task set-status 5 in_review
+# Update the task owning this terminal:
+ouijit task current
+ouijit task set-status $(ouijit task current | jq .taskNumber) in_review
 
 # Create a task and immediately start working:
 ouijit task create-and-start "Fix auth timeout" --prompt "Session expires too early"

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -1,7 +1,7 @@
 import * as pty from 'node-pty';
 import { BrowserWindow } from 'electron';
 import type { PtySpawnOptions, PtySpawnResult, PtyId } from '../types';
-import { registerSandboxPtyId, unregisterSandboxPtyId, type ActiveSession } from '../ptyManager';
+import { registerSandboxPty, unregisterSandboxPty, type ActiveSession } from '../ptyManager';
 import { generateId } from '../utils/ids';
 import { buildLimactlHostEnv, ensureRunning, getLimactlPath } from './manager';
 import { getApiPort, HELPER_SCRIPT, buildVmHookSettings } from '../hookServer';
@@ -209,7 +209,7 @@ export async function spawnSandboxedPty(options: PtySpawnOptions, window: Browse
     };
 
     activeSandboxPtys.set(ptyId, managed);
-    registerSandboxPtyId(ptyId);
+    registerSandboxPty(ptyId, { projectPath, taskId: options.taskId });
 
     // Watch the sandbox branch ref so agent commits fast-forward onto the
     // user's branch. Fires per-PTY, not per-terminal-card; sharing the
@@ -247,7 +247,7 @@ export async function spawnSandboxedPty(options: PtySpawnOptions, window: Browse
         const m = activeSandboxPtys.get(ptyId);
         m?.disposeRefWatcher?.();
         activeSandboxPtys.delete(ptyId);
-        unregisterSandboxPtyId(ptyId);
+        unregisterSandboxPty(ptyId);
         revokeToken(ptyId);
       }
     });
@@ -306,7 +306,7 @@ export function killSandboxPty(ptyId: PtyId): void {
     }
   }
   activeSandboxPtys.delete(ptyId);
-  unregisterSandboxPtyId(ptyId);
+  unregisterSandboxPty(ptyId);
   revokeToken(ptyId);
 }
 
@@ -360,7 +360,7 @@ export function cleanupSandboxPtys(): void {
         // Ignore errors during cleanup
       }
     }
-    unregisterSandboxPtyId(ptyId);
+    unregisterSandboxPty(ptyId);
     revokeToken(ptyId);
   }
   activeSandboxPtys.clear();

--- a/src/ptyManager.ts
+++ b/src/ptyManager.ts
@@ -320,25 +320,45 @@ export function getActiveSessionCount(): number {
 
 /**
  * Sandbox PTYs are tracked in src/lima/spawn.ts in their own map — they never
- * enter `activePtys`. But hookServer / setPlanPath need a single source of
- * truth for "is this ptyId live?" across both kinds. spawn.ts registers /
- * unregisters ids here over its lifecycle; hookServer calls isPtyActive.
- * Direct import would cycle (spawn already imports from hookServer), hence
- * this narrow one-way hook.
+ * enter `activePtys`. But hookServer / setPlanPath / `task current` need a
+ * single source of truth for "is this ptyId live?" and "what task does this
+ * ptyId belong to?" across both kinds. spawn.ts registers / unregisters ids
+ * here over its lifecycle. Direct import would cycle (spawn already imports
+ * from hookServer), hence this narrow one-way hook.
  */
-const sandboxPtyIds = new Set<PtyId>();
+interface SandboxPtyInfo {
+  projectPath: string;
+  taskId?: number;
+}
+const sandboxPtyInfo = new Map<PtyId, SandboxPtyInfo>();
 
-export function registerSandboxPtyId(ptyId: PtyId): void {
-  sandboxPtyIds.add(ptyId);
+export function registerSandboxPty(ptyId: PtyId, info: SandboxPtyInfo): void {
+  sandboxPtyInfo.set(ptyId, info);
 }
 
-export function unregisterSandboxPtyId(ptyId: PtyId): void {
-  sandboxPtyIds.delete(ptyId);
+export function unregisterSandboxPty(ptyId: PtyId): void {
+  sandboxPtyInfo.delete(ptyId);
 }
 
 /** Check if a PTY is currently active — covers host and sandbox PTYs. */
 export function isPtyActive(ptyId: PtyId): boolean {
-  return activePtys.has(ptyId) || sandboxPtyIds.has(ptyId);
+  return activePtys.has(ptyId) || sandboxPtyInfo.has(ptyId);
+}
+
+/**
+ * Resolve the task context for a ptyId — covers host and sandbox PTYs.
+ * Returns null when the pty isn't live or isn't bound to a task.
+ */
+export function getPtyTaskContext(ptyId: PtyId): { projectPath: string; taskId: number } | null {
+  const host = activePtys.get(ptyId);
+  if (host && host.taskId != null) {
+    return { projectPath: host.projectPath, taskId: host.taskId };
+  }
+  const sandbox = sandboxPtyInfo.get(ptyId);
+  if (sandbox && sandbox.taskId != null) {
+    return { projectPath: sandbox.projectPath, taskId: sandbox.taskId };
+  }
+  return null;
 }
 
 export function writeToPty(ptyId: PtyId, data: string): void {


### PR DESCRIPTION
## Summary

- New `ouijit task current` zero-arg CLI command — returns the task owning the calling terminal as the same JSON shape as `ouijit task get <n>`. Drop-in primitive for agents that need to self-identify without parsing `task list` output.
- New `GET /api/tasks/current` route. Resolves `ptyId` from the verified bearer token (`r.auth.ptyId`), so it deliberately does not take `?project=` — the project is derived from the pty's record.
- New `getPtyTaskContext(ptyId)` helper that covers both host (`activePtys`) and sandbox (`lima/spawn`) PTYs. The sandbox bridge upgraded from `Set<PtyId>` to `Map<PtyId, { projectPath, taskId? }>` so the lookup works for sandboxed tasks too; `register/unregisterSandboxPtyId` renamed to `register/unregisterSandboxPty` accordingly.
- CLI command pre-flights `OUIJIT_PTY_ID` before hitting the API for a friendly fast-fail outside Ouijit terminals.
- System-prompt CLI reference in `hookServer.ts` updated so agents discover the new command.