### PR TITLE
Scope home view transition to main content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -237,10 +237,10 @@ export function App() {
         onAddExisting={handleAddExisting}
         onCreateNew={handleCreateNew}
       />
-      <div className="app-content-shell flex-1 flex flex-col min-w-0 overflow-hidden">
+      <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
         <TitleBar mode={activeView} />
         <main
-          className="flex-1 min-h-0"
+          className="app-content-main flex-1 min-h-0"
           style={
             activeView === 'project' || activeView === 'home'
               ? { padding: 0 }

--- a/src/index.css
+++ b/src/index.css
@@ -226,11 +226,11 @@ textarea,
 }
 
 /* View Transitions — used for home/project/sub-panel switches. We name the
-   right-hand content shell so only it animates; the sidebar is part of the
-   root snapshot and we suppress its animation explicitly so it stays still
-   during the crossfade. Triggered via `withViewTransition` in
+   main content area so only it animates; the sidebar and title bar are part
+   of the root snapshot and we suppress its animation explicitly so they stay
+   still during the crossfade. Triggered via `withViewTransition` in
    src/utils/viewTransition.ts. */
-.app-content-shell {
+.app-content-main {
   view-transition-name: app-content;
 }
 ::view-transition-old(root),


### PR DESCRIPTION
## Summary
- Move `view-transition-name: app-content` from the shell wrapper (which contained the title bar) to the `<main>` element, so toggling project/tag/settings in home view only crossfades the content, not the header.