### PR TITLE
Spawn terminal when CLI starts a task

### DIFF
--- a/src/__tests__/cliTaskStartedPush.test.ts
+++ b/src/__tests__/cliTaskStartedPush.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Verifies the API router fires the `cli:task-started` push channel after a
+ * successful CLI-initiated task start, so the renderer can spawn a terminal
+ * + run the configured hook (T-366). Companion to apiRouterAuth.test.ts.
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as http from 'node:http';
+import type { BrowserWindow } from 'electron';
+
+vi.mock('../ptyManager', () => ({
+  isPtyActive: () => true,
+  getPtyTaskContext: () => null,
+}));
+
+const typedPushMock = vi.fn();
+vi.mock('../ipc/helpers', () => ({
+  typedPush: (...args: unknown[]) => typedPushMock(...args),
+}));
+
+const createTaskWorktreeMock = vi.fn();
+vi.mock('../worktree', () => ({
+  createTodoTask: vi.fn(async () => ({ success: true })),
+  createTaskWorktree: (...args: unknown[]) => createTaskWorktreeMock(...args),
+}));
+
+vi.mock('../db', () => ({
+  setTaskMergeTarget: vi.fn(),
+  setTaskName: vi.fn(),
+  setTaskDescription: vi.fn(),
+  getHooks: vi.fn(() => ({})),
+  saveHook: vi.fn(),
+  deleteHook: vi.fn(),
+  getAllTags: vi.fn(() => []),
+  getTaskTags: vi.fn(() => []),
+  addTagToTask: vi.fn(),
+  removeTagFromTask: vi.fn(),
+  setTaskTags: vi.fn(),
+  getScripts: vi.fn(() => []),
+  saveScript: vi.fn(),
+  deleteScript: vi.fn(),
+}));
+
+const beginTaskMock = vi.fn();
+vi.mock('../taskLifecycle', () => ({
+  beginTask: (...args: unknown[]) => beginTaskMock(...args),
+  setTaskStatusWithHooks: vi.fn(async () => ({})),
+  deleteTaskWithWorktree: vi.fn(async () => ({})),
+  getTasksWithWorkspaces: vi.fn(async () => []),
+  getTaskWithWorkspace: vi.fn(async () => null),
+}));
+
+vi.mock('../scanner', () => ({
+  getProjectList: vi.fn(async () => []),
+}));
+
+import { startHookServer, stopHookServer, getApiPort } from '../hookServer';
+import { issueToken, revokeAllTokens } from '../apiAuth';
+
+function mockWindow(): BrowserWindow {
+  return {
+    isDestroyed: () => false,
+    webContents: { send: vi.fn() },
+  } as unknown as BrowserWindow;
+}
+
+function request(method: string, path: string, token?: string, body?: Record<string, unknown>) {
+  return new Promise<{ status: number; body: Record<string, unknown> }>((resolve, reject) => {
+    const port = getApiPort();
+    const payload = body ? JSON.stringify(body) : undefined;
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: {
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          ...(payload ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) } : {}),
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk: Buffer) => (raw += chunk.toString()));
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode!, body: raw ? JSON.parse(raw) : {} });
+          } catch {
+            resolve({ status: res.statusCode!, body: { raw } });
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+beforeEach(async () => {
+  typedPushMock.mockClear();
+  createTaskWorktreeMock.mockReset();
+  beginTaskMock.mockReset();
+  revokeAllTokens();
+  await startHookServer(mockWindow());
+});
+
+afterEach(async () => {
+  await stopHookServer();
+});
+
+const PROJECT = encodeURIComponent('/tmp/test-project');
+
+function getTaskStartedPushes() {
+  return typedPushMock.mock.calls.filter((call) => call[1] === 'cli:task-started');
+}
+
+describe('cli:task-started push', () => {
+  test('fires after POST /api/tasks/start when result is successful', async () => {
+    createTaskWorktreeMock.mockResolvedValueOnce({
+      success: true,
+      worktreePath: '/tmp/wt/T-7',
+      task: {
+        taskNumber: 7,
+        branch: 'feat-7',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        sandboxed: false,
+      },
+    });
+    const token = issueToken('pty-host', 'host');
+    const res = await request('POST', `/api/tasks/start?project=${PROJECT}`, token, { name: 'x' });
+
+    expect(res.status).toBe(200);
+    const pushes = getTaskStartedPushes();
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0][2]).toEqual({
+      project: '/tmp/test-project',
+      taskNumber: 7,
+      worktreePath: '/tmp/wt/T-7',
+      branch: 'feat-7',
+      createdAt: '2026-05-10T00:00:00.000Z',
+      sandboxed: false,
+    });
+  });
+
+  test('fires after POST /api/tasks/:number/start when result is successful', async () => {
+    beginTaskMock.mockResolvedValueOnce({
+      success: true,
+      worktreePath: '/tmp/wt/T-42',
+      task: {
+        taskNumber: 42,
+        branch: 'fix-42',
+        createdAt: '2026-05-10T01:00:00.000Z',
+        sandboxed: true,
+      },
+    });
+    const token = issueToken('pty-host', 'host');
+    const res = await request('POST', `/api/tasks/42/start?project=${PROJECT}`, token, {});
+
+    expect(res.status).toBe(200);
+    const pushes = getTaskStartedPushes();
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0][2]).toMatchObject({
+      taskNumber: 42,
+      worktreePath: '/tmp/wt/T-42',
+      branch: 'fix-42',
+      sandboxed: true,
+    });
+  });
+
+  test('does not fire when start returns success:false', async () => {
+    createTaskWorktreeMock.mockResolvedValueOnce({ success: false, error: 'boom' });
+    const token = issueToken('pty-host', 'host');
+    const res = await request('POST', `/api/tasks/start?project=${PROJECT}`, token, { name: 'x' });
+
+    expect(res.status).toBe(200);
+    expect(getTaskStartedPushes()).toHaveLength(0);
+  });
+
+  test('does not fire when start succeeds but task has no branch (defensive)', async () => {
+    createTaskWorktreeMock.mockResolvedValueOnce({
+      success: true,
+      worktreePath: '/tmp/wt/T-9',
+      task: { taskNumber: 9, createdAt: '2026-05-10T00:00:00.000Z' },
+    });
+    const token = issueToken('pty-host', 'host');
+    const res = await request('POST', `/api/tasks/start?project=${PROJECT}`, token, { name: 'x' });
+
+    expect(res.status).toBe(200);
+    expect(getTaskStartedPushes()).toHaveLength(0);
+  });
+
+  test('still emits cli-change alongside cli:task-started', async () => {
+    createTaskWorktreeMock.mockResolvedValueOnce({
+      success: true,
+      worktreePath: '/tmp/wt/T-1',
+      task: { taskNumber: 1, branch: 'b', createdAt: '2026-05-10T00:00:00.000Z', sandboxed: false },
+    });
+    const token = issueToken('pty-host', 'host');
+    await request('POST', `/api/tasks/start?project=${PROJECT}`, token, { name: 'x' });
+
+    const channels = typedPushMock.mock.calls.map((c) => c[1]);
+    expect(channels).toContain('cli-change');
+    expect(channels).toContain('cli:task-started');
+  });
+
+  test('does not fire for unrelated mutating routes', async () => {
+    const token = issueToken('pty-host', 'host');
+    await request('PATCH', `/api/tasks/3/name?project=${PROJECT}`, token, { name: 'rename' });
+    expect(getTaskStartedPushes()).toHaveLength(0);
+  });
+});

