### PR TITLE
Open sidebar on launch, fill empty home state

### DIFF
--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -34,6 +34,7 @@ export function HomeView() {
   const [projects, setProjects] = useState<Map<string, Project>>(new Map());
   const allProjects = useAppStore((s) => s.projects);
   const projectCount = allProjects.length;
+  const homeRecents = useAppStore((s) => s.homeRecents);
   const terminalsByProject = useTerminalStore((s) => s.terminalsByProject);
   const displayStates = useTerminalStore((s) => s.displayStates);
   const homeGroupMode = useUIStore((s) => s.homeGroupMode);
@@ -291,6 +292,8 @@ export function HomeView() {
 
   if (allPtyIds.length === 0) {
     const noProjects = projectCount === 0;
+    const noRecents = !noProjects && homeRecents !== null && homeRecents.length === 0;
+    const isMac = navigator.platform.toLowerCase().includes('mac');
 
     return (
       <div
@@ -317,6 +320,17 @@ export function HomeView() {
               >
                 Add your first project
               </button>
+            </div>
+          </div>
+        ) : noRecents ? (
+          <div
+            className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-text-tertiary rounded-[14px] border border-dashed border-white/10"
+            style={{ background: 'var(--color-terminal-bg)' }}
+          >
+            <div className="text-sm">No tasks yet.</div>
+            <div className="flex items-center gap-2 text-xs">
+              <span className="font-mono text-[13px]">{isMac ? '⌘ I' : 'Ctrl+I'}</span>
+              <span>to open a terminal</span>
             </div>
           </div>
         ) : (

--- a/src/components/RecentTasksPanel.tsx
+++ b/src/components/RecentTasksPanel.tsx
@@ -5,7 +5,7 @@
  * click toggles selection for bulk opening.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAppStore, type HomeRecentTask } from '../stores/appStore';
 import { useProjectStore } from '../stores/projectStore';
 import { addProjectTerminal } from './terminal/terminalActions';
@@ -67,7 +67,7 @@ export function RecentTasksPanel({ projects }: RecentTasksPanelProps) {
   }, [projects]);
 
   if (recents === null) return null;
-  if (recents.length === 0) return <EmptyHint />;
+  if (recents.length === 0) return null;
 
   const allSelected = selected.size === recents.length;
 
@@ -174,22 +174,6 @@ export function RecentTasksPanel({ projects }: RecentTasksPanelProps) {
           </div>
         </div>
       )}
-    </div>
-  );
-}
-
-function EmptyHint() {
-  const isMac = useMemo(() => navigator.platform.toLowerCase().includes('mac'), []);
-  return (
-    <div
-      className="w-full flex flex-col items-center justify-center gap-3 text-text-tertiary rounded-[14px] border border-dashed border-white/10 py-16"
-      style={{ background: 'var(--color-terminal-bg)' }}
-    >
-      <div className="text-sm">No tasks yet.</div>
-      <div className="flex items-center gap-2 text-xs">
-        <span className="font-mono text-[13px]">{isMac ? '⌘ I' : 'Ctrl+I'}</span>
-        <span>to open a terminal</span>
-      </div>
     </div>
   );
 }

--- a/src/components/SidebarReact.tsx
+++ b/src/components/SidebarReact.tsx
@@ -37,11 +37,12 @@ export function Sidebar({ onProjectSelect, onHomeSelect, onAddExisting, onCreate
   const sidebarPinned = useUIStore((s) => s.sidebarPinned);
 
   const sidebarRef = useRef<HTMLElement>(null);
-  const triggerRef = useRef<HTMLDivElement>(null);
   const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const showTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const noProjects = projects.length === 0;
-  const [visible, setVisible] = useState(noProjects);
+  // Start visible on every app open so the sidebar is always discoverable;
+  // the existing hideSidebar path (mouse-leave) collapses it from there.
+  const [visible, setVisible] = useState(true);
   const effectiveVisible = visible || sidebarPinned;
 
   const addBtnRef = useRef<HTMLButtonElement>(null);
@@ -106,6 +107,13 @@ export function Sidebar({ onProjectSelect, onHomeSelect, onAddExisting, onCreate
     document.addEventListener('show-sidebar', handler);
     return () => document.removeEventListener('show-sidebar', handler);
   }, [showSidebar]);
+
+  // Sidebar starts visible (see initial useState above) — match the layout
+  // offset to that on mount so content doesn't render under the sidebar
+  // before the first show/hide tick.
+  useEffect(() => {
+    document.documentElement.style.setProperty('--sidebar-offset', 'var(--sidebar-width)');
+  }, []);
 
   // Listen for open-add-menu events from the home empty state CTA
   useEffect(() => {
@@ -180,7 +188,6 @@ export function Sidebar({ onProjectSelect, onHomeSelect, onAddExisting, onCreate
       {/* Trigger zone — hidden when sidebar is visible */}
       {!effectiveVisible && (
         <div
-          ref={triggerRef}
           className="fixed top-0 bottom-0 left-0 z-[10000]"
           style={{ width: 24 }}
           onMouseEnter={(e) => {


### PR DESCRIPTION
## Summary
- Sidebar opens automatically on every app launch so the navigation column is discoverable without an edge-hover affordance.
- Replace the small "No tasks yet" card on the home view with a full-bleed empty state that matches the no-projects layout.