### PR TITLE
Make home navigation instant via cached recents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -171,10 +171,10 @@ export function App() {
   // the new view up into place; above slides down. Home is treated as the
   // top of the list.
   //
-  // Both handlers pre-fetch the data the new view needs *before* triggering
-  // the view transition. The transition snapshots the new DOM synchronously,
-  // so any data still loading in a useEffect would be missed by the crossfade
-  // and pop in afterwards.
+  // Project select pre-fetches tasks before navigating so the kanban paints
+  // correctly through the view-transition snapshot. Home select navigates
+  // immediately and refreshes in the background, since `homeRecents` is kept
+  // warm by `projectStore.loadTasks` and the app-init pre-fetch.
   const handleProjectSelect = useCallback(async (path: string, project: Project) => {
     const state = useAppStore.getState();
     if (state.activeProjectPath === path) return;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,10 +153,13 @@ export function App() {
         }
       }
 
-      // If we're landing on home (default or post-resume), pre-warm recents
-      // so the "pick up where you left off" surface is populated on first paint.
+      // Pre-warm the home recents cache regardless of which view we're
+      // restoring to, so a later home click paints from cache instantly.
+      // Awaited only when landing on home, to keep the initial home paint
+      // populated; for project restores the fetch runs in the background.
+      const recentsPromise = useAppStore.getState().loadHomeRecents();
       if (!restoredToProject) {
-        await useAppStore.getState().loadHomeRecents();
+        await recentsPromise;
       }
 
       setInitialized(true);
@@ -184,11 +187,15 @@ export function App() {
     window.api.globalSettings.set('lastActiveView', JSON.stringify({ type: 'project', path }));
   }, []);
 
-  const handleHomeSelect = useCallback(async () => {
+  const handleHomeSelect = useCallback(() => {
     const state = useAppStore.getState();
     if (state.activeView === 'home') return;
-    await state.loadHomeRecents();
+    // Navigate immediately; the cached homeRecents (kept warm by
+    // projectStore.loadTasks via updateProjectTaskCache, plus app-init
+    // pre-fetch) paints during the view transition. Refresh in background
+    // to reconcile with the source of truth.
     state.navigateHome({ direction: 'up' });
+    void state.loadHomeRecents();
     window.api.globalSettings.set('lastActiveView', JSON.stringify({ type: 'home' }));
   }, []);
 

--- a/src/__tests__/renderer/appStoreHomeRecents.test.tsx
+++ b/src/__tests__/renderer/appStoreHomeRecents.test.tsx
@@ -1,0 +1,92 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { useAppStore } from '../../stores/appStore';
+import type { Project, TaskWithWorkspace } from '../../types';
+
+function makeProject(path: string, name = path): Project {
+  return {
+    path,
+    name,
+    hasGit: true,
+    hasClaude: false,
+    lastModified: new Date('2026-01-01T00:00:00Z'),
+  };
+}
+
+function makeTask(taskNumber: number, status: TaskWithWorkspace['status'], createdAt: string): TaskWithWorkspace {
+  return {
+    taskNumber,
+    name: `Task ${taskNumber}`,
+    status,
+    order: taskNumber,
+    createdAt,
+  };
+}
+
+describe('appStore home-recents derivation', () => {
+  beforeEach(() => {
+    useAppStore.setState({ projects: [], taskCacheByProject: {}, homeRecents: null });
+  });
+
+  test('updateProjectTaskCache filters out done tasks and sorts by createdAt desc', () => {
+    useAppStore.setState({ projects: [makeProject('/a')] });
+    useAppStore
+      .getState()
+      .updateProjectTaskCache('/a', [
+        makeTask(1, 'todo', '2026-01-01T00:00:00Z'),
+        makeTask(2, 'done', '2026-01-05T00:00:00Z'),
+        makeTask(3, 'in_progress', '2026-01-03T00:00:00Z'),
+        makeTask(4, 'in_review', '2026-01-02T00:00:00Z'),
+      ]);
+
+    const recents = useAppStore.getState().homeRecents;
+    expect(recents?.map((r) => r.taskNumber)).toEqual([3, 4, 1]);
+  });
+
+  test('caps homeRecents at 8 entries', () => {
+    useAppStore.setState({ projects: [makeProject('/a')] });
+    const tasks = Array.from({ length: 12 }, (_, i) =>
+      // Newer tasks first by createdAt — task 12 is newest, task 1 oldest.
+      makeTask(i + 1, 'todo', `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`),
+    );
+    useAppStore.getState().updateProjectTaskCache('/a', tasks);
+
+    const recents = useAppStore.getState().homeRecents;
+    expect(recents).toHaveLength(8);
+    expect(recents?.map((r) => r.taskNumber)).toEqual([12, 11, 10, 9, 8, 7, 6, 5]);
+  });
+
+  test('skips cache entries for projects no longer in projects list', () => {
+    useAppStore.setState({ projects: [makeProject('/a')] });
+    useAppStore.getState().updateProjectTaskCache('/a', [makeTask(1, 'todo', '2026-01-01T00:00:00Z')]);
+    useAppStore.getState().updateProjectTaskCache('/removed', [makeTask(99, 'todo', '2026-02-01T00:00:00Z')]);
+
+    const recents = useAppStore.getState().homeRecents;
+    expect(recents?.map((r) => r.taskNumber)).toEqual([1]);
+  });
+
+  test('updating one project does not clobber another project’s tasks', () => {
+    useAppStore.setState({ projects: [makeProject('/a'), makeProject('/b')] });
+    const store = useAppStore.getState();
+    store.updateProjectTaskCache('/a', [makeTask(1, 'todo', '2026-01-01T00:00:00Z')]);
+    store.updateProjectTaskCache('/b', [makeTask(2, 'todo', '2026-01-02T00:00:00Z')]);
+    // Re-update /a — /b's contribution must remain.
+    store.updateProjectTaskCache('/a', [makeTask(3, 'in_progress', '2026-01-03T00:00:00Z')]);
+
+    const recents = useAppStore.getState().homeRecents ?? [];
+    const numbers = recents.map((r) => r.taskNumber).sort();
+    expect(numbers).toEqual([2, 3]);
+  });
+
+  test('homeRecents entries carry their project reference', () => {
+    const projA = makeProject('/a', 'Alpha');
+    const projB = makeProject('/b', 'Bravo');
+    useAppStore.setState({ projects: [projA, projB] });
+    useAppStore.getState().updateProjectTaskCache('/a', [makeTask(1, 'todo', '2026-01-01T00:00:00Z')]);
+    useAppStore.getState().updateProjectTaskCache('/b', [makeTask(2, 'todo', '2026-01-02T00:00:00Z')]);
+
+    const recents = useAppStore.getState().homeRecents ?? [];
+    const byNumber = new Map(recents.map((r) => [r.taskNumber, r.project.name]));
+    expect(byNumber.get(1)).toBe('Alpha');
+    expect(byNumber.get(2)).toBe('Bravo');
+  });
+});

--- a/src/__tests__/renderer/projectStore.test.tsx
+++ b/src/__tests__/renderer/projectStore.test.tsx
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { useProjectStore } from '../../stores/projectStore';
+import { useAppStore } from '../../stores/appStore';
 import type { TaskWithWorkspace } from '../../types';
 
 function makeTask(taskNumber: number, status: string, order: number): TaskWithWorkspace {
@@ -66,5 +67,39 @@ describe('projectStore.moveTask', () => {
 
     const rolled = useProjectStore.getState().tasks;
     expect(rolled).toEqual(tasks);
+  });
+});
+
+describe('projectStore.loadTasks → appStore cache', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ tasks: [], _version: 0, toasts: [] });
+    useAppStore.setState({
+      projects: [
+        {
+          path: '/project',
+          name: 'project',
+          hasGit: true,
+          hasClaude: false,
+          lastModified: new Date('2026-01-01T00:00:00Z'),
+        },
+      ],
+      taskCacheByProject: {},
+      homeRecents: null,
+    });
+  });
+
+  test('writes loaded tasks through to appStore.taskCacheByProject', async () => {
+    const tasks = [makeTask(1, 'todo', 0), makeTask(2, 'in_progress', 1)];
+    vi.mocked(window.api.task.getAll).mockResolvedValue(tasks);
+
+    await useProjectStore.getState().loadTasks('/project');
+
+    expect(useAppStore.getState().taskCacheByProject['/project']).toEqual(tasks);
+    expect(
+      useAppStore
+        .getState()
+        .homeRecents?.map((r) => r.taskNumber)
+        .sort(),
+    ).toEqual([1, 2]);
   });
 });