--- a/src/__tests__/renderer/projectStore.test.tsx
+++ b/src/__tests__/renderer/projectStore.test.tsx
@@ -103,3 +103,48 @@ describe('projectStore.loadTasks → appStore cache', () => {
     ).toEqual([1, 2]);
   });
 });
+
+describe('projectStore.pendingCliStarts (T-366)', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ pendingCliStarts: {} });
+  });
+
+  const start = (n: number) => ({
+    taskNumber: n,
+    worktreePath: `/wt/T-${n}`,
+    branch: `b-${n}`,
+    createdAt: '2026-05-10T00:00:00.000Z',
+    sandboxed: false,
+  });
+
+  test('enqueueCliStart appends per project', () => {
+    useProjectStore.getState().enqueueCliStart('/a', start(1));
+    useProjectStore.getState().enqueueCliStart('/a', start(2));
+    useProjectStore.getState().enqueueCliStart('/b', start(3));
+
+    const queue = useProjectStore.getState().pendingCliStarts;
+    expect(queue['/a'].map((s) => s.taskNumber)).toEqual([1, 2]);
+    expect(queue['/b'].map((s) => s.taskNumber)).toEqual([3]);
+  });
+
+  test('enqueueCliStart dedupes by taskNumber', () => {
+    useProjectStore.getState().enqueueCliStart('/a', start(1));
+    useProjectStore.getState().enqueueCliStart('/a', start(1));
+    expect(useProjectStore.getState().pendingCliStarts['/a']).toHaveLength(1);
+  });
+
+  test('drainCliStarts returns and clears the queue for a project', () => {
+    useProjectStore.getState().enqueueCliStart('/a', start(1));
+    useProjectStore.getState().enqueueCliStart('/a', start(2));
+    useProjectStore.getState().enqueueCliStart('/b', start(3));
+
+    const drained = useProjectStore.getState().drainCliStarts('/a');
+    expect(drained.map((s) => s.taskNumber)).toEqual([1, 2]);
+    expect(useProjectStore.getState().pendingCliStarts['/a']).toBeUndefined();
+    expect(useProjectStore.getState().pendingCliStarts['/b']).toHaveLength(1);
+  });
+
+  test('drainCliStarts returns empty array when nothing is queued', () => {
+    expect(useProjectStore.getState().drainCliStarts('/none')).toEqual([]);
+  });
+});

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -97,6 +97,30 @@ class HttpError extends Error {
   }
 }
 
