### PR TITLE
Copy shared UI into website

### DIFF
--- a/src/stores/terminalDisplay.ts
+++ b/src/stores/terminalDisplay.ts
@@ -1,0 +1,62 @@
+import type { GitFileStatus } from '../types';
+
+/** Renderable state pushed from OuijitTerminal class to React */
+export interface TerminalDisplayState {
+  ptyId: string;
+  label: string;
+  summary: string;
+  summaryType: 'thinking' | 'ready';
+  gitFileStatus: GitFileStatus | null;
+  lastOscTitle: string;
+  tags: string[];
+  hookStatus: 'thinking' | 'ready' | null;
+  runnerStatus: 'running' | 'success' | 'error' | 'idle';
+  runnerScriptName: string | null;
+  runnerPanelOpen: boolean;
+  runnerFullWidth: boolean;
+  diffPanelOpen: boolean;
+  diffPanelSelectedFile: string | null;
+  diffPanelMode: 'uncommitted' | 'worktree';
+  planPath: string | null;
+  planPanelOpen: boolean;
+  planFullWidth: boolean;
+  webPreviewUrl: string | null;
+  webPreviewPanelOpen: boolean;
+  webPreviewFullWidth: boolean;
+  sandboxed: boolean;
+  taskId: number | null;
+  worktreeBranch: string | null;
+  projectPath: string;
+  exited: boolean;
+  /** Placeholder slot for an in-flight task start. Card renders the loading
+   *  body; the slot will be rekey'd + flag cleared when the real PTY spawns. */
+  isLoading: boolean;
+}
+
+export const DEFAULT_DISPLAY_STATE: Omit<TerminalDisplayState, 'ptyId' | 'projectPath'> = {
+  label: '',
+  summary: '',
+  summaryType: 'ready',
+  gitFileStatus: null,
+  lastOscTitle: '',
+  tags: [],
+  hookStatus: null,
+  runnerStatus: 'idle',
+  runnerScriptName: null,
+  runnerPanelOpen: false,
+  runnerFullWidth: true,
+  diffPanelOpen: false,
+  diffPanelSelectedFile: null,
+  diffPanelMode: 'uncommitted',
+  planPath: null,
+  planPanelOpen: false,
+  planFullWidth: true,
+  webPreviewUrl: null,
+  webPreviewPanelOpen: false,
+  webPreviewFullWidth: true,
+  sandboxed: false,
+  taskId: null,
+  worktreeBranch: null,
+  exited: false,
+  isLoading: false,
+};

--- a/src/stores/terminalStore.ts
+++ b/src/stores/terminalStore.ts
@@ -1,66 +1,7 @@
 import { create } from 'zustand';
-import type { GitFileStatus } from '../types';
+import { DEFAULT_DISPLAY_STATE, type TerminalDisplayState } from './terminalDisplay';
 