--- a/src/components/RecentTasksPanel.tsx
+++ b/src/components/RecentTasksPanel.tsx
@@ -59,9 +59,10 @@ export function RecentTasksPanel({ projects }: RecentTasksPanelProps) {
   const recents = useAppStore((s) => s.homeRecents);
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  // Refresh whenever the projects list changes (add/remove). App.tsx
-  // pre-fetches before navigating home so the view transition snapshot is
-  // correct; this keeps recents fresh while we're already on home.
+  // Refresh whenever the projects list changes (add/remove). The recents
+  // cache is kept warm by projectStore.loadTasks (per-project updates) and
+  // pre-warmed at app init; this catches the add/remove case where a new
+  // project's tasks haven't been fetched yet.
   useEffect(() => {
     void useAppStore.getState().loadHomeRecents();
   }, [projects]);

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -24,6 +24,10 @@ interface AppStoreState {
   health: HealthStatus | null;
   homeActivePanel: 'home' | 'settings';
   homeRecents: HomeRecentTask[] | null;
+  /** Per-project task cache. Source of truth for `homeRecents`; updated whenever
+   *  any project's tasks are (re)loaded. Lets the home view paint instantly
+   *  from cache while a background refresh reconciles. */
+  taskCacheByProject: Record<string, TaskWithWorkspace[]>;
   _version: number;
 }
 
@@ -39,7 +43,23 @@ interface AppStoreActions {
   navigateToProject: (path: string, project: Project, options?: { direction?: ViewTransitionDirection }) => void;
   navigateHome: (options?: { direction?: ViewTransitionDirection }) => void;
   loadHomeRecents: () => Promise<void>;
+  /** Update one project's slice of the task cache; re-derives `homeRecents`. */
+  updateProjectTaskCache: (projectPath: string, tasks: TaskWithWorkspace[]) => void;
   resetProjectState: () => void;
+}
+
+function deriveHomeRecents(projects: Project[], cache: Record<string, TaskWithWorkspace[]>): HomeRecentTask[] {
+  const projectByPath = new Map(projects.map((p) => [p.path, p]));
+  const all: HomeRecentTask[] = [];
+  for (const [path, tasks] of Object.entries(cache)) {
+    const project = projectByPath.get(path);
+    if (!project) continue;
+    for (const t of tasks) all.push({ ...t, project });
+  }
+  return all
+    .filter((t) => t.status !== 'done')
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+    .slice(0, MAX_HOME_RECENTS);
 }
 
 type AppStore = AppStoreState & AppStoreActions;
@@ -59,6 +79,7 @@ export const useAppStore = create<AppStore>()((set, get) => ({
   health: null,
   homeActivePanel: 'home',
   homeRecents: null,
+  taskCacheByProject: {},
   _version: 0,
 
   setProjects: (projects) => set({ projects }),
@@ -111,20 +132,22 @@ export const useAppStore = create<AppStore>()((set, get) => ({
 
   loadHomeRecents: async () => {
     const projects = get().projects;
-    const arrays = await Promise.all(
+    const results = await Promise.all(
       projects.map((project) =>
         window.api.task
           .getAll(project.path)
-          .then((tasks) => tasks.map((t) => ({ ...t, project })))
-          .catch(() => [] as HomeRecentTask[]),
+          .then((tasks) => ({ path: project.path, tasks }))
+          .catch(() => ({ path: project.path, tasks: [] as TaskWithWorkspace[] })),
       ),
     );
-    const recents = arrays
-      .flat()
-      .filter((t) => t.status !== 'done')
-      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
-      .slice(0, MAX_HOME_RECENTS);
-    set({ homeRecents: recents });
+    const cache: Record<string, TaskWithWorkspace[]> = { ...get().taskCacheByProject };
+    for (const { path, tasks } of results) cache[path] = tasks;
+    set({ taskCacheByProject: cache, homeRecents: deriveHomeRecents(get().projects, cache) });
+  },
+
+  updateProjectTaskCache: (projectPath, tasks) => {
+    const cache = { ...get().taskCacheByProject, [projectPath]: tasks };
+    set({ taskCacheByProject: cache, homeRecents: deriveHomeRecents(get().projects, cache) });
   },
 
   resetProjectState: () => {

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type { TaskWithWorkspace, Script, ScriptHook, HookType } from '../types';
 import type { RunHookResult } from '../components/dialogs/RunHookDialog';
+import { useAppStore } from './appStore';
 
 export type TerminalLayout = 'stack' | 'canvas';
 
@@ -259,6 +260,7 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
       const tasks = await window.api.task.getAll(projectPath);
       if (get()._version !== version) return;
       set({ tasks });
+      useAppStore.getState().updateProjectTaskCache(projectPath, tasks);
     } catch (err) {
       if (get()._version !== version) return;
       get().addToast(`Failed to load tasks: ${err instanceof Error ? err.message : String(err)}`, 'error');


### PR DESCRIPTION
## Summary
- Sidebar home click awaited a fan-out task fetch across all projects before triggering the view transition, so the click felt dead until IPC returned. Move that fetch off the click path and keep the recents cache warm in the background.
- `appStore` now owns `taskCacheByProject` as the source of truth for `homeRecents`, re-derived whenever any project's slice updates.
- `projectStore.loadTasks` writes through to that cache, so kanban mutations keep the home view in sync without a separate fetch.
- `handleHomeSelect` no longer awaits — it navigates immediately and refreshes in the background. App init pre-warms the cache regardless of which view is restored.