### PR TITLE
Pre-create draft release before parallel publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,30 @@ jobs:
       - run: npm rebuild better-sqlite3 --silent
       - run: npx vitest run --project unit
 
-  publish:
+  create-draft:
     needs: test
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create or reuse draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Draft for $TAG already exists, reusing."
+          else
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG" \
+              --draft \
+              --generate-notes
+          fi
+
+  publish:
+    needs: create-draft
     permissions:
       contents: write
     strategy:


### PR DESCRIPTION
## Summary
- Adds a `create-draft` job that runs after `test` and before the matrix `publish` jobs, creating (or reusing) the draft release for the tag.
- Prevents the v1.0.37 issue where simultaneous matrix jobs each created their own draft and split assets across them.