### PR TITLE
Improve UI responsiveness across kanban, terminals, and PTY output

### DIFF
--- a/src/__tests__/mainBranchCache.test.ts
+++ b/src/__tests__/mainBranchCache.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock `execFile` from node:child_process so we can count the spawns.
+// `promisify(execFile)` produces a function compatible with what git.ts
+// stores under `execFileAsync`.
+const execFileMock = vi.fn();
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    execFile: (...args: unknown[]) => execFileMock(...args),
+  };
+});
+
+// Re-import after the mock is registered so git.ts sees the mocked execFile.
+const { getMainBranchAsync, invalidateMainBranchCache } = await import('../git');
+
+beforeEach(() => {
+  invalidateMainBranchCache();
+  execFileMock.mockReset();
+});
+
+describe('getMainBranchAsync', () => {
+  it('caches the result so subsequent calls do not spawn git', async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(null, { stdout: '* main\n', stderr: '' });
+    });
+
+    const first = await getMainBranchAsync('/repo');
+    const second = await getMainBranchAsync('/repo');
+
+    expect(first).toBe('main');
+    expect(second).toBe('main');
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to "main" when git fails (and does not cache the failure)', async () => {
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      cb(new Error('not a git repo'), null);
+    });
+    expect(await getMainBranchAsync('/repo')).toBe('main');
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+
+    // Recovery path: a later call should retry rather than serve a poisoned cache.
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      cb(null, { stdout: '* master\n', stderr: '' });
+    });
+    expect(await getMainBranchAsync('/repo')).toBe('master');
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('prefers main over master when both branches exist', async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(null, { stdout: '  main\n* master\n', stderr: '' });
+    });
+    expect(await getMainBranchAsync('/repo')).toBe('main');
+  });
+
+  it('dedupes concurrent cold-cache misses to a single git spawn', async () => {
+    let resolveExec!: (value: { stdout: string; stderr: string }) => void;
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      // Defer the callback so both callers race against the same in-flight promise.
+      new Promise<{ stdout: string; stderr: string }>((res) => {
+        resolveExec = res;
+      }).then((v) => cb(null, v));
+    });
+
+    const a = getMainBranchAsync('/repo');
+    const b = getMainBranchAsync('/repo');
+    const c = getMainBranchAsync('/repo');
+
+    // Single spawn so far — all three share the in-flight Promise.
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+
+    resolveExec({ stdout: '* main\n', stderr: '' });
+    expect(await Promise.all([a, b, c])).toEqual(['main', 'main', 'main']);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidateMainBranchCache forces a fresh spawn', async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(null, { stdout: '* main\n', stderr: '' });
+    });
+
+    await getMainBranchAsync('/repo');
+    invalidateMainBranchCache('/repo');
+    await getMainBranchAsync('/repo');
+
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/renderer/projectStore.test.tsx
+++ b/src/__tests__/renderer/projectStore.test.tsx
@@ -148,3 +148,94 @@ describe('projectStore.pendingCliStarts (T-366)', () => {
     expect(useProjectStore.getState().drainCliStarts('/none')).toEqual([]);
   });
 });
+
+describe('projectStore.loadProjectConfig', () => {
+  beforeEach(() => {
+    useProjectStore.setState({
+      sandboxAvailable: false,
+      configuredHooks: {},
+      configProjectPath: null,
+    });
+    vi.mocked(window.api.lima.status).mockReset();
+    vi.mocked(window.api.hooks.get).mockReset();
+  });
+
+  test('writes sandbox availability + configured hooks into the store', async () => {
+    vi.mocked(window.api.lima.status).mockResolvedValue({ available: true, vmStatus: 'Running' });
+    vi.mocked(window.api.hooks.get).mockResolvedValue({
+      editor: { name: 'edit', command: 'code' },
+      run: undefined,
+    });
+
+    await useProjectStore.getState().loadProjectConfig('/a');
+
+    const s = useProjectStore.getState();
+    expect(s.sandboxAvailable).toBe(true);
+    expect(s.configuredHooks).toEqual({ editor: true });
+    expect(s.configProjectPath).toBe('/a');
+  });
+
+  test('the most-recent load wins regardless of IPC resolve order (stale-load race)', async () => {
+    // load(A) hangs longer than load(B); we expect B's state to land, not A's.
+    let resolveA!: (v: { available: boolean; vmStatus: string }) => void;
+    const aStatus = new Promise<{ available: boolean; vmStatus: string }>((res) => {
+      resolveA = res;
+    });
+    vi.mocked(window.api.lima.status).mockImplementationOnce(() => aStatus);
+    vi.mocked(window.api.hooks.get).mockImplementationOnce(() =>
+      Promise.resolve({ editor: { name: 'a', command: 'a' } }),
+    );
+
+    vi.mocked(window.api.lima.status).mockResolvedValueOnce({ available: true, vmStatus: 'Running' });
+    vi.mocked(window.api.hooks.get).mockResolvedValueOnce({ run: { name: 'b', command: 'b' } });
+
+    const aPromise = useProjectStore.getState().loadProjectConfig('/a');
+    const bPromise = useProjectStore.getState().loadProjectConfig('/b');
+
+    // Resolve B first (it has mockResolvedValueOnce so it resolves immediately).
+    await bPromise;
+    expect(useProjectStore.getState().configProjectPath).toBe('/b');
+    expect(useProjectStore.getState().configuredHooks).toEqual({ run: true });
+
+    // Now let A resolve — its writes must be ignored.
+    resolveA({ available: false, vmStatus: 'NotCreated' });
+    await aPromise;
+
+    const s = useProjectStore.getState();
+    expect(s.configProjectPath).toBe('/b');
+    expect(s.configuredHooks).toEqual({ run: true });
+    expect(s.sandboxAvailable).toBe(true);
+  });
+
+  test('IPC failures are swallowed and leave the store untouched', async () => {
+    useProjectStore.setState({ sandboxAvailable: true, configuredHooks: { editor: true }, configProjectPath: '/prev' });
+    vi.mocked(window.api.lima.status).mockRejectedValueOnce(new Error('boom'));
+    vi.mocked(window.api.hooks.get).mockResolvedValueOnce({});
+
+    await useProjectStore.getState().loadProjectConfig('/a');
+
+    const s = useProjectStore.getState();
+    expect(s.sandboxAvailable).toBe(true);
+    expect(s.configuredHooks).toEqual({ editor: true });
+    expect(s.configProjectPath).toBe('/prev');
+  });
+});
+
+describe('projectStore.markHookConfigured', () => {
+  beforeEach(() => {
+    useProjectStore.setState({ configuredHooks: {} });
+  });
+
+  test('adds the hook type to configuredHooks', () => {
+    useProjectStore.getState().markHookConfigured('editor');
+    expect(useProjectStore.getState().configuredHooks).toEqual({ editor: true });
+  });
+
+  test('is idempotent — repeating the call does not allocate a new object', () => {
+    useProjectStore.getState().markHookConfigured('editor');
+    const ref = useProjectStore.getState().configuredHooks;
+    useProjectStore.getState().markHookConfigured('editor');
+    // Same reference proves the early-return path was taken.
+    expect(useProjectStore.getState().configuredHooks).toBe(ref);
+  });
+});

