### PR TITLE
Confirm closing other terminals when closing a task

### DIFF
--- a/src/__tests__/findOtherTaskTerminals.test.ts
+++ b/src/__tests__/findOtherTaskTerminals.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect } from 'vitest';
+import { findOtherTaskTerminals } from '../components/terminal/findOtherTaskTerminals';
+import type { TerminalDisplayState } from '../stores/terminalStore';
+
+const PROJECT = '/path/to/project';
+const OTHER_PROJECT = '/path/to/other';
+
+function makeDisplay(ptyId: string, patch: Partial<TerminalDisplayState>): TerminalDisplayState {
+  return {
+    ptyId,
+    label: '',
+    summary: '',
+    summaryType: 'ready',
+    gitFileStatus: null,
+    lastOscTitle: '',
+    tags: [],
+    hookStatus: null,
+    runnerStatus: 'idle',
+    runnerScriptName: null,
+    runnerPanelOpen: false,
+    runnerFullWidth: true,
+    diffPanelOpen: false,
+    diffPanelSelectedFile: null,
+    diffPanelMode: 'uncommitted',
+    planPath: null,
+    planPanelOpen: false,
+    planFullWidth: true,
+    webPreviewUrl: null,
+    webPreviewPanelOpen: false,
+    webPreviewFullWidth: true,
+    sandboxed: false,
+    taskId: null,
+    worktreeBranch: null,
+    projectPath: PROJECT,
+    exited: false,
+    isLoading: false,
+    ...patch,
+  } as TerminalDisplayState;
+}
+
+describe('findOtherTaskTerminals', () => {
+  test('returns siblings on the same task, excluding self', () => {
+    const displayStates = {
+      a: makeDisplay('a', { taskId: 1 }),
+      b: makeDisplay('b', { taskId: 1 }),
+      c: makeDisplay('c', { taskId: 1 }),
+    };
+    const terminalsByProject = { [PROJECT]: ['a', 'b', 'c'] };
+
+    expect(findOtherTaskTerminals(terminalsByProject, displayStates, PROJECT, 1, 'b')).toEqual(['a', 'c']);
+  });
+
+  test('skips terminals attached to other tasks', () => {
+    const displayStates = {
+      a: makeDisplay('a', { taskId: 1 }),
+      b: makeDisplay('b', { taskId: 2 }),
+      c: makeDisplay('c', { taskId: 1 }),
+    };
+    const terminalsByProject = { [PROJECT]: ['a', 'b', 'c'] };
+
+    expect(findOtherTaskTerminals(terminalsByProject, displayStates, PROJECT, 1, 'a')).toEqual(['c']);
+  });
+
+  test('skips loading placeholders', () => {
+    const displayStates = {
+      a: makeDisplay('a', { taskId: 1 }),
+      b: makeDisplay('b', { taskId: 1, isLoading: true }),
+    };
+    const terminalsByProject = { [PROJECT]: ['a', 'b'] };
+
+    expect(findOtherTaskTerminals(terminalsByProject, displayStates, PROJECT, 1, 'a')).toEqual([]);
+  });
+
+  test('skips terminals without a taskId', () => {
+    const displayStates = {
+      a: makeDisplay('a', { taskId: 1 }),
+      b: makeDisplay('b', { taskId: null }),
+    };
+    const terminalsByProject = { [PROJECT]: ['a', 'b'] };
+
+    expect(findOtherTaskTerminals(terminalsByProject, displayStates, PROJECT, 1, 'a')).toEqual([]);
+  });
+
+  test('ignores terminals from other projects', () => {
+    const displayStates = {
+      a: makeDisplay('a', { taskId: 1 }),
+      x: makeDisplay('x', { taskId: 1, projectPath: OTHER_PROJECT }),
+    };
+    const terminalsByProject = { [PROJECT]: ['a'], [OTHER_PROJECT]: ['x'] };
+
+    expect(findOtherTaskTerminals(terminalsByProject, displayStates, PROJECT, 1, 'a')).toEqual([]);
+  });
+
+  test('returns empty when project has no terminals', () => {
+    expect(findOtherTaskTerminals({}, {}, PROJECT, 1, 'a')).toEqual([]);
+  });
+
+  test('tolerates missing displayState entries', () => {
+    const terminalsByProject = { [PROJECT]: ['ghost', 'a'] };
+    const displayStates = { a: makeDisplay('a', { taskId: 1 }) };
+
+    expect(findOtherTaskTerminals(terminalsByProject, displayStates, PROJECT, 1, 'a')).toEqual([]);
+  });
+});

