### PR TITLE
Soak releases as prerelease before promoting to auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,30 +22,30 @@ jobs:
       - run: npm rebuild better-sqlite3 --silent
       - run: npx vitest run --project unit
 
-  create-draft:
+  create-prerelease:
     needs: test
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Create or reuse draft release
+      - name: Create or reuse prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "Draft for $TAG already exists, reusing."
+            echo "Release for $TAG already exists, reusing."
           else
             gh release create "$TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --title "$TAG" \
-              --draft \
+              --prerelease \
               --generate-notes
           fi
 
   publish:
-    needs: create-draft
+    needs: create-prerelease
     permissions:
       contents: write
     strategy:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,16 @@ Do NOT run `npm run start` or other dev server commands.
 
 Dev userData is isolated per worktree via a hash of the repo path (`…/ouijit-dev-<hash>`), so multiple worktrees can run in parallel without stomping each other and never touch the production DB.
 
+### Releasing
+
+Tagging `v*` builds and publishes a release as **prerelease**. Prereleases are downloadable from the Releases page but are invisible to auto-updaters (`update.electronjs.org` and `releases/latest` both skip them). Soak the build for ~3 days of real use, then promote it:
+
+```
+./scripts/promote-release.sh v1.0.41
+```
+
+Promotion clears the prerelease flag and marks the release as `latest`. Auto-updaters pick it up within their next hourly check.
+
 ### Project Structure
 
 **Entry points:**

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -224,7 +224,10 @@ const config: ForgeConfig = {
       // Publish as prerelease so the release is downloadable but auto-updaters
       // skip it (update.electronjs.org and GitHub's releases/latest both honor
       // this flag). Promote with scripts/promote-release.sh after soaking.
+      // draft: false guards the fallback path where forge creates the release
+      // itself — its default is draft=true, which would hide the build.
       prerelease: true,
+      draft: false,
       generateReleaseNotes: true,
     }),
   ],

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -221,7 +221,10 @@ const config: ForgeConfig = {
         owner: 'ouijit',
         name: 'ouijit',
       },
-      draft: true,
+      // Publish as prerelease so the release is downloadable but auto-updaters
+      // skip it (update.electronjs.org and GitHub's releases/latest both honor
+      // this flag). Promote with scripts/promote-release.sh after soaking.
+      prerelease: true,
       generateReleaseNotes: true,
     }),
   ],

--- a/scripts/promote-release.sh
+++ b/scripts/promote-release.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Promote a soaked prerelease to a "live" release so auto-updaters pick it up.
+#
+# Releases are published as prereleases (see forge.config.ts) and stay invisible
+# to the auto-updater until promoted. Run this after a few days of soaking with
+# no reported regressions.
+#
+# Usage: ./scripts/promote-release.sh v1.0.41
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <tag>"
+  echo "Example: $0 v1.0.41"
+  exit 1
+fi
+
+TAG="$1"
+
+if ! gh release view "$TAG" >/dev/null 2>&1; then
+  echo "Error: release $TAG not found." >&2
+  exit 1
+fi
+
+echo "Promoting $TAG → live (clearing prerelease flag, marking as latest)..."
+gh release edit "$TAG" --prerelease=false --latest
+
+echo "Done. Auto-updaters will pick up $TAG within their next check (≤1 hour)."


### PR DESCRIPTION
## Summary

- Publish tagged releases as GitHub prereleases instead of drafts. Builds become downloadable from the Releases page but auto-updaters (`update.electronjs.org` and `releases/latest`) skip them.
- Add `scripts/promote-release.sh <tag>` — wraps `gh release edit <tag> --prerelease=false --latest`. Run it after a few days of soaking to push the build to all users on their next hourly auto-update check.
- Document the soak-then-promote flow in `CLAUDE.md`.