+interface TaskStartResult {
+  success: boolean;
+  worktreePath?: string;
+  task?: { taskNumber: number; branch?: string; createdAt: string; sandboxed?: boolean };
+}
+
+function isSuccessfulStart(result: unknown): result is TaskStartResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    (result as { success?: unknown }).success === true &&
+    typeof (result as { worktreePath?: unknown }).worktreePath === 'string'
+  );
+}
+
+function isTaskStartRoute(method: string, segments: string[]): boolean {
+  if (method !== 'POST') return false;
+  // POST /api/tasks/start
+  if (segments.length === 2 && segments[0] === 'tasks' && segments[1] === 'start') return true;
+  // POST /api/tasks/:number/start
+  if (segments.length === 3 && segments[0] === 'tasks' && segments[2] === 'start') return true;
+  return false;
+}
+
 // ── Route dispatch ───────────────────────────────────────────────────
 
 type RouteHandler = (req: ParsedRequest) => Promise<unknown> | unknown;
@@ -515,6 +539,24 @@ async function handleAsync(req: IncomingMessage, res: ServerResponse, window: Br
         action: `${method} /api/${apiPath}`,
         ts: Date.now(),
       });
+
+      // Task-start routes also need a terminal + hook in the renderer.
+      // The HTTP handler only creates the worktree + DB row; the renderer
+      // owns terminal/hook lifecycle, so signal it explicitly here.
+      if (isTaskStartRoute(method, segments) && isSuccessfulStart(result)) {
+        const startResult = result as TaskStartResult;
+        const task = startResult.task;
+        if (task && startResult.worktreePath && task.branch) {
+          typedPush(window, 'cli:task-started', {
+            project,
+            taskNumber: task.taskNumber,
+            worktreePath: startResult.worktreePath,
+            branch: task.branch,
+            createdAt: task.createdAt,
+            sandboxed: task.sandboxed ?? false,
+          });
+        }
+      }
     }
   } catch (err) {
     if (err instanceof HttpError) {

--- a/src/hooks/useIPCListeners.ts
+++ b/src/hooks/useIPCListeners.ts
@@ -1,9 +1,37 @@
 import { useEffect } from 'react';
 import { useAppStore } from '../stores/appStore';
-import { useProjectStore } from '../stores/projectStore';
+import { useProjectStore, type PendingCliStart } from '../stores/projectStore';
+import { useTerminalStore } from '../stores/terminalStore';
+import { addProjectTerminal } from '../components/terminal/terminalActions';
 import log from 'electron-log/renderer';
 
 const ipcLog = log.scope('ipcListeners');
+
+async function spawnTerminalForCliStart(projectPath: string, start: PendingCliStart): Promise<void> {
+  // Guard against double-spawn: skip if a terminal for this task already exists.
+  const terminals = useTerminalStore.getState().terminalsByProject[projectPath] ?? [];
+  const displayStates = useTerminalStore.getState().displayStates;
+  if (terminals.some((ptyId) => displayStates[ptyId]?.taskId === start.taskNumber)) {
+    ipcLog.info('skipping CLI task-started spawn — terminal already exists', {
+      project: projectPath,
+      taskNumber: start.taskNumber,
+    });
+    return;
+  }
+
+  await addProjectTerminal(projectPath, undefined, {
+    existingWorktree: {
+      path: start.worktreePath,
+      branch: start.branch,
+      createdAt: start.createdAt,
+      sandboxed: start.sandboxed,
+    },
+    taskId: start.taskNumber,
+    sandboxed: start.sandboxed,
+    // skipAutoHook left at default `false` so the configured `continue` hook
+    // runs on spawn, matching the kanban "existing worktree" open-terminal path.
+  });
+}
 
 /**
  * Registers global IPC push event listeners.
@@ -65,6 +93,63 @@ export function useIPCListeners() {
         }
       }),
     );
+
+    // CLI-initiated task start — spawn a terminal + run the configured hook.
+    // If the user isn't viewing the project, queue it and drain on navigation.
+    cleanups.push(
+      window.api.onCliTaskStarted((payload) => {
+        const activeProject = useAppStore.getState().activeProjectPath;
+        const start: PendingCliStart = {
+          taskNumber: payload.taskNumber,
+          worktreePath: payload.worktreePath,
+          branch: payload.branch,
+          createdAt: payload.createdAt,
+          sandboxed: payload.sandboxed,
+        };
+
+        if (activeProject === payload.project) {
+          ipcLog.info('CLI task-started: spawning terminal', { taskNumber: payload.taskNumber });
+          void spawnTerminalForCliStart(payload.project, start).catch((err) => {
+            ipcLog.error('CLI task-started spawn failed', {
+              taskNumber: payload.taskNumber,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
+        } else {
+          ipcLog.info('CLI task-started: queuing for later navigation', {
+            project: payload.project,
+            taskNumber: payload.taskNumber,
+          });
+          useProjectStore.getState().enqueueCliStart(payload.project, start);
+        }
+      }),
+    );
+
+    // Drain queued CLI starts whenever the active project changes.
+    const drain = (projectPath: string | null) => {
+      if (!projectPath) return;
+      const queued = useProjectStore.getState().drainCliStarts(projectPath);
+      for (const start of queued) {
+        ipcLog.info('draining queued CLI task-started', {
+          project: projectPath,
+          taskNumber: start.taskNumber,
+        });
+        void spawnTerminalForCliStart(projectPath, start).catch((err) => {
+          ipcLog.error('queued CLI task-started spawn failed', {
+            taskNumber: start.taskNumber,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
+    };
+    // Initial drain in case events arrived before this effect mounted.
+    drain(useAppStore.getState().activeProjectPath);
+    const unsubscribeAppStore = useAppStore.subscribe((state, prev) => {
+      if (state.activeProjectPath !== prev.activeProjectPath) {
+        drain(state.activeProjectPath);
+      }
+    });
+    cleanups.push(unsubscribeAppStore);
 
     // Sandbox branch diverged — agent commits can't fast-forward onto the
     // user's task branch because the user committed in parallel. Surface a

--- a/src/hooks/useIPCListeners.ts
+++ b/src/hooks/useIPCListeners.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useAppStore } from '../stores/appStore';
 import { useProjectStore, type PendingCliStart } from '../stores/projectStore';
 import { useTerminalStore } from '../stores/terminalStore';
-import { addProjectTerminal } from '../components/terminal/terminalActions';
+import { beginTransition } from '../services/taskStartService';
 import log from 'electron-log/renderer';
 
 const ipcLog = log.scope('ipcListeners');
@@ -19,17 +19,26 @@ async function spawnTerminalForCliStart(projectPath: string, start: PendingCliSt
     return;
   }
 
-  await addProjectTerminal(projectPath, undefined, {
-    existingWorktree: {
-      path: start.worktreePath,
-      branch: start.branch,
-      createdAt: start.createdAt,
-      sandboxed: start.sandboxed,
+  // Use the full task record so beginTransition has name/mergeTarget/etc.
+  // The CLI already created the worktree and flipped status, so the
+  // transition's worktree-creation step short-circuits on task.worktreePath.
+  const task = await window.api.task.getByNumber(projectPath, start.taskNumber);
+  if (!task) {
+    ipcLog.warn('CLI task-started: task not found, skipping spawn', { taskNumber: start.taskNumber });
+    return;
+  }
+
+  // Route through the same service the kanban drag uses so the `start` hook
+  // dialog appears and (on accept) its command runs in the spawned terminal,
+  // matching the todo → in_progress drop UX exactly.
+  beginTransition(projectPath, {
+    origStatus: 'todo',
+    newStatus: 'in_progress',
+    task: {
+      ...task,
+      worktreePath: task.worktreePath ?? start.worktreePath,
+      branch: task.branch ?? start.branch,
     },
-    taskId: start.taskNumber,
-    sandboxed: start.sandboxed,
-    // skipAutoHook left at default `false` so the configured `continue` hook
-    // runs on spawn, matching the kanban "existing worktree" open-terminal path.
   });
 }
 

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -229,5 +229,17 @@ export interface IpcPushContract {
   'update-available': { args: [info: { version: string; url: string }] };
   'whats-new': { args: [info: { version: string; notes: string }] };
   'cli-change': { args: [payload: { project: string; action: string; message?: string; ts: number }] };
+  'cli:task-started': {
+    args: [
+      payload: {
+        project: string;
+        taskNumber: number;
+        worktreePath: string;
+        branch: string;
+        createdAt: string;
+        sandboxed: boolean;
+      },
+    ];
+  };
   'capture:navigate': { args: [payload: import('../capture/types').CaptureNavigatePayload] };
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -205,6 +205,17 @@ contextBridge.exposeInMainWorld('api', {
   onCliChange: (callback: (payload: { project: string; action: string; message?: string; ts: number }) => void) =>
     typedListen('cli-change', callback),
 
+  onCliTaskStarted: (
+    callback: (payload: {
+      project: string;
+      taskNumber: number;
+      worktreePath: string;
+      branch: string;
+      createdAt: string;
+      sandboxed: boolean;
+    }) => void,
+  ) => typedListen('cli:task-started', callback),
+
   capture: {
     onNavigate: (callback: (payload: import('./capture/types').CaptureNavigatePayload) => void) =>
       typedListen('capture:navigate', callback),

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -14,6 +14,14 @@ export interface RunHookRequest {
   resolve: (result: RunHookResult | null) => void;
 }
 
+export interface PendingCliStart {
+  taskNumber: number;
+  worktreePath: string;
+  branch: string;
+  createdAt: string;
+  sandboxed: boolean;
+}
+
 interface ProjectStoreState {
   tasks: TaskWithWorkspace[];
   kanbanVisible: boolean;
@@ -41,6 +49,8 @@ interface ProjectStoreState {
   startingTaskNumbers: Set<number>;
   /** Active hook prompt; rendered globally so it survives view switches. */
   runHookRequest: RunHookRequest | null;
+  /** Queued CLI-initiated task starts awaiting the user to enter the project. */
+  pendingCliStarts: Record<string, PendingCliStart[]>;
   _version: number;
 }
 
@@ -96,6 +106,11 @@ interface ProjectStoreActions {
   requestRunHook: (req: Omit<RunHookRequest, 'id' | 'resolve'>) => Promise<RunHookResult | null>;
   /** Resolve the active hook prompt with a result (or null for cancel). */
   resolveRunHookRequest: (id: number, result: RunHookResult | null) => void;
+
+  /** Queue a CLI-initiated start for a project the user isn't currently viewing. */
+  enqueueCliStart: (projectPath: string, start: PendingCliStart) => void;
+  /** Atomically drain all queued starts for a project. */
+  drainCliStarts: (projectPath: string) => PendingCliStart[];
 }
 
 type ProjectStore = ProjectStoreState & ProjectStoreActions;
@@ -122,6 +137,7 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   toasts: [],
   startingTaskNumbers: new Set<number>(),
   runHookRequest: null,
+  pendingCliStarts: {},
   _version: 0,
 
   setTasks: (tasks) => {
@@ -345,5 +361,21 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
     if (!current || current.id !== id) return;
     set({ runHookRequest: null });
     current.resolve(result);
+  },
+
+  enqueueCliStart: (projectPath, start) => {
+    const current = get().pendingCliStarts[projectPath] ?? [];
+    if (current.some((s) => s.taskNumber === start.taskNumber)) return;
+    set({
+      pendingCliStarts: { ...get().pendingCliStarts, [projectPath]: [...current, start] },
+    });
+  },
+
+  drainCliStarts: (projectPath) => {
+    const queued = get().pendingCliStarts[projectPath];
+    if (!queued || queued.length === 0) return [];
+    const { [projectPath]: _drained, ...rest } = get().pendingCliStarts;
+    set({ pendingCliStarts: rest });
+    return queued;
   },
 }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -476,6 +476,17 @@ export interface ElectronAPI {
   onCliChange(
     callback: (payload: { project: string; action: string; message?: string; ts: number }) => void,
   ): () => void;
+  /** Listen for a CLI-initiated task start that requires spawning a terminal */
+  onCliTaskStarted(
+    callback: (payload: {
+      project: string;
+      taskNumber: number;
+      worktreePath: string;
+      branch: string;
+      createdAt: string;
+      sandboxed: boolean;
+    }) => void,
+  ): () => void;
   /** Get project settings */
   getProjectSettings(projectPath: string): Promise<ProjectSettings>;
   /** Set whether to kill existing command instances on run */


### PR DESCRIPTION
## Summary

- `ouijit task start` and `ouijit task create-and-start` only did server-side work (worktree + DB row + `in_progress`) and never opened a terminal or ran the start hook. The kanban update appeared but nothing launched.
- Added a dedicated `cli:task-started` IPC push fired from `src/api/router.ts` after a successful start (alongside the existing generic `cli-change` refresh).
- The renderer listener in `src/hooks/useIPCListeners.ts` routes through `taskStartService.beginTransition` with `origStatus: 'todo'` so the `start` hook dialog appears and (on accept) its command runs in the spawned terminal — exactly matching the kanban todo → in_progress drag.
- If the user is on the home view when the CLI fires, the start is queued on `useProjectStore.pendingCliStarts` and drained when they navigate into the project. A double-spawn guard skips when a terminal for that task already exists.
- Tests: `src/__tests__/cliTaskStartedPush.test.ts` covers the push (both routes, success/failure, dedup with `cli-change`); `src/__tests__/renderer/projectStore.test.tsx` covers enqueue/drain/dedupe. Full suite green (465 tests).