--- a/src/components/dialogs/CloseTaskDialog.tsx
+++ b/src/components/dialogs/CloseTaskDialog.tsx
@@ -1,0 +1,61 @@
+import { useState, useEffect, useCallback } from 'react';
+import { DialogOverlay } from './DialogOverlay';
+
+interface CloseTaskDialogProps {
+  taskName: string;
+  otherTerminalCount: number;
+  onClose: (action: 'close-all' | 'just-this' | null) => void;
+}
+
+export function CloseTaskDialog({ taskName, otherTerminalCount, onClose }: CloseTaskDialogProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    requestAnimationFrame(() => setVisible(true));
+  }, []);
+
+  const dismiss = useCallback(
+    (action: 'close-all' | 'just-this' | null) => {
+      setVisible(false);
+      setTimeout(() => onClose(action), 200);
+    },
+    [onClose],
+  );
+
+  const plural = otherTerminalCount === 1 ? 'terminal' : 'terminals';
+
+  return (
+    <DialogOverlay visible={visible} onDismiss={() => dismiss(null)} maxWidth={340}>
+      <h2 data-testid="dialog-title" className="text-lg font-semibold text-text-primary mb-4 text-center">
+        Close Task
+      </h2>
+      <p className="text-sm text-text-secondary text-center">
+        &ldquo;<strong className="text-text-primary">{taskName}</strong>&rdquo; has {otherTerminalCount} other open{' '}
+        {plural}. Close {otherTerminalCount === 1 ? 'it' : 'them'} too?
+      </p>
+      <div className="flex gap-2 justify-end mt-4 items-center">
+        <button
+          data-testid="dialog-cancel"
+          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-text-secondary bg-transparent hover:bg-white/[0.06] whitespace-nowrap"
+          onClick={() => dismiss(null)}
+        >
+          Cancel
+        </button>
+        <button
+          data-testid="dialog-just-this"
+          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-accent bg-accent-light hover:bg-[rgba(0,122,255,0.15)] whitespace-nowrap"
+          onClick={() => dismiss('just-this')}
+        >
+          Keep Others
+        </button>
+        <button
+          data-testid="dialog-close-all"
+          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98] whitespace-nowrap"
+          onClick={() => dismiss('close-all')}
+        >
+          Close All
+        </button>
+      </div>
+    </DialogOverlay>
+  );
+}

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -3,7 +3,7 @@ import { useTerminalStore } from '../../stores/terminalStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useUIStore } from '../../stores/uiStore';
 import { terminalInstances } from './terminalReact';
-import { addProjectTerminal } from './terminalActions';
+import { addProjectTerminal, closeProjectTerminal } from './terminalActions';
 
 const EMPTY_TAGS: string[] = [];
 import type { GitFileStatus, RunnerScript } from '../../types';
@@ -12,6 +12,7 @@ import { StatusDot } from './StatusDot';
 import { TagInput } from './TagInput';
 import { ContextMenu, type ContextMenuEntry } from '../ui/ContextMenu';
 import { HookConfigDialog } from '../dialogs/HookConfigDialog';
+import { CloseTaskDialog } from '../dialogs/CloseTaskDialog';
 import { RunScriptDropdown } from '../scripts/RunScriptDropdown';
 
 const isMac = navigator.platform.toLowerCase().includes('mac');
@@ -63,6 +64,7 @@ export const TerminalHeader = memo(function TerminalHeader({
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [editorHookDialog, setEditorHookDialog] = useState(false);
   const [runHookDialog, setRunHookDialog] = useState<{ killExistingOnRun?: boolean } | null>(null);
+  const [closeTaskDialog, setCloseTaskDialog] = useState<{ otherPtyIds: string[]; taskName: string } | null>(null);
   const [renaming, setRenaming] = useState(false);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const chevronRef = useRef<HTMLButtonElement>(null);
@@ -191,6 +193,21 @@ export const TerminalHeader = memo(function TerminalHeader({
         label: 'Close Task',
         icon: 'archive',
         onClick: async () => {
+          const store = useTerminalStore.getState();
+          const projectPtyIds = store.terminalsByProject[projectPath] ?? [];
+          const otherPtyIds = projectPtyIds.filter((id) => {
+            if (id === ptyId) return false;
+            const d = store.displayStates[id];
+            return d?.taskId === taskId && !d.isLoading;
+          });
+
+          if (otherPtyIds.length > 0) {
+            const taskName =
+              useProjectStore.getState().tasks.find((t) => t.taskNumber === taskId)?.name ?? `Task #${taskId}`;
+            setCloseTaskDialog({ otherPtyIds, taskName });
+            return;
+          }
+
           await window.api.task.setStatus(projectPath, taskId!, 'done');
           onClose();
           useProjectStore.getState().invalidateTaskList();
@@ -205,6 +222,7 @@ export const TerminalHeader = memo(function TerminalHeader({
     instance,
     projectPath,
     taskId,
+    ptyId,
     sandboxAvailable,
     hasEditorHook,
     onClose,
@@ -358,6 +376,24 @@ export const TerminalHeader = memo(function TerminalHeader({
               setHasRunHook(true);
               onToggleRunner?.();
             }
+          }}
+        />
+      )}
+      {closeTaskDialog && (
+        <CloseTaskDialog
+          taskName={closeTaskDialog.taskName}
+          otherTerminalCount={closeTaskDialog.otherPtyIds.length}
+          onClose={async (action) => {
+            const otherPtyIds = closeTaskDialog.otherPtyIds;
+            setCloseTaskDialog(null);
+            if (action == null) return;
+            await window.api.task.setStatus(projectPath, taskId!, 'done');
+            if (action === 'close-all') {
+              for (const id of otherPtyIds) closeProjectTerminal(id);
+            }
+            onClose();
+            useProjectStore.getState().invalidateTaskList();
+            useProjectStore.getState().addToast('Task closed', 'success');
           }}
         />
       )}

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -4,6 +4,7 @@ import { useProjectStore } from '../../stores/projectStore';
 import { useUIStore } from '../../stores/uiStore';
 import { terminalInstances } from './terminalReact';
 import { addProjectTerminal, closeProjectTerminal } from './terminalActions';
+import { findOtherTaskTerminals } from './findOtherTaskTerminals';
 
 const EMPTY_TAGS: string[] = [];
 import type { GitFileStatus, RunnerScript } from '../../types';
@@ -194,12 +195,13 @@ export const TerminalHeader = memo(function TerminalHeader({
         icon: 'archive',
         onClick: async () => {
           const store = useTerminalStore.getState();
-          const projectPtyIds = store.terminalsByProject[projectPath] ?? [];
-          const otherPtyIds = projectPtyIds.filter((id) => {
-            if (id === ptyId) return false;
-            const d = store.displayStates[id];
-            return d?.taskId === taskId && !d.isLoading;
-          });
+          const otherPtyIds = findOtherTaskTerminals(
+            store.terminalsByProject,
+            store.displayStates,
+            projectPath,
+            taskId!,
+            ptyId,
+          );
 
           if (otherPtyIds.length > 0) {
             const taskName =

--- a/src/components/terminal/findOtherTaskTerminals.ts
+++ b/src/components/terminal/findOtherTaskTerminals.ts
@@ -1,0 +1,21 @@
+import type { TerminalDisplayState } from '../../stores/terminalStore';
+
+/**
+ * Returns ptyIds of terminals connected to `taskId` in `projectPath`,
+ * excluding `excludePtyId` and any terminals still loading. Pure over
+ * the passed snapshots so it's easy to unit-test.
+ */
+export function findOtherTaskTerminals(
+  terminalsByProject: Record<string, string[]>,
+  displayStates: Record<string, TerminalDisplayState>,
+  projectPath: string,
+  taskId: number,
+  excludePtyId: string,
+): string[] {
+  const projectPtyIds = terminalsByProject[projectPath] ?? [];
+  return projectPtyIds.filter((id) => {
+    if (id === excludePtyId) return false;
+    const d = displayStates[id];
+    return d != null && d.taskId === taskId && !d.isLoading;
+  });
+}


### PR DESCRIPTION
## Summary

- Closing a task from a terminal's context menu now prompts when other terminals are connected to the same task, with options: Cancel / Keep Others / Close All
- New `CloseTaskDialog` component (compact, three-button confirmation)
- Extracted pure `findOtherTaskTerminals` helper with unit tests