### PR TITLE
Decouple website build from root node_modules

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,3 @@
-@import 'tailwindcss';
 @font-face {
   font-family: 'Iosevka Extended';
   font-style: normal;

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,4 +1,4 @@
-import './index.css';
+import './tailwind.css';
 import '@xterm/xterm/css/xterm.css';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,0 +1,10 @@
+/*
+ * App entry CSS. Imports Tailwind followed by the shared design tokens.
+ *
+ * The marketing site (website/) also imports index.css, but does its own
+ * `@import 'tailwindcss'` from website/node_modules so the website build
+ * doesn't depend on root node_modules. Keeping the tailwindcss import here
+ * (instead of inside index.css) is what enables that split.
+ */
+@import 'tailwindcss';
+@import './index.css';


### PR DESCRIPTION
## Summary
- Move `@import 'tailwindcss';` out of `src/index.css` into a new `src/tailwind.css` wrapper that `src/renderer.tsx` imports.
- The website's `global.css` imports `src/index.css` via a relative path; previously that file's `tailwindcss` import forced the deploy workflow to install root dependencies so Tailwind could resolve from `/root/node_modules`.
- With the import lifted to a separate app entry, `src/index.css` contains only relative paths and the website builds with only `website/node_modules`.