--- a/src/__tests__/renderer/setup.ts
+++ b/src/__tests__/renderer/setup.ts
@@ -113,7 +113,7 @@ const mockApi = {
     checkFilesExist: vi.fn().mockResolvedValue({}),
   },
   lima: {
-    status: vi.fn().mockResolvedValue('stopped'),
+    status: vi.fn().mockResolvedValue({ available: false, vmStatus: 'Stopped' }),
     start: vi.fn().mockResolvedValue({ success: true }),
     stop: vi.fn().mockResolvedValue({ success: true }),
     getConfig: vi.fn().mockResolvedValue({ memoryGiB: 4, diskGiB: 50 }),

--- a/src/components/ProjectViewReact.tsx
+++ b/src/components/ProjectViewReact.tsx
@@ -258,13 +258,38 @@ export function ProjectView() {
     });
   }, [projectPath]);
 
-  // Periodic git status refresh
+  // Load project-scoped config (sandbox availability + configured hooks) once.
+  // Terminal headers and kanban cards read this from the store instead of each
+  // making their own `lima.status` (subprocess spawn) + `hooks.get` IPC calls.
   useEffect(() => {
     if (!projectPath) return;
-    const interval = setInterval(() => {
-      refreshAllTerminalGitStatus(projectPath);
-    }, GIT_STATUS_PERIODIC_INTERVAL);
-    return () => clearInterval(interval);
+    useProjectStore.getState().loadProjectConfig(projectPath);
+  }, [projectPath]);
+
+  // Periodic git status refresh — pauses while the window is hidden so we
+  // don't keep spawning git subprocesses for a project the user isn't watching.
+  useEffect(() => {
+    if (!projectPath) return;
+    let interval: ReturnType<typeof setInterval> | null = null;
+    const start = () => {
+      if (interval != null || document.hidden) return;
+      interval = setInterval(() => {
+        refreshAllTerminalGitStatus(projectPath);
+      }, GIT_STATUS_PERIODIC_INTERVAL);
+    };
+    const stop = () => {
+      if (interval != null) {
+        clearInterval(interval);
+        interval = null;
+      }
+    };
+    const onVisibility = () => (document.hidden ? stop() : start());
+    start();
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      stop();
+    };
   }, [projectPath]);
 
   // Hook status: register ongoing listener + seed existing terminals

--- a/src/components/diff/DiffPanel.tsx
+++ b/src/components/diff/DiffPanel.tsx
@@ -62,41 +62,46 @@ export function DiffPanel({ ptyId, projectPath, onClose }: DiffPanelProps) {
     if (inst) refreshTerminalGitStatus(inst);
   }, [ptyId]);
 
-  // Load per-file diffs in batches when the file list changes
+  // Load per-file diffs in batches when the file list changes.
+  // Within each batch we mutate a single Map and call setDiffs once with a
+  // fresh clone — previously each finished file cloned the entire map
+  // (O(N) per file → O(N²) for the whole load). With ~300 files that was
+  // tens of thousands of redundant copies during the load.
   useEffect(() => {
     let cancelled = false;
     setDiffs(new Map());
 
     if (files.length === 0) return;
 
+    const accumulated = new Map<string, FileDiff | null>();
+
     const loadDiffs = async () => {
       for (let i = 0; i < files.length; i += DIFF_BATCH_SIZE) {
         if (cancelled) return;
         const batch = files.slice(i, i + DIFF_BATCH_SIZE);
-        await Promise.all(
-          batch.map(async (file) => {
+        const results = await Promise.all(
+          batch.map(async (file): Promise<[string, FileDiff | null]> => {
             try {
-              let diff: FileDiff | null;
-              if (effectiveMode === 'worktree' && instance?.worktreeBranch) {
-                diff = await window.api.worktree.getFileDiff(
-                  projectPath,
-                  instance.worktreeBranch,
-                  file.path,
-                  instance.mergeTarget,
-                );
-              } else {
-                diff = await window.api.getFileDiff(gitPath, file.path);
-              }
-              if (!cancelled) {
-                setDiffs((prev) => new Map(prev).set(file.path, diff));
-              }
+              const diff =
+                effectiveMode === 'worktree' && instance?.worktreeBranch
+                  ? await window.api.worktree.getFileDiff(
+                      projectPath,
+                      instance.worktreeBranch,
+                      file.path,
+                      instance.mergeTarget,
+                    )
+                  : await window.api.getFileDiff(gitPath, file.path);
+              return [file.path, diff];
             } catch {
-              if (!cancelled) {
-                setDiffs((prev) => new Map(prev).set(file.path, null));
-              }
+              return [file.path, null];
             }
           }),
         );
+        if (cancelled) return;
+        for (const [path, diff] of results) accumulated.set(path, diff);
+        // One copy per batch instead of one per file — batches of 10 means
+        // ~30 copies for 300 files instead of ~45 000.
+        setDiffs(new Map(accumulated));
       }
     };
 

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -122,13 +122,9 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     [projectPath],
   );
 
-  // Project-scoped config is owned by projectStore; loaded by ProjectViewReact.
-  // We re-fetch when the board opens in case a hook was added since first load
-  // (e.g. via Project Settings) so the column hook badges stay accurate.
-  useEffect(() => {
-    useProjectStore.getState().loadProjectConfig(projectPath);
-  }, [projectPath]);
-
+  // Project config is owned by projectStore; loaded once per project by
+  // ProjectViewReact, and refreshed by HookList / this board's hook-dialog
+  // close handler whenever a hook is added. No on-mount refetch needed.
   const markEditorHookConfigured = useCallback(() => {
     useProjectStore.getState().markHookConfigured('editor');
   }, []);

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -68,7 +68,9 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
   const startingTaskNumbers = useProjectStore((s) => s.startingTaskNumbers);
   const [activeTask, setActiveTask] = useState<TaskWithWorkspace | null>(null);
   const activeBadgeDrag = useProjectStore((s) => s.activeBadgeDrag);
-  const [configuredHooks, setConfiguredHooks] = useState<Record<string, boolean>>({});
+  // Project-scoped config is loaded once by ProjectViewReact; we just subscribe.
+  const configuredHooks = useProjectStore((s) => s.configuredHooks);
+  const sandboxAvailable = useProjectStore((s) => s.sandboxAvailable);
   const [hookDialog, setHookDialog] = useState<
     | { mode: 'single'; hookType: HookType; existingHook?: any }
     | { mode: 'combined'; start?: any; continue?: any }
@@ -120,19 +122,36 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     [projectPath],
   );
 
-  // Load which hooks are configured
+  // Project-scoped config is owned by projectStore; loaded by ProjectViewReact.
+  // We re-fetch when the board opens in case a hook was added since first load
+  // (e.g. via Project Settings) so the column hook badges stay accurate.
   useEffect(() => {
-    window.api.hooks.get(projectPath).then((hooks) => {
-      const configured: Record<string, boolean> = {};
-      for (const key of Object.keys(hooks)) {
-        if (hooks[key as HookType]) configured[key] = true;
-      }
-      setConfiguredHooks(configured);
-    });
+    useProjectStore.getState().loadProjectConfig(projectPath);
   }, [projectPath]);
 
-  // Local task state for drag preview — synced from store, mutated during drag
-  const chainMap = useMemo(() => buildChainMap(storeTasks), [storeTasks]);
+  const markEditorHookConfigured = useCallback(() => {
+    useProjectStore.getState().markHookConfigured('editor');
+  }, []);
+
+  // Local task state for drag preview — synced from store, mutated during drag.
+  // chainMap depends only on parent relations, but `storeTasks` identity churns
+  // on every task edit (name, status, order). Memoize on a content fingerprint
+  // of just (taskNumber → parentTaskNumber) so the Map identity stays stable
+  // across reorders, status changes, and renames — and memoized cards keep
+  // their memo intact instead of re-rendering on every unrelated task tweak.
+  const chainFingerprint = useMemo(
+    () =>
+      storeTasks
+        .map((t) => `${t.taskNumber}:${t.parentTaskNumber ?? ''}`)
+        .sort()
+        .join('|'),
+    [storeTasks],
+  );
+  const chainMap = useMemo(
+    () => buildChainMap(storeTasks),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: rebuild only when parent relations change
+    [chainFingerprint],
+  );
   const [items, setItems] = useState<Record<string, TaskWithWorkspace[]>>({});
   const originalStatusRef = useRef<TaskStatus | null>(null);
 
@@ -209,16 +228,26 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     }),
   );
 
+  // O(1) reverse lookup for findContainer. `items` only changes when a card
+  // actually crosses a column (or when the store syncs); dnd-kit's onDragOver
+  // fires continuously during drag, so doing this once per items mutation
+  // instead of scanning every column on every drag tick is a clear win as
+  // the task list grows.
+  const taskStatusByNumber = useMemo(() => {
+    const lookup = new Map<number, TaskStatus>();
+    for (const [status, tasks] of Object.entries(items)) {
+      for (const t of tasks) lookup.set(t.taskNumber, status as TaskStatus);
+    }
+    return lookup;
+  }, [items]);
+
   const findContainer = useCallback(
     (id: string): TaskStatus | null => {
       if (COLUMN_IDS.has(id)) return id as TaskStatus;
       const taskNum = parseInt(id.replace('task-', ''), 10);
-      for (const [status, tasks] of Object.entries(items)) {
-        if (tasks.some((t) => t.taskNumber === taskNum)) return status as TaskStatus;
-      }
-      return null;
+      return taskStatusByNumber.get(taskNum) ?? null;
     },
-    [items],
+    [taskStatusByNumber],
   );
 
   const [showTrash, setShowTrash] = useState(false);
@@ -226,7 +255,9 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
   const overTrashRef = useRef(false);
   const trashRef = useRef<HTMLDivElement>(null);
 
-  // Track pointer proximity to right edge during drag, and whether pointer is over the trash zone
+  // Track pointer proximity to right edge during drag, and whether pointer is over the trash zone.
+  // Coalesce pointermove processing to one tick per animation frame — pointer events fire on every
+  // pixel during a drag and we don't need higher resolution than the display.
   useEffect(() => {
     if (!activeTask || activeBadgeDrag) {
       setShowTrash(false);
@@ -234,15 +265,18 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       return;
     }
     const threshold = 200;
-    const onMove = (e: PointerEvent) => {
-      const distFromRight = window.innerWidth - e.clientX;
+    let rafId: number | null = null;
+    let lastX = 0;
+    let lastY = 0;
+    const flush = () => {
+      rafId = null;
+      const distFromRight = window.innerWidth - lastX;
       setShowTrash(distFromRight < threshold);
 
       const el = trashRef.current;
       if (el) {
         const rect = el.getBoundingClientRect();
-        const isOver =
-          e.clientX >= rect.left && e.clientX <= rect.right && e.clientY >= rect.top && e.clientY <= rect.bottom;
+        const isOver = lastX >= rect.left && lastX <= rect.right && lastY >= rect.top && lastY <= rect.bottom;
         overTrashRef.current = isOver;
         setOverTrash(isOver);
       } else {
@@ -250,8 +284,16 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
         setOverTrash(false);
       }
     };
+    const onMove = (e: PointerEvent) => {
+      lastX = e.clientX;
+      lastY = e.clientY;
+      if (rafId == null) rafId = requestAnimationFrame(flush);
+    };
     window.addEventListener('pointermove', onMove);
-    return () => window.removeEventListener('pointermove', onMove);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      if (rafId != null) cancelAnimationFrame(rafId);
+    };
   }, [activeTask, activeBadgeDrag]);
 
   // Track multi-drag: task numbers being dragged together (null = single drag)
@@ -591,14 +633,8 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
 
   const handleHookDialogClose = useCallback(() => {
     setHookDialog(null);
-    // Refresh configured hooks
-    window.api.hooks.get(projectPath).then((hooks) => {
-      const configured: Record<string, boolean> = {};
-      for (const key of Object.keys(hooks)) {
-        if (hooks[key as HookType]) configured[key] = true;
-      }
-      setConfiguredHooks(configured);
-    });
+    // Refresh in the store so terminal headers and column badges agree.
+    useProjectStore.getState().loadProjectConfig(projectPath);
   }, [projectPath]);
 
   return (
@@ -672,6 +708,9 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
                 onSelect={handleCardSelect}
                 onConfigureHook={handleConfigureHook}
                 hasConfiguredHook={hookActive}
+                sandboxAvailable={sandboxAvailable}
+                hasEditorHook={!!configuredHooks.editor}
+                onEditorHookConfigured={markEditorHookConfigured}
               />
             );
           })}

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -22,6 +22,12 @@ interface KanbanCardProps {
   chainMap?: Map<number, TaskChainInfo>;
   isSettingUp?: boolean;
   isSelected?: boolean;
+  /** Hoisted from per-card IPC to a single board-level call. */
+  sandboxAvailable?: boolean;
+  /** Hoisted from per-card IPC to a single board-level call. */
+  hasEditorHook?: boolean;
+  /** Called after the user saves an editor hook from this card's dialog. */
+  onEditorHookConfigured?: () => void;
   onRename: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
@@ -36,6 +42,9 @@ export const KanbanCard = memo(function KanbanCard({
   chainMap,
   isSettingUp,
   isSelected,
+  sandboxAvailable = false,
+  hasEditorHook = false,
+  onEditorHookConfigured,
   onRename,
   onUpdateDescription,
   onOpenTerminal,
@@ -81,13 +90,6 @@ export const KanbanCard = memo(function KanbanCard({
   const formattedDate = task.createdAt
     ? new Date(task.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
     : '';
-
-  const [sandboxAvailable, setSandboxAvailable] = useState(false);
-  const [hasEditorHook, setHasEditorHook] = useState(false);
-  useEffect(() => {
-    window.api.lima.status(projectPath).then((s) => setSandboxAvailable(s.available));
-    window.api.hooks.get(projectPath).then((hooks) => setHasEditorHook(!!hooks.editor));
-  }, [projectPath]);
 
   const handleCommitRenameTerminal = useCallback((ptyId: string, label: string) => {
     useTerminalStore.getState().updateDisplay(ptyId, { label });
@@ -384,7 +386,7 @@ export const KanbanCard = memo(function KanbanCard({
           hookType="editor"
           onClose={(result) => {
             setEditorHookDialog(false);
-            if (result?.saved) setHasEditorHook(true);
+            if (result?.saved) onEditorHookConfigured?.();
           }}
         />
       )}

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -32,6 +32,9 @@ interface KanbanColumnProps {
   onConfigureHook?: (hookTypes: HookType[]) => void;
   hasConfiguredHook?: boolean;
   chainMap?: Map<number, TaskChainInfo>;
+  sandboxAvailable?: boolean;
+  hasEditorHook?: boolean;
+  onEditorHookConfigured?: () => void;
 }
 
 export function KanbanColumn({
@@ -49,6 +52,9 @@ export function KanbanColumn({
   onConfigureHook,
   hasConfiguredHook,
   chainMap,
+  sandboxAvailable,
+  hasEditorHook,
+  onEditorHookConfigured,
 }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: status });
   const taskIds = useMemo(() => tasks.map((t) => `task-${t.taskNumber}`), [tasks]);
@@ -83,6 +89,9 @@ export function KanbanColumn({
             onOpenTerminal={onOpenTerminal}
             onSwitchToTerminal={onSwitchToTerminal}
             onSelect={onSelect}
+            sandboxAvailable={sandboxAvailable}
+            hasEditorHook={hasEditorHook}
+            onEditorHookConfigured={onEditorHookConfigured}
           />
         ))}
       </SortableContext>
@@ -108,6 +117,9 @@ function SortableCard({
   onOpenTerminal,
   onSwitchToTerminal,
   onSelect,
+  sandboxAvailable,
+  hasEditorHook,
+  onEditorHookConfigured,
 }: {
   task: TaskWithWorkspace;
   projectPath: string;
@@ -118,6 +130,9 @@ function SortableCard({
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;
   onSwitchToTerminal: (ptyId: string) => void;
   onSelect: (taskNumber: number, event: MouseEvent) => void;
+  sandboxAvailable?: boolean;
+  hasEditorHook?: boolean;
+  onEditorHookConfigured?: () => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: `task-${task.taskNumber}`,
@@ -165,6 +180,9 @@ function SortableCard({
         onOpenTerminal={onOpenTerminal}
         onSwitchToTerminal={onSwitchToTerminal}
         onSelect={onSelect}
+        sandboxAvailable={sandboxAvailable}
+        hasEditorHook={hasEditorHook}
+        onEditorHookConfigured={onEditorHookConfigured}
       />
     </div>
   );

--- a/src/components/scripts/HookList.tsx
+++ b/src/components/scripts/HookList.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import type { HookType, ScriptHook } from '../../types';
 import { HookConfigDialog } from '../dialogs/HookConfigDialog';
 import { HookRowView } from './HookRowView';
+import { useProjectStore } from '../../stores/projectStore';
 
 export interface HookEntry {
   type: HookType;
@@ -33,9 +34,14 @@ export function HookList({ projectPath, hooks: hookEntries, bare }: HookListProp
   const handleDialogClose = useCallback(
     (result: { saved: boolean } | null) => {
       setEditingHook(null);
-      if (result?.saved) loadHooks();
+      if (result?.saved) {
+        loadHooks();
+        // Keep the shared projectStore in sync so terminal headers and kanban
+        // column badges see the new hook without a stale window.
+        useProjectStore.getState().loadProjectConfig(projectPath);
+      }
     },
-    [loadHooks],
+    [loadHooks, projectPath],
   );
 
   const rows = hookEntries.map(({ type, label, description }) => {

--- a/src/components/scripts/SandboxSection.tsx
+++ b/src/components/scripts/SandboxSection.tsx
@@ -46,9 +46,12 @@ export function SandboxSection({ projectPath }: SandboxSectionProps) {
     })();
   }, [projectPath]);
 
-  // Poll VM status
+  // Poll VM status. Each tick spawns a `limactl list --json` subprocess; pausing
+  // while the window is hidden stops the steady drumbeat of subprocess spawns
+  // when the user isn't looking.
   useEffect(() => {
-    const poll = setInterval(async () => {
+    let poll: ReturnType<typeof setInterval> | null = null;
+    const tick = async () => {
       try {
         const s = await window.api.lima.status(projectPath);
         setVmStatus(s.vmStatus);
@@ -56,8 +59,32 @@ export function SandboxSection({ projectPath }: SandboxSectionProps) {
       } catch {
         /* ignore */
       }
-    }, 3000);
-    return () => clearInterval(poll);
+    };
+    const start = () => {
+      if (poll != null || document.hidden) return;
+      poll = setInterval(tick, 3000);
+    };
+    const stop = () => {
+      if (poll != null) {
+        clearInterval(poll);
+        poll = null;
+      }
+    };
+    const onVisibility = () => {
+      if (document.hidden) {
+        stop();
+      } else {
+        // Catch up immediately on re-show in case the VM transitioned while hidden.
+        tick();
+        start();
+      }
+    };
+    start();
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      stop();
+    };
   }, [projectPath]);
 
   const handleEditorChange = useCallback(

--- a/src/components/terminal/TerminalBody.tsx
+++ b/src/components/terminal/TerminalBody.tsx
@@ -1,4 +1,5 @@
 import { useTerminalStore } from '../../stores/terminalStore';
+import { useShallow } from 'zustand/react/shallow';
 import { XTermContainer } from './XTermContainer';
 import { RunnerPanel } from './RunnerPanel';
 import { DiffPanel } from '../diff/DiffPanel';
@@ -30,15 +31,35 @@ export function TerminalBody({
   onKillRunner,
   onRestartRunner,
 }: TerminalBodyProps) {
-  const diffPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.diffPanelOpen ?? false);
-  const planPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.planPanelOpen ?? false);
-  const planPath = useTerminalStore((s) => s.displayStates[ptyId]?.planPath ?? null);
-  const planFullWidth = useTerminalStore((s) => s.displayStates[ptyId]?.planFullWidth ?? true);
-  const webPreviewPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.webPreviewPanelOpen ?? false);
-  const webPreviewUrl = useTerminalStore((s) => s.displayStates[ptyId]?.webPreviewUrl ?? null);
-  const webPreviewFullWidth = useTerminalStore((s) => s.displayStates[ptyId]?.webPreviewFullWidth ?? true);
-  const runnerPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.runnerPanelOpen ?? false);
-  const runnerFullWidth = useTerminalStore((s) => s.displayStates[ptyId]?.runnerFullWidth ?? true);
+  // One shallow-compared subscription replaces nine individual selectors.
+  // Every `updateDisplay` previously ran nine closures per terminal body to
+  // pick out primitive panel-state fields; now it runs one + a shallow compare.
+  const {
+    diffPanelOpen,
+    planPanelOpen,
+    planPath,
+    planFullWidth,
+    webPreviewPanelOpen,
+    webPreviewUrl,
+    webPreviewFullWidth,
+    runnerPanelOpen,
+    runnerFullWidth,
+  } = useTerminalStore(
+    useShallow((s) => {
+      const d = s.displayStates[ptyId];
+      return {
+        diffPanelOpen: d?.diffPanelOpen ?? false,
+        planPanelOpen: d?.planPanelOpen ?? false,
+        planPath: d?.planPath ?? null,
+        planFullWidth: d?.planFullWidth ?? true,
+        webPreviewPanelOpen: d?.webPreviewPanelOpen ?? false,
+        webPreviewUrl: d?.webPreviewUrl ?? null,
+        webPreviewFullWidth: d?.webPreviewFullWidth ?? true,
+        runnerPanelOpen: d?.runnerPanelOpen ?? false,
+        runnerFullWidth: d?.runnerFullWidth ?? true,
+      };
+    }),
+  );
 
   return (
     <div className="relative flex-1 flex flex-row min-h-0 overflow-hidden">

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -2,6 +2,7 @@ import { Fragment, memo, useState, useCallback, useEffect, useMemo, useRef } fro
 import { useTerminalStore } from '../../stores/terminalStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useUIStore } from '../../stores/uiStore';
+import { useShallow } from 'zustand/react/shallow';
 import { terminalInstances } from './terminalReact';
 import { addProjectTerminal, closeProjectTerminal } from './terminalActions';
 import { findOtherTaskTerminals } from './findOtherTaskTerminals';
@@ -41,23 +42,52 @@ export const TerminalHeader = memo(function TerminalHeader({
   onToggleWebPreviewPanel,
   onToggleRunner,
 }: TerminalHeaderProps) {
-  const label = useTerminalStore((s) => s.displayStates[ptyId]?.label ?? '');
-  const summary = useTerminalStore((s) => s.displayStates[ptyId]?.summary ?? '');
-  const summaryType = useTerminalStore((s) => s.displayStates[ptyId]?.summaryType ?? 'ready');
-  const gitFileStatus = useTerminalStore((s) => s.displayStates[ptyId]?.gitFileStatus ?? null);
-  const lastOscTitle = useTerminalStore((s) => s.displayStates[ptyId]?.lastOscTitle ?? '');
-  const tags = useTerminalStore((s) => s.displayStates[ptyId]?.tags) ?? EMPTY_TAGS;
-  const sandboxed = useTerminalStore((s) => s.displayStates[ptyId]?.sandboxed ?? false);
-  const runnerStatus = useTerminalStore((s) => s.displayStates[ptyId]?.runnerStatus ?? 'idle');
-  const runnerScriptName = useTerminalStore((s) => s.displayStates[ptyId]?.runnerScriptName ?? null);
-  const runnerPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.runnerPanelOpen ?? false);
-  const diffPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.diffPanelOpen ?? false);
-  const planPath = useTerminalStore((s) => s.displayStates[ptyId]?.planPath ?? null);
-  const planPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.planPanelOpen ?? false);
-  const webPreviewUrl = useTerminalStore((s) => s.displayStates[ptyId]?.webPreviewUrl ?? null);
-  const webPreviewPanelOpen = useTerminalStore((s) => s.displayStates[ptyId]?.webPreviewPanelOpen ?? false);
-  const taskId = useTerminalStore((s) => s.displayStates[ptyId]?.taskId ?? null);
-  const worktreeBranch = useTerminalStore((s) => s.displayStates[ptyId]?.worktreeBranch ?? null);
+  // One shallow-compared subscription replaces seventeen individual selectors.
+  // Each `updateDisplay` (~4Hz during active terminal output) previously ran
+  // 17 selector closures per visible card; now it runs one + a shallow compare,
+  // and the header only re-renders when one of these fields actually changes.
+  const {
+    label,
+    summary,
+    summaryType,
+    gitFileStatus,
+    lastOscTitle,
+    tags,
+    sandboxed,
+    runnerStatus,
+    runnerScriptName,
+    runnerPanelOpen,
+    diffPanelOpen,
+    planPath,
+    planPanelOpen,
+    webPreviewUrl,
+    webPreviewPanelOpen,
+    taskId,
+    worktreeBranch,
+  } = useTerminalStore(
+    useShallow((s) => {
+      const d = s.displayStates[ptyId];
+      return {
+        label: d?.label ?? '',
+        summary: d?.summary ?? '',
+        summaryType: d?.summaryType ?? 'ready',
+        gitFileStatus: d?.gitFileStatus ?? null,
+        lastOscTitle: d?.lastOscTitle ?? '',
+        tags: d?.tags ?? EMPTY_TAGS,
+        sandboxed: d?.sandboxed ?? false,
+        runnerStatus: d?.runnerStatus ?? 'idle',
+        runnerScriptName: d?.runnerScriptName ?? null,
+        runnerPanelOpen: d?.runnerPanelOpen ?? false,
+        diffPanelOpen: d?.diffPanelOpen ?? false,
+        planPath: d?.planPath ?? null,
+        planPanelOpen: d?.planPanelOpen ?? false,
+        webPreviewUrl: d?.webPreviewUrl ?? null,
+        webPreviewPanelOpen: d?.webPreviewPanelOpen ?? false,
+        taskId: d?.taskId ?? null,
+        worktreeBranch: d?.worktreeBranch ?? null,
+      };
+    }),
+  );
 
   const [tagInputOpen, setTagInputOpen] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
@@ -74,24 +104,18 @@ export const TerminalHeader = memo(function TerminalHeader({
 
   const scriptDropdownVisible = useUIStore((s) => s.scriptDropdownVisible && s.scriptDropdownPtyId === ptyId);
 
-  const [sandboxAvailable, setSandboxAvailable] = useState(false);
-  const [hasEditorHook, setHasEditorHook] = useState(false);
-  const [hasRunHook, setHasRunHook] = useState(false);
-  // Subscribe to scripts from projectStore for live updates
+  // Project-scoped config lives in the store (loaded once per project by
+  // ProjectViewReact) — reading from the store keeps every card sharing one
+  // pair of IPC calls instead of fanning out N spawns of limactl.
+  const sandboxAvailable = useProjectStore((s) => s.sandboxAvailable);
+  const hasEditorHook = useProjectStore((s) => !!s.configuredHooks.editor);
+  const hasRunHook = useProjectStore((s) => !!s.configuredHooks.run);
   const storeScripts = useProjectStore((s) => s.scripts);
   const hasScripts = storeScripts.length > 0;
 
   useEffect(() => {
-    if (projectPath) {
-      window.api.lima.status(projectPath).then((s) => setSandboxAvailable(s.available));
-      window.api.hooks.get(projectPath).then((h) => {
-        setHasEditorHook(!!h.editor);
-        setHasRunHook(!!h.run);
-      });
-      // Also load scripts into store if not already loaded
-      if (storeScripts.length === 0) {
-        useProjectStore.getState().loadScripts(projectPath);
-      }
+    if (projectPath && storeScripts.length === 0) {
+      useProjectStore.getState().loadScripts(projectPath);
     }
   }, [projectPath, storeScripts.length]);
 
@@ -442,7 +466,7 @@ export const TerminalHeader = memo(function TerminalHeader({
           hookType="editor"
           onClose={(result) => {
             setEditorHookDialog(false);
-            if (result?.saved) setHasEditorHook(true);
+            if (result?.saved) useProjectStore.getState().markHookConfigured('editor');
           }}
         />
       )}
@@ -454,7 +478,7 @@ export const TerminalHeader = memo(function TerminalHeader({
           onClose={(result) => {
             setRunHookDialog(null);
             if (result?.saved && result.hook) {
-              setHasRunHook(true);
+              useProjectStore.getState().markHookConfigured('run');
               onToggleRunner?.();
             }
           }}

--- a/src/git.ts
+++ b/src/git.ts
@@ -184,21 +184,70 @@ export function getGitStatus(projectPath: string): GitStatus | null {
 }
 
 /**
- * Detects the main branch (main or master) for a repo
+ * Cache the resolved main branch per project. `git branch --list` is cheap
+ * but it spawns a child process — when this used to run synchronously from
+ * inside the otherwise-async `getGitFileStatus`, it blocked the main process
+ * on every git-status refresh (30s timer per project, plus 3s after every
+ * terminal output burst). The cache is a Map<projectPath, mainBranch>; main
+ * branches effectively never change during a session.
+ */
+const projectMainBranchCache = new Map<string, string>();
+
+function parseMainBranchOutput(stdout: string): string {
+  if (!stdout) return 'main';
+  const branches = stdout
+    .split('\n')
+    .map((b) => b.replace(/^\*?\s+/, '').trim())
+    .filter(Boolean);
+  if (branches.includes('main')) return 'main';
+  if (branches.includes('master')) return 'master';
+  return 'main';
+}
+
+/**
+ * Detects the main branch (main or master) for a repo. Sync — kept for the
+ * many legacy sync git helpers in this file. First call per project spawns
+ * `git branch --list`; subsequent calls return from cache.
  */
 export function getMainBranch(projectPath: string): string {
-  const opts = gitExecOpts(projectPath);
+  const cached = projectMainBranchCache.get(projectPath);
+  if (cached) return cached;
 
+  const opts = gitExecOpts(projectPath);
   try {
-    const result = execFileSync('git', ['branch', '--list', 'main', 'master'], opts).toString().trim();
-    if (!result) return 'main';
-    // Each line is "  branchname" or "* branchname" - check if 'main' exists
-    const branches = result.split('\n').map((b) => b.replace(/^\*?\s+/, '').trim());
-    if (branches.includes('main')) return 'main';
-    if (branches.includes('master')) return 'master';
-    return 'main';
+    const result = execFileSync('git', ['branch', '--list', 'main', 'master'], opts).toString();
+    const main = parseMainBranchOutput(result);
+    projectMainBranchCache.set(projectPath, main);
+    return main;
   } catch {
     return 'main';
+  }
+}
+
+/**
+ * Async variant for hot paths (most importantly `getGitFileStatus`). Falls
+ * through to `execFileAsync` on cache miss so the main process isn't blocked.
+ */
+export async function getMainBranchAsync(projectPath: string): Promise<string> {
+  const cached = projectMainBranchCache.get(projectPath);
+  if (cached) return cached;
+
+  try {
+    const { stdout } = await execFileAsync('git', ['branch', '--list', 'main', 'master'], gitExecOpts(projectPath));
+    const main = parseMainBranchOutput(stdout);
+    projectMainBranchCache.set(projectPath, main);
+    return main;
+  } catch {
+    return 'main';
+  }
+}
+
+/** Drop the cached main branch for a project (call after a rename or fresh clone). */
+export function invalidateMainBranchCache(projectPath?: string): void {
+  if (projectPath == null) {
+    projectMainBranchCache.clear();
+  } else {
+    projectMainBranchCache.delete(projectPath);
   }
 }
 
@@ -660,7 +709,7 @@ export async function getGitFileStatus(projectPath: string, diffBase?: string): 
       return null; // Not a git repo
     }
 
-    const mainBranch = getMainBranch(projectPath);
+    const mainBranch = await getMainBranchAsync(projectPath);
     const base = diffBase || mainBranch;
     const isOnBase = branch === base;
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -225,6 +225,14 @@ export function getMainBranch(projectPath: string): string {
 }
 
 /**
+ * Per-project in-flight Promise for `getMainBranchAsync`. Without it, the
+ * periodic git-status refresh, an open DiffPanel, and a worktree merge can
+ * all hit a cold cache concurrently and each spawn their own `git branch
+ * --list` — the cache exists to prevent exactly that.
+ */
+const mainBranchInflight = new Map<string, Promise<string>>();
+
+/**
  * Async variant for hot paths (most importantly `getGitFileStatus`). Falls
  * through to `execFileAsync` on cache miss so the main process isn't blocked.
  */
@@ -232,13 +240,25 @@ export async function getMainBranchAsync(projectPath: string): Promise<string> {
   const cached = projectMainBranchCache.get(projectPath);
   if (cached) return cached;
 
+  const pending = mainBranchInflight.get(projectPath);
+  if (pending) return pending;
+
+  const fetchPromise = (async () => {
+    try {
+      const { stdout } = await execFileAsync('git', ['branch', '--list', 'main', 'master'], gitExecOpts(projectPath));
+      const main = parseMainBranchOutput(stdout);
+      projectMainBranchCache.set(projectPath, main);
+      return main;
+    } catch {
+      return 'main';
+    }
+  })();
+
+  mainBranchInflight.set(projectPath, fetchPromise);
   try {
-    const { stdout } = await execFileAsync('git', ['branch', '--list', 'main', 'master'], gitExecOpts(projectPath));
-    const main = parseMainBranchOutput(stdout);
-    projectMainBranchCache.set(projectPath, main);
-    return main;
-  } catch {
-    return 'main';
+    return await fetchPromise;
+  } finally {
+    mainBranchInflight.delete(projectPath);
   }
 }
 
@@ -246,8 +266,10 @@ export async function getMainBranchAsync(projectPath: string): Promise<string> {
 export function invalidateMainBranchCache(projectPath?: string): void {
   if (projectPath == null) {
     projectMainBranchCache.clear();
+    mainBranchInflight.clear();
   } else {
     projectMainBranchCache.delete(projectPath);
+    mainBranchInflight.delete(projectPath);
   }
 }
 

--- a/src/ptyManager.ts
+++ b/src/ptyManager.ts
@@ -31,6 +31,12 @@ interface ManagedPty {
   outputChunks: string[];
   outputSize: number;
   maxBufferSize: number;
+  // Per-tick IPC coalescing — heavy output (find /, builds, log tails) emits
+  // many small chunks; sending each as its own IPC message saturates the
+  // renderer with serialization work and stutters the UI. We collect chunks
+  // and flush once per Node event-loop tick.
+  pendingForwardChunks: string[];
+  forwardFlushScheduled: boolean;
   // Terminal state tracking for accurate reconnection replay
   isAltScreen: boolean;
   lastCols: number;
@@ -79,7 +85,34 @@ function canSendToRenderer(): boolean {
 }
 
 /**
- * Handle PTY output: always buffer for history, and forward to renderer if connected
+ * Flush any pending forwarded chunks for a PTY as a single concatenated IPC
+ * message. Safe to call when nothing is pending or when no renderer is attached.
+ */
+function flushPendingForward(ptyId: PtyId, channel: string): void {
+  const managed = activePtys.get(ptyId);
+  if (!managed) return;
+  managed.forwardFlushScheduled = false;
+  if (managed.pendingForwardChunks.length === 0) return;
+  if (!canSendToRenderer()) {
+    // Drop the queue if there's no renderer to receive it; the chunks are
+    // already retained in `outputChunks` for reconnection replay.
+    managed.pendingForwardChunks.length = 0;
+    return;
+  }
+  const payload =
+    managed.pendingForwardChunks.length === 1 ? managed.pendingForwardChunks[0] : managed.pendingForwardChunks.join('');
+  managed.pendingForwardChunks.length = 0;
+  currentWindow!.webContents.send(channel, payload);
+}
+
+/**
+ * Handle PTY output: always buffer for history, and forward to renderer if connected.
+ *
+ * Forwarding is coalesced once per Node event-loop tick via `setImmediate`. A
+ * heavy command (build, `find /`, log tail) can emit many small data events
+ * per millisecond; sending each as its own IPC was saturating the renderer
+ * with serialization + xterm side-effect work, stuttering kanban drag and
+ * other UI animations.
  */
 function handlePtyOutput(ptyId: PtyId, channel: string, data: string): void {
   const managed = activePtys.get(ptyId);
@@ -93,19 +126,19 @@ function handlePtyOutput(ptyId: PtyId, channel: string, data: string): void {
     managed.isAltScreen = false;
   }
 
-  // Array-based buffering to avoid string concatenation churn
+  // Array-based history buffer (preserved per-chunk for accurate replay)
   managed.outputChunks.push(data);
   managed.outputSize += data.length;
-
-  // Trim from front when over limit
   while (managed.outputSize > managed.maxBufferSize && managed.outputChunks.length > 1) {
     const removed = managed.outputChunks.shift()!;
     managed.outputSize -= removed.length;
   }
 
-  // Forward to renderer if available
-  if (canSendToRenderer()) {
-    currentWindow!.webContents.send(channel, data);
+  // Coalesce forwards to the renderer
+  managed.pendingForwardChunks.push(data);
+  if (!managed.forwardFlushScheduled) {
+    managed.forwardFlushScheduled = true;
+    setImmediate(() => flushPendingForward(ptyId, channel));
   }
 }
 
@@ -230,6 +263,8 @@ export async function spawnPty(options: PtySpawnOptions, window: BrowserWindow):
       outputChunks: [],
       outputSize: 0,
       maxBufferSize: MAX_BUFFER_SIZE,
+      pendingForwardChunks: [],
+      forwardFlushScheduled: false,
       isAltScreen: false,
       lastCols: options.cols || 80,
       lastRows: options.rows || 24,
@@ -244,6 +279,9 @@ export async function spawnPty(options: PtySpawnOptions, window: BrowserWindow):
 
     ptyProcess.onExit(({ exitCode }) => {
       ptyLog.info('exited', { ptyId, exitCode });
+      // Drain any output buffered in the same tick as the exit so the user
+      // sees the final lines before the exit message.
+      flushPendingForward(ptyId, `pty:data:${ptyId}`);
       if (canSendToRenderer()) {
         currentWindow!.webContents.send(`pty:exit:${ptyId}`, exitCode);
       }
@@ -283,6 +321,12 @@ export function reconnectPty(
 
   // Update window reference
   currentWindow = window;
+
+  // Drop any chunks queued for forwarding — `outputChunks` already contains
+  // them, and the renderer replays the full history below. Without this clear,
+  // a scheduled setImmediate flush would re-send those same chunks after the
+  // replay, producing duplicated output on reconnect.
+  managed.pendingForwardChunks.length = 0;
 
   // Join chunks for replay (only done on reconnection, not per data event)
   const bufferedOutput = managed.outputChunks.join('');

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -135,6 +135,7 @@ type ProjectStore = ProjectStoreState & ProjectStoreActions;
 let toastCounter = 0;
 let moveCounter = 0;
 let runHookRequestCounter = 0;
+let configLoadVersion = 0;
 
 export const useProjectStore = create<ProjectStore>()((set, get) => ({
   tasks: [],
@@ -316,13 +317,17 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   },
 
   loadProjectConfig: async (projectPath) => {
+    // Version counter: a later call (e.g. user switched projects A → B while
+    // A's IPC was still in flight) bumps the version, so when A's responses
+    // arrive their `version !== configLoadVersion` check drops them.
+    // Otherwise stale A config could land under project B.
+    const version = ++configLoadVersion;
     try {
       const [status, hooks] = await Promise.all([
         window.api.lima.status(projectPath),
         window.api.hooks.get(projectPath),
       ]);
-      // Bail if another project was loaded while these were in flight.
-      if (get().configProjectPath != null && get().configProjectPath !== projectPath) return;
+      if (version !== configLoadVersion) return;
       const configured: Record<string, boolean> = {};
       for (const key of Object.keys(hooks)) {
         if (hooks[key as HookType]) configured[key] = true;

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -51,6 +51,15 @@ interface ProjectStoreState {
   runHookRequest: RunHookRequest | null;
   /** Queued CLI-initiated task starts awaiting the user to enter the project. */
   pendingCliStarts: Record<string, PendingCliStart[]>;
+  /**
+   * Project-scoped config used by terminal/kanban cards. Loaded once per project
+   * so we don't fan out N `lima.status` (subprocess spawn) + `hooks.get` calls
+   * across every visible card.
+   */
+  sandboxAvailable: boolean;
+  configuredHooks: Record<string, boolean>;
+  /** projectPath the config currently reflects; null = not loaded. */
+  configProjectPath: string | null;
   _version: number;
 }
 
@@ -95,6 +104,14 @@ interface ProjectStoreActions {
   loadTasks: (projectPath: string) => Promise<void>;
   /** Load scripts from IPC */
   loadScripts: (projectPath: string) => Promise<void>;
+  /**
+   * Load project-scoped config (sandbox availability + configured hooks) in a
+   * single pair of IPC calls. Replaces per-card fan-out where every kanban card
+   * and terminal header spawned its own limactl subprocess on mount.
+   */
+  loadProjectConfig: (projectPath: string) => Promise<void>;
+  /** Mark a hook as configured after the user saves one from a card dialog. */
+  markHookConfigured: (hookType: HookType) => void;
   /** Move a task with optimistic update and rollback */
   moveTask: (projectPath: string, taskNumber: number, newStatus: string, targetIndex: number) => Promise<void>;
 
@@ -138,6 +155,9 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   startingTaskNumbers: new Set<number>(),
   runHookRequest: null,
   pendingCliStarts: {},
+  sandboxAvailable: false,
+  configuredHooks: {},
+  configProjectPath: null,
   _version: 0,
 
   setTasks: (tasks) => {
@@ -232,6 +252,9 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
       selectionAnchor: null,
       startingTaskNumbers: new Set<number>(),
       runHookRequest: null,
+      sandboxAvailable: false,
+      configuredHooks: {},
+      configProjectPath: null,
       _version: 0,
     });
   },
@@ -290,6 +313,36 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
     } catch (err) {
       get().addToast(`Failed to load scripts: ${err instanceof Error ? err.message : String(err)}`, 'error');
     }
+  },
+
+  loadProjectConfig: async (projectPath) => {
+    try {
+      const [status, hooks] = await Promise.all([
+        window.api.lima.status(projectPath),
+        window.api.hooks.get(projectPath),
+      ]);
+      // Bail if another project was loaded while these were in flight.
+      if (get().configProjectPath != null && get().configProjectPath !== projectPath) return;
+      const configured: Record<string, boolean> = {};
+      for (const key of Object.keys(hooks)) {
+        if (hooks[key as HookType]) configured[key] = true;
+      }
+      set({
+        sandboxAvailable: status.available,
+        configuredHooks: configured,
+        configProjectPath: projectPath,
+      });
+    } catch {
+      // Swallow — project config (sandbox availability + configured hooks) is
+      // a UX nicety; if IPC fails the cards just render with falsy defaults
+      // and the user retries the action.
+    }
+  },
+
+  markHookConfigured: (hookType) => {
+    const prev = get().configuredHooks;
+    if (prev[hookType]) return;
+    set({ configuredHooks: { ...prev, [hookType]: true } });
   },
 
   moveTask: async (projectPath, taskNumber, newStatus, targetIndex) => {


### PR DESCRIPTION
## Summary

Targets four felt-symptom buckets: sluggish project switch, terminal-busy stutter, idle battery drain, and laggy kanban drag.

- Hoist `lima.status` + `hooks.get` from per-card useEffects (`KanbanCard`, `TerminalHeader`) into a single `projectStore` slice loaded once per project, eliminating N×limactl subprocess spawns on every board mount.
- Coalesce PTY output IPC per Node event-loop tick via `setImmediate`; heavy output (builds, `find /`, log tails) no longer saturates the renderer with one IPC message per node-pty `data` event.
- Add async `getMainBranchAsync` with a per-project cache; the periodic git-status refresh no longer blocks the main process on `git branch --list`.
- Pause periodic git-status refresh and sandbox status polling when the window is hidden.
- Throttle the kanban trash-zone `pointermove` handler to rAF.
- Consolidate 17 `TerminalHeader` and 9 `TerminalBody` zustand selectors into one `useShallow` subscription each.
- Memoize `KanbanBoard` `chainMap` on a parent-relation fingerprint so unrelated task edits don't break every memoized card.
- Batch `DiffPanel` per-file diff loads (one `Map` clone per batch instead of per file — O(N²) → O(N²/batchSize)).
- Replace kanban `findContainer` O(N)-per-drag-tick scan with an O(1) `taskNumber → status` Map.