### PR TITLE
Reveal terminal immediately on Run & Open

### DIFF
--- a/src/__tests__/renderer/taskStartService.test.tsx
+++ b/src/__tests__/renderer/taskStartService.test.tsx
@@ -132,6 +132,79 @@ describe('taskStartService.beginTransition', () => {
     expect(vi.mocked(addProjectTerminal).mock.calls[0][1]).toMatchObject({ command: 'npm ci' });
   });
 
+  test('Run & Open fires onForegroundOpen as soon as the dialog closes, not after worktree create', async () => {
+    vi.mocked(window.api.hooks.get).mockResolvedValue({
+      start: { command: 'npm install', name: 'Start', source: 'configured', priority: 0 },
+    });
+
+    // Hold worktree creation open so we can assert ordering.
+    let releaseWorktree: (() => void) | undefined;
+    vi.mocked(window.api.task.start).mockReturnValue(
+      new Promise((resolve) => {
+        releaseWorktree = () =>
+          resolve({
+            success: true,
+            worktreePath: '/wt/T-7',
+            task: {
+              taskNumber: 7,
+              name: 'Wire up auth',
+              branch: 'wire-up-auth-7',
+              status: 'in_progress',
+              createdAt: '',
+            },
+          });
+      }),
+    );
+
+    const onForegroundOpen = vi.fn();
+    beginTransition(PROJECT, {
+      origStatus: 'todo',
+      newStatus: 'in_progress',
+      task: makeTask(),
+      onForegroundOpen,
+    });
+
+    await waitFor(() => useProjectStore.getState().runHookRequest != null);
+    const req = useProjectStore.getState().runHookRequest!;
+    useProjectStore.getState().resolveRunHookRequest(req.id, { command: 'npm ci', sandboxed: false, foreground: true });
+
+    // Should fire before the worktree resolves.
+    await waitFor(() => onForegroundOpen.mock.calls.length === 1);
+    expect(addProjectTerminal).not.toHaveBeenCalled();
+
+    releaseWorktree!();
+
+    await waitFor(() => !useProjectStore.getState().startingTaskNumbers.has(7));
+
+    // Still only fired once — not double-called after the spawn.
+    expect(onForegroundOpen).toHaveBeenCalledTimes(1);
+    expect(addProjectTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  test('Run (background) does not fire onForegroundOpen', async () => {
+    vi.mocked(window.api.hooks.get).mockResolvedValue({
+      start: { command: 'npm install', name: 'Start', source: 'configured', priority: 0 },
+    });
+
+    const onForegroundOpen = vi.fn();
+    beginTransition(PROJECT, {
+      origStatus: 'todo',
+      newStatus: 'in_progress',
+      task: makeTask(),
+      onForegroundOpen,
+    });
+
+    await waitFor(() => useProjectStore.getState().runHookRequest != null);
+    const req = useProjectStore.getState().runHookRequest!;
+    useProjectStore
+      .getState()
+      .resolveRunHookRequest(req.id, { command: 'npm ci', sandboxed: false, foreground: false });
+
+    await waitFor(() => !useProjectStore.getState().startingTaskNumbers.has(7));
+
+    expect(onForegroundOpen).not.toHaveBeenCalled();
+  });
+
   test('worktree creation failure: cleans up the loading slot', async () => {
     vi.mocked(window.api.task.start).mockResolvedValue({ success: false, error: 'boom' });
 

--- a/src/services/taskStartService.ts
+++ b/src/services/taskStartService.ts
@@ -152,6 +152,13 @@ async function runTransition(
             ms: Math.round(performance.now() - tDialog),
             accepted: !!res,
           });
+          // For an in_progress drop with "Run & Open", reveal the terminal
+          // stack right away. The loading placeholder is already on-screen
+          // and the worktree is still creating in parallel — there's no
+          // reason to make the user wait staring at the kanban.
+          if (res?.foreground && transitioningToInProgress && onForegroundOpen) {
+            onForegroundOpen();
+          }
           return res;
         });
     }
@@ -184,7 +191,7 @@ async function runTransition(
     // loading slot always morphs into a real card. For review/done the
     // terminal only spawns if the user accepted the hook.
     if (transitioningToInProgress) {
-      await spawnTerminalForInProgress(projectPath, resolvedTask, hookResult, slotId, onForegroundOpen);
+      await spawnTerminalForInProgress(projectPath, resolvedTask, hookResult, slotId);
     } else if (hookResult) {
       await runNonStartHookInTerminal(projectPath, resolvedTask, newStatus, hookResult, onForegroundOpen);
     }
@@ -213,13 +220,15 @@ async function runTransition(
  * Spawn a terminal for a task that just landed in in_progress. Always opens a
  * terminal so the loading slot always resolves into a real card. The hook
  * command runs if the user accepted it; otherwise it's a plain shell.
+ *
+ * Note: the kanban-hide for foreground hooks happens earlier (right after the
+ * dialog returns) so the user sees the loading placeholder immediately.
  */
 async function spawnTerminalForInProgress(
   projectPath: string,
   task: TaskWithWorkspace,
   hookResult: RunHookResult | null,
   loadingSlot: string | null,
-  onForegroundOpen?: () => void,
 ): Promise<void> {
   if (!task.worktreePath) {
     // Worktree creation must have failed earlier; nothing to do.
@@ -237,8 +246,6 @@ async function spawnTerminalForInProgress(
     skipAutoHook: true,
     replaceLoadingId: loadingSlot ?? undefined,
   });
-
-  if (hookResult?.foreground && onForegroundOpen) onForegroundOpen();
 }
 
 async function runNonStartHookInTerminal(


### PR DESCRIPTION
## Summary

- When 'Run & Open' is selected on the start hook, fire `onForegroundOpen` as soon as the dialog returns instead of after the worktree finishes creating
- The loading placeholder card is already in the terminal stack at this point, so the user sees the spinner immediately rather than staring at the kanban
- Added tests covering the new ordering and verifying plain 'Run' still doesn't open the terminal view