### PR TITLE
Improve terminal card actions and identity

### DIFF
--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -1,9 +1,10 @@
-import { memo } from 'react';
-import { NodeResizer, Handle, Position, useViewport, type NodeProps } from '@xyflow/react';
+import { memo, useCallback } from 'react';
+import { NodeResizer, Handle, Position, type NodeProps } from '@xyflow/react';
 import { type TerminalNode as TerminalNodeType } from '../../stores/canvasStore';
-import { useTerminalStore } from '../../stores/terminalStore';
 import { useTerminalPanels } from '../terminal/useTerminalPanels';
 import { TerminalBody } from '../terminal/TerminalBody';
+import { TerminalHeader } from '../terminal/TerminalHeader';
+import { closeProjectTerminal } from '../terminal/terminalActions';
 
 const INSET_TOP = 8;
 const INSET_SIDE = 10;
@@ -46,6 +47,10 @@ const ActiveTerminalNode = memo(function ActiveTerminalNode({
   const { ptyId, projectPath } = data;
 
   const {
+    toggleDiffPanel,
+    togglePlanPanel,
+    toggleWebPreviewPanel,
+    toggleRunner,
     closeDiffPanel,
     collapseRunner,
     killRunner,
@@ -55,6 +60,10 @@ const ActiveTerminalNode = memo(function ActiveTerminalNode({
     closeWebPreviewPanel,
     changeWebPreviewUrl,
   } = useTerminalPanels(ptyId);
+
+  const handleClose = useCallback(() => {
+    closeProjectTerminal(ptyId);
+  }, [ptyId]);
 
   const bodyClasses = selected ? 'nodrag nowheel nopan flex flex-col flex-1 min-h-0' : 'flex flex-col flex-1 min-h-0';
 
@@ -89,7 +98,17 @@ const ActiveTerminalNode = memo(function ActiveTerminalNode({
           boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
         }}
       >
-        <NodeHeader ptyId={ptyId} />
+        <div className="terminal-drag-handle shrink-0" style={{ zIndex: 2 }}>
+          <TerminalHeader
+            ptyId={ptyId}
+            isActive
+            onClose={handleClose}
+            onToggleDiffPanel={toggleDiffPanel}
+            onTogglePlanPanel={togglePlanPanel}
+            onToggleWebPreviewPanel={toggleWebPreviewPanel}
+            onToggleRunner={toggleRunner}
+          />
+        </div>
         <div className={bodyClasses} style={selected ? undefined : { pointerEvents: 'none' }}>
           <TerminalBody
             ptyId={ptyId}
@@ -106,42 +125,5 @@ const ActiveTerminalNode = memo(function ActiveTerminalNode({
         </div>
       </div>
     </>
-  );
-});
-
-// ── Header: status light + title, inside the card (drag handle) ─────
-
-const NodeHeader = memo(function NodeHeader({ ptyId }: { ptyId: string }) {
-  const label = useTerminalStore((s) => s.displayStates[ptyId]?.label ?? '');
-  const summary = useTerminalStore((s) => s.displayStates[ptyId]?.summary ?? '');
-  const summaryType = useTerminalStore((s) => s.displayStates[ptyId]?.summaryType ?? 'ready');
-  const { zoom } = useViewport();
-
-  const displayText = summary ? `${label} \u2014 ${summary}` : label || 'Shell';
-  const MAX_SCALE = 1.4;
-  const inverseScale = zoom > 0 ? Math.min(MAX_SCALE, Math.max(1, 1 / zoom)) : 1;
-
-  return (
-    <div className="terminal-drag-handle relative shrink-0 pl-4 pr-3 py-2.5" style={{ zIndex: 2 }}>
-      <div
-        className="flex items-center gap-2 min-w-0 origin-top-left"
-        style={{
-          transform: `scale(${inverseScale})`,
-          width: `${100 / inverseScale}%`,
-          willChange: 'transform',
-        }}
-      >
-        <span
-          className={`w-2.5 h-2.5 rounded-full shrink-0 transition-all duration-200 ease-out ${summaryType === 'thinking' ? 'bg-[#da77f2]' : 'bg-[#69db7c]'}`}
-          data-status={summaryType}
-          style={{
-            boxShadow:
-              summaryType === 'thinking' ? '0 0 4px rgba(218, 119, 242, 0.5)' : '0 0 4px rgba(105, 219, 124, 0.5)',
-            ...(summaryType === 'thinking' ? { animation: 'terminal-status-pulse 1s ease-in-out infinite' } : {}),
-          }}
-        />
-        <span className="font-mono text-sm font-medium text-white/85 truncate min-w-0">{displayText}</span>
-      </div>
-    </div>
   );
 });

--- a/src/components/terminal/TagInput.tsx
+++ b/src/components/terminal/TagInput.tsx
@@ -136,7 +136,7 @@ export function TagInput({ ptyId, onClose }: TagInputProps) {
       {tags.map((tag) => (
         <span
           key={tag}
-          className="inline-flex items-center gap-0.5 font-mono text-[11px] text-white/50 bg-white/[0.06] rounded-full px-2 py-px shrink-0"
+          className="inline-flex items-center gap-1 font-mono text-[11px] font-medium text-white/55 bg-white/[0.05] rounded-full px-2 py-0.5 shrink-0"
         >
           {tag}
           <button
@@ -153,7 +153,7 @@ export function TagInput({ ptyId, onClose }: TagInputProps) {
       <input
         ref={inputRef}
         type="text"
-        className="bg-transparent border-none outline-none font-mono text-[11px] text-white/70 min-w-[60px] py-px placeholder:text-white/25"
+        className="bg-transparent border-none outline-none font-mono text-[11px] font-medium text-white/70 min-w-[60px] py-0.5 placeholder:text-white/25"
         style={{ width: 60 }}
         placeholder={tags.length ? '' : 'Add tag\u2026'}
         value={inputValue}

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { Fragment, memo, useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTerminalStore } from '../../stores/terminalStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useUIStore } from '../../stores/uiStore';
@@ -425,43 +425,24 @@ export const TerminalHeader = memo(function TerminalHeader({
         )}
       </div>
       <div className="flex items-center gap-2 shrink-0 justify-end">
-        {!compact && isActive && planPath && (
-          <button
-            className={`flex items-center gap-1 px-2.5 py-1 rounded-full font-mono text-[13px] font-medium text-white/60 bg-white/[0.06] transition-all duration-150 ease-out hover:bg-white/[0.12] hover:text-white/90 active:bg-white/[0.10] active:text-white/80 ${planPanelOpen ? '!bg-accent !text-white' : ''}`}
-            title="View plan"
-            onClick={handlePlanClick}
-          >
-            <Icon name="list-checks" className="w-3.5 h-3.5" />
-            <span>Plan</span>
-          </button>
-        )}
-        {!compact && isActive && webPreviewUrl && (
-          <button
-            className={`flex items-center gap-1 px-2.5 py-1 rounded-full font-mono text-[13px] font-medium text-white/60 bg-white/[0.06] transition-all duration-150 ease-out hover:bg-white/[0.12] hover:text-white/90 active:bg-white/[0.10] active:text-white/80 ${webPreviewPanelOpen ? '!bg-accent !text-white' : ''}`}
-            title={`Preview ${webPreviewUrl}`}
-            onClick={handleWebPreviewClick}
-          >
-            <Icon name="globe-simple" className="w-3.5 h-3.5" />
-            <span>Preview</span>
-          </button>
-        )}
-        {!compact && isActive && (
-          <div>
-            <GitStats
-              gitFileStatus={gitFileStatus}
-              isWorktree={isWorktree}
-              diffPanelOpen={diffPanelOpen}
-              onClick={handleDiffClick}
-            />
-          </div>
-        )}
         {isActive && (
-          <RunnerPill
+          <ActionGroup
+            compact={compact}
+            planPath={planPath}
+            planPanelOpen={planPanelOpen}
+            onPlanClick={handlePlanClick}
+            webPreviewUrl={webPreviewUrl}
+            webPreviewPanelOpen={webPreviewPanelOpen}
+            onWebPreviewClick={handleWebPreviewClick}
+            gitFileStatus={gitFileStatus}
+            isWorktree={isWorktree}
+            diffPanelOpen={diffPanelOpen}
+            onDiffClick={handleDiffClick}
             runnerStatus={runnerStatus}
             runnerScriptName={runnerScriptName}
             runnerPanelOpen={runnerPanelOpen}
             showChevron={showChevron}
-            onPrimaryClick={handleRunnerPrimaryClick}
+            onRunnerPrimaryClick={handleRunnerPrimaryClick}
             onChevronClick={handleChevronClick}
             chevronRef={chevronRef}
           />
@@ -500,133 +481,178 @@ function GitBranch({ gitFileStatus }: { gitFileStatus: GitFileStatus | null }) {
   );
 }
 
-function GitStats({
+// Shared button class for items inside the joined ActionGroup.
+const groupButtonBase =
+  'h-full px-2.5 flex items-center gap-1 border-none font-sans text-[13px] font-medium transition-colors duration-150 ease-out';
+const groupButtonInactive = 'bg-transparent text-text-secondary hover:text-text-primary hover:bg-background-tertiary';
+const groupButtonActive = 'bg-accent text-white hover:bg-accent';
+
+function ActionGroup({
+  compact,
+  planPath,
+  planPanelOpen,
+  onPlanClick,
+  webPreviewUrl,
+  webPreviewPanelOpen,
+  onWebPreviewClick,
   gitFileStatus,
   isWorktree,
   diffPanelOpen,
-  onClick,
-}: {
-  gitFileStatus: GitFileStatus | null;
-  isWorktree: boolean;
-  diffPanelOpen: boolean;
-  onClick: (e: React.MouseEvent) => void;
-}) {
-  if (!gitFileStatus) return null;
-
-  const { uncommittedFiles, branchDiffFiles } = gitFileStatus;
-  const dirtyFileCount = uncommittedFiles.length;
-  const insertions = uncommittedFiles.reduce((s, f) => s + f.additions, 0);
-  const deletions = uncommittedFiles.reduce((s, f) => s + f.deletions, 0);
-  const hasChanges = dirtyFileCount > 0;
-
-  if (hasChanges) {
-    const fileLabel = dirtyFileCount === 1 ? 'file' : 'files';
-    return (
-      <button
-        className={`flex items-center gap-1 px-2.5 py-1 rounded-full font-mono text-[13px] font-medium text-white/60 bg-white/[0.06] transition-all duration-150 ease-out hover:bg-white/[0.12] hover:text-white/90 active:bg-white/[0.10] active:text-white/80 ${diffPanelOpen ? '!bg-accent !text-white' : ''}`}
-        title="View uncommitted changes"
-        onClick={onClick}
-      >
-        <span className="font-medium">
-          {dirtyFileCount} {fileLabel}
-        </span>
-        {insertions > 0 && <span className="text-[#69db7c]">+{insertions}</span>}
-        {deletions > 0 && <span className="text-[#ff6b6b]">-{deletions}</span>}
-      </button>
-    );
-  }
-
-  if (isWorktree && branchDiffFiles.length > 0) {
-    return (
-      <button
-        className={`px-2.5 py-1 bg-white/[0.06] border-none font-sans text-[13px] font-medium text-white/60 rounded-full transition-all duration-150 ease-out hover:bg-white/[0.12] hover:text-white/90 active:bg-white/[0.10] active:text-white/80 ${diffPanelOpen ? '!bg-accent !text-white' : ''}`}
-        title="Compare branch changes"
-        onClick={onClick}
-      >
-        Compare
-      </button>
-    );
-  }
-
-  return null;
-}
-
-function RunnerPill({
+  onDiffClick,
   runnerStatus,
   runnerScriptName,
   runnerPanelOpen,
   showChevron,
-  onPrimaryClick,
+  onRunnerPrimaryClick,
   onChevronClick,
   chevronRef,
 }: {
+  compact?: boolean;
+  planPath: string | null;
+  planPanelOpen: boolean;
+  onPlanClick: (e: React.MouseEvent) => void;
+  webPreviewUrl: string | null;
+  webPreviewPanelOpen: boolean;
+  onWebPreviewClick: (e: React.MouseEvent) => void;
+  gitFileStatus: GitFileStatus | null;
+  isWorktree: boolean;
+  diffPanelOpen: boolean;
+  onDiffClick: (e: React.MouseEvent) => void;
   runnerStatus: string;
   runnerScriptName: string | null;
   runnerPanelOpen: boolean;
   showChevron: boolean;
-  onPrimaryClick: (e: React.MouseEvent) => void;
+  onRunnerPrimaryClick: (e: React.MouseEvent) => void;
   onChevronClick: (e: React.MouseEvent) => void;
   chevronRef: React.RefObject<HTMLButtonElement | null>;
 }) {
-  let text = 'Run';
+  const showPlan = !compact && !!planPath;
+  const showPreview = !compact && !!webPreviewUrl;
 
+  const dirtyFileCount = gitFileStatus?.uncommittedFiles.length ?? 0;
+  const insertions = gitFileStatus?.uncommittedFiles.reduce((s, f) => s + f.additions, 0) ?? 0;
+  const deletions = gitFileStatus?.uncommittedFiles.reduce((s, f) => s + f.deletions, 0) ?? 0;
+  const branchDiffCount = gitFileStatus?.branchDiffFiles.length ?? 0;
+  const hasUncommitted = !!gitFileStatus && dirtyFileCount > 0;
+  const showCompare = !!gitFileStatus && !hasUncommitted && isWorktree && branchDiffCount > 0;
+  const showGit = !compact && (hasUncommitted || showCompare);
+
+  let runText = 'Run';
   switch (runnerStatus) {
     case 'running':
-      text = runnerScriptName ?? 'Running';
+      runText = runnerScriptName ?? 'Running';
       break;
     case 'success':
-      text = 'Done';
+      runText = 'Done';
       break;
     case 'error':
-      text = 'Failed';
+      runText = 'Failed';
       break;
   }
-
-  const baseColors =
+  const runColor =
     runnerStatus === 'running' || runnerStatus === 'success'
-      ? 'text-[#69db7c]'
+      ? 'text-[#69db7c] hover:text-[#8de89a] hover:bg-background-tertiary'
       : runnerStatus === 'error'
-        ? 'text-[#ff6b6b]'
-        : 'text-white/60';
+        ? 'text-[#ff6b6b] hover:text-[#ff8e8e] hover:bg-background-tertiary'
+        : groupButtonInactive;
+  const runActive = runnerPanelOpen ? groupButtonActive : runColor;
 
-  const activeHighlight = runnerPanelOpen ? '!bg-accent !text-white' : '';
+  const slots: { key: string; content: React.ReactNode }[] = [];
 
-  if (!showChevron) {
-    return (
-      <button
-        className={`px-2.5 py-1 bg-white/[0.06] border-none font-sans text-[13px] font-medium rounded-full transition-all duration-150 ease-out hover:bg-white/[0.12] hover:text-white/90 active:bg-white/[0.10] active:text-white/80 ${activeHighlight} ${baseColors}`}
-        data-action="run"
-        onClick={onPrimaryClick}
-      >
-        {text}
-      </button>
-    );
+  if (showPlan) {
+    slots.push({
+      key: 'plan',
+      content: (
+        <button
+          className={`${groupButtonBase} ${planPanelOpen ? groupButtonActive : groupButtonInactive}`}
+          title="View plan"
+          onClick={onPlanClick}
+        >
+          <Icon name="list-checks" className="w-3.5 h-3.5" />
+          <span>Plan</span>
+        </button>
+      ),
+    });
   }
 
-  // Split button: primary action + chevron dropdown
+  if (showPreview) {
+    slots.push({
+      key: 'preview',
+      content: (
+        <button
+          className={`${groupButtonBase} ${webPreviewPanelOpen ? groupButtonActive : groupButtonInactive}`}
+          title={`Preview ${webPreviewUrl}`}
+          onClick={onWebPreviewClick}
+        >
+          <Icon name="globe-simple" className="w-3.5 h-3.5" />
+          <span>Preview</span>
+        </button>
+      ),
+    });
+  }
+
+  if (showGit && hasUncommitted) {
+    slots.push({
+      key: 'diff',
+      content: (
+        <button
+          className={`${groupButtonBase} ${diffPanelOpen ? groupButtonActive : groupButtonInactive}`}
+          title="View uncommitted changes"
+          onClick={onDiffClick}
+        >
+          <span>
+            {dirtyFileCount} {dirtyFileCount === 1 ? 'file' : 'files'}
+          </span>
+          {insertions > 0 && <span className="text-[#69db7c]">+{insertions}</span>}
+          {deletions > 0 && <span className="text-[#ff6b6b]">-{deletions}</span>}
+        </button>
+      ),
+    });
+  } else if (showGit && showCompare) {
+    slots.push({
+      key: 'compare',
+      content: (
+        <button
+          className={`${groupButtonBase} ${diffPanelOpen ? groupButtonActive : groupButtonInactive}`}
+          title="Compare branch changes"
+          onClick={onDiffClick}
+        >
+          Compare
+        </button>
+      ),
+    });
+  }
+
+  slots.push({
+    key: 'run',
+    content: (
+      <>
+        <button className={`${groupButtonBase} ${runActive}`} data-action="run" onClick={onRunnerPrimaryClick}>
+          {runText}
+        </button>
+        {showChevron && (
+          <button
+            ref={chevronRef}
+            className={`${groupButtonBase} !px-2 ${runnerPanelOpen ? groupButtonActive : runColor}`}
+            aria-haspopup="menu"
+            aria-label="More run options"
+            onClick={onChevronClick}
+          >
+            <Icon name="caret-down" className="w-2.5 h-2.5" />
+          </button>
+        )}
+      </>
+    ),
+  });
+
   return (
-    <div
-      role="group"
-      aria-label="Run options"
-      className={`inline-flex items-stretch rounded-full overflow-hidden bg-white/[0.06] ${activeHighlight}`}
-    >
-      <button
-        className={`px-2.5 py-1 border-none font-sans text-[13px] font-medium transition-all duration-150 ease-out hover:bg-white/[0.06] hover:text-white/90 active:bg-white/[0.04] active:text-white/80 ${baseColors}`}
-        data-action="run"
-        onClick={onPrimaryClick}
-      >
-        {text}
-      </button>
-      <div className="w-px self-stretch bg-white/[0.04]" />
-      <button
-        ref={chevronRef}
-        className={`flex items-center justify-center px-2 border-none transition-all duration-150 ease-out hover:bg-white/[0.06] active:bg-white/[0.04] ${baseColors}`}
-        aria-haspopup="menu"
-        aria-label="More run options"
-        onClick={onChevronClick}
-      >
-        <Icon name="caret-down" className="w-2.5 h-2.5" />
-      </button>
+    <div className="inline-flex items-center h-7 bg-background-secondary glass-bevel relative border border-black/60 rounded-[12px] overflow-hidden">
+      {slots.map((slot, i) => (
+        <Fragment key={slot.key}>
+          {i > 0 && <div aria-hidden className="w-px h-3 bg-white/10 self-center" />}
+          {slot.content}
+        </Fragment>
+      ))}
     </div>
   );
 }

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -682,12 +682,16 @@ function ActionGroup({
     });
   }
 
+  const runIcon =
+    runnerStatus === 'running' || runnerStatus === 'success' || runnerStatus === 'error' ? 'terminal' : null;
+
   slots.push({
     key: 'run',
     content: (
       <>
         <button className={`${groupButtonBase} ${runActive}`} data-action="run" onClick={onRunnerPrimaryClick}>
-          {runText}
+          {runIcon && <Icon name={runIcon} className="w-3.5 h-3.5" />}
+          <span>{runText}</span>
         </button>
         {showChevron && (
           <Tooltip text="More run options" placement="bottom" referenceClassName={slotWrapClass}>

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -521,12 +521,12 @@ function StatusDot({ summaryType, sandboxed }: { summaryType: string; sandboxed:
   const isThinking = summaryType === 'thinking';
   return (
     <span
-      className={`w-[9px] h-[9px] rounded-full shrink-0 transition-all duration-200 ease-out ${isThinking ? 'bg-[#da77f2]' : 'bg-[#69db7c]'}`}
+      className={`w-[9px] h-[9px] rounded-full shrink-0 transition-all duration-200 ease-out ${isThinking ? 'bg-[#da77f2]' : 'bg-[#4ee82e]'}`}
       data-status={summaryType}
       style={{
         boxShadow: isThinking
           ? '0 0 4px rgba(218, 119, 242, 0.5), inset 0 0 0 1px #000'
-          : '0 0 4px rgba(105, 219, 124, 0.5), inset 0 0 0 1px #000',
+          : '0 0 4px rgba(78, 232, 46, 0.5), inset 0 0 0 1px #000',
         ...(isThinking ? { animation: 'terminal-status-pulse 1s ease-in-out infinite' } : {}),
         ...(sandboxed ? { outline: '1.5px solid rgba(116, 192, 252, 0.6)', outlineOffset: '2px' } : {}),
       }}
@@ -604,7 +604,7 @@ function ActionGroup({
   }
   const runColor =
     runnerStatus === 'running' || runnerStatus === 'success'
-      ? 'text-[#69db7c] hover:text-[#8de89a] hover:bg-background-tertiary'
+      ? 'text-[#4ee82e] hover:text-[#76ee5c] hover:bg-background-tertiary'
       : runnerStatus === 'error'
         ? 'text-[#ff6b6b] hover:text-[#ff8e8e] hover:bg-background-tertiary'
         : groupButtonInactive;
@@ -660,7 +660,7 @@ function ActionGroup({
             <span>
               {dirtyFileCount} {dirtyFileCount === 1 ? 'file' : 'files'}
             </span>
-            {insertions > 0 && <span className="text-[#69db7c]">+{insertions}</span>}
+            {insertions > 0 && <span className="text-[#4ee82e]">+{insertions}</span>}
             {deletions > 0 && <span className="text-[#ff6b6b]">-{deletions}</span>}
           </button>
         </Tooltip>

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -521,10 +521,12 @@ function StatusDot({ summaryType, sandboxed }: { summaryType: string; sandboxed:
   const isThinking = summaryType === 'thinking';
   return (
     <span
-      className={`w-1.5 h-1.5 rounded-full shrink-0 transition-all duration-200 ease-out ${isThinking ? 'bg-[#da77f2]' : 'bg-[#69db7c]'}`}
+      className={`w-[9px] h-[9px] rounded-full shrink-0 transition-all duration-200 ease-out ${isThinking ? 'bg-[#da77f2]' : 'bg-[#69db7c]'}`}
       data-status={summaryType}
       style={{
-        boxShadow: isThinking ? '0 0 4px rgba(218, 119, 242, 0.5)' : '0 0 4px rgba(105, 219, 124, 0.5)',
+        boxShadow: isThinking
+          ? '0 0 4px rgba(218, 119, 242, 0.5), inset 0 0 0 1px #000'
+          : '0 0 4px rgba(105, 219, 124, 0.5), inset 0 0 0 1px #000',
         ...(isThinking ? { animation: 'terminal-status-pulse 1s ease-in-out infinite' } : {}),
         ...(sandboxed ? { outline: '1.5px solid rgba(116, 192, 252, 0.6)', outlineOffset: '2px' } : {}),
       }}

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -12,6 +12,7 @@ import { TagInput } from './TagInput';
 import { ContextMenu, type ContextMenuEntry } from '../ui/ContextMenu';
 import { HookConfigDialog } from '../dialogs/HookConfigDialog';
 import { RunScriptDropdown } from '../scripts/RunScriptDropdown';
+import { Tooltip } from '../ui/Tooltip';
 
 const isMac = navigator.platform.toLowerCase().includes('mac');
 
@@ -44,7 +45,6 @@ export const TerminalHeader = memo(function TerminalHeader({
   const summary = useTerminalStore((s) => s.displayStates[ptyId]?.summary ?? '');
   const summaryType = useTerminalStore((s) => s.displayStates[ptyId]?.summaryType ?? 'ready');
   const gitFileStatus = useTerminalStore((s) => s.displayStates[ptyId]?.gitFileStatus ?? null);
-  const lastOscTitle = useTerminalStore((s) => s.displayStates[ptyId]?.lastOscTitle ?? '');
   const tags = useTerminalStore((s) => s.displayStates[ptyId]?.tags) ?? EMPTY_TAGS;
   const sandboxed = useTerminalStore((s) => s.displayStates[ptyId]?.sandboxed ?? false);
   const runnerStatus = useTerminalStore((s) => s.displayStates[ptyId]?.runnerStatus ?? 'idle');
@@ -320,7 +320,6 @@ export const TerminalHeader = memo(function TerminalHeader({
     [onToggleWebPreviewPanel],
   );
 
-  const displayText = summary ? `${label} \u2014 ${summary}` : label;
   const isWorktree = taskId != null && !!worktreeBranch;
   const showChevron = runnerStatus === 'idle' && (hasRunHook || hasScripts);
 
@@ -361,18 +360,10 @@ export const TerminalHeader = memo(function TerminalHeader({
           }}
         />
       )}
-      <div className="flex flex-col min-w-0 shrink">
-        <div className="flex items-center gap-2 min-w-0 flex-wrap">
-          <span
-            className={`w-1.5 h-1.5 rounded-full shrink-0 transition-all duration-200 ease-out ${summaryType === 'thinking' ? 'bg-[#da77f2]' : 'bg-[#69db7c]'}`}
-            data-status={summaryType}
-            style={{
-              boxShadow:
-                summaryType === 'thinking' ? '0 0 4px rgba(218, 119, 242, 0.5)' : '0 0 4px rgba(105, 219, 124, 0.5)',
-              ...(summaryType === 'thinking' ? { animation: 'terminal-status-pulse 1s ease-in-out infinite' } : {}),
-              ...(sandboxed ? { outline: '1.5px solid rgba(116, 192, 252, 0.6)', outlineOffset: '2px' } : {}),
-            }}
-          />
+      <div className="flex flex-col min-w-0 shrink gap-0.5">
+        {/* Row 1 \u2014 identity: status + label/summary + tags */}
+        <div className="group/meta flex items-center gap-2 min-w-0">
+          <StatusDot summaryType={summaryType} sandboxed={sandboxed} />
           {!isActive && stackPosition != null && stackPosition <= 9 && (
             <kbd className="inline-flex items-center font-mono text-base text-white/40 shrink-0">
               {isMac ? '\u2318' : 'Ctrl+'}
@@ -382,7 +373,7 @@ export const TerminalHeader = memo(function TerminalHeader({
           {renaming ? (
             <input
               ref={renameInputRef}
-              className="font-mono text-xs font-medium text-white/70 bg-transparent border-0 border-b border-accent p-0 outline-none min-w-0 shrink-0 [-webkit-app-region:no-drag]"
+              className="font-mono text-xs font-medium text-white/85 bg-transparent border-0 border-b border-accent p-0 outline-none min-w-0 shrink-0 [-webkit-app-region:no-drag]"
               onBlur={commitRename}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') commitRename();
@@ -390,39 +381,51 @@ export const TerminalHeader = memo(function TerminalHeader({
               }}
             />
           ) : (
-            <span className="font-mono text-xs font-medium text-white/70 shrink-0">{displayText}</span>
+            <span className="font-mono text-xs font-medium text-white/85 shrink-0">{label}</span>
           )}
-          <button
-            className="flex items-center justify-center w-5 h-5 rounded text-white/30 bg-transparent border-none shrink-0"
-            onMouseDown={handleTagButtonClick}
-          >
-            <Icon name="tag" className="w-3.5 h-3.5" />
-          </button>
-          <span className="inline-flex items-center gap-1 min-w-0">
-            {tagInputOpen ? (
+          {summary && !renaming && (
+            <span className="font-mono text-xs text-white/45 min-w-0 truncate">\u2014 {summary}</span>
+          )}
+          <span className="inline-flex items-center gap-1 min-w-0 shrink-0">
+            {isActive && tagInputOpen ? (
               <TagInput ptyId={ptyId} onClose={() => setTagInputOpen(false)} />
+            ) : isActive ? (
+              <>
+                {tags.map((tag) => (
+                  <Tooltip key={tag} text="Edit tag" placement="bottom">
+                    <button
+                      className={`${METADATA_CHIP} border-none hover:bg-white/[0.1] hover:text-white/75 transition-colors duration-150`}
+                      onMouseDown={handleTagButtonClick}
+                    >
+                      {tag}
+                    </button>
+                  </Tooltip>
+                ))}
+                {tags.length === 0 && (
+                  <Tooltip text="Add tag" placement="bottom">
+                    <button
+                      className="inline-flex items-center gap-1 font-mono text-[11px] text-white/35 bg-transparent border-none px-2 py-0.5 rounded-full shrink-0 opacity-0 group-hover/meta:opacity-100 hover:text-white/70 hover:bg-white/[0.05] transition-all duration-150"
+                      onMouseDown={handleTagButtonClick}
+                      aria-label="Add tag"
+                    >
+                      <Icon name="tag" className="w-3 h-3" />
+                      <span>Tag</span>
+                    </button>
+                  </Tooltip>
+                )}
+              </>
             ) : (
               tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="font-mono text-[11px] text-white/50 bg-white/[0.06] rounded-full px-2 py-px shrink-0"
-                >
+                <span key={tag} className={METADATA_CHIP}>
                   {tag}
                 </span>
               ))
             )}
           </span>
-          {!compact && lastOscTitle && (
-            <span className="font-mono text-[11px] text-white/40 bg-white/5 rounded-full px-2 py-px truncate">
-              {lastOscTitle}
-            </span>
-          )}
         </div>
-        {!compact && isActive && (
-          <div className="min-w-0 overflow-hidden">
-            <GitBranch gitFileStatus={gitFileStatus} />
-          </div>
-        )}
+
+        {/* Row 2 \u2014 subordinate context: branch */}
+        {!compact && isActive && gitFileStatus?.branch && <BranchCopy branch={gitFileStatus.branch} />}
       </div>
       <div className="flex items-center gap-2 shrink-0 justify-end">
         {isActive && (
@@ -470,14 +473,62 @@ export const TerminalHeader = memo(function TerminalHeader({
 
 // ── Sub-components ───────────────────────────────────────────────────
 
-function GitBranch({ gitFileStatus }: { gitFileStatus: GitFileStatus | null }) {
-  if (!gitFileStatus) return null;
+const METADATA_CHIP =
+  'inline-flex items-center gap-1 font-mono text-[11px] font-medium text-white/55 bg-white/[0.05] rounded-full px-2 py-0.5 shrink-0';
+
+function BranchCopy({ branch }: { branch: string }) {
+  const [copied, setCopied] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    [],
+  );
+
+  const handleClick = useCallback(() => {
+    void navigator.clipboard.writeText(branch).then(() => {
+      setCopied(true);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 1200);
+    });
+  }, [branch]);
+
+  const iconName = copied ? 'check' : hovered ? 'copy' : 'git-branch';
 
   return (
-    <span className="flex items-center gap-1 font-mono text-[13px] text-white/50 min-w-0 overflow-hidden">
-      <Icon name="git-branch" className="w-3.5 h-3.5 shrink-0 text-white/40" />
-      <span className="truncate min-w-0">{gitFileStatus.branch}</span>
-    </span>
+    <Tooltip
+      text={copied ? 'Copied' : 'Copy branch'}
+      placement="bottom-start"
+      onHoverChange={setHovered}
+      referenceClassName="inline-flex min-w-0 self-start"
+    >
+      <button
+        type="button"
+        className="inline-flex items-center gap-1 font-mono text-[11px] text-white/45 bg-transparent border-none p-0 min-w-0 shrink-0 transition-colors duration-150 hover:text-white/75"
+        onClick={handleClick}
+      >
+        <Icon name={iconName} className="w-3 h-3 shrink-0 text-white/35" />
+        <span className="truncate">{copied ? 'Copied' : branch}</span>
+      </button>
+    </Tooltip>
+  );
+}
+
+function StatusDot({ summaryType, sandboxed }: { summaryType: string; sandboxed: boolean }) {
+  const isThinking = summaryType === 'thinking';
+  return (
+    <span
+      className={`w-1.5 h-1.5 rounded-full shrink-0 transition-all duration-200 ease-out ${isThinking ? 'bg-[#da77f2]' : 'bg-[#69db7c]'}`}
+      data-status={summaryType}
+      style={{
+        boxShadow: isThinking ? '0 0 4px rgba(218, 119, 242, 0.5)' : '0 0 4px rgba(105, 219, 124, 0.5)',
+        ...(isThinking ? { animation: 'terminal-status-pulse 1s ease-in-out infinite' } : {}),
+        ...(sandboxed ? { outline: '1.5px solid rgba(116, 192, 252, 0.6)', outlineOffset: '2px' } : {}),
+      }}
+    />
   );
 }
 
@@ -559,18 +610,21 @@ function ActionGroup({
 
   const slots: { key: string; content: React.ReactNode }[] = [];
 
+  const slotWrapClass = 'inline-flex h-full';
+
   if (showPlan) {
     slots.push({
       key: 'plan',
       content: (
-        <button
-          className={`${groupButtonBase} ${planPanelOpen ? groupButtonActive : groupButtonInactive}`}
-          title="View plan"
-          onClick={onPlanClick}
-        >
-          <Icon name="list-checks" className="w-3.5 h-3.5" />
-          <span>Plan</span>
-        </button>
+        <Tooltip text="View plan" placement="bottom" referenceClassName={slotWrapClass}>
+          <button
+            className={`${groupButtonBase} ${planPanelOpen ? groupButtonActive : groupButtonInactive}`}
+            onClick={onPlanClick}
+          >
+            <Icon name="list-checks" className="w-3.5 h-3.5" />
+            <span>Plan</span>
+          </button>
+        </Tooltip>
       ),
     });
   }
@@ -579,14 +633,15 @@ function ActionGroup({
     slots.push({
       key: 'preview',
       content: (
-        <button
-          className={`${groupButtonBase} ${webPreviewPanelOpen ? groupButtonActive : groupButtonInactive}`}
-          title={`Preview ${webPreviewUrl}`}
-          onClick={onWebPreviewClick}
-        >
-          <Icon name="globe-simple" className="w-3.5 h-3.5" />
-          <span>Preview</span>
-        </button>
+        <Tooltip text={`Preview ${webPreviewUrl}`} placement="bottom" referenceClassName={slotWrapClass}>
+          <button
+            className={`${groupButtonBase} ${webPreviewPanelOpen ? groupButtonActive : groupButtonInactive}`}
+            onClick={onWebPreviewClick}
+          >
+            <Icon name="globe-simple" className="w-3.5 h-3.5" />
+            <span>Preview</span>
+          </button>
+        </Tooltip>
       ),
     });
   }
@@ -595,30 +650,32 @@ function ActionGroup({
     slots.push({
       key: 'diff',
       content: (
-        <button
-          className={`${groupButtonBase} ${diffPanelOpen ? groupButtonActive : groupButtonInactive}`}
-          title="View uncommitted changes"
-          onClick={onDiffClick}
-        >
-          <span>
-            {dirtyFileCount} {dirtyFileCount === 1 ? 'file' : 'files'}
-          </span>
-          {insertions > 0 && <span className="text-[#69db7c]">+{insertions}</span>}
-          {deletions > 0 && <span className="text-[#ff6b6b]">-{deletions}</span>}
-        </button>
+        <Tooltip text="View uncommitted changes" placement="bottom" referenceClassName={slotWrapClass}>
+          <button
+            className={`${groupButtonBase} ${diffPanelOpen ? groupButtonActive : groupButtonInactive}`}
+            onClick={onDiffClick}
+          >
+            <span>
+              {dirtyFileCount} {dirtyFileCount === 1 ? 'file' : 'files'}
+            </span>
+            {insertions > 0 && <span className="text-[#69db7c]">+{insertions}</span>}
+            {deletions > 0 && <span className="text-[#ff6b6b]">-{deletions}</span>}
+          </button>
+        </Tooltip>
       ),
     });
   } else if (showGit && showCompare) {
     slots.push({
       key: 'compare',
       content: (
-        <button
-          className={`${groupButtonBase} ${diffPanelOpen ? groupButtonActive : groupButtonInactive}`}
-          title="Compare branch changes"
-          onClick={onDiffClick}
-        >
-          Compare
-        </button>
+        <Tooltip text="Compare branch changes" placement="bottom" referenceClassName={slotWrapClass}>
+          <button
+            className={`${groupButtonBase} ${diffPanelOpen ? groupButtonActive : groupButtonInactive}`}
+            onClick={onDiffClick}
+          >
+            Compare
+          </button>
+        </Tooltip>
       ),
     });
   }
@@ -631,15 +688,17 @@ function ActionGroup({
           {runText}
         </button>
         {showChevron && (
-          <button
-            ref={chevronRef}
-            className={`${groupButtonBase} !px-2 ${runnerPanelOpen ? groupButtonActive : runColor}`}
-            aria-haspopup="menu"
-            aria-label="More run options"
-            onClick={onChevronClick}
-          >
-            <Icon name="caret-down" className="w-2.5 h-2.5" />
-          </button>
+          <Tooltip text="More run options" placement="bottom" referenceClassName={slotWrapClass}>
+            <button
+              ref={chevronRef}
+              className={`${groupButtonBase} !px-2 ${runnerPanelOpen ? groupButtonActive : runColor}`}
+              aria-haspopup="menu"
+              aria-label="More run options"
+              onClick={onChevronClick}
+            >
+              <Icon name="caret-down" className="w-2.5 h-2.5" />
+            </button>
+          </Tooltip>
         )}
       </>
     ),

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -12,7 +12,6 @@ import { TagInput } from './TagInput';
 import { ContextMenu, type ContextMenuEntry } from '../ui/ContextMenu';
 import { HookConfigDialog } from '../dialogs/HookConfigDialog';
 import { RunScriptDropdown } from '../scripts/RunScriptDropdown';
-import { Tooltip } from '../ui/Tooltip';
 
 const isMac = navigator.platform.toLowerCase().includes('mac');
 
@@ -392,26 +391,23 @@ export const TerminalHeader = memo(function TerminalHeader({
             ) : isActive ? (
               <>
                 {tags.map((tag) => (
-                  <Tooltip key={tag} text="Edit tag" placement="bottom">
-                    <button
-                      className={`${METADATA_CHIP} border-none hover:bg-white/[0.1] hover:text-white/75 transition-colors duration-150`}
-                      onMouseDown={handleTagButtonClick}
-                    >
-                      {tag}
-                    </button>
-                  </Tooltip>
+                  <button
+                    key={tag}
+                    className={`${METADATA_CHIP} border-none hover:bg-white/[0.1] hover:text-white/75 transition-colors duration-150`}
+                    onMouseDown={handleTagButtonClick}
+                  >
+                    {tag}
+                  </button>
                 ))}
                 {tags.length === 0 && (
-                  <Tooltip text="Add tag" placement="bottom">
-                    <button
-                      className="inline-flex items-center gap-1 font-mono text-[11px] text-white/35 bg-transparent border-none px-2 py-0.5 rounded-full shrink-0 opacity-0 group-hover/meta:opacity-100 hover:text-white/70 hover:bg-white/[0.05] transition-all duration-150"
-                      onMouseDown={handleTagButtonClick}
-                      aria-label="Add tag"
-                    >
-                      <Icon name="tag" className="w-3 h-3" />
-                      <span>Tag</span>
-                    </button>
-                  </Tooltip>
+                  <button
+                    className="inline-flex items-center gap-1 font-mono text-[11px] text-white/35 bg-transparent border-none px-2 py-0.5 rounded-full shrink-0 opacity-0 group-hover/meta:opacity-100 hover:text-white/70 hover:bg-white/[0.05] transition-all duration-150"
+                    onMouseDown={handleTagButtonClick}
+                    aria-label="Add tag"
+                  >
+                    <Icon name="tag" className="w-3 h-3" />
+                    <span>Tag</span>
+                  </button>
                 )}
               </>
             ) : (
@@ -499,21 +495,16 @@ function BranchCopy({ branch }: { branch: string }) {
   const iconName = copied ? 'check' : hovered ? 'copy' : 'git-branch';
 
   return (
-    <Tooltip
-      text={copied ? 'Copied' : 'Copy branch'}
-      placement="bottom-start"
-      onHoverChange={setHovered}
-      referenceClassName="inline-flex min-w-0 self-start"
+    <button
+      type="button"
+      className="inline-flex items-center gap-1 font-mono text-[11px] text-white/45 bg-transparent border-none p-0 min-w-0 self-start shrink-0 transition-colors duration-150 hover:text-white/75"
+      onClick={handleClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
-      <button
-        type="button"
-        className="inline-flex items-center gap-1 font-mono text-[11px] text-white/45 bg-transparent border-none p-0 min-w-0 shrink-0 transition-colors duration-150 hover:text-white/75"
-        onClick={handleClick}
-      >
-        <Icon name={iconName} className="w-3 h-3 shrink-0 text-white/35" />
-        <span className="truncate">{copied ? 'Copied' : branch}</span>
-      </button>
-    </Tooltip>
+      <Icon name={iconName} className="w-3 h-3 shrink-0 text-white/35" />
+      <span className="truncate">{copied ? 'Copied' : branch}</span>
+    </button>
   );
 }
 
@@ -612,21 +603,17 @@ function ActionGroup({
 
   const slots: { key: string; content: React.ReactNode }[] = [];
 
-  const slotWrapClass = 'inline-flex h-full';
-
   if (showPlan) {
     slots.push({
       key: 'plan',
       content: (
-        <Tooltip text="View plan" placement="bottom" referenceClassName={slotWrapClass}>
-          <button
-            className={`${groupButtonBase} ${planPanelOpen ? groupButtonActive : groupButtonInactive}`}
-            onClick={onPlanClick}
-          >
-            <Icon name="list-checks" className="w-3.5 h-3.5" />
-            <span>Plan</span>
-          </button>
-        </Tooltip>
+        <button
+          className={`${groupButtonBase} ${planPanelOpen ? groupButtonActive : groupButtonInactive}`}
+          onClick={onPlanClick}
+        >
+          <Icon name="list-checks" className="w-3.5 h-3.5" />
+          <span>Plan</span>
+        </button>
       ),
     });
   }
@@ -635,15 +622,13 @@ function ActionGroup({
     slots.push({
       key: 'preview',
       content: (
-        <Tooltip text={`Preview ${webPreviewUrl}`} placement="bottom" referenceClassName={slotWrapClass}>
-          <button
-            className={`${groupButtonBase} ${webPreviewPanelOpen ? groupButtonActive : groupButtonInactive}`}
-            onClick={onWebPreviewClick}
-          >
-            <Icon name="globe-simple" className="w-3.5 h-3.5" />
-            <span>Preview</span>
-          </button>
-        </Tooltip>
+        <button
+          className={`${groupButtonBase} ${webPreviewPanelOpen ? groupButtonActive : groupButtonInactive}`}
+          onClick={onWebPreviewClick}
+        >
+          <Icon name="globe-simple" className="w-3.5 h-3.5" />
+          <span>Preview</span>
+        </button>
       ),
     });
   }
@@ -652,32 +637,28 @@ function ActionGroup({
     slots.push({
       key: 'diff',
       content: (
-        <Tooltip text="View uncommitted changes" placement="bottom" referenceClassName={slotWrapClass}>
-          <button
-            className={`${groupButtonBase} ${diffPanelOpen ? groupButtonActive : groupButtonInactive}`}
-            onClick={onDiffClick}
-          >
-            <span>
-              {dirtyFileCount} {dirtyFileCount === 1 ? 'file' : 'files'}
-            </span>
-            {insertions > 0 && <span className="text-[#4ee82e]">+{insertions}</span>}
-            {deletions > 0 && <span className="text-[#ff6b6b]">-{deletions}</span>}
-          </button>
-        </Tooltip>
+        <button
+          className={`${groupButtonBase} ${diffPanelOpen ? groupButtonActive : groupButtonInactive}`}
+          onClick={onDiffClick}
+        >
+          <span>
+            {dirtyFileCount} {dirtyFileCount === 1 ? 'file' : 'files'}
+          </span>
+          {insertions > 0 && <span className="text-[#4ee82e]">+{insertions}</span>}
+          {deletions > 0 && <span className="text-[#ff6b6b]">-{deletions}</span>}
+        </button>
       ),
     });
   } else if (showGit && showCompare) {
     slots.push({
       key: 'compare',
       content: (
-        <Tooltip text="Compare branch changes" placement="bottom" referenceClassName={slotWrapClass}>
-          <button
-            className={`${groupButtonBase} ${diffPanelOpen ? groupButtonActive : groupButtonInactive}`}
-            onClick={onDiffClick}
-          >
-            Compare
-          </button>
-        </Tooltip>
+        <button
+          className={`${groupButtonBase} ${diffPanelOpen ? groupButtonActive : groupButtonInactive}`}
+          onClick={onDiffClick}
+        >
+          Compare
+        </button>
       ),
     });
   }
@@ -694,17 +675,15 @@ function ActionGroup({
           <span>{runText}</span>
         </button>
         {showChevron && (
-          <Tooltip text="More run options" placement="bottom" referenceClassName={slotWrapClass}>
-            <button
-              ref={chevronRef}
-              className={`${groupButtonBase} !px-2 ${runnerPanelOpen ? groupButtonActive : runColor}`}
-              aria-haspopup="menu"
-              aria-label="More run options"
-              onClick={onChevronClick}
-            >
-              <Icon name="caret-down" className="w-2.5 h-2.5" />
-            </button>
-          </Tooltip>
+          <button
+            ref={chevronRef}
+            className={`${groupButtonBase} !px-2 ${runnerPanelOpen ? groupButtonActive : runColor}`}
+            aria-haspopup="menu"
+            aria-label="More run options"
+            onClick={onChevronClick}
+          >
+            <Icon name="caret-down" className="w-2.5 h-2.5" />
+          </button>
         )}
       </>
     ),

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -44,6 +44,7 @@ export const TerminalHeader = memo(function TerminalHeader({
   const summary = useTerminalStore((s) => s.displayStates[ptyId]?.summary ?? '');
   const summaryType = useTerminalStore((s) => s.displayStates[ptyId]?.summaryType ?? 'ready');
   const gitFileStatus = useTerminalStore((s) => s.displayStates[ptyId]?.gitFileStatus ?? null);
+  const lastOscTitle = useTerminalStore((s) => s.displayStates[ptyId]?.lastOscTitle ?? '');
   const tags = useTerminalStore((s) => s.displayStates[ptyId]?.tags) ?? EMPTY_TAGS;
   const sandboxed = useTerminalStore((s) => s.displayStates[ptyId]?.sandboxed ?? false);
   const runnerStatus = useTerminalStore((s) => s.displayStates[ptyId]?.runnerStatus ?? 'idle');
@@ -384,6 +385,9 @@ export const TerminalHeader = memo(function TerminalHeader({
           )}
           {summary && !renaming && (
             <span className="font-mono text-xs text-white/45 min-w-0 truncate">\u2014 {summary}</span>
+          )}
+          {lastOscTitle && !renaming && (
+            <span className="font-mono text-xs font-medium text-white/40 min-w-0 truncate">{lastOscTitle}</span>
           )}
           <span className="inline-flex items-center gap-1 min-w-0 shrink-0">
             {isActive && tagInputOpen ? (

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -29,6 +29,7 @@ import cardsThree from '@phosphor-icons/core/assets/regular/cards-three.svg?raw'
 import check from '@phosphor-icons/core/assets/regular/check.svg?raw';
 import clipboardText from '@phosphor-icons/core/assets/regular/clipboard-text.svg?raw';
 import code from '@phosphor-icons/core/assets/regular/code.svg?raw';
+import copy from '@phosphor-icons/core/assets/regular/copy.svg?raw';
 import cube from '@phosphor-icons/core/assets/regular/cube.svg?raw';
 import download from '@phosphor-icons/core/assets/regular/download.svg?raw';
 import fileDashed from '@phosphor-icons/core/assets/regular/file-dashed.svg?raw';
@@ -95,6 +96,7 @@ export const iconMap: Record<string, string> = {
   check: check,
   'clipboard-text': clipboardText,
   code: code,
+  copy: copy,
   cube: cube,
   download: download,
   'file-dashed': fileDashed,


### PR DESCRIPTION
## Summary
- Joined the per-terminal action pills (Plan / Preview / Diff·Compare / Run) into a single grouped button strip with thin separators, styled to match the project header buttons; active panel highlights in solid accent.
- Reworked the terminal identity row: status LED with black inset ring, label + summary + OSC title inline (with the OSC trailing in a muted gray), branch on its own row with click-to-copy (icon swaps to copy on hover, check on success).
- Tags are interactive chips on the active terminal only; back-stack terminals show tags as plain spans. Add-tag affordance reveals on hover with a tag icon.
- Canvas terminal nodes now reuse the shared `TerminalHeader`, so they inherit the same identity row, branch copy, tags, and joined action group.
- Tuned the "ready" green to a neon lime (`#4ee82e`) across the status dot, runner success, and `+insertions`.