### PR TITLE
Sync view transitions with their data

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "postinstall": "./scripts/download-lima.sh && chmod +x node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true",
     "db:reset": "node scripts/dev-db.mjs reset",
     "db:seed": "node scripts/dev-db.mjs seed",
+    "db:clone-prod": "node scripts/dev-db.mjs clone-prod",
     "capture": "node scripts/capture/run.mjs"
   },
   "keywords": [],

--- a/scripts/dev-db.mjs
+++ b/scripts/dev-db.mjs
@@ -3,9 +3,10 @@
 // production data and other worktrees' dev data are untouched.
 //
 // Usage:
-//   node scripts/dev-db.mjs reset   Delete dev DB + seed project (next launch = first-launch)
-//   node scripts/dev-db.mjs seed    Create the demo project used in marketing screenshots
-//   node scripts/dev-db.mjs path    Print the dev userData dir for this worktree
+//   node scripts/dev-db.mjs reset        Delete dev DB + seed project (next launch = first-launch)
+//   node scripts/dev-db.mjs seed         Create the demo project used in marketing screenshots
+//   node scripts/dev-db.mjs clone-prod   Copy prod DB into this worktree's dev DB
+//   node scripts/dev-db.mjs path         Print the dev userData dir for this worktree
 
 import { execFileSync, spawnSync } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
@@ -24,6 +25,14 @@ function devDbDir() {
   }
   const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
   return join(xdg, `ouijit${suffix}`);
