### PR TITLE
Match project icon size to identicons

### DIFF
--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -477,7 +477,7 @@ export function HomeView() {
                   project?.iconDataUrl ? (
                     <img
                       className="shrink-0 object-cover"
-                      style={{ width: 16, minWidth: 16, height: 16, borderRadius: 4, aspectRatio: '1' }}
+                      style={{ width: 16, minWidth: 16, height: 16, aspectRatio: '1' }}
                       src={project.iconDataUrl}
                       alt={name}
                       draggable={false}

--- a/src/components/RecentTasksPanel.tsx
+++ b/src/components/RecentTasksPanel.tsx
@@ -281,7 +281,7 @@ function Checkbox({ checked, onChange, onPointerEnter, onPointerLeave }: Checkbo
 
 function ProjectThumb({ project }: { project: Project }) {
   return (
-    <div className="w-7 h-7 overflow-hidden rounded-md shrink-0">
+    <div className={`w-7 h-7 shrink-0 ${project.iconDataUrl ? '' : 'overflow-hidden rounded-md'}`}>
       {project.iconDataUrl ? (
         <img src={project.iconDataUrl} alt="" className="w-full h-full object-cover" draggable={false} />
       ) : (

--- a/src/components/ResumeBanner.tsx
+++ b/src/components/ResumeBanner.tsx
@@ -198,7 +198,7 @@ function EntryRow({ entry }: { entry: RestorableEntry }) {
 
 function ProjectThumb({ project }: { project: Project }) {
   return (
-    <div className="w-4 h-4 overflow-hidden rounded-[3px] shrink-0">
+    <div className={`w-4 h-4 shrink-0 ${project.iconDataUrl ? '' : 'overflow-hidden rounded-[3px]'}`}>
       {project.iconDataUrl ? (
         <img src={project.iconDataUrl} alt="" className="w-full h-full object-cover" draggable={false} />
       ) : (

--- a/src/components/SidebarReact.tsx
+++ b/src/components/SidebarReact.tsx
@@ -431,7 +431,7 @@ function SortableProjectIcon({ project, isActive, onClick, onContextMenu }: Sort
             isActive ? 'h-9 opacity-100' : 'h-0 opacity-0 group-hover:h-5 group-hover:opacity-50'
           }`}
         />
-        <div className="w-10 h-10 overflow-hidden rounded-md">
+        <div className={`w-10 h-10 ${project.iconDataUrl ? '' : 'overflow-hidden rounded-md'}`}>
           {project.iconDataUrl ? (
             <img
               src={project.iconDataUrl}

--- a/src/components/TitleBarReact.tsx
+++ b/src/components/TitleBarReact.tsx
@@ -95,7 +95,7 @@ export function TitleBar({ mode }: TitleBarProps) {
       >
         {activeView === 'project' && activeProjectData && activeProjectPath ? (
           <div key="project-header" className="flex items-center gap-3 flex-1 pl-2 pr-4 min-w-0">
-            <div className="w-8 h-8 overflow-hidden rounded-md shrink-0">
+            <div className={`w-8 h-8 shrink-0 ${activeProjectData.iconDataUrl ? '' : 'overflow-hidden rounded-md'}`}>
               {activeProjectData.iconDataUrl ? (
                 <img
                   src={activeProjectData.iconDataUrl}

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -128,6 +128,44 @@ const ICON_FILES = [
 ];
 
 /**
+ * Trims fully-transparent border pixels so macOS-style app icons (which include
+ * built-in padding) render at the same visual size as identicons.
+ */
+function trimTransparentBorder(image: Electron.NativeImage): Electron.NativeImage {
+  const { width, height } = image.getSize();
+  if (width === 0 || height === 0) return image;
+
+  const bitmap = image.toBitmap();
+  if (bitmap.length < width * height * 4) return image;
+
+  const alphaThreshold = 8;
+  let top = height;
+  let bottom = -1;
+  let left = width;
+  let right = -1;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const alpha = bitmap[(y * width + x) * 4 + 3];
+      if (alpha > alphaThreshold) {
+        if (y < top) top = y;
+        if (y > bottom) bottom = y;
+        if (x < left) left = x;
+        if (x > right) right = x;
+      }
+    }
+  }
+
+  if (bottom < 0 || right < 0) return image;
+
+  const cropW = right - left + 1;
+  const cropH = bottom - top + 1;
+  if (cropW === width && cropH === height) return image;
+
+  return image.crop({ x: left, y: top, width: cropW, height: cropH });
+}
+
+/**
  * Finds an icon file and converts it to a data URL
  */
 async function getIconDataUrl(dirPath: string): Promise<string | undefined> {
@@ -137,8 +175,9 @@ async function getIconDataUrl(dirPath: string): Promise<string | undefined> {
       try {
         const image = nativeImage.createFromPath(iconPath);
         if (!image.isEmpty()) {
+          const trimmed = trimTransparentBorder(image);
           // Resize to 96x96 for consistent display (2x for retina)
-          const resized = image.resize({ width: 96, height: 96, quality: 'best' });
+          const resized = trimmed.resize({ width: 96, height: 96, quality: 'best' });
           return resized.toDataURL();
         }
       } catch (error) {


### PR DESCRIPTION
## Summary

- Trim transparent padding from project icons in the scanner so macOS-style app icons render at the same visual size as the generated identicons.
- Drop `rounded-md overflow-hidden` (and the inline `borderRadius` in HomeView) on icon containers when an `iconDataUrl` is present, so the icon's own bevel and shape stay visible instead of being clipped by the container's CSS corner radius. Identicons keep their CSS rounding.