### PR TITLE
Add per-project worktree creation mode

### DIFF
--- a/src/__tests__/worktreeMode.test.ts
+++ b/src/__tests__/worktreeMode.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { createTask, setGlobalSetting } from '../db';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execSync: vi.fn(),
+    exec: vi.fn((_cmd: string, _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+      cb(null, { stdout: 'main\n', stderr: '' });
+    }),
+    execFile: vi.fn(
+      (
+        _file: string,
+        args: string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        if (Array.isArray(args) && args.includes('--verify')) {
+          cb(new Error('not found'), '', '');
+        } else {
+          cb(null, '', '');
+        }
+      },
+    ),
+  };
+});
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    mkdir: vi.fn(async () => undefined),
+    access: vi.fn(async () => {
+      throw new Error('ENOENT');
+    }),
+    cp: vi.fn(async () => undefined),
+    rm: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock('koffi', () => ({
+  default: { load: vi.fn() },
+}));
+
+import { createTaskWorktree, recoverTaskWorktree } from '../worktree';
+import { beginTask } from '../taskLifecycle';
+import { exec as execMockedRaw } from 'node:child_process';
+
+const execMocked = vi.mocked(execMockedRaw);
+
+function findLsFilesCall(): unknown[] | undefined {
+  return execMocked.mock.calls.find(
+    (call) => typeof call[0] === 'string' && (call[0] as string).includes('git ls-files'),
+  ) as unknown[] | undefined;
+}
+
+async function setMode(project: string, mode: 'quick-start' | 'clean-checkout'): Promise<void> {
+  await setGlobalSetting(`worktree:${project}`, JSON.stringify({ mode }));
+}
+
+beforeEach(() => {
+  execMocked.mockClear();
+});
+
+describe('createTaskWorktree worktree-mode gating', () => {
+  test('skips git ls-files when project mode is clean-checkout', async () => {
+    const project = '/test/wt-mode-create-clean';
+    await setMode(project, 'clean-checkout');
+
+    const result = await createTaskWorktree(project, 'Clean task', undefined, undefined, false);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeUndefined();
+  });
+
+  test('runs git ls-files when project mode is quick-start (explicit)', async () => {
+    const project = '/test/wt-mode-create-quick';
+    await setMode(project, 'quick-start');
+
+    const result = await createTaskWorktree(project, 'Quick task', undefined, undefined, false);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeDefined();
+  });
+
+  test('runs git ls-files by default when no mode is set', async () => {
+    const project = '/test/wt-mode-create-default';
+
+    const result = await createTaskWorktree(project, 'Default task', undefined, undefined, false);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeDefined();
+  });
+
+  test('falls back to copy when stored mode JSON is malformed', async () => {
+    const project = '/test/wt-mode-create-garbage';
+    await setGlobalSetting(`worktree:${project}`, '{not valid json');
+
+    const result = await createTaskWorktree(project, 'Garbage task', undefined, undefined, false);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeDefined();
+  });
+});
+
+describe('beginTask / startTask worktree-mode gating', () => {
+  test('skips copy when project mode is clean-checkout', async () => {
+    const project = '/test/wt-mode-begin-clean';
+    await setMode(project, 'clean-checkout');
+    await createTask(project, 1, 'Clean todo', { status: 'todo' });
+
+    const result = await beginTask(project, 1);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeUndefined();
+  });
+
+  test('runs copy when project mode is quick-start', async () => {
+    const project = '/test/wt-mode-begin-quick';
+    await setMode(project, 'quick-start');
+    await createTask(project, 1, 'Quick todo', { status: 'todo' });
+
+    const result = await beginTask(project, 1);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeDefined();
+  });
+});
+
+describe('recoverTaskWorktree worktree-mode gating', () => {
+  test('skips copy when project mode is clean-checkout', async () => {
+    const project = '/test/wt-mode-recover-clean';
+    await setMode(project, 'clean-checkout');
+    await createTask(project, 3, 'Clean recovery', {
+      branch: 'feat/clean-recover',
+      status: 'in_progress',
+      worktreePath: '/old/path',
+    });
+
+    const result = await recoverTaskWorktree(project, 3);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeUndefined();
+  });
+
+  test('runs copy by default', async () => {
+    const project = '/test/wt-mode-recover-default';
+    await createTask(project, 3, 'Default recovery', {
+      branch: 'feat/default-recover',
+      status: 'in_progress',
+      worktreePath: '/old/path',
+    });
+
+    const result = await recoverTaskWorktree(project, 3);
+    expect(result.success).toBe(true);
+    expect(findLsFilesCall()).toBeDefined();
+  });
+});

--- a/src/components/scripts/ProjectSettingsPanel.tsx
+++ b/src/components/scripts/ProjectSettingsPanel.tsx
@@ -6,6 +6,8 @@ import { HookList } from './HookList';
 import type { HookEntry } from './HookList';
 import { SandboxSection } from './SandboxSection';
 import { ExperimentalFeaturesSection } from './ExperimentalFeaturesSection';
+import { WorktreeSection } from './WorktreeSection';
+import { useWorktreeSettingsStore } from '../../stores/worktreeSettingsStore';
 
 const LIFECYCLE_HOOKS: HookEntry[] = [
   { type: 'start', label: 'Start', description: 'Runs when a task moves to In Progress' },
@@ -29,6 +31,7 @@ export function ProjectSettingsPanel({ projectPath }: ProjectSettingsPanelProps)
 
   useEffect(() => {
     useProjectStore.getState().loadScripts(projectPath);
+    void useWorktreeSettingsStore.getState().loadFor(projectPath);
   }, [projectPath]);
 
   // Escape key returns to terminals
@@ -57,6 +60,11 @@ export function ProjectSettingsPanel({ projectPath }: ProjectSettingsPanelProps)
           <h1 className="text-base font-semibold text-text-primary">Project Settings</h1>
         </div>
         <div className="px-6 pt-4 pb-16 min-w-full max-w-2xl space-y-8">
+          <section>
+            <h2 className="text-sm font-semibold text-text-primary mb-2">Worktree</h2>
+            <p className="text-xs text-text-tertiary mb-4">How task worktrees are created from this project.</p>
+            <WorktreeSection projectPath={projectPath} />
+          </section>
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-2">Lifecycle Hooks</h2>
             <p className="text-xs text-text-tertiary mb-4">

--- a/src/components/scripts/ProjectSettingsPanel.tsx
+++ b/src/components/scripts/ProjectSettingsPanel.tsx
@@ -62,7 +62,10 @@ export function ProjectSettingsPanel({ projectPath }: ProjectSettingsPanelProps)
         <div className="px-6 pt-4 pb-16 min-w-full max-w-2xl space-y-8">
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-2">Worktree</h2>
-            <p className="text-xs text-text-tertiary mb-4">How task worktrees are created from this project.</p>
+            <p className="text-xs text-text-tertiary mb-4">
+              How task worktrees are created from this project. Sandboxed tasks always use a clean checkout for safety.
+              Configure the Lima VM under Sandbox to provision what they need.
+            </p>
             <WorktreeSection projectPath={projectPath} />
           </section>
           <section>

--- a/src/components/scripts/WorktreeSection.tsx
+++ b/src/components/scripts/WorktreeSection.tsx
@@ -20,7 +20,8 @@ const MODE_OPTIONS: ModeOption[] = [
   {
     value: 'clean-checkout',
     label: 'Clean checkout',
-    description: 'Just `git worktree add` — only tracked files. Configure your setup using the Start hook below.',
+    description:
+      'Just `git worktree add`. Only tracked files appear in the worktree. Configure your setup using the Start hook below.',
   },
 ];
 

--- a/src/components/scripts/WorktreeSection.tsx
+++ b/src/components/scripts/WorktreeSection.tsx
@@ -1,0 +1,80 @@
+import { useWorktreeSettingsStore, type WorktreeMode } from '../../stores/worktreeSettingsStore';
+
+interface WorktreeSectionProps {
+  projectPath: string;
+}
+
+interface ModeOption {
+  value: WorktreeMode;
+  label: string;
+  description: string;
+}
+
+const MODE_OPTIONS: ModeOption[] = [
+  {
+    value: 'quick-start',
+    label: 'Quick start',
+    description:
+      'Instant, ready-to-go worktree. Gitignored files (deps, configs, secrets) are copied via Copy-on-Write. Less control over what ends up in the worktree.',
+  },
+  {
+    value: 'clean-checkout',
+    label: 'Clean checkout',
+    description: 'Just `git worktree add` — only tracked files. Configure your setup using the Start hook below.',
+  },
+];
+
+export function WorktreeSection({ projectPath }: WorktreeSectionProps) {
+  const selected = useWorktreeSettingsStore((s) => s.settingsByProject[projectPath]?.mode) ?? 'quick-start';
+
+  const handleSelect = (mode: WorktreeMode) => {
+    if (mode === selected) return;
+    void useWorktreeSettingsStore.getState().setMode(projectPath, mode);
+  };
+
+  return (
+    <div className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden divide-y divide-white/[0.06] bg-[var(--color-terminal-bg,#171717)]">
+      {MODE_OPTIONS.map((option) => (
+        <ModeRow
+          key={option.value}
+          label={option.label}
+          description={option.description}
+          checked={selected === option.value}
+          onSelect={() => handleSelect(option.value)}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface ModeRowProps {
+  label: string;
+  description: string;
+  checked: boolean;
+  onSelect: () => void;
+}
+
+function ModeRow({ label, description, checked, onSelect }: ModeRowProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={checked}
+      onClick={onSelect}
+      className="w-full flex items-center gap-4 px-4 py-3 text-left hover:bg-white/[0.02] focus:outline-none focus-visible:bg-white/[0.03]"
+    >
+      <span
+        aria-hidden="true"
+        className={`relative inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors duration-150 ${
+          checked ? 'border-blue-500 bg-blue-500' : 'border-white/30 bg-transparent'
+        }`}
+      >
+        {checked && <span className="h-1.5 w-1.5 rounded-full bg-white" />}
+      </span>
+      <span className="flex-1 min-w-0">
+        <span className="block text-sm text-text-primary">{label}</span>
+        <span className="block text-xs text-text-tertiary mt-0.5">{description}</span>
+      </span>
+    </button>
+  );
+}

--- a/src/ipc/handlers/settings.ts
+++ b/src/ipc/handlers/settings.ts
@@ -11,7 +11,8 @@ function isAllowedKey(key: string): boolean {
     key.startsWith('experimental:') ||
     key.startsWith('terminal:') ||
     key.startsWith('lastSession:') ||
-    key.startsWith('ui:')
+    key.startsWith('ui:') ||
+    key.startsWith('worktree:')
   );
 }
 

--- a/src/stores/worktreeSettingsStore.ts
+++ b/src/stores/worktreeSettingsStore.ts
@@ -1,0 +1,76 @@
+import { create } from 'zustand';
+import log from 'electron-log/renderer';
+
+const worktreeSettingsLog = log.scope('worktreeSettings');
+
+export type WorktreeMode = 'quick-start' | 'clean-checkout';
+
+export const DEFAULT_MODE: WorktreeMode = 'quick-start';
+
+interface WorktreeSettings {
+  mode: WorktreeMode;
+}
+
+const DEFAULT_SETTINGS: WorktreeSettings = {
+  mode: DEFAULT_MODE,
+};
+
+interface WorktreeSettingsStoreState {
+  settingsByProject: Record<string, WorktreeSettings>;
+}
+
+interface WorktreeSettingsStoreActions {
+  loadFor: (projectPath: string) => Promise<void>;
+  setMode: (projectPath: string, mode: WorktreeMode) => Promise<void>;
+  getMode: (projectPath: string) => WorktreeMode;
+}
+
+type WorktreeSettingsStore = WorktreeSettingsStoreState & WorktreeSettingsStoreActions;
+
+function storageKey(projectPath: string): string {
+  return 'worktree:' + projectPath;
+}
+
+function isWorktreeMode(value: unknown): value is WorktreeMode {
+  return value === 'quick-start' || value === 'clean-checkout';
+}
+
+export const useWorktreeSettingsStore = create<WorktreeSettingsStore>()((set, get) => ({
+  settingsByProject: {},
+
+  getMode: (projectPath) => get().settingsByProject[projectPath]?.mode ?? DEFAULT_MODE,
+
+  loadFor: async (projectPath) => {
+    try {
+      const json = await window.api.globalSettings.get(storageKey(projectPath));
+      const parsed = json ? (JSON.parse(json) as { mode?: unknown }) : {};
+      const mode = isWorktreeMode(parsed.mode) ? parsed.mode : DEFAULT_MODE;
+      set((s) => ({
+        settingsByProject: { ...s.settingsByProject, [projectPath]: { mode } },
+      }));
+    } catch (error) {
+      worktreeSettingsLog.error('failed to load settings', {
+        projectPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      set((s) => ({
+        settingsByProject: { ...s.settingsByProject, [projectPath]: { ...DEFAULT_SETTINGS } },
+      }));
+    }
+  },
+
+  setMode: async (projectPath, mode) => {
+    set((s) => ({
+      settingsByProject: { ...s.settingsByProject, [projectPath]: { mode } },
+    }));
+    try {
+      await window.api.globalSettings.set(storageKey(projectPath), JSON.stringify({ mode }));
+    } catch (error) {
+      worktreeSettingsLog.error('failed to persist mode', {
+        projectPath,
+        mode,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  },
+}));

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -19,6 +19,7 @@ import {
   setTaskBranch,
   setTaskWorktreePath,
   setTaskMergeTarget,
+  getGlobalSetting,
   type TaskMetadata,
 } from './db';
 import { mergeWorktreeBranch } from './git';
@@ -152,6 +153,21 @@ async function runWithConcurrency<T>(items: T[], limit: number, worker: (item: T
   };
   for (let i = 0; i < Math.min(limit, items.length); i++) runners.push(runOne());
   await Promise.all(runners);
+}
+
+/**
+ * Read the per-project worktree mode. Defaults to quick-start (copy ignored files)
+ * to preserve the current behavior when the user hasn't picked a mode.
+ */
+async function shouldCopyIgnoredFiles(projectPath: string): Promise<boolean> {
+  try {
+    const json = await getGlobalSetting(`worktree:${projectPath}`);
+    if (!json) return true;
+    const parsed = JSON.parse(json) as { mode?: string };
+    return parsed.mode !== 'clean-checkout';
+  } catch {
+    return true;
+  }
 }
 
 async function copyGitIgnoredFiles(
@@ -386,7 +402,8 @@ export async function startTask(
       () => true,
       () => false,
     );
-    const ignoredFilesPromise = sandboxed ? Promise.resolve<string[]>([]) : fetchIgnoredFiles(projectPath);
+    const copyIgnored = !sandboxed && (await shouldCopyIgnoredFiles(projectPath));
+    const ignoredFilesPromise = copyIgnored ? fetchIgnoredFiles(projectPath) : Promise.resolve<string[]>([]);
 
     // Probe for an available worktree path. Needs the base dir created first.
     await mkdirPromise;
@@ -434,9 +451,11 @@ export async function startTask(
     await Promise.all(dbWrites);
     t.mark('dbWrites');
 
-    if (!sandboxed) {
+    if (copyIgnored) {
       const ignoredFiles = await ignoredFilesPromise;
       await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
+    } else if (!sandboxed) {
+      worktreeLog.info('clean checkout mode — skipping ignored file copy', { projectPath, taskNumber });
     }
     t.mark('copyIgnored');
 
@@ -515,11 +534,13 @@ export async function createTaskWorktree(
       ? ['worktree', 'add', worktreePath, branch]
       : ['worktree', 'add', '-b', branch, worktreePath];
 
+    const copyIgnored = !sandboxed && (await shouldCopyIgnoredFiles(projectPath));
+
     // Start ls-files in parallel with git worktree add
     // ls-files reads from source dir, doesn't need the worktree to exist
     const [, ignoredFiles] = await Promise.all([
       execFileAsync('git', wtAddArgs, { cwd: projectPath }),
-      sandboxed ? Promise.resolve<string[]>([]) : fetchIgnoredFiles(projectPath),
+      copyIgnored ? fetchIgnoredFiles(projectPath) : Promise.resolve<string[]>([]),
     ]);
 
     const task = await createTask(projectPath, currentTaskNumber, displayName, {
@@ -530,8 +551,13 @@ export async function createTaskWorktree(
       sandboxed,
     });
 
-    if (!sandboxed) {
+    if (copyIgnored) {
       await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
+    } else if (!sandboxed) {
+      worktreeLog.info('clean checkout mode — skipping ignored file copy', {
+        projectPath,
+        taskNumber: currentTaskNumber,
+      });
     }
 
     return {
@@ -747,17 +773,21 @@ export async function recoverTaskWorktree(projectPath: string, taskNumber: numbe
       worktreePath = path.join(baseDir, `T-${dirNum}`);
     }
 
+    const copyIgnored = !task.sandboxed && (await shouldCopyIgnoredFiles(projectPath));
+
     // Re-create worktree from the existing branch (no -b flag)
     const [, ignoredFiles] = await Promise.all([
       execAsync(`git worktree add ${shellEscape(worktreePath)} ${shellEscape(task.branch)}`, { cwd: projectPath }),
-      task.sandboxed ? Promise.resolve<string[]>([]) : fetchIgnoredFiles(projectPath),
+      copyIgnored ? fetchIgnoredFiles(projectPath) : Promise.resolve<string[]>([]),
     ]);
 
     // Update metadata with new path
     await setTaskWorktreePath(projectPath, taskNumber, worktreePath);
 
-    if (!task.sandboxed) {
+    if (copyIgnored) {
       await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
+    } else if (!task.sandboxed) {
+      worktreeLog.info('clean checkout mode — skipping ignored file copy', { projectPath, taskNumber });
     }
 
     worktreeLog.info('recovered', { taskNumber, worktreePath });

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -455,7 +455,7 @@ export async function startTask(
       const ignoredFiles = await ignoredFilesPromise;
       await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
     } else if (!sandboxed) {
-      worktreeLog.info('clean checkout mode — skipping ignored file copy', { projectPath, taskNumber });
+      worktreeLog.info('clean checkout mode, skipping ignored file copy', { projectPath, taskNumber });
     }
     t.mark('copyIgnored');
 
@@ -554,7 +554,7 @@ export async function createTaskWorktree(
     if (copyIgnored) {
       await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
     } else if (!sandboxed) {
-      worktreeLog.info('clean checkout mode — skipping ignored file copy', {
+      worktreeLog.info('clean checkout mode, skipping ignored file copy', {
         projectPath,
         taskNumber: currentTaskNumber,
       });
@@ -787,7 +787,7 @@ export async function recoverTaskWorktree(projectPath: string, taskNumber: numbe
     if (copyIgnored) {
       await copyGitIgnoredFiles(projectPath, worktreePath, ignoredFiles);
     } else if (!task.sandboxed) {
-      worktreeLog.info('clean checkout mode — skipping ignored file copy', { projectPath, taskNumber });
+      worktreeLog.info('clean checkout mode, skipping ignored file copy', { projectPath, taskNumber });
     }
 
     worktreeLog.info('recovered', { taskNumber, worktreePath });


### PR DESCRIPTION
## Summary

- Adds a Worktree section at the top of Project Settings letting users pick between Quick start (current behavior: `git worktree add` plus CoW-copy of gitignored files) and Clean checkout (just `git worktree add`, configure setup via the Start hook).
- Reads the per-project mode in the main process so `createTaskWorktree`, `beginTask`/`startTask`, and `recoverTaskWorktree` all respect it without IPC plumbing changes.
- Sandboxed tasks always use a clean checkout for safety; the section subtitle points users at Lima provisioning under Sandbox for in-VM setup.
- Defaults to Quick start when no setting is stored, so existing projects see no behavior change.
- New unit tests in `worktreeMode.test.ts` mirror the sandbox test pattern and pin the gating across all three creation paths plus malformed-JSON fallback.