+}
+
+function prodDbDir() {
+  if (platform() === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support', 'ouijit');
+  }
+  const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+  return join(xdg, 'ouijit');
 }
 
 function dbPath() {
@@ -45,6 +54,38 @@ function exec(sql) {
     process.exit(result.status ?? 1);
   }
   return result.stdout;
+}
+
+function cloneProd() {
+  const srcDir = prodDbDir();
+  const srcDb = join(srcDir, 'ouijit.db');
+  if (!existsSync(srcDb)) {
+    process.stderr.write(`Prod DB not found at ${srcDb}\n`);
+    process.exit(1);
+  }
+
+  const dstDir = devDbDir();
+  if (!/-dev-[0-9a-f]{8}$/.test(dstDir)) {
+    throw new Error(`Refusing to write to non-dev path: ${dstDir}`);
+  }
+  mkdirSync(dstDir, { recursive: true });
+
+  // Wipe any existing dev DB so the backup lands on a clean target.
+  for (const ext of ['', '-wal', '-shm']) {
+    const f = join(dstDir, `ouijit.db${ext}`);
+    if (existsSync(f)) rmSync(f);
+  }
+
+  const dstDb = join(dstDir, 'ouijit.db');
+  // sqlite3 .backup is an online backup — safe even if the prod app is running.
+  const result = spawnSync('sqlite3', [srcDb, `.backup '${dstDb.replace(/'/g, "''")}'`], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr || `sqlite3 .backup exited ${result.status}\n`);
+    process.exit(result.status ?? 1);
+  }
+
+  console.log(`Cloned prod DB → ${dstDb}`);
+  console.log('Migrations will run on next launch of the dev app in this worktree.');
 }
 
 function reset() {
@@ -174,15 +215,19 @@ switch (cmd) {
   case 'seed':
     seed();
     break;
+  case 'clone-prod':
+    cloneProd();
+    break;
   case 'path':
     console.log(devDbDir());
     break;
   default:
     process.stderr.write(
-      `Usage: node scripts/dev-db.mjs <reset|seed|path>\n\n` +
-        `  reset   Delete dev DB + seed project (next launch = first-launch state)\n` +
-        `  seed    Create the demo project used in marketing screenshots\n` +
-        `  path    Print this worktree's dev userData dir\n`,
+      `Usage: node scripts/dev-db.mjs <reset|seed|clone-prod|path>\n\n` +
+        `  reset       Delete dev DB + seed project (next launch = first-launch state)\n` +
+        `  seed        Create the demo project used in marketing screenshots\n` +
+        `  clone-prod  Copy prod DB into this worktree's dev DB\n` +
+        `  path        Print this worktree's dev userData dir\n`,
     );
     process.exit(1);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -129,6 +129,7 @@ export function App() {
       const pendingSnapshot = await window.api.globalSettings.get('lastSession:snapshot');
       const hasResumable = !!pendingSnapshot && pendingSnapshot.length > 0;
 
+      let restoredToProject = false;
       if (!hasResumable) {
         const lastView = await window.api.globalSettings.get('lastActiveView');
         if (lastView) {
@@ -137,16 +138,25 @@ export function App() {
             if (parsed.type === 'project' && parsed.path) {
               const project = projects.find((p) => p.path === parsed.path);
               if (project) {
-                // Fetch sandbox status before navigating so button renders instantly
+                // Pre-fetch sandbox status + tasks before navigating so the
+                // first project paint (kanban included) shows correct content.
                 const limaStatus = await window.api.lima.status(parsed.path);
                 useAppStore.getState().setSandboxStatus(limaStatus.available, limaStatus.vmStatus);
+                await useProjectStore.getState().loadTasks(parsed.path);
                 useAppStore.getState().navigateToProject(parsed.path, project);
+                restoredToProject = true;
               }
             }
           } catch {
             /* invalid JSON, stay on home */
           }
         }
+      }
+
+      // If we're landing on home (default or post-resume), pre-warm recents
+      // so the "pick up where you left off" surface is populated on first paint.
+      if (!restoredToProject) {
+        await useAppStore.getState().loadHomeRecents();
       }
 
       setInitialized(true);
@@ -157,20 +167,27 @@ export function App() {
   // position in the sidebar — clicking a project below the current one slides
   // the new view up into place; above slides down. Home is treated as the
   // top of the list.
-  const handleProjectSelect = useCallback((path: string, project: Project) => {
+  //
+  // Both handlers pre-fetch the data the new view needs *before* triggering
+  // the view transition. The transition snapshots the new DOM synchronously,
+  // so any data still loading in a useEffect would be missed by the crossfade
+  // and pop in afterwards.
+  const handleProjectSelect = useCallback(async (path: string, project: Project) => {
     const state = useAppStore.getState();
     if (state.activeProjectPath === path) return;
     const orderedPaths = state.projects.map((p) => p.path);
     const oldIndex = state.activeView === 'home' ? -1 : orderedPaths.indexOf(state.activeProjectPath ?? '');
     const newIndex = orderedPaths.indexOf(path);
     const direction = newIndex > oldIndex ? 'down' : newIndex < oldIndex ? 'up' : undefined;
+    await useProjectStore.getState().loadTasks(path);
     state.navigateToProject(path, project, { direction });
     window.api.globalSettings.set('lastActiveView', JSON.stringify({ type: 'project', path }));
   }, []);
 
-  const handleHomeSelect = useCallback(() => {
+  const handleHomeSelect = useCallback(async () => {
     const state = useAppStore.getState();
     if (state.activeView === 'home') return;
+    await state.loadHomeRecents();
     state.navigateHome({ direction: 'up' });
     window.api.globalSettings.set('lastActiveView', JSON.stringify({ type: 'home' }));
   }, []);

--- a/src/components/RecentTasksPanel.tsx
+++ b/src/components/RecentTasksPanel.tsx
@@ -6,23 +6,20 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { useAppStore } from '../stores/appStore';
+import { useAppStore, type HomeRecentTask } from '../stores/appStore';
 import { useProjectStore } from '../stores/projectStore';
 import { addProjectTerminal } from './terminal/terminalActions';
 import { stringToColor, getInitials } from '../utils/projectIcon';
 import { formatRelativeTime } from '../utils/formatDate';
-import type { Project, TaskWithWorkspace } from '../types';
+import type { Project } from '../types';
 
-const MAX_TASKS = 8;
 const STATUS_LABEL: Record<string, string> = {
   todo: 'to do',
   in_progress: 'in progress',
   in_review: 'to review',
 };
 
-interface RecentTask extends TaskWithWorkspace {
-  project: Project;
-}
+type RecentTask = HomeRecentTask;
 
 function taskKey(task: RecentTask): string {
   return `${task.project.path}#${task.taskNumber}`;
@@ -59,30 +56,14 @@ interface RecentTasksPanelProps {
 }
 
 export function RecentTasksPanel({ projects }: RecentTasksPanelProps) {
-  const [recents, setRecents] = useState<RecentTask[] | null>(null);
+  const recents = useAppStore((s) => s.homeRecents);
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
+  // Refresh whenever the projects list changes (add/remove). App.tsx
+  // pre-fetches before navigating home so the view transition snapshot is
+  // correct; this keeps recents fresh while we're already on home.
   useEffect(() => {
-    let cancelled = false;
-    Promise.all(
-      projects.map((project) =>
-        window.api.task
-          .getAll(project.path)
-          .then((tasks) => tasks.map((t) => ({ ...t, project })))
-          .catch(() => [] as RecentTask[]),
-      ),
-    ).then((arrays) => {
-      if (cancelled) return;
-      const all = arrays
-        .flat()
-        .filter((t) => t.status !== 'done')
-        .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
-        .slice(0, MAX_TASKS);
-      setRecents(all);
-    });
-    return () => {
-      cancelled = true;
-    };
+    void useAppStore.getState().loadHomeRecents();
   }, [projects]);
 
   if (recents === null) return null;

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,7 +1,13 @@
 import { create } from 'zustand';
-import type { Project } from '../types';
+import type { Project, TaskWithWorkspace } from '../types';
 import type { HealthStatus } from '../healthCheck';
 import { withViewTransition, type ViewTransitionDirection } from '../utils/viewTransition';
+
+export interface HomeRecentTask extends TaskWithWorkspace {
+  project: Project;
+}
+
+const MAX_HOME_RECENTS = 8;
 
 interface AppStoreState {
   activeView: 'home' | 'project';
@@ -17,6 +23,7 @@ interface AppStoreState {
   whatsNew: { version: string; notes: string } | null;
   health: HealthStatus | null;
   homeActivePanel: 'home' | 'settings';
+  homeRecents: HomeRecentTask[] | null;
   _version: number;
 }
 
@@ -31,6 +38,7 @@ interface AppStoreActions {
   setHomeActivePanel: (panel: 'home' | 'settings') => void;
   navigateToProject: (path: string, project: Project, options?: { direction?: ViewTransitionDirection }) => void;
   navigateHome: (options?: { direction?: ViewTransitionDirection }) => void;
+  loadHomeRecents: () => Promise<void>;
   resetProjectState: () => void;
 }
 
@@ -50,6 +58,7 @@ export const useAppStore = create<AppStore>()((set, get) => ({
   whatsNew: null,
   health: null,
   homeActivePanel: 'home',
+  homeRecents: null,
   _version: 0,
 
   setProjects: (projects) => set({ projects }),
@@ -99,6 +108,24 @@ export const useAppStore = create<AppStore>()((set, get) => ({
       },
       { direction: options?.direction },
     ),
+
+  loadHomeRecents: async () => {
+    const projects = get().projects;
+    const arrays = await Promise.all(
+      projects.map((project) =>
+        window.api.task
+          .getAll(project.path)
+          .then((tasks) => tasks.map((t) => ({ ...t, project })))
+          .catch(() => [] as HomeRecentTask[]),
+      ),
+    );
+    const recents = arrays
+      .flat()
+      .filter((t) => t.status !== 'done')
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      .slice(0, MAX_HOME_RECENTS);
+    set({ homeRecents: recents });
+  },
 
   resetProjectState: () => {
     set({


### PR DESCRIPTION
## Summary

- Pre-fetch the data each view needs before triggering `withViewTransition`. The view-transition API snapshots the new DOM synchronously, so anything loaded inside a `useEffect` arrives after the crossfade and pops in late.
- Hoist "pick up where you left off" into `appStore` as `homeRecents` so the panel renders from store state on the first paint.
- Prefetch `loadTasks(path)` before `navigateToProject` so the kanban snapshot already contains the new project's tasks (no flash of the previous project's content).
- Prefetch `loadHomeRecents()` before `navigateHome`, and apply the same prefetch to the startup-restore path so the very first home/project paint is correct.
- Adds `npm run db:clone-prod` — a `sqlite3 .backup`-based script that copies the prod DB into this worktree's dev DB for QA against real data.