### PR TITLE
Add website transitive deps for CI build

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,11 +9,14 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/react": "^4.4.0",
+        "@phosphor-icons/core": "^2.1.1",
         "@tailwindcss/vite": "^4.1.18",
         "astro": "^5.16.6",
+        "electron-log": "^5.4.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "tailwindcss": "^4.1.18"
+        "tailwindcss": "^4.1.18",
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@types/react": "^19.0.0",
@@ -1328,6 +1331,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
+    },
+    "node_modules/@phosphor-icons/core": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/core/-/core-2.1.1.tgz",
+      "integrity": "sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==",
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2953,6 +2962,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.3.tgz",
+      "integrity": "sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6616,6 +6634,35 @@
       "peerDependencies": {
         "typescript": "^4.9.4 || ^5.0.2",
         "zod": "^3"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/website/package.json
+++ b/website/package.json
@@ -10,11 +10,14 @@
   },
   "dependencies": {
     "@astrojs/react": "^4.4.0",
+    "@phosphor-icons/core": "^2.1.1",
     "@tailwindcss/vite": "^4.1.18",
     "astro": "^5.16.6",
+    "electron-log": "^5.4.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "tailwindcss": "^4.1.18"
+    "tailwindcss": "^4.1.18",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",


### PR DESCRIPTION
## Summary
- Add `zustand`, `@phosphor-icons/core`, and `electron-log` to `website/package.json` (versions matching root) so Rollup can resolve modules transitively imported via `@app/*`.
- Verified with a clean `npm install` + `npm run build` in `website/`.