-/** Renderable state pushed from OuijitTerminal class to React */
-export interface TerminalDisplayState {
-  ptyId: string;
-  label: string;
-  summary: string;
-  summaryType: 'thinking' | 'ready';
-  gitFileStatus: GitFileStatus | null;
-  lastOscTitle: string;
-  tags: string[];
-  hookStatus: 'thinking' | 'ready' | null;
-  runnerStatus: 'running' | 'success' | 'error' | 'idle';
-  runnerScriptName: string | null;
-  runnerPanelOpen: boolean;
-  runnerFullWidth: boolean;
-  diffPanelOpen: boolean;
-  diffPanelSelectedFile: string | null;
-  diffPanelMode: 'uncommitted' | 'worktree';
-  planPath: string | null;
-  planPanelOpen: boolean;
-  planFullWidth: boolean;
-  webPreviewUrl: string | null;
-  webPreviewPanelOpen: boolean;
-  webPreviewFullWidth: boolean;
-  sandboxed: boolean;
-  taskId: number | null;
-  worktreeBranch: string | null;
-  projectPath: string;
-  exited: boolean;
-  /** Placeholder slot for an in-flight task start. Card renders the loading
-   *  body; the slot will be rekey'd + flag cleared when the real PTY spawns. */
-  isLoading: boolean;
-}
-
-export const DEFAULT_DISPLAY_STATE: Omit<TerminalDisplayState, 'ptyId' | 'projectPath'> = {
-  label: '',
-  summary: '',
-  summaryType: 'ready',
-  gitFileStatus: null,
-  lastOscTitle: '',
-  tags: [],
-  hookStatus: null,
-  runnerStatus: 'idle',
-  runnerScriptName: null,
-  runnerPanelOpen: false,
-  runnerFullWidth: true,
-  diffPanelOpen: false,
-  diffPanelSelectedFile: null,
-  diffPanelMode: 'uncommitted',
-  planPath: null,
-  planPanelOpen: false,
-  planFullWidth: true,
-  webPreviewUrl: null,
-  webPreviewPanelOpen: false,
-  webPreviewFullWidth: true,
-  sandboxed: false,
-  taskId: null,
-  worktreeBranch: null,
-  exited: false,
-  isLoading: false,
-};
+export { DEFAULT_DISPLAY_STATE, type TerminalDisplayState } from './terminalDisplay';
 
 export const STACK_PAGE_SIZE = 5;
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -8,15 +8,6 @@ export default defineConfig({
   integrations: [react()],
   vite: {
     plugins: [tailwindcss()],
-    resolve: {
-      alias: {
-        '@app': new URL('../src', import.meta.url).pathname,
-      },
-      // Without dedupe, files imported via @app/* resolve react from the
-      // root node_modules while website-local files use website/node_modules,
-      // pulling two React copies into the bundle and breaking context.
-      dedupe: ['react', 'react-dom'],
-    },
   },
   build: {
     format: 'directory',

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,11 +12,9 @@
         "@phosphor-icons/core": "^2.1.1",
         "@tailwindcss/vite": "^4.1.18",
         "astro": "^5.16.6",
-        "electron-log": "^5.4.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "tailwindcss": "^4.1.18",
-        "zustand": "^5.0.11"
+        "tailwindcss": "^4.1.18"
       },
       "devDependencies": {
         "@types/react": "^19.0.0",
@@ -2962,15 +2960,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/electron-log": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.3.tgz",
-      "integrity": "sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6634,35 +6623,6 @@
       "peerDependencies": {
         "typescript": "^4.9.4 || ^5.0.2",
         "zod": "^3"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
-      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
       }
     },
     "node_modules/zwitch": {

--- a/website/package.json
+++ b/website/package.json
@@ -13,11 +13,9 @@
     "@phosphor-icons/core": "^2.1.1",
     "@tailwindcss/vite": "^4.1.18",
     "astro": "^5.16.6",
-    "electron-log": "^5.4.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "tailwindcss": "^4.1.18",
-    "zustand": "^5.0.11"
+    "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/website/src/components/demo/AgentStatesDemo.tsx
+++ b/website/src/components/demo/AgentStatesDemo.tsx
@@ -1,4 +1,4 @@
-import { TerminalHeaderView, TerminalHeaderName } from '@app/components/terminal/TerminalHeaderView';
+import { TerminalHeaderView, TerminalHeaderName } from '../../ouijit-ui/components/terminal/TerminalHeaderView';
 
 interface State {
   summaryType: 'thinking' | 'ready';

--- a/website/src/components/demo/AutomationDemo.tsx
+++ b/website/src/components/demo/AutomationDemo.tsx
@@ -1,5 +1,5 @@
-import { HookRowView } from '@app/components/scripts/HookRowView';
-import { ScriptRowView } from '@app/components/scripts/ScriptRowView';
+import { HookRowView } from '../../ouijit-ui/components/scripts/HookRowView';
+import { ScriptRowView } from '../../ouijit-ui/components/scripts/ScriptRowView';
 
 const HOOKS: { label: string; description: string; command?: string }[] = [
   {

--- a/website/src/components/demo/BoardDemo.tsx
+++ b/website/src/components/demo/BoardDemo.tsx
@@ -1,7 +1,7 @@
-import { KanbanColumnView } from '@app/components/kanban/KanbanColumnView';
-import { KanbanCardView } from '@app/components/kanban/KanbanCardView';
-import { KanbanBadgeView } from '@app/components/kanban/KanbanBadgeView';
-import { isChainMember } from '@app/utils/taskChain';
+import { KanbanColumnView } from '../../ouijit-ui/components/kanban/KanbanColumnView';
+import { KanbanCardView } from '../../ouijit-ui/components/kanban/KanbanCardView';
+import { KanbanBadgeView } from '../../ouijit-ui/components/kanban/KanbanBadgeView';
+import { isChainMember } from '../../ouijit-ui/utils/taskChain';
 import { demoTasks, demoTerminalsByTask, demoChainMap } from './fixtures';
 
 /**

--- a/website/src/components/demo/MockPanels.tsx
+++ b/website/src/components/demo/MockPanels.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react';
-import { Icon } from '@app/components/terminal/Icon';
+import { Icon } from '../../ouijit-ui/components/terminal/Icon';
 
 /* ─── Plan ────────────────────────────────────────────────────────── */
 

--- a/website/src/components/demo/StackDemo.tsx
+++ b/website/src/components/demo/StackDemo.tsx
@@ -1,9 +1,9 @@
-import { TerminalCardView } from '@app/components/terminal/TerminalCardView';
+import { TerminalCardView } from '../../ouijit-ui/components/terminal/TerminalCardView';
 import {
   TerminalHeaderView,
   TerminalHeaderName,
   TerminalHeaderTags,
-} from '@app/components/terminal/TerminalHeaderView';
+} from '../../ouijit-ui/components/terminal/TerminalHeaderView';
 
 /**
  * Composed stack of terminal cards demonstrating the active card + back cards.

--- a/website/src/components/demo/WorkspaceScene.tsx
+++ b/website/src/components/demo/WorkspaceScene.tsx
@@ -1,17 +1,17 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import type { TaskStatus, TaskWithWorkspace } from '@app/types';
-import { KanbanColumnView } from '@app/components/kanban/KanbanColumnView';
-import { KanbanCardView } from '@app/components/kanban/KanbanCardView';
-import { KanbanAddInput } from '@app/components/kanban/KanbanAddInput';
-import { TerminalCardView } from '@app/components/terminal/TerminalCardView';
+import type { TaskStatus, TaskWithWorkspace } from '../../ouijit-ui/types';
+import { KanbanColumnView } from '../../ouijit-ui/components/kanban/KanbanColumnView';
+import { KanbanCardView } from '../../ouijit-ui/components/kanban/KanbanCardView';
+import { KanbanAddInput } from '../../ouijit-ui/components/kanban/KanbanAddInput';
+import { TerminalCardView } from '../../ouijit-ui/components/terminal/TerminalCardView';
 import {
   TerminalHeaderView,
   TerminalHeaderName,
   TerminalHeaderTags,
-} from '@app/components/terminal/TerminalHeaderView';
-import { Icon } from '@app/components/terminal/Icon';
-import type { TerminalDisplayState } from '@app/stores/terminalStore';
-import { DEFAULT_DISPLAY_STATE } from '@app/stores/terminalStore';
+} from '../../ouijit-ui/components/terminal/TerminalHeaderView';
+import { Icon } from '../../ouijit-ui/components/terminal/Icon';
+import type { TerminalDisplayState } from '../../ouijit-ui/terminalDisplay';
+import { DEFAULT_DISPLAY_STATE } from '../../ouijit-ui/terminalDisplay';
 import {
   featuresTasks,
   featuresTerminalsByTask,

--- a/website/src/components/demo/featuresFixtures.ts
+++ b/website/src/components/demo/featuresFixtures.ts
@@ -1,8 +1,8 @@
-import type { TaskWithWorkspace } from '@app/types';
-import type { TerminalDisplayState } from '@app/stores/terminalStore';
-import { DEFAULT_DISPLAY_STATE } from '@app/stores/terminalStore';
-import type { TaskChainInfo } from '@app/utils/taskChain';
-import { buildChainMap } from '@app/utils/taskChain';
+import type { TaskWithWorkspace } from '../../ouijit-ui/types';
+import type { TerminalDisplayState } from '../../ouijit-ui/terminalDisplay';
+import { DEFAULT_DISPLAY_STATE } from '../../ouijit-ui/terminalDisplay';
+import type { TaskChainInfo } from '../../ouijit-ui/utils/taskChain';
+import { buildChainMap } from '../../ouijit-ui/utils/taskChain';
 
 const PROJECT_PATH = '/demo/horizon';
 

--- a/website/src/components/demo/fixtures.ts
+++ b/website/src/components/demo/fixtures.ts
@@ -1,8 +1,8 @@
-import type { TaskWithWorkspace } from '@app/types';
-import type { TerminalDisplayState } from '@app/stores/terminalStore';
-import { DEFAULT_DISPLAY_STATE } from '@app/stores/terminalStore';
-import type { TaskChainInfo } from '@app/utils/taskChain';
-import { buildChainMap } from '@app/utils/taskChain';
+import type { TaskWithWorkspace } from '../../ouijit-ui/types';
+import type { TerminalDisplayState } from '../../ouijit-ui/terminalDisplay';
+import { DEFAULT_DISPLAY_STATE } from '../../ouijit-ui/terminalDisplay';
+import type { TaskChainInfo } from '../../ouijit-ui/utils/taskChain';
+import { buildChainMap } from '../../ouijit-ui/utils/taskChain';
 
 const PROJECT_PATH = '/demo/horizon';
 

--- a/website/src/ouijit-ui/components/kanban/KanbanAddInput.tsx
+++ b/website/src/ouijit-ui/components/kanban/KanbanAddInput.tsx
@@ -1,0 +1,46 @@
+import { useState, useRef, useCallback } from 'react';
+
+interface KanbanAddInputProps {
+  onAdd: (name: string) => void;
+}
+
+export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
+  const [value, setValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const name = value.trim();
+        if (name) {
+          onAdd(name);
+          setValue('');
+        }
+      } else if (e.key === 'Escape') {
+        setValue('');
+        inputRef.current?.blur();
+      }
+    },
+    [value, onAdd],
+  );
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      className="kanban-add-input w-full font-mono text-sm font-medium text-text-primary bg-transparent px-3 py-3.5 outline-none transition-all duration-150 ease-out border-none focus:bg-white/[0.04]"
+      style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
+      placeholder="New task..."
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onKeyDown={handleKeyDown}
+    />
+  );
+}
+
+/** Focus the kanban add input programmatically */
+export function focusKanbanAddInput(): void {
+  const input = document.querySelector('.kanban-add-input') as HTMLInputElement;
+  input?.focus();
+}

--- a/website/src/ouijit-ui/components/kanban/KanbanBadgeView.tsx
+++ b/website/src/ouijit-ui/components/kanban/KanbanBadgeView.tsx
@@ -1,0 +1,62 @@
+import type { CSSProperties, ReactNode } from 'react';
+import type { TaskChainInfo } from '../../utils/taskChain';
+import { getChainBgColor, getChainColor, isChainMember } from '../../utils/taskChain';
+import { Icon } from '../terminal/Icon';
+
+export interface KanbanBadgeViewProps {
+  taskNumber: number;
+  chainInfo?: TaskChainInfo;
+  /** Visual emphasis for drag/detach states. The wrapper sets these. */
+  isDragging?: boolean;
+  isDimmed?: boolean;
+  shouldJitter?: boolean;
+  /** Slot for the wrapper to inject the dnd-kit drag handle ref + listeners. */
+  dragHandleProps?: Record<string, unknown>;
+  /** Detach button rendered to the right when this task has a parent. */
+  detachButton?: ReactNode;
+}
+
+/**
+ * Pure visual badge for a task. Renders the rounded-pill chip with the
+ * chain-derived color and the optional git-merge glyph for nested tasks.
+ *
+ * The smart DraggableBadge (in KanbanCard.tsx) wraps this with useDraggable,
+ * Tooltip, and the detach affordance. The marketing site uses this directly.
+ */
+export function KanbanBadgeView({
+  taskNumber,
+  chainInfo,
+  isDragging = false,
+  isDimmed = false,
+  shouldJitter = false,
+  dragHandleProps,
+  detachButton,
+}: KanbanBadgeViewProps) {
+  const isInChain = isChainMember(chainInfo);
+  const color =
+    isInChain && chainInfo ? getChainColor(chainInfo.rootTaskNumber, chainInfo.depth) : 'rgba(255, 255, 255, 0.2)';
+  const background =
+    isInChain && chainInfo ? getChainBgColor(chainInfo.rootTaskNumber, chainInfo.depth) : 'rgba(255, 255, 255, 0.04)';
+
+  const style: CSSProperties = {
+    color,
+    background,
+    ...(shouldJitter && { animation: 'chain-badge-jitter 0.4s ease-out forwards' }),
+    ...(isDragging && { opacity: 0.3 }),
+    ...(isDimmed && { opacity: 0.4 }),
+  };
+
+  return (
+    <span
+      className="group/badge inline-flex items-center gap-0.5 shrink-0 font-mono text-[11px] leading-none px-2 py-1 rounded-full whitespace-nowrap"
+      style={style}
+    >
+      <span {...dragHandleProps} className="inline-flex items-center gap-0.5">
+        {chainInfo && chainInfo.depth > 0 && <Icon name="git-merge" className="w-3 h-3" />}
+        <span className="opacity-50">#</span>
+        {taskNumber}
+      </span>
+      {detachButton}
+    </span>
+  );
+}

--- a/website/src/ouijit-ui/components/kanban/KanbanCardView.tsx
+++ b/website/src/ouijit-ui/components/kanban/KanbanCardView.tsx
@@ -1,0 +1,321 @@
+import { memo, useCallback, useEffect, useRef, useState, type MouseEvent, type ReactNode } from 'react';
+import type { TaskWithWorkspace } from '../../types';
+import type { TerminalDisplayState } from '../../terminalDisplay';
+import { Icon } from '../terminal/Icon';
+import { StatusDot } from '../terminal/StatusDot';
+
+const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
+
+export interface KanbanCardViewProps {
+  task: TaskWithWorkspace;
+  connectedDisplays?: TerminalDisplayState[];
+  isSettingUp?: boolean;
+  isSelected?: boolean;
+  isHoveredBadgeTarget?: boolean;
+  isValidBadgeTarget?: boolean;
+  isInvalidBadgeTarget?: boolean;
+  showBadge?: boolean;
+  badge?: ReactNode;
+  formattedDate?: string;
+  onSelect?: (taskNumber: number, event: MouseEvent) => void;
+  onPlainClick?: () => void;
+  onContextMenu?: (event: MouseEvent) => void;
+  onUpdateDescription?: (taskNumber: number, description: string) => void;
+  onSwitchToTerminal?: (ptyId: string) => void;
+  onTerminalContextMenu?: (ptyId: string, event: MouseEvent) => void;
+
+  /** Controlled — when true, the View renders the name as an editable textarea. */
+  isRenamingTask?: boolean;
+  /** Called when the user double-clicks the name to enter rename mode. */
+  onStartRenameTask?: () => void;
+  /** Called on Enter or blur with a non-empty value different from the current name. */
+  onCommitRenameTask?: (taskNumber: number, newName: string) => void;
+  /** Called on Escape, or when blur produces no committable value. The wrapper
+   *  is expected to clear `isRenamingTask` in response. */
+  onCancelRenameTask?: () => void;
+
+  /** Controlled — ptyId currently being renamed inline. View renders an input when set. */
+  renamingTerminalId?: string | null;
+  initialRenamingLabel?: string;
+  /** Called on Enter or blur with a non-empty value. */
+  onCommitRenameTerminal?: (ptyId: string, label: string) => void;
+  /** Called on Escape, or when blur produces no committable value. The wrapper
+   *  is expected to clear `renamingTerminalId` in response. */
+  onCancelRenameTerminal?: (ptyId: string) => void;
+}
+
+/**
+ * Pure presentational kanban card. Owns local UI state (expanded, editing,
+ * description edit, terminal rename input). No store reads, no dnd, no
+ * window.api, no context menus or dialogs — those are rendered as siblings
+ * by the smart KanbanCard wrapper.
+ */
+export const KanbanCardView = memo(function KanbanCardView({
+  task,
+  connectedDisplays = [],
+  isSettingUp = false,
+  isSelected = false,
+  isHoveredBadgeTarget = false,
+  isValidBadgeTarget = false,
+  isInvalidBadgeTarget = false,
+  showBadge = false,
+  badge,
+  formattedDate,
+  onSelect,
+  onPlainClick,
+  onContextMenu,
+  onUpdateDescription,
+  onSwitchToTerminal,
+  onTerminalContextMenu,
+  isRenamingTask = false,
+  onStartRenameTask,
+  onCommitRenameTask,
+  onCancelRenameTask,
+  renamingTerminalId,
+  initialRenamingLabel,
+  onCommitRenameTerminal,
+  onCancelRenameTerminal,
+}: KanbanCardViewProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [editingDesc, setEditingDesc] = useState(false);
+  const nameInputRef = useRef<HTMLTextAreaElement>(null);
+  const descInputRef = useRef<HTMLSpanElement>(null);
+  const terminalRenameRef = useRef<HTMLInputElement>(null);
+
+  const isDone = task.status === 'done';
+
+  useEffect(() => {
+    if (isRenamingTask && nameInputRef.current) {
+      nameInputRef.current.value = task.name;
+      nameInputRef.current.focus();
+      nameInputRef.current.select();
+      nameInputRef.current.style.height = 'auto';
+      nameInputRef.current.style.height = `${nameInputRef.current.scrollHeight}px`;
+    }
+  }, [isRenamingTask, task.name]);
+
+  const commitRename = useCallback(() => {
+    if (!nameInputRef.current) {
+      onCancelRenameTask?.();
+      return;
+    }
+    const newName = nameInputRef.current.value.trim();
+    if (newName && newName !== task.name) {
+      onCommitRenameTask?.(task.taskNumber, newName);
+    } else {
+      onCancelRenameTask?.();
+    }
+  }, [task.taskNumber, task.name, onCommitRenameTask, onCancelRenameTask]);
+
+  const handleNameKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        commitRename();
+      } else if (e.key === 'Escape') {
+        onCancelRenameTask?.();
+      }
+    },
+    [commitRename, onCancelRenameTask],
+  );
+
+  const commitDescription = useCallback(() => {
+    if (!descInputRef.current) return;
+    const desc = descInputRef.current.textContent?.trim() || '';
+    onUpdateDescription?.(task.taskNumber, desc);
+    setEditingDesc(false);
+  }, [task.taskNumber, onUpdateDescription]);
+
+  const commitTerminalRename = useCallback(() => {
+    if (!renamingTerminalId) return;
+    const value = terminalRenameRef.current?.value.trim();
+    if (value) {
+      onCommitRenameTerminal?.(renamingTerminalId, value);
+    } else {
+      // Empty/whitespace value on blur — cancel so the wrapper closes the input.
+      // Without this, an empty blur leaves the rename UI stuck open.
+      onCancelRenameTerminal?.(renamingTerminalId);
+    }
+  }, [renamingTerminalId, onCommitRenameTerminal, onCancelRenameTerminal]);
+
+  useEffect(() => {
+    if (renamingTerminalId && terminalRenameRef.current) {
+      terminalRenameRef.current.value = initialRenamingLabel ?? '';
+      terminalRenameRef.current.focus();
+      terminalRenameRef.current.select();
+    }
+  }, [renamingTerminalId, initialRenamingLabel]);
+
+  return (
+    <div
+      className="kanban-card group px-3 py-3.5 ease-out [-webkit-app-region:no-drag] hover:bg-black/10 active:bg-black/[0.12]"
+      style={{
+        background: isSelected
+          ? 'rgba(10, 132, 255, 0.06)'
+          : isHoveredBadgeTarget
+            ? 'rgba(10, 132, 255, 0.08)'
+            : expanded
+              ? 'rgba(0, 0, 0, 0.15)'
+              : 'var(--color-terminal-bg)',
+        transition:
+          'background 150ms ease-out, opacity 150ms ease-out, outline-color 150ms ease-out, box-shadow 150ms ease-out',
+        borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
+        outline: isHoveredBadgeTarget
+          ? '1px solid rgba(10, 132, 255, 0.6)'
+          : isValidBadgeTarget
+            ? '1px dashed rgba(10, 132, 255, 0.3)'
+            : 'none',
+        outlineOffset: -1,
+        ...(isInvalidBadgeTarget && { opacity: 0.4 }),
+        ...(isSelected && { boxShadow: 'inset 2px 0 0 0 #0A84FF' }),
+      }}
+      data-task-number={task.taskNumber}
+      onMouseDown={(e) => {
+        if (e.shiftKey) e.preventDefault();
+      }}
+      onClick={(e) => {
+        if (e.detail >= 2) return;
+        const mod = isMac ? e.metaKey : e.ctrlKey;
+        if (mod || e.shiftKey) {
+          e.stopPropagation();
+          onSelect?.(task.taskNumber, e);
+        } else {
+          onPlainClick?.();
+        }
+      }}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onContextMenu?.(e);
+      }}
+    >
+      <div className="flex items-start gap-2">
+        {isSettingUp && (
+          <span
+            className="w-2 h-2 rounded-full bg-transparent border-[1.5px] border-white/30 border-t-white/80 shrink-0 mt-[5px]"
+            style={{ animation: 'loading-dot-spin 0.8s linear infinite' }}
+          />
+        )}
+        {isRenamingTask ? (
+          <textarea
+            ref={nameInputRef}
+            className="flex-1 font-mono text-sm font-medium text-text-primary bg-transparent border-0 border-b border-accent p-0 outline-none min-w-0 resize-none overflow-hidden [-webkit-app-region:no-drag] break-words"
+            onBlur={commitRename}
+            onKeyDown={handleNameKeyDown}
+            rows={1}
+          />
+        ) : (
+          <span
+            className={`kanban-card-name flex-1 font-mono text-sm font-medium min-w-0 break-words ${isDone ? 'line-through text-text-secondary' : 'text-text-primary'}`}
+            onDoubleClick={onStartRenameTask}
+          >
+            {task.name}
+          </span>
+        )}
+        <button
+          className={`flex items-center justify-center w-5 h-5 p-0 bg-transparent border-none rounded text-text-secondary opacity-0 transition-all duration-150 ease-out shrink-0 [-webkit-app-region:no-drag] group-hover:opacity-60 hover:!opacity-100 [&>svg]:w-3 [&>svg]:h-3 [&>svg]:transition-transform [&>svg]:duration-150 [&>svg]:ease-out${expanded ? ' [&>svg]:rotate-180' : ''}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded(!expanded);
+          }}
+        >
+          <Icon name="caret-down" />
+        </button>
+      </div>
+      {showBadge && badge && <div className="mt-1">{badge}</div>}
+
+      {isSettingUp && <div className="font-mono text-xs text-white/40 mt-1">Setting up workspace{'…'}</div>}
+
+      {connectedDisplays.length > 0 && (
+        <div className="flex flex-col" style={{ paddingTop: 3 }}>
+          {connectedDisplays.map((display, i) => {
+            const isLast = i === connectedDisplays.length - 1;
+            const isRenaming = renamingTerminalId === display.ptyId;
+            const dotLabel = display.lastOscTitle || display.label || 'Shell';
+            const truncated = dotLabel.length > 35 ? dotLabel.slice(0, 35) + '…' : dotLabel;
+
+            return (
+              <div
+                key={display.ptyId}
+                className="flex flex-row items-center gap-1.5 hover:bg-white/[0.06] active:bg-white/[0.03]"
+                style={{ padding: '3px 2px', borderRadius: 3, transition: 'background 0.1s ease' }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSwitchToTerminal?.(display.ptyId);
+                }}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onTerminalContextMenu?.(display.ptyId, e);
+                }}
+              >
+                <span className="font-mono text-sm leading-none text-text-secondary shrink-0 select-none opacity-40">
+                  {isLast ? '└─' : '├─'}
+                </span>
+                <StatusDot summaryType={display.summaryType} sandboxed={display.sandboxed} />
+                {isRenaming ? (
+                  <input
+                    ref={terminalRenameRef}
+                    className="font-mono text-[10px] leading-tight text-text-secondary bg-transparent border-0 border-b border-accent p-0 outline-none min-w-0 [-webkit-app-region:no-drag]"
+                    onClick={(e) => e.stopPropagation()}
+                    onBlur={commitTerminalRename}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') commitTerminalRename();
+                      if (e.key === 'Escape' && renamingTerminalId) onCancelRenameTerminal?.(renamingTerminalId);
+                    }}
+                  />
+                ) : (
+                  <span className="font-mono text-[10px] leading-tight text-text-secondary truncate min-w-0">
+                    {truncated}
+                    {display.sandboxed ? ' (sandbox)' : ''}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {expanded && (
+        <div className="grid mt-2 pt-2 border-t border-white/[0.04] gap-2">
+          <div className="flex flex-col gap-1 text-sm">
+            <span
+              ref={descInputRef}
+              className={`text-text-secondary cursor-text break-words${editingDesc ? ' outline-none' : ' line-clamp-3'}${!task.prompt && !editingDesc ? ' text-text-tertiary italic transition-colors duration-150 ease-out hover:text-text-secondary' : ''}`}
+              style={editingDesc ? { whiteSpace: 'pre-wrap', wordWrap: 'break-word', lineHeight: 1.5 } : undefined}
+              contentEditable={editingDesc}
+              suppressContentEditableWarning
+              onClick={() => {
+                if (!editingDesc) {
+                  setEditingDesc(true);
+                  requestAnimationFrame(() => {
+                    if (descInputRef.current && !task.prompt) {
+                      descInputRef.current.textContent = '';
+                    }
+                    descInputRef.current?.focus();
+                  });
+                }
+              }}
+              onBlur={commitDescription}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  commitDescription();
+                }
+              }}
+            >
+              {task.prompt || (editingDesc ? '' : 'Add description…')}
+            </span>
+          </div>
+          {task.branch && (
+            <div className="flex items-center gap-1 font-mono text-[13px] text-white/50 min-w-0 overflow-hidden [&>svg]:w-3 [&>svg]:h-3 [&>svg]:shrink-0">
+              <Icon name="git-branch" />
+              <span className="truncate min-w-0">{task.branch}</span>
+            </div>
+          )}
+          {formattedDate && <div className="flex flex-col gap-1 text-sm">Created {formattedDate}</div>}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/website/src/ouijit-ui/components/kanban/KanbanColumnView.tsx
+++ b/website/src/ouijit-ui/components/kanban/KanbanColumnView.tsx
@@ -1,0 +1,73 @@
+import type { MouseEvent, ReactNode, Ref } from 'react';
+import type { HookType } from '../../types';
+import { Icon } from '../terminal/Icon';
+
+export interface KanbanColumnViewProps {
+  status: string;
+  label: string;
+  count: number;
+  hookTypes?: HookType[];
+  hasConfiguredHook?: boolean;
+  onConfigureHook?: (hookTypes: HookType[]) => void;
+  isOver?: boolean;
+  bodyRef?: Ref<HTMLDivElement>;
+  onBodyClick?: (e: MouseEvent<HTMLDivElement>) => void;
+  children?: ReactNode;
+}
+
+/**
+ * Pure presentational kanban column. No store reads, no dnd hooks.
+ *
+ * Used by the smart KanbanColumn wrapper (which attaches dnd-kit via bodyRef)
+ * and by the marketing site (which omits bodyRef and renders static cards).
+ */
+export function KanbanColumnView({
+  status,
+  label,
+  count,
+  hookTypes = [],
+  hasConfiguredHook = false,
+  onConfigureHook,
+  isOver = false,
+  bodyRef,
+  onBodyClick,
+  children,
+}: KanbanColumnViewProps) {
+  return (
+    <div
+      className="kanban-column flex flex-col transition-all duration-150 ease-out shrink-0 last:border-r-0"
+      style={{ minWidth: 240, flex: '1 0 240px', borderRight: '1px solid rgba(255, 255, 255, 0.06)' }}
+      data-status={status}
+    >
+      <div className="flex items-center gap-2 px-3 py-2.5 shrink-0 h-[46px]">
+        <span className="text-[13px] font-medium text-text-secondary tracking-wide flex-1">
+          {label}
+          <span className="kanban-column-count text-text-secondary opacity-50 tracking-normal ml-1.5">{count}</span>
+        </span>
+        {hookTypes.length > 0 && onConfigureHook && (
+          <button
+            className={`flex items-center justify-center border-none text-text-tertiary transition-all duration-150 ease-out rounded-md hover:text-text-secondary hover:bg-white/[0.08] [&>svg]:w-[18px] [&>svg]:h-[18px]${hasConfiguredHook ? ' !text-accent hover:!text-accent-hover' : ''}`}
+            style={{ padding: '4px 10px', background: 'transparent' }}
+            onClick={() => onConfigureHook(hookTypes)}
+          >
+            <Icon name="webhooks-logo" />
+          </button>
+        )}
+      </div>
+      <div
+        ref={bodyRef}
+        className="kanban-column-body flex flex-col overflow-y-auto flex-1 min-h-0"
+        style={{
+          borderTop: '1px solid rgba(255, 255, 255, 0.06)',
+          scrollbarColor: 'transparent transparent',
+          transition: 'background 150ms ease',
+          minHeight: 80,
+          background: isOver ? 'rgba(10, 132, 255, 0.08)' : undefined,
+        }}
+        onClick={onBodyClick}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/website/src/ouijit-ui/components/scripts/HookRowView.tsx
+++ b/website/src/ouijit-ui/components/scripts/HookRowView.tsx
@@ -1,0 +1,37 @@
+import type { MouseEvent } from 'react';
+
+export interface HookRowViewProps {
+  label: string;
+  description: string;
+  /** The current command for this hook, if configured. */
+  command?: string;
+  /** Click handler for the right-side action. */
+  onAction?: (e: MouseEvent) => void;
+  /** Override the action label (defaults to "Edit" when configured, "+ Configure" when not). */
+  actionLabel?: string;
+}
+
+/**
+ * Pure visual row for a single lifecycle hook. Used by HookList (smart wrapper)
+ * and by the marketing site's Automation demo.
+ */
+export function HookRowView({ label, description, command, onAction, actionLabel }: HookRowViewProps) {
+  const buttonLabel = actionLabel ?? (command ? 'Edit' : '+ Configure');
+  return (
+    <div className="group flex items-center gap-3 px-3 py-2 hover:bg-white/[0.04] transition-colors duration-100">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-text-primary">{label}</span>
+          <span className="text-[11px] text-text-tertiary">{description}</span>
+        </div>
+        {command && <div className="font-mono text-[11px] text-text-secondary mt-0.5 truncate">{command}</div>}
+      </div>
+      <button
+        className="shrink-0 px-2 py-1 text-[11px] bg-transparent border-none text-text-tertiary hover:text-text-primary transition-colors duration-150"
+        onClick={onAction}
+      >
+        {buttonLabel}
+      </button>
+    </div>
+  );
+}

--- a/website/src/ouijit-ui/components/scripts/ScriptRowView.tsx
+++ b/website/src/ouijit-ui/components/scripts/ScriptRowView.tsx
@@ -1,0 +1,51 @@
+import type { CSSProperties, MouseEvent, Ref } from 'react';
+import { Icon } from '../terminal/Icon';
+
+export interface ScriptRowViewProps {
+  name: string;
+  command: string;
+  expanded?: boolean;
+  /** Drag handle props (forwarded from useSortable in the wrapper). Omit for marketing. */
+  dragHandleRef?: Ref<HTMLButtonElement>;
+  dragHandleProps?: Record<string, unknown>;
+  containerRef?: Ref<HTMLDivElement>;
+  containerStyle?: CSSProperties;
+  onClick?: (e: MouseEvent) => void;
+}
+
+/**
+ * Pure visual row for a single project script. Used by ScriptList's sortable
+ * wrapper (which fills the dnd handle props) and by the marketing site's
+ * Automation demo (which omits them).
+ */
+export function ScriptRowView({
+  name,
+  command,
+  expanded = false,
+  dragHandleRef,
+  dragHandleProps,
+  containerRef,
+  containerStyle,
+  onClick,
+}: ScriptRowViewProps) {
+  return (
+    <div ref={containerRef} style={containerStyle}>
+      <div
+        className="flex items-center gap-2 px-3 py-2 hover:bg-white/[0.04] transition-colors duration-100"
+        onClick={onClick}
+      >
+        <button
+          ref={dragHandleRef}
+          className="flex items-center justify-center w-5 h-5 text-text-tertiary hover:text-text-secondary shrink-0 touch-none"
+          {...dragHandleProps}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Icon name="dots-six-vertical" className="w-4 h-4" />
+        </button>
+        <span className="text-xs font-medium text-text-primary truncate">{name}</span>
+        <span className="text-[11px] text-text-tertiary truncate ml-auto font-mono">{command}</span>
+        <Icon name={expanded ? 'caret-down' : 'caret-right'} className="w-3 h-3 text-text-tertiary shrink-0" />
+      </div>
+    </div>
+  );
+}

--- a/website/src/ouijit-ui/components/terminal/Icon.tsx
+++ b/website/src/ouijit-ui/components/terminal/Icon.tsx
@@ -1,0 +1,26 @@
+/**
+ * Renders a Phosphor icon as a React-owned <svg> element.
+ * Extracts inner content from the raw SVG string so React owns the
+ * outer <svg> node — no MutationObserver replacement that breaks reconciliation.
+ */
+import { iconMap } from '../../utils/icons';
+
+const SVG_INNER_RE = /<svg[^>]*>([\s\S]*)<\/svg>/;
+const VIEWBOX_RE = /viewBox="([^"]*)"/;
+
+export function Icon({ name, className }: { name: string; className?: string }) {
+  const raw = iconMap[name];
+  if (!raw) return null;
+
+  const inner = SVG_INNER_RE.exec(raw)?.[1] ?? '';
+  const viewBox = VIEWBOX_RE.exec(raw)?.[1] ?? '0 0 256 256';
+
+  return (
+    <svg
+      viewBox={viewBox}
+      fill="currentColor"
+      className={className ? `shrink-0 ${className}` : 'w-4 h-4 shrink-0'}
+      dangerouslySetInnerHTML={{ __html: inner }}
+    />
+  );
+}

--- a/website/src/ouijit-ui/components/terminal/StatusDot.tsx
+++ b/website/src/ouijit-ui/components/terminal/StatusDot.tsx
@@ -1,0 +1,22 @@
+interface StatusDotProps {
+  summaryType: string;
+  sandboxed?: boolean;
+  size?: number;
+}
+
+export function StatusDot({ summaryType, sandboxed = false, size = 6 }: StatusDotProps) {
+  const isThinking = summaryType === 'thinking';
+  return (
+    <span
+      className="rounded-full shrink-0 transition-all duration-200 ease-out"
+      data-status={summaryType}
+      style={{
+        width: size,
+        height: size,
+        background: isThinking ? '#da77f2' : '#4ee82e',
+        ...(isThinking ? { animation: 'terminal-status-pulse 1s ease-in-out infinite' } : {}),
+        ...(sandboxed ? { outline: '1.5px solid rgba(116, 192, 252, 0.6)', outlineOffset: '2px' } : {}),
+      }}
+    />
+  );
+}

--- a/website/src/ouijit-ui/components/terminal/TerminalCardView.tsx
+++ b/website/src/ouijit-ui/components/terminal/TerminalCardView.tsx
@@ -1,0 +1,102 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+interface DepthStyle {
+  translateY: number;
+  scaleX: number;
+  zIndex: number;
+  boxShadow: string;
+}
+
+const DEPTH_STYLES: Record<number, DepthStyle> = {
+  1: {
+    translateY: -24,
+    scaleX: 0.98,
+    zIndex: 9,
+    boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.12)',
+  },
+  2: {
+    translateY: -48,
+    scaleX: 0.96,
+    zIndex: 8,
+    boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.1), 0 1px 4px rgba(0, 0, 0, 0.08)',
+  },
+  3: {
+    translateY: -72,
+    scaleX: 0.94,
+    zIndex: 7,
+    boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.08)',
+  },
+  4: {
+    translateY: -96,
+    scaleX: 0.92,
+    zIndex: 6,
+    boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.06)',
+  },
+};
+
+const ACTIVE_STYLE: CSSProperties = {
+  zIndex: 10,
+  transform: 'translateY(0) scaleX(1)',
+  boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+};
+
+export interface TerminalCardViewProps {
+  isActive?: boolean;
+  /** 0 = active, 1..4 = depth behind the active card */
+  backDepth?: number;
+  /** Adds a small upward lift when hovered behind cards */
+  hoverLift?: number;
+  ptyId?: string;
+  className?: string;
+  onClick?: () => void;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+  children?: ReactNode;
+}
+
+/**
+ * Pure presentational terminal card chrome with the stack depth styling.
+ * Used by the smart TerminalCard wrapper (which mounts xterm and reads stores)
+ * and by the marketing site (which renders demo content as children).
+ */
+export function TerminalCardView({
+  isActive = false,
+  backDepth = 0,
+  hoverLift = 0,
+  ptyId,
+  className,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  children,
+}: TerminalCardViewProps) {
+  const depthBase = !isActive && backDepth > 0 ? DEPTH_STYLES[Math.min(backDepth, 4)] : undefined;
+
+  const style: CSSProperties = {
+    background: 'var(--color-terminal-bg, #171717)',
+    transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+    contain: 'layout style paint',
+    ...(isActive
+      ? ACTIVE_STYLE
+      : depthBase
+        ? {
+            zIndex: depthBase.zIndex,
+            transform: `translateY(${depthBase.translateY - hoverLift}px) scaleX(${depthBase.scaleX})`,
+            boxShadow: depthBase.boxShadow,
+          }
+        : {}),
+  };
+
+  return (
+    <div
+      className={`project-card glass-bevel absolute inset-0 rounded-[14px] border border-black/60 overflow-hidden flex flex-col ${isActive ? 'project-card--active' : 'hover:border-accent'}${className ? ' ' + className : ''}`}
+      style={style}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      data-pty-id={ptyId}
+      onClick={onClick}
+    >
+      {children}
+    </div>
+  );
+}

--- a/website/src/ouijit-ui/components/terminal/TerminalHeaderView.tsx
+++ b/website/src/ouijit-ui/components/terminal/TerminalHeaderView.tsx
@@ -1,0 +1,135 @@
+import { type MouseEvent, type ReactNode, Fragment } from 'react';
+import { Icon } from './Icon';
+import { StatusDot } from './StatusDot';
+
+const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
+
+const METADATA_CHIP =
+  'inline-flex items-center gap-1 font-mono text-[11px] font-medium text-white/55 bg-white/[0.05] rounded-full px-2 py-0.5 shrink-0';
+
+export interface TerminalHeaderViewProps {
+  summaryType: string;
+  sandboxed?: boolean;
+  stackPosition?: number;
+  isActive?: boolean;
+  isBackCard?: boolean;
+  compact?: boolean;
+
+  /** Identity slot (label, summary, optional rename input). Required. */
+  nameContent: ReactNode;
+
+  /** Tag chips. Optional. */
+  tagsContent?: ReactNode;
+
+  /** Branch row content (typically a copy-button). Rendered below the identity row when active. */
+  branchContent?: ReactNode;
+
+  /** Right-side action area (ActionGroup, RunScriptDropdown anchor, etc.). */
+  actions?: ReactNode;
+
+  /** When true, renders a close × button to the right of actions. */
+  showCloseButton?: boolean;
+  onClose?: (e: MouseEvent) => void;
+  onContextMenu?: (e: MouseEvent) => void;
+
+  /** Slot for dialogs and context menus the wrapper renders alongside. Rendered
+   *  outside the header's flex row so it doesn't participate in layout. */
+  overlays?: ReactNode;
+}
+
+/**
+ * Pure presentational terminal header. Used by the smart TerminalHeader
+ * wrapper (which fills slots with editable inputs, action groups, dialogs)
+ * and by the marketing site (which composes nameContent/tagsContent inline
+ * using the helpers below).
+ */
+export function TerminalHeaderView({
+  summaryType,
+  sandboxed = false,
+  stackPosition,
+  isActive = false,
+  isBackCard = false,
+  compact = false,
+  nameContent,
+  tagsContent,
+  branchContent,
+  actions,
+  showCloseButton = false,
+  onClose,
+  onContextMenu,
+  overlays,
+}: TerminalHeaderViewProps) {
+  return (
+    <Fragment>
+      {overlays}
+      <div
+        className={`flex items-center justify-between pl-3 pr-3 ${compact || isBackCard ? 'pt-0.5 pb-1' : 'py-2'} min-h-9`}
+        onContextMenu={onContextMenu}
+      >
+        <div className="flex flex-col min-w-0 shrink gap-0.5">
+          <div className="group/meta flex items-center gap-2 min-w-0">
+            <StatusDot summaryType={summaryType} sandboxed={sandboxed} />
+            {!isActive && stackPosition != null && stackPosition <= 9 && (
+              <kbd className="inline-flex items-center font-mono text-base text-white/40 shrink-0">
+                {isMac ? '⌘' : 'Ctrl+'}
+                <span className="text-xs">{stackPosition}</span>
+              </kbd>
+            )}
+            {nameContent}
+            {tagsContent && <span className="inline-flex items-center gap-1 min-w-0 shrink-0">{tagsContent}</span>}
+          </div>
+          {!compact && isActive && branchContent}
+        </div>
+        <div className="flex items-center gap-2 shrink-0 justify-end">
+          {actions}
+          {showCloseButton && (
+            <button
+              className="w-7 h-7 flex items-center justify-center bg-transparent border-none text-white/40 hover:text-white/90 transition-colors duration-150 ml-1 [&_svg]:w-4 [&_svg]:h-4"
+              onClick={onClose}
+            >
+              <Icon name="x" />
+            </button>
+          )}
+        </div>
+      </div>
+    </Fragment>
+  );
+}
+
+/**
+ * Standard identity content for a terminal header: label, optional summary
+ * (em-dash separated), optional OSC title. Used by the in-app TerminalHeader
+ * (when not renaming) and by marketing demos.
+ */
+export function TerminalHeaderName({
+  label,
+  summary,
+  lastOscTitle,
+}: {
+  label?: string;
+  summary?: string;
+  lastOscTitle?: string;
+}) {
+  return (
+    <Fragment>
+      {label && <span className="font-mono text-xs font-medium text-white/85 shrink-0">{label}</span>}
+      {summary && <span className="font-mono text-xs text-white/45 min-w-0 truncate">— {summary}</span>}
+      {lastOscTitle && (
+        <span className="font-mono text-xs font-medium text-white/40 min-w-0 truncate">{lastOscTitle}</span>
+      )}
+    </Fragment>
+  );
+}
+
+/** Standard pill renderer for a list of tag strings. */
+export function TerminalHeaderTags({ tags }: { tags: string[] }) {
+  return (
+    <Fragment>
+      {tags.map((tag) => (
+        <span key={tag} className={METADATA_CHIP}>
+          {tag}
+        </span>
+      ))}
+    </Fragment>
+  );
+}

--- a/website/src/ouijit-ui/terminalDisplay.ts
+++ b/website/src/ouijit-ui/terminalDisplay.ts
@@ -1,0 +1,62 @@
+import type { GitFileStatus } from './types';
+
+/** Renderable state pushed from OuijitTerminal class to React */
+export interface TerminalDisplayState {
+  ptyId: string;
+  label: string;
+  summary: string;
+  summaryType: 'thinking' | 'ready';
+  gitFileStatus: GitFileStatus | null;
+  lastOscTitle: string;
+  tags: string[];
+  hookStatus: 'thinking' | 'ready' | null;
+  runnerStatus: 'running' | 'success' | 'error' | 'idle';
+  runnerScriptName: string | null;
+  runnerPanelOpen: boolean;
+  runnerFullWidth: boolean;
+  diffPanelOpen: boolean;
+  diffPanelSelectedFile: string | null;
+  diffPanelMode: 'uncommitted' | 'worktree';
+  planPath: string | null;
+  planPanelOpen: boolean;
+  planFullWidth: boolean;
+  webPreviewUrl: string | null;
+  webPreviewPanelOpen: boolean;
+  webPreviewFullWidth: boolean;
+  sandboxed: boolean;
+  taskId: number | null;
+  worktreeBranch: string | null;
+  projectPath: string;
+  exited: boolean;
+  /** Placeholder slot for an in-flight task start. Card renders the loading
+   *  body; the slot will be rekey'd + flag cleared when the real PTY spawns. */
+  isLoading: boolean;
+}
+
+export const DEFAULT_DISPLAY_STATE: Omit<TerminalDisplayState, 'ptyId' | 'projectPath'> = {
+  label: '',
+  summary: '',
+  summaryType: 'ready',
+  gitFileStatus: null,
+  lastOscTitle: '',
+  tags: [],
+  hookStatus: null,
+  runnerStatus: 'idle',
+  runnerScriptName: null,
+  runnerPanelOpen: false,
+  runnerFullWidth: true,
+  diffPanelOpen: false,
+  diffPanelSelectedFile: null,
+  diffPanelMode: 'uncommitted',
+  planPath: null,
+  planPanelOpen: false,
+  planFullWidth: true,
+  webPreviewUrl: null,
+  webPreviewPanelOpen: false,
+  webPreviewFullWidth: true,
+  sandboxed: false,
+  taskId: null,
+  worktreeBranch: null,
+  exited: false,
+  isLoading: false,
+};

--- a/website/src/ouijit-ui/types.ts
+++ b/website/src/ouijit-ui/types.ts
@@ -1,0 +1,35 @@
+export type TaskStatus = 'todo' | 'in_progress' | 'in_review' | 'done';
+
+export type HookType = 'start' | 'continue' | 'run' | 'review' | 'cleanup' | 'editor';
+
+export interface ChangedFile {
+  path: string;
+  status: 'M' | 'A' | 'D' | 'R' | '?';
+  oldPath?: string;
+  additions: number;
+  deletions: number;
+}
+
+export interface GitFileStatus {
+  branch: string;
+  mainBranch: string;
+  commitsAheadOfMain: number;
+  uncommittedFiles: ChangedFile[];
+  branchDiffFiles: ChangedFile[];
+  untrackedFiles: string[];
+}
+
+export interface TaskWithWorkspace {
+  taskNumber: number;
+  name: string;
+  status: TaskStatus;
+  branch?: string;
+  worktreePath?: string;
+  createdAt: string;
+  closedAt?: string;
+  mergeTarget?: string;
+  prompt?: string;
+  sandboxed?: boolean;
+  order?: number;
+  parentTaskNumber?: number;
+}

--- a/website/src/ouijit-ui/utils/icons.ts
+++ b/website/src/ouijit-ui/utils/icons.ts
@@ -1,0 +1,210 @@
+/**
+ * Centralized icon management using Phosphor icons with automatic DOM conversion.
+ *
+ * Usage: Just write `<i data-icon="icon-name"></i>` in HTML and icons are
+ * automatically converted to SVGs when added to the DOM.
+ */
+
+import alignBottom from '@phosphor-icons/core/assets/regular/align-bottom.svg?raw';
+import alignCenterHorizontal from '@phosphor-icons/core/assets/regular/align-center-horizontal.svg?raw';
+import alignCenterVertical from '@phosphor-icons/core/assets/regular/align-center-vertical.svg?raw';
+import alignLeft from '@phosphor-icons/core/assets/regular/align-left.svg?raw';
+import alignRight from '@phosphor-icons/core/assets/regular/align-right.svg?raw';
+import alignTop from '@phosphor-icons/core/assets/regular/align-top.svg?raw';
+import archive from '@phosphor-icons/core/assets/regular/archive.svg?raw';
+import arrowCounterClockwise from '@phosphor-icons/core/assets/regular/arrow-counter-clockwise.svg?raw';
+import arrowLeft from '@phosphor-icons/core/assets/regular/arrow-left.svg?raw';
+import arrowRight from '@phosphor-icons/core/assets/regular/arrow-right.svg?raw';
+import arrowsClockwise from '@phosphor-icons/core/assets/regular/arrows-clockwise.svg?raw';
+import arrowsIn from '@phosphor-icons/core/assets/regular/arrows-in.svg?raw';
+import arrowsOut from '@phosphor-icons/core/assets/regular/arrows-out.svg?raw';
+import arrowsOutLineHorizontal from '@phosphor-icons/core/assets/regular/arrows-out-line-horizontal.svg?raw';
+import arrowsOutLineVertical from '@phosphor-icons/core/assets/regular/arrows-out-line-vertical.svg?raw';
+import bug from '@phosphor-icons/core/assets/regular/bug.svg?raw';
+import caretDown from '@phosphor-icons/core/assets/regular/caret-down.svg?raw';
+import dotsSixVertical from '@phosphor-icons/core/assets/regular/dots-six-vertical.svg?raw';
+import caretLeft from '@phosphor-icons/core/assets/regular/caret-left.svg?raw';
+import caretRight from '@phosphor-icons/core/assets/regular/caret-right.svg?raw';
+import cardsThree from '@phosphor-icons/core/assets/regular/cards-three.svg?raw';
+import check from '@phosphor-icons/core/assets/regular/check.svg?raw';
+import clipboardText from '@phosphor-icons/core/assets/regular/clipboard-text.svg?raw';
+import code from '@phosphor-icons/core/assets/regular/code.svg?raw';
+import copy from '@phosphor-icons/core/assets/regular/copy.svg?raw';
+import cube from '@phosphor-icons/core/assets/regular/cube.svg?raw';
+import download from '@phosphor-icons/core/assets/regular/download.svg?raw';
+import fileDashed from '@phosphor-icons/core/assets/regular/file-dashed.svg?raw';
+import fileMinus from '@phosphor-icons/core/assets/regular/file-minus.svg?raw';
+import filePlus from '@phosphor-icons/core/assets/regular/file-plus.svg?raw';
+import fileText from '@phosphor-icons/core/assets/regular/file-text.svg?raw';
+import folderOpen from '@phosphor-icons/core/assets/regular/folder-open.svg?raw';
+import folderPlus from '@phosphor-icons/core/assets/regular/folder-plus.svg?raw';
+import gear from '@phosphor-icons/core/assets/regular/gear.svg?raw';
+import globeSimple from '@phosphor-icons/core/assets/regular/globe-simple.svg?raw';
+import gitBranch from '@phosphor-icons/core/assets/regular/git-branch.svg?raw';
+import gitFork from '@phosphor-icons/core/assets/regular/git-fork.svg?raw';
+import gridFour from '@phosphor-icons/core/assets/regular/grid-four.svg?raw';
+import gitDiff from '@phosphor-icons/core/assets/regular/git-diff.svg?raw';
+import gitMerge from '@phosphor-icons/core/assets/regular/git-merge.svg?raw';
+import info from '@phosphor-icons/core/assets/regular/info.svg?raw';
+import kanban from '@phosphor-icons/core/assets/regular/kanban.svg?raw';
+import listChecks from '@phosphor-icons/core/assets/regular/list-checks.svg?raw';
+import magnifyingGlass from '@phosphor-icons/core/assets/regular/magnifying-glass.svg?raw';
+import minus from '@phosphor-icons/core/assets/regular/minus.svg?raw';
+import pencilSimple from '@phosphor-icons/core/assets/regular/pencil-simple.svg?raw';
+import play from '@phosphor-icons/core/assets/regular/play.svg?raw';
+import plus from '@phosphor-icons/core/assets/regular/plus.svg?raw';
+import prohibit from '@phosphor-icons/core/assets/regular/prohibit.svg?raw';
+import rocket from '@phosphor-icons/core/assets/regular/rocket.svg?raw';
+import sidebarSimple from '@phosphor-icons/core/assets/regular/sidebar-simple.svg?raw';
+import splitHorizontal from '@phosphor-icons/core/assets/regular/split-horizontal.svg?raw';
+import squareSplitHorizontal from '@phosphor-icons/core/assets/regular/square-split-horizontal.svg?raw';
+import star from '@phosphor-icons/core/assets/regular/star.svg?raw';
+import tag from '@phosphor-icons/core/assets/regular/tag.svg?raw';
+import terminal from '@phosphor-icons/core/assets/regular/terminal.svg?raw';
+import trash from '@phosphor-icons/core/assets/regular/trash.svg?raw';
+import treeStructure from '@phosphor-icons/core/assets/regular/tree-structure.svg?raw';
+import upload from '@phosphor-icons/core/assets/regular/upload.svg?raw';
+import webhooksLogo from '@phosphor-icons/core/assets/regular/webhooks-logo.svg?raw';
+import x from '@phosphor-icons/core/assets/regular/x.svg?raw';
+import log from 'electron-log/renderer';
+
+const iconsLog = log.scope('icons');
+
+// Map of icon names (kebab-case) to SVG strings
+export const iconMap: Record<string, string> = {
+  'align-bottom': alignBottom,
+  'align-center-horizontal': alignCenterHorizontal,
+  'align-center-vertical': alignCenterVertical,
+  'align-left': alignLeft,
+  'align-right': alignRight,
+  'align-top': alignTop,
+  archive: archive,
+  'arrow-counter-clockwise': arrowCounterClockwise,
+  'arrow-left': arrowLeft,
+  'arrow-right': arrowRight,
+  'arrows-clockwise': arrowsClockwise,
+  'arrows-in': arrowsIn,
+  'arrows-out': arrowsOut,
+  'arrows-out-line-horizontal': arrowsOutLineHorizontal,
+  'arrows-out-line-vertical': arrowsOutLineVertical,
+  bug: bug,
+  'caret-down': caretDown,
+  'dots-six-vertical': dotsSixVertical,
+  'caret-left': caretLeft,
+  'caret-right': caretRight,
+  'cards-three': cardsThree,
+  check: check,
+  'clipboard-text': clipboardText,
+  code: code,
+  copy: copy,
+  cube: cube,
+  download: download,
+  'file-dashed': fileDashed,
+  'file-minus': fileMinus,
+  'file-plus': filePlus,
+  'file-text': fileText,
+  'folder-open': folderOpen,
+  'folder-plus': folderPlus,
+  gear: gear,
+  'globe-simple': globeSimple,
+  'git-branch': gitBranch,
+  'git-diff': gitDiff,
+  'git-fork': gitFork,
+  'grid-four': gridFour,
+  'git-merge': gitMerge,
+  info: info,
+  kanban: kanban,
+  'list-checks': listChecks,
+  'magnifying-glass': magnifyingGlass,
+  minus: minus,
+  'pencil-simple': pencilSimple,
+  play: play,
+  plus: plus,
+  prohibit: prohibit,
+  rocket: rocket,
+  'sidebar-simple': sidebarSimple,
+  'split-horizontal': splitHorizontal,
+  'square-split-horizontal': squareSplitHorizontal,
+  star: star,
+  tag: tag,
+  terminal: terminal,
+  trash: trash,
+  'tree-structure': treeStructure,
+  upload: upload,
+  'webhooks-logo': webhooksLogo,
+  x: x,
+};
+
+/**
+ * Convert an <i data-icon="icon-name"> element to an SVG
+ */
+function convertIcon(element: Element): void {
+  const iconName = element.getAttribute('data-icon');
+  if (!iconName) return;
+
+  const svgString = iconMap[iconName];
+  if (!svgString) {
+    iconsLog.warn('unknown icon', { name: iconName });
+    return;
+  }
+
+  const template = document.createElement('template');
+  template.innerHTML = svgString.trim();
+  const svg = template.content.firstElementChild as SVGElement;
+  if (!svg) return;
+
+  svg.setAttribute('width', '24');
+  svg.setAttribute('height', '24');
+
+  // Copy over classes from the original element
+  if (element.className) {
+    svg.classList.add(...element.classList);
+  }
+
+  // Copy the data-icon attribute for identification
+  svg.setAttribute('data-icon', iconName);
+
+  // Replace the placeholder with the SVG
+  element.replaceWith(svg);
+}
+
+/**
+ * Convert all icon placeholders within an element
+ */
+export function convertIconsIn(root: Element | Document): void {
+  const placeholders = root.querySelectorAll('i[data-icon]');
+  for (const el of placeholders) {
+    convertIcon(el);
+  }
+}
+
+let observer: MutationObserver | null = null;
+
+/**
+ * Initialize automatic icon conversion.
+ * Call this once at app startup.
+ */
+export function initIcons(): void {
+  if (observer) return; // Already initialized
+
+  // Convert any existing icons
+  convertIconsIn(document);
+
+  // Watch for new icons added to the DOM
+  observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node instanceof Element) {
+          // Check if the node itself is an icon placeholder
+          if (node.matches('i[data-icon]')) {
+            convertIcon(node);
+          }
+          // Check for icon placeholders within the node
+          convertIconsIn(node);
+        }
+      }
+    }
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+}

--- a/website/src/ouijit-ui/utils/taskChain.ts
+++ b/website/src/ouijit-ui/utils/taskChain.ts
@@ -1,0 +1,108 @@
+import type { TaskWithWorkspace } from '../types';
+
+export interface TaskChainInfo {
+  rootTaskNumber: number;
+  depth: number;
+  childTaskNumbers: number[];
+}
+
+/** Whether a task is part of a parent-child chain (has a parent or children). */
+export function isChainMember(info: TaskChainInfo | undefined): boolean {
+  return info != null && (info.depth > 0 || info.childTaskNumbers.length > 0);
+}
+
+/**
+ * Build a map of chain info for all tasks in a project.
+ * Walks parent chains to compute root and depth for each task.
+ */
+export function buildChainMap(tasks: TaskWithWorkspace[]): Map<number, TaskChainInfo> {
+  const byNumber = new Map(tasks.map((t) => [t.taskNumber, t]));
+  const childrenMap = new Map<number, number[]>();
+  const result = new Map<number, TaskChainInfo>();
+
+  // Build children index
+  for (const task of tasks) {
+    if (task.parentTaskNumber != null) {
+      const siblings = childrenMap.get(task.parentTaskNumber);
+      if (siblings) {
+        siblings.push(task.taskNumber);
+      } else {
+        childrenMap.set(task.parentTaskNumber, [task.taskNumber]);
+      }
+    }
+  }
+
+  // Compute root + depth for each task via parent walk, memoizing as we go
+  const visiting = new Set<number>();
+  function resolve(taskNumber: number): { root: number; depth: number } {
+    const cached = result.get(taskNumber);
+    if (cached) return { root: cached.rootTaskNumber, depth: cached.depth };
+
+    const task = byNumber.get(taskNumber);
+    if (!task?.parentTaskNumber || !byNumber.has(task.parentTaskNumber) || visiting.has(taskNumber)) {
+      result.set(taskNumber, {
+        rootTaskNumber: taskNumber,
+        depth: 0,
+        childTaskNumbers: childrenMap.get(taskNumber) ?? [],
+      });
+      return { root: taskNumber, depth: 0 };
+    }
+
+    visiting.add(taskNumber);
+    const parent = resolve(task.parentTaskNumber);
+    visiting.delete(taskNumber);
+    const info = {
+      rootTaskNumber: parent.root,
+      depth: parent.depth + 1,
+      childTaskNumbers: childrenMap.get(taskNumber) ?? [],
+    };
+    result.set(taskNumber, info);
+    return { root: info.rootTaskNumber, depth: info.depth };
+  }
+
+  for (const task of tasks) {
+    resolve(task.taskNumber);
+  }
+
+  return result;
+}
+
+/** Deterministic hue from root task number (golden angle for good distribution). */
+export function getChainHue(rootTaskNumber: number): number {
+  return (rootTaskNumber * 137.508) % 360;
+}
+
+function getChainHsl(rootTaskNumber: number, depth: number): [number, number] {
+  return [getChainHue(rootTaskNumber), Math.max(72 - depth * 14, 30)];
+}
+
+/** HSL color string for a badge at a given depth within a chain. */
+export function getChainColor(rootTaskNumber: number, depth: number): string {
+  const [hue, lightness] = getChainHsl(rootTaskNumber, depth);
+  return `hsl(${hue}, 55%, ${lightness}%)`;
+}
+
+/** Semi-transparent background for badge. */
+export function getChainBgColor(rootTaskNumber: number, depth: number): string {
+  const [hue, lightness] = getChainHsl(rootTaskNumber, depth);
+  return `hsla(${hue}, 55%, ${lightness}%, 0.15)`;
+}
+
+/** Check if possibleDescendant is a descendant of ancestor in the chain map. */
+export function isDescendantOf(
+  possibleDescendant: number,
+  ancestor: number,
+  chainMap: Map<number, TaskChainInfo>,
+): boolean {
+  const queue = [...(chainMap.get(ancestor)?.childTaskNumbers ?? [])];
+  const visited = new Set<number>();
+  for (let i = 0; i < queue.length; i++) {
+    const current = queue[i];
+    if (current === possibleDescendant) return true;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    const children = chainMap.get(current)?.childTaskNumbers;
+    if (children) queue.push(...children);
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

- Duplicate the View components, icon map, taskChain, and TerminalDisplayState into `website/src/ouijit-ui/` so the website is self-contained and CI never resolves from root `node_modules`.
- Extract `TerminalDisplayState` + `DEFAULT_DISPLAY_STATE` from `src/stores/terminalStore.ts` into `src/stores/terminalDisplay.ts`; the zustand store re-exports them so root callers are unaffected.
- Sweep `website/src/components/demo/*` to import from `../../ouijit-ui/...` instead of `@app/...`.
- Drop the `@app` alias and React `dedupe` workaround from `astro.config.mjs`; drop `zustand` and `electron-log` from `website/package.json`.
- View components and the website tree now drift independently — accepted, since the Views are pure and rarely change.