### PR TITLE
Add Codex CLI support

### DIFF
--- a/src/__tests__/healthCheck.test.ts
+++ b/src/__tests__/healthCheck.test.ts
@@ -36,16 +36,16 @@ describe('healthCheck', () => {
   });
 
   test('reports all tools present and parses git version', async () => {
-    execFileMock.mockImplementation((cmd: string, _args: string[], cb: Function) => {
+    execFileMock.mockImplementation((cmd: string, args: string[], cb: Function) => {
       if (cmd === 'git') cb(null, 'git version 2.39.5\n', '');
-      else if (cmd === 'which') cb(null, '/usr/local/bin/claude\n', '');
+      else if (cmd === 'which') cb(null, `/usr/local/bin/${args[0]}\n`, '');
       else cb(new Error(`unexpected ${cmd}`));
     });
     isLimaInstalledMock.mockResolvedValue(true);
 
     const { checkHealth } = await import('../healthCheck');
     const status = await checkHealth();
-    expect(status).toEqual({ git: true, claude: true, lima: true, gitVersion: '2.39.5' });
+    expect(status).toEqual({ git: true, claude: true, codex: true, lima: true, gitVersion: '2.39.5' });
   });
 
   test('reports git missing when execFile rejects', async () => {
@@ -58,7 +58,21 @@ describe('healthCheck', () => {
 
     const { checkHealth } = await import('../healthCheck');
     const status = await checkHealth();
-    expect(status).toEqual({ git: false, claude: false, lima: false, gitVersion: undefined });
+    expect(status).toEqual({ git: false, claude: false, codex: false, lima: false, gitVersion: undefined });
+  });
+
+  test('detects codex independently of claude', async () => {
+    execFileMock.mockImplementation((cmd: string, args: string[], cb: Function) => {
+      if (cmd === 'git') cb(null, 'git version 2.41.0\n', '');
+      else if (cmd === 'which' && args[0] === 'codex') cb(null, '/opt/homebrew/bin/codex\n', '');
+      else if (cmd === 'which') cb(new Error('not found'));
+      else cb(new Error(`unexpected ${cmd}`));
+    });
+    isLimaInstalledMock.mockResolvedValue(false);
+
+    const { checkHealth } = await import('../healthCheck');
+    const status = await checkHealth();
+    expect(status).toEqual({ git: true, claude: false, codex: true, lima: false, gitVersion: '2.41.0' });
   });
 
   test('caches result and exposes via getCachedHealth', async () => {
@@ -72,6 +86,6 @@ describe('healthCheck', () => {
     const { checkHealth, getCachedHealth } = await import('../healthCheck');
     expect(getCachedHealth()).toBeNull();
     await checkHealth();
-    expect(getCachedHealth()).toEqual({ git: true, claude: false, lima: true, gitVersion: '2.40.0' });
+    expect(getCachedHealth()).toEqual({ git: true, claude: false, codex: false, lima: true, gitVersion: '2.40.0' });
   });
 });

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -340,10 +340,10 @@ describe('installWrapper', () => {
     expect(wrapper).toContain('#!/bin/bash');
     expect(wrapper).toContain('REAL_CODEX=');
     expect(wrapper).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
-    // Injects the CLI reference, notify, and hooks via -c overrides
+    // Injects the CLI reference + status notifier via -c overrides
     expect(wrapper).toContain('-c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)"');
     expect(wrapper).toContain("-c 'notify=");
-    expect(wrapper).toContain("-c 'hooks=");
+    expect(wrapper).not.toContain("-c 'hooks=");
     // Launch-time thinking ping
     expect(wrapper).toContain('"$HOME/.config/Ouijit/bin/ouijit-hook" status status=thinking &');
     // No-API fallthrough still passes developer_instructions
@@ -468,24 +468,18 @@ describe('CODEX_WRAPPER', () => {
     expect(CODEX_WRAPPER).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
   });
 
-  test('contains valid embedded JSON for notify and hooks overrides', () => {
+  test('the notify override is a valid TOML/JSON array pointing at ouijit-hook', () => {
     const notifyMatch = CODEX_WRAPPER.match(/-c 'notify=(.+?)' \\/);
     expect(notifyMatch).not.toBeNull();
     const notify = JSON.parse(notifyMatch![1]) as string[];
     expect(notify[0]).toBe('bash');
     expect(notify).toContain('-c');
-    expect(notify[2]).toContain('ouijit-hook status status=ready');
+    expect(notify[2]).toBe('$HOME/.config/Ouijit/bin/ouijit-hook status status=ready');
+  });
 
-    const hooksMatch = CODEX_WRAPPER.match(/-c 'hooks=(.+?)' \\/);
-    expect(hooksMatch).not.toBeNull();
-    const hooks = JSON.parse(hooksMatch![1]) as Record<string, Array<{ hooks: Array<{ command: string }> }>>;
-    expect(hooks.UserPromptSubmit[0].hooks[0].command).toContain('status status=thinking');
-    expect(hooks.PostToolUse[0].hooks[0].command).toContain('status status=thinking');
-    expect(hooks.Stop[0].hooks[0].command).toContain('status status=ready');
-    expect(hooks.PermissionRequest[0].hooks[0].command).toContain('status status=ready');
-    for (const event of Object.values(hooks)) {
-      expect(event[0].hooks[0].command).toContain('$HOME/.config/Ouijit/bin/ouijit-hook');
-    }
+  test('does not inject a `hooks` config override (Codex -c cannot take a TOML table)', () => {
+    expect(CODEX_WRAPPER).not.toContain("-c 'hooks=");
+    expect(CODEX_WRAPPER).not.toContain('-c "hooks=');
   });
 
   test('emits a launch-time thinking ping and falls through without OUIJIT_API_URL', () => {

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -340,12 +340,13 @@ describe('installWrapper', () => {
     expect(wrapper).toContain('#!/bin/bash');
     expect(wrapper).toContain('REAL_CODEX=');
     expect(wrapper).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
-    // Injects the CLI reference + status notifier via -c overrides
+    // Injects the CLI reference + lifecycle hooks + notify via -c overrides
     expect(wrapper).toContain('-c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)"');
+    expect(wrapper).toContain("-c 'hooks.UserPromptSubmit=");
+    expect(wrapper).toContain("-c 'hooks.PostToolUse=");
+    expect(wrapper).toContain("-c 'hooks.Stop=");
+    expect(wrapper).toContain("-c 'hooks.PermissionRequest=");
     expect(wrapper).toContain("-c 'notify=");
-    expect(wrapper).not.toContain("-c 'hooks=");
-    // Launch-time thinking ping
-    expect(wrapper).toContain('"$HOME/.config/Ouijit/bin/ouijit-hook" status status=thinking &');
     // No-API fallthrough still passes developer_instructions
     expect(wrapper).toContain('if [ -z "$OUIJIT_API_URL" ]; then');
     expect(wrapper).toContain(
@@ -477,13 +478,31 @@ describe('CODEX_WRAPPER', () => {
     expect(notify[2]).toBe('$HOME/.config/Ouijit/bin/ouijit-hook status status=ready');
   });
 
-  test('does not inject a `hooks` config override (Codex -c cannot take a TOML table)', () => {
-    expect(CODEX_WRAPPER).not.toContain("-c 'hooks=");
-    expect(CODEX_WRAPPER).not.toContain('-c "hooks=');
+  test('injects the four status hooks as TOML arrays of inline tables (must NOT be JSON)', () => {
+    // Each hooks.<Event> override is a TOML array. Codex parses -c values as
+    // TOML; a JSON object would fail parse and degrade to a string, failing
+    // typed deserialization. Asserting TOML inline-table syntax (`{k=v}`).
+    const expected: Array<[string, 'thinking' | 'ready']> = [
+      ['UserPromptSubmit', 'thinking'],
+      ['PostToolUse', 'thinking'],
+      ['Stop', 'ready'],
+      ['PermissionRequest', 'ready'],
+    ];
+    for (const [event, status] of expected) {
+      const re = new RegExp(
+        `-c 'hooks\\.${event}=(\\[\\{hooks=\\[\\{type="command",command="[^"]+",async=true\\}\\]\\}\\])' \\\\`,
+      );
+      const match = CODEX_WRAPPER.match(re);
+      expect(match, `hooks.${event} override should be a TOML array of inline tables`).not.toBeNull();
+      // Pull the command out and check the status mapping
+      const cmdMatch = match![1].match(/command="([^"]+)"/);
+      expect(cmdMatch![1]).toBe(`$HOME/.config/Ouijit/bin/ouijit-hook status status=${status}`);
+      // Must be TOML, not JSON: no `"key":value` syntax
+      expect(match![1]).not.toMatch(/"[A-Za-z_]+":/);
+    }
   });
 
-  test('emits a launch-time thinking ping and falls through without OUIJIT_API_URL', () => {
-    expect(CODEX_WRAPPER).toContain('"$HOME/.config/Ouijit/bin/ouijit-hook" status status=thinking &');
+  test('falls through with just developer_instructions when OUIJIT_API_URL is unset', () => {
     expect(CODEX_WRAPPER).toContain('if [ -z "$OUIJIT_API_URL" ]; then');
     expect(CODEX_WRAPPER).toContain(
       'exec "$REAL_CODEX" -c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"',
@@ -909,9 +928,15 @@ describe('buildVmHookSettings', () => {
 // ── buildVmCodexConfig ───────────────────────────────────────────────
 
 describe('buildVmCodexConfig', () => {
-  test('wires a notify command via $HOME/ouijit-hook and omits the CLI reference', () => {
+  test('wires notify + the four status hooks via $HOME/ouijit-hook and omits the CLI reference', () => {
     const toml = buildVmCodexConfig();
     expect(toml).toContain('notify = ["bash", "-c", "$HOME/ouijit-hook status status=ready"]');
+    expect(toml).toMatch(
+      /hooks\.UserPromptSubmit = \[\{hooks=\[\{type="command",command="\$HOME\/ouijit-hook status status=thinking",async=true\}\]\}\]/,
+    );
+    expect(toml).toMatch(/hooks\.PostToolUse = .+status=thinking/);
+    expect(toml).toMatch(/hooks\.Stop = .+status=ready/);
+    expect(toml).toMatch(/hooks\.PermissionRequest = .+status=ready/);
     // Sandbox must not get the ouijit CLI reference (lateral-movement concern)
     expect(toml).not.toContain('developer_instructions');
     expect(toml).not.toContain('.config/Ouijit');

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -37,7 +37,9 @@ import {
   installWrapper,
   migrateFromSettingsHooks,
   buildVmHookSettings,
+  buildVmCodexConfig,
   CLAUDE_WRAPPER,
+  CODEX_WRAPPER,
 } from '../hookServer';
 import { issueToken, revokeAllTokens } from '../apiAuth';
 
@@ -330,6 +332,27 @@ describe('installWrapper', () => {
     expect(settings.hooks!.Notification![0].matcher).toBe('permission_prompt|idle_prompt');
   });
 
+  test('creates codex wrapper on first install', () => {
+    installWrapper();
+
+    const wrapperPath = path.join(tmpHome, '.config', 'Ouijit', 'bin', 'codex');
+    const wrapper = fs.readFileSync(wrapperPath, 'utf-8');
+    expect(wrapper).toContain('#!/bin/bash');
+    expect(wrapper).toContain('REAL_CODEX=');
+    expect(wrapper).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
+    // Injects the CLI reference, notify, and hooks via -c overrides
+    expect(wrapper).toContain('-c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)"');
+    expect(wrapper).toContain("-c 'notify=");
+    expect(wrapper).toContain("-c 'hooks=");
+    // Launch-time thinking ping
+    expect(wrapper).toContain('"$HOME/.config/Ouijit/bin/ouijit-hook" status status=thinking &');
+    // No-API fallthrough still passes developer_instructions
+    expect(wrapper).toContain('if [ -z "$OUIJIT_API_URL" ]; then');
+    expect(wrapper).toContain(
+      'exec "$REAL_CODEX" -c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"',
+    );
+  });
+
   test('creates CLI reference file with command documentation', () => {
     installWrapper();
 
@@ -433,6 +456,44 @@ describe('CLAUDE_WRAPPER', () => {
     ]);
 
     expect(result.stdout.trim()).toBe('/usr/bin:/usr/local/bin');
+  });
+});
+
+// ── CODEX_WRAPPER constant ───────────────────────────────────────────
+
+describe('CODEX_WRAPPER', () => {
+  test('resolves real codex and re-exports wrapper dir on PATH', () => {
+    expect(CODEX_WRAPPER).toContain('WRAPPER_DIR=');
+    expect(CODEX_WRAPPER).toContain('REAL_CODEX=');
+    expect(CODEX_WRAPPER).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
+  });
+
+  test('contains valid embedded JSON for notify and hooks overrides', () => {
+    const notifyMatch = CODEX_WRAPPER.match(/-c 'notify=(.+?)' \\/);
+    expect(notifyMatch).not.toBeNull();
+    const notify = JSON.parse(notifyMatch![1]) as string[];
+    expect(notify[0]).toBe('bash');
+    expect(notify).toContain('-c');
+    expect(notify[2]).toContain('ouijit-hook status status=ready');
+
+    const hooksMatch = CODEX_WRAPPER.match(/-c 'hooks=(.+?)' \\/);
+    expect(hooksMatch).not.toBeNull();
+    const hooks = JSON.parse(hooksMatch![1]) as Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    expect(hooks.UserPromptSubmit[0].hooks[0].command).toContain('status status=thinking');
+    expect(hooks.PostToolUse[0].hooks[0].command).toContain('status status=thinking');
+    expect(hooks.Stop[0].hooks[0].command).toContain('status status=ready');
+    expect(hooks.PermissionRequest[0].hooks[0].command).toContain('status status=ready');
+    for (const event of Object.values(hooks)) {
+      expect(event[0].hooks[0].command).toContain('$HOME/.config/Ouijit/bin/ouijit-hook');
+    }
+  });
+
+  test('emits a launch-time thinking ping and falls through without OUIJIT_API_URL', () => {
+    expect(CODEX_WRAPPER).toContain('"$HOME/.config/Ouijit/bin/ouijit-hook" status status=thinking &');
+    expect(CODEX_WRAPPER).toContain('if [ -z "$OUIJIT_API_URL" ]; then');
+    expect(CODEX_WRAPPER).toContain(
+      'exec "$REAL_CODEX" -c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"',
+    );
   });
 });
 
@@ -848,5 +909,24 @@ describe('buildVmHookSettings', () => {
       expect(cmd).not.toContain('CLAUDE_PROJECT_DIR');
       expect(cmd).not.toContain('.config/Ouijit');
     }
+  });
+});
+
+// ── buildVmCodexConfig ───────────────────────────────────────────────
+
+describe('buildVmCodexConfig', () => {
+  test('wires a notify command via $HOME/ouijit-hook and omits the CLI reference', () => {
+    const toml = buildVmCodexConfig();
+    expect(toml).toContain('notify = ["bash", "-c", "$HOME/ouijit-hook status status=ready"]');
+    // Sandbox must not get the ouijit CLI reference (lateral-movement concern)
+    expect(toml).not.toContain('developer_instructions');
+    expect(toml).not.toContain('.config/Ouijit');
+  });
+
+  test('the embedded notify array is valid JSON', () => {
+    const match = buildVmCodexConfig().match(/notify = (\[.+\])/);
+    expect(match).not.toBeNull();
+    const notify = JSON.parse(match![1]) as string[];
+    expect(notify).toEqual(['bash', '-c', '$HOME/ouijit-hook status status=ready']);
   });
 });

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -38,6 +38,7 @@ import {
   migrateFromSettingsHooks,
   buildVmHookSettings,
   buildVmCodexConfig,
+  buildVmCodexTrustState,
   CLAUDE_WRAPPER,
   CODEX_WRAPPER,
 } from '../hookServer';
@@ -340,12 +341,14 @@ describe('installWrapper', () => {
     expect(wrapper).toContain('#!/bin/bash');
     expect(wrapper).toContain('REAL_CODEX=');
     expect(wrapper).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
-    // Injects the CLI reference + lifecycle hooks + notify via -c overrides
+    // Injects the CLI reference + lifecycle hooks + per-hook pre-trust + notify via -c overrides
     expect(wrapper).toContain('-c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)"');
     expect(wrapper).toContain("-c 'hooks.UserPromptSubmit=");
     expect(wrapper).toContain("-c 'hooks.PostToolUse=");
     expect(wrapper).toContain("-c 'hooks.Stop=");
     expect(wrapper).toContain("-c 'hooks.PermissionRequest=");
+    expect(wrapper).toContain('-c \'hooks.state."/<session-flags>/config.toml:user_prompt_submit:0:0".trusted_hash=');
+    expect(wrapper).toContain('-c \'hooks.state."/<session-flags>/config.toml:permission_request:0:0".trusted_hash=');
     expect(wrapper).toContain("-c 'notify=");
     // No-API fallthrough still passes developer_instructions
     expect(wrapper).toContain('if [ -z "$OUIJIT_API_URL" ]; then');
@@ -509,6 +512,26 @@ describe('CODEX_WRAPPER', () => {
     expect(CODEX_WRAPPER).toContain(
       'exec "$REAL_CODEX" -c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"',
     );
+  });
+
+  test('pre-trusts each hook with the sha256 codex expects (locks the hash recipe)', () => {
+    // These hashes mirror codex-rs/hooks/src/engine/discovery.rs:command_hook_hash —
+    // sha256(canonical_json({event_name, hooks:[{type:"command",command,timeout:600,async:false}]})).
+    // If any of them ever fail, either Codex's normalization changed or our recipe drifted;
+    // a mismatch is graceful (Codex falls back to the /hooks review prompt) but we still
+    // want a tripwire so we know to recompute.
+    const expected: Record<string, string> = {
+      'user_prompt_submit:0:0': 'sha256:f5cd19bf6ce12a88c683852526d77e2553778f51f15d92b0d7f18c1773161245',
+      'post_tool_use:0:0': 'sha256:bba7cb97708e558b3d7746468ec196312d9c1a6cb685467177da4e99cca85115',
+      'stop:0:0': 'sha256:bd8907212bcda4a71b2e580355c07c837a9f34ac96d01a037526921bdf435ffd',
+      'permission_request:0:0': 'sha256:cb24d6656dd4fef6523820ae479cec67acfeae414590e837a926a7aa0daae1e5',
+    };
+    for (const [keySuffix, hash] of Object.entries(expected)) {
+      const re = new RegExp(
+        `-c 'hooks\\.state\\."/<session-flags>/config\\.toml:${keySuffix.replace(/:/g, '\\:')}"\\.trusted_hash="${hash}"'`,
+      );
+      expect(CODEX_WRAPPER, `pre-trust hash for ${keySuffix}`).toMatch(re);
+    }
   });
 });
 
@@ -951,5 +974,20 @@ describe('buildVmCodexConfig', () => {
     expect(match).not.toBeNull();
     const notify = JSON.parse(match![1]) as string[];
     expect(notify).toEqual(['bash', '-c', '$HOME/ouijit-hook status status=ready']);
+  });
+});
+
+// ── buildVmCodexTrustState ───────────────────────────────────────────
+
+describe('buildVmCodexTrustState', () => {
+  test('emits a trusted_hash line per event keyed off the VM config path with $HOME literal', () => {
+    const toml = buildVmCodexTrustState();
+    // $HOME stays literal — the unquoted heredoc in lima/spawn expands it at write time.
+    for (const event of ['user_prompt_submit', 'post_tool_use', 'stop', 'permission_request']) {
+      const re = new RegExp(
+        `hooks\\.state\\."\\$HOME/\\.codex/config\\.toml:${event}:0:0"\\.trusted_hash = "sha256:[0-9a-f]{64}"`,
+      );
+      expect(toml).toMatch(re);
+    }
   });
 });

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -490,7 +490,7 @@ describe('CODEX_WRAPPER', () => {
     ];
     for (const [event, status] of expected) {
       const re = new RegExp(
-        `-c 'hooks\\.${event}=(\\[\\{hooks=\\[\\{type="command",command="[^"]+",async=true\\}\\]\\}\\])' \\\\`,
+        `-c 'hooks\\.${event}=(\\[\\{hooks=\\[\\{type="command",command="[^"]+"\\}\\]\\}\\])' \\\\`,
       );
       const match = CODEX_WRAPPER.match(re);
       expect(match, `hooks.${event} override should be a TOML array of inline tables`).not.toBeNull();
@@ -499,6 +499,8 @@ describe('CODEX_WRAPPER', () => {
       expect(cmdMatch![1]).toBe(`$HOME/.config/Ouijit/bin/ouijit-hook status status=${status}`);
       // Must be TOML, not JSON: no `"key":value` syntax
       expect(match![1]).not.toMatch(/"[A-Za-z_]+":/);
+      // Codex skips async hooks today ("async hooks are not supported yet")
+      expect(match![1]).not.toContain('async');
     }
   });
 
@@ -932,11 +934,13 @@ describe('buildVmCodexConfig', () => {
     const toml = buildVmCodexConfig();
     expect(toml).toContain('notify = ["bash", "-c", "$HOME/ouijit-hook status status=ready"]');
     expect(toml).toMatch(
-      /hooks\.UserPromptSubmit = \[\{hooks=\[\{type="command",command="\$HOME\/ouijit-hook status status=thinking",async=true\}\]\}\]/,
+      /hooks\.UserPromptSubmit = \[\{hooks=\[\{type="command",command="\$HOME\/ouijit-hook status status=thinking"\}\]\}\]/,
     );
     expect(toml).toMatch(/hooks\.PostToolUse = .+status=thinking/);
     expect(toml).toMatch(/hooks\.Stop = .+status=ready/);
     expect(toml).toMatch(/hooks\.PermissionRequest = .+status=ready/);
+    // Codex skips async hooks today ("async hooks are not supported yet")
+    expect(toml).not.toContain('async');
     // Sandbox must not get the ouijit CLI reference (lateral-movement concern)
     expect(toml).not.toContain('developer_instructions');
     expect(toml).not.toContain('.config/Ouijit');

--- a/src/components/dialogs/CombinedHookConfigDialog.tsx
+++ b/src/components/dialogs/CombinedHookConfigDialog.tsx
@@ -151,6 +151,13 @@ export function CombinedHookConfigDialog({
             ))}
           </ul>
         </details>
+
+        <p className="mt-3 text-xs text-text-tertiary leading-snug">
+          Works with Claude Code (<code className="font-mono">claude "$OUIJIT_TASK_PROMPT"</code> /{' '}
+          <code className="font-mono">claude -c</code>) and Codex (
+          <code className="font-mono">codex "$OUIJIT_TASK_PROMPT"</code> /{' '}
+          <code className="font-mono">codex resume --last</code>).
+        </p>
       </div>
 
       <div className="flex gap-2 justify-end mt-4 items-center">

--- a/src/components/dialogs/CombinedHookConfigDialog.tsx
+++ b/src/components/dialogs/CombinedHookConfigDialog.tsx
@@ -151,13 +151,6 @@ export function CombinedHookConfigDialog({
             ))}
           </ul>
         </details>
-
-        <p className="mt-3 text-xs text-text-tertiary leading-snug">
-          Works with Claude Code (<code className="font-mono">claude "$OUIJIT_TASK_PROMPT"</code> /{' '}
-          <code className="font-mono">claude -c</code>) and Codex (
-          <code className="font-mono">codex "$OUIJIT_TASK_PROMPT"</code> /{' '}
-          <code className="font-mono">codex resume --last</code>).
-        </p>
       </div>
 
       <div className="flex gap-2 justify-end mt-4 items-center">

--- a/src/healthCheck.ts
+++ b/src/healthCheck.ts
@@ -10,6 +10,7 @@ const healthLog = getLogger().scope('health');
 export interface HealthStatus {
   git: boolean;
   claude: boolean;
+  codex: boolean;
   lima: boolean;
   gitVersion?: string;
 }
@@ -35,12 +36,22 @@ async function detectClaude(): Promise<boolean> {
   }
 }
 
+async function detectCodex(): Promise<boolean> {
+  try {
+    await execFileAsync('which', ['codex']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function checkHealth(): Promise<HealthStatus> {
-  const [git, claude, lima] = await Promise.all([detectGit(), detectClaude(), isLimaInstalled()]);
-  cached = { git: git.ok, claude, lima, gitVersion: git.version };
+  const [git, claude, codex, lima] = await Promise.all([detectGit(), detectClaude(), detectCodex(), isLimaInstalled()]);
+  cached = { git: git.ok, claude, codex, lima, gitVersion: git.version };
   healthLog.info('health probe', {
     git: cached.git,
     claude: cached.claude,
+    codex: cached.codex,
     lima: cached.lima,
     gitVersion: cached.gitVersion,
   });

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -10,6 +10,7 @@ import * as http from 'node:http';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { createHash } from 'node:crypto';
 import { BrowserWindow } from 'electron';
 import { isPtyActive } from './ptyManager';
 import { getLogger } from './logger';
@@ -490,16 +491,30 @@ export const CLAUDE_WRAPPER = [
 //     Codex runs `notify[0] notify[1..] <json>` with no shell, so we wrap it
 //     as ["bash","-c","<cmd>"] — bash expands $HOME and the trailing JSON
 //     payload becomes $0 (ignored).
+//   • hooks.state."<key>".trusted_hash — pre-trust each hook so Codex doesn't
+//     gate it behind the `/hooks` review prompt on every fresh session. The
+//     hash mirrors codex-rs/hooks/src/engine/discovery.rs:command_hook_hash:
+//     sha256 of canonical JSON of the normalized hook identity. If a future
+//     Codex changes the normalization our hash mismatches → trust_status is
+//     `Modified` → hook is skipped just like an untrusted hook, and the user
+//     falls back to the same one-time `/hooks` approval as before. Graceful.
 
 /** Path to ouijit-hook with literal $HOME (expanded by whatever shell runs it). */
 const CODEX_OUIJIT_HOOK = '$HOME/.config/Ouijit/bin/ouijit-hook';
 
-/** Lifecycle hook events Codex exposes that we map to a status, in `[event, status]` pairs. */
-const CODEX_STATUS_HOOKS: ReadonlyArray<readonly [event: string, status: 'thinking' | 'ready']> = [
-  ['UserPromptSubmit', 'thinking'],
-  ['PostToolUse', 'thinking'],
-  ['Stop', 'ready'],
-  ['PermissionRequest', 'ready'],
+/** SessionFlags layer source path Codex synthesizes for `-c` overrides (see discovery.rs). */
+const CODEX_SESSION_FLAGS_PATH = '/<session-flags>/config.toml';
+
+/**
+ * Lifecycle hook events Codex exposes that we map to a status. Each entry is
+ * `[event_name, status, event_snake]`. `event_snake` matches `hook_event_key_label`
+ * in codex-rs and is what Codex uses inside the persisted hook key.
+ */
+const CODEX_STATUS_HOOKS: ReadonlyArray<readonly [event: string, status: 'thinking' | 'ready', eventSnake: string]> = [
+  ['UserPromptSubmit', 'thinking', 'user_prompt_submit'],
+  ['PostToolUse', 'thinking', 'post_tool_use'],
+  ['Stop', 'ready', 'stop'],
+  ['PermissionRequest', 'ready', 'permission_request'],
 ];
 
 function codexHookCommand(hookPath: string, status: 'thinking' | 'ready'): string {
@@ -514,6 +529,48 @@ function codexHookEventValue(hookPath: string, status: 'thinking' | 'ready'): st
 /** TOML/JSON array value for Codex's `notify` config — a shell wrapper that ignores the trailing payload arg. */
 function codexNotifyValue(hookPath: string): string {
   return JSON.stringify(['bash', '-c', codexHookCommand(hookPath, 'ready')]);
+}
+
+/**
+ * Build the persisted hook key Codex uses for a single command hook in our
+ * single-group/single-handler layout: `<source>:<event_snake>:0:0`.
+ */
+function codexHookStateKey(source: string, eventSnake: string): string {
+  return `${source}:${eventSnake}:0:0`;
+}
+
+/**
+ * Canonical JSON: recursively sort object keys, no whitespace. Mirrors
+ * codex-rs/config/src/fingerprint.rs:canonical_json + serde_json::to_vec.
+ */
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonicalJson).join(',') + ']';
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return '{' + keys.map((k) => JSON.stringify(k) + ':' + canonicalJson(obj[k])).join(',') + '}';
+}
+
+/**
+ * Compute the `current_hash` Codex expects in `hooks.state.<key>.trusted_hash`
+ * for one of our command hooks. Mirrors `command_hook_hash` in
+ * codex-rs/hooks/src/engine/discovery.rs:
+ *
+ *   identity = { event_name, matcher (skipped when None), hooks: [normalized] }
+ *   normalized = { type:"command", command, commandWindows (skipped when None),
+ *                  timeout (default 600), async:false, statusMessage (skipped) }
+ *   hash = sha256(canonical_json(identity))
+ *
+ * None-valued Options are skipped by toml::Serializer (TOML has no null) and so
+ * don't appear in the JSON Codex hashes.
+ */
+function codexHookTrustHash(eventSnake: string, command: string): string {
+  const identity = {
+    event_name: eventSnake,
+    hooks: [{ type: 'command', command, timeout: 600, async: false }],
+  };
+  const hex = createHash('sha256').update(canonicalJson(identity)).digest('hex');
+  return `sha256:${hex}`;
 }
 
 /** Bash wrapper that shadows `codex` and injects the CLI reference + status hooks via `-c` overrides. */
@@ -550,9 +607,15 @@ export const CODEX_WRAPPER = [
   '',
   'exec "$REAL_CODEX" \\',
   '  -c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)" \\',
-  ...CODEX_STATUS_HOOKS.map(
-    ([event, status]) => `  -c 'hooks.${event}=${codexHookEventValue(CODEX_OUIJIT_HOOK, status)}' \\`,
-  ),
+  ...CODEX_STATUS_HOOKS.flatMap(([event, status, eventSnake]) => {
+    const cmd = codexHookCommand(CODEX_OUIJIT_HOOK, status);
+    const stateKey = codexHookStateKey(CODEX_SESSION_FLAGS_PATH, eventSnake);
+    const hash = codexHookTrustHash(eventSnake, cmd);
+    return [
+      `  -c 'hooks.${event}=${codexHookEventValue(CODEX_OUIJIT_HOOK, status)}' \\`,
+      `  -c 'hooks.state."${stateKey}".trusted_hash="${hash}"' \\`,
+    ];
+  }),
   `  -c 'notify=${codexNotifyValue(CODEX_OUIJIT_HOOK)}' \\`,
   '  "$@"',
   '',
@@ -751,6 +814,9 @@ export function buildVmHookSettings(): string {
  * are wired via the config file instead. The CLI reference is deliberately
  * omitted — the ouijit CLI is not installed in the sandbox. $HOME stays
  * literal so the in-VM shell expands it.
+ *
+ * Written into the VM via a *quoted* heredoc (no expansion) so that `$HOME` in
+ * hook commands reaches Codex unchanged and gets expanded by the agent's shell.
  */
 export function buildVmCodexConfig(): string {
   const hookPath = '$HOME/ouijit-hook';
@@ -758,6 +824,25 @@ export function buildVmCodexConfig(): string {
   for (const [event, status] of CODEX_STATUS_HOOKS) {
     lines.push(`hooks.${event} = ${codexHookEventValue(hookPath, status)}`);
   }
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Build the `[hooks.state]` trust-state lines for the VM's ~/.codex/config.toml.
+ * The key prefix is the absolute path of the config file, which we can only
+ * resolve at write time inside the VM — so this is meant to be appended via an
+ * *unquoted* heredoc so the VM's bash expands `$HOME` in the key.
+ */
+export function buildVmCodexTrustState(): string {
+  const hookPath = '$HOME/ouijit-hook';
+  const source = '$HOME/.codex/config.toml';
+  const lines = CODEX_STATUS_HOOKS.map(([, status, eventSnake]) => {
+    const cmd = codexHookCommand(hookPath, status);
+    const stateKey = codexHookStateKey(source, eventSnake);
+    const hash = codexHookTrustHash(eventSnake, cmd);
+    return `hooks.state."${stateKey}".trusted_hash = "${hash}"`;
+  });
   lines.push('');
   return lines.join('\n');
 }

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -469,6 +469,91 @@ export const CLAUDE_WRAPPER = [
   '',
 ].join('\n');
 
+// ── Codex wrapper ────────────────────────────────────────────────────
+// Codex has no `--settings` / `--append-system-prompt-file` flags, so the
+// wrapper injects everything via `codex -c key=value` config overrides:
+//   • developer_instructions — appends the Ouijit CLI reference as a
+//     `developer` role message (does NOT replace base instructions, unlike
+//     model_instructions_file).
+//   • notify — Codex's stable, always-on turn-complete notifier; mapped to
+//     status=ready. Codex runs `notify[0] notify[1..] <json>` with no shell,
+//     so we wrap it as ["bash","-c","<cmd>"] — bash expands $HOME and the
+//     trailing JSON payload becomes $0 (ignored).
+//   • hooks — Codex's lifecycle-hook engine (currently experimental). The
+//     override is a valid config key whether or not the engine is enabled,
+//     so it's inert until the user turns it on; commands run via the user's
+//     shell, so $HOME is left literal here.
+// A launch-time status=thinking ping covers the common case where the hook
+// engine is off (so the dot still transitions launch → ready via `notify`).
+
+/** Path to ouijit-hook with literal $HOME (expanded by whatever shell runs it). */
+const CODEX_OUIJIT_HOOK = '$HOME/.config/Ouijit/bin/ouijit-hook';
+
+function codexHookCommand(hookPath: string, status: 'thinking' | 'ready'): string {
+  return `${hookPath} status status=${status}`;
+}
+
+/** JSON value for Codex's `notify` config — a shell wrapper that ignores the trailing payload arg. */
+function codexNotifyValue(hookPath: string): string {
+  return JSON.stringify(['bash', '-c', codexHookCommand(hookPath, 'ready')]);
+}
+
+/** JSON value for Codex's `hooks` config table. */
+function codexHooksValue(hookPath: string): string {
+  const group = (status: 'thinking' | 'ready') => ({
+    hooks: [{ type: 'command', command: codexHookCommand(hookPath, status) }],
+  });
+  return JSON.stringify({
+    UserPromptSubmit: [group('thinking')],
+    PostToolUse: [group('thinking')],
+    Stop: [group('ready')],
+    PermissionRequest: [group('ready')],
+  });
+}
+
+/** Bash wrapper that shadows `codex` and injects hooks + CLI reference via `-c` overrides. */
+export const CODEX_WRAPPER = [
+  '#!/bin/bash',
+  '# Ouijit codex wrapper — mirrors the claude wrapper. Removes its own',
+  '# directory from PATH to find the real codex binary, then re-exports it',
+  '# so the ouijit CLI is available inside Codex. Injects status hooks and the',
+  '# Ouijit CLI reference via `-c` config overrides (Codex has no --settings).',
+  'WRAPPER_DIR="$(cd "$(dirname "$0")" && pwd)"',
+  'CLEAN_PATH=":$PATH:"',
+  'CLEAN_PATH="${CLEAN_PATH//:$WRAPPER_DIR:/:}"',
+  'CLEAN_PATH="${CLEAN_PATH#:}"',
+  'CLEAN_PATH="${CLEAN_PATH%:}"',
+  '',
+  '# Resolve the real codex binary from the clean PATH',
+  'REAL_CODEX="$(PATH="$CLEAN_PATH" command -v codex)"',
+  'if [ -z "$REAL_CODEX" ]; then',
+  '  echo "ouijit: codex not found on PATH" >&2',
+  '  exit 1',
+  'fi',
+  '',
+  '# Re-export PATH with wrapper dir so ouijit CLI works inside Codex',
+  'export PATH="$WRAPPER_DIR:$CLEAN_PATH"',
+  '',
+  '# Ouijit CLI reference file — appended as developer instructions',
+  'REFERENCE_FILE="$HOME/.config/Ouijit/ouijit-cli-reference.md"',
+  '',
+  '# If ouijit is not running, just exec the real codex with CLI awareness',
+  'if [ -z "$OUIJIT_API_URL" ]; then',
+  '  exec "$REAL_CODEX" -c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"',
+  'fi',
+  '',
+  '# Launch-time status=thinking ping (the lifecycle hooks below only fire if',
+  "# the user has Codex's experimental hooks engine enabled).",
+  '"$HOME/.config/Ouijit/bin/ouijit-hook" status status=thinking &',
+  '',
+  'exec "$REAL_CODEX" \\',
+  '  -c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)" \\',
+  `  -c 'notify=${codexNotifyValue(CODEX_OUIJIT_HOOK)}' \\`,
+  `  -c 'hooks=${codexHooksValue(CODEX_OUIJIT_HOOK)}' \\`,
+  '  "$@"',
+  '',
+].join('\n');
+
 // ── Shell integration scripts ────────────────────────────────────────
 // These scripts ensure the wrapper dir stays first in PATH even after
 // shell init files (.zshrc, .bashrc) prepend other directories.
@@ -549,6 +634,9 @@ export function installWrapper(): void {
 
     // Write claude wrapper script (shadows `claude` to inject --settings)
     fs.writeFileSync(path.join(binDir, 'claude'), CLAUDE_WRAPPER, { mode: 0o755 });
+
+    // Write codex wrapper script (shadows `codex` to inject -c config overrides)
+    fs.writeFileSync(path.join(binDir, 'codex'), CODEX_WRAPPER, { mode: 0o755 });
 
     // Write ouijit CLI wrapper (delegates to the bundled CLI JS via env vars set by PTY manager)
     fs.writeFileSync(
@@ -651,4 +739,16 @@ export function migrateFromSettingsHooks(): void {
  */
 export function buildVmHookSettings(): string {
   return JSON.stringify(buildHookSettings('$HOME/ouijit-hook', '$HOME/ouijit-plan-hook'), null, 2);
+}
+
+/**
+ * Build the TOML content for the VM's ~/.codex/config.toml. There is no `codex`
+ * wrapper inside the sandbox, so Codex's turn-complete notifier is wired via the
+ * config file instead. Only the stable `notify` channel is used (mapped to
+ * status=ready); the CLI reference is deliberately omitted — the ouijit CLI is
+ * not installed in the sandbox. $HOME stays literal so the in-VM shell expands it.
+ */
+export function buildVmCodexConfig(): string {
+  const readyCmd = codexHookCommand('$HOME/ouijit-hook', 'ready');
+  return [`notify = ["bash", "-c", "${readyCmd}"]`, ''].join('\n');
 }

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -471,20 +471,19 @@ export const CLAUDE_WRAPPER = [
 
 // ── Codex wrapper ────────────────────────────────────────────────────
 // Codex has no `--settings` / `--append-system-prompt-file` flags, so the
-// wrapper injects everything via `codex -c key=value` config overrides:
-//   • developer_instructions — appends the Ouijit CLI reference as a
-//     `developer` role message (does NOT replace base instructions, unlike
-//     model_instructions_file).
+// wrapper injects what it can via `codex -c key=value` config overrides:
+//   • developer_instructions — the Ouijit CLI reference, surfaced as a
+//     `developer` role message (appends; does NOT replace base instructions
+//     like model_instructions_file would). A `-c` value that fails TOML
+//     parsing is kept as a string, which is exactly the type this key wants.
 //   • notify — Codex's stable, always-on turn-complete notifier; mapped to
 //     status=ready. Codex runs `notify[0] notify[1..] <json>` with no shell,
 //     so we wrap it as ["bash","-c","<cmd>"] — bash expands $HOME and the
-//     trailing JSON payload becomes $0 (ignored).
-//   • hooks — Codex's lifecycle-hook engine (currently experimental). The
-//     override is a valid config key whether or not the engine is enabled,
-//     so it's inert until the user turns it on; commands run via the user's
-//     shell, so $HOME is left literal here.
-// A launch-time status=thinking ping covers the common case where the hook
-// engine is off (so the dot still transitions launch → ready via `notify`).
+//     trailing JSON payload becomes $0 (ignored). The value is a TOML array.
+// A launch-time status=thinking ping pairs with notify→ready to give the dot
+// a launch → ready transition. (Codex's richer lifecycle-hook engine isn't
+// wired here: it can't be configured via `-c` — the value would have to be a
+// TOML inline table — and writing into the user's ~/.codex/ is out of scope.)
 
 /** Path to ouijit-hook with literal $HOME (expanded by whatever shell runs it). */
 const CODEX_OUIJIT_HOOK = '$HOME/.config/Ouijit/bin/ouijit-hook';
@@ -493,31 +492,19 @@ function codexHookCommand(hookPath: string, status: 'thinking' | 'ready'): strin
   return `${hookPath} status status=${status}`;
 }
 
-/** JSON value for Codex's `notify` config — a shell wrapper that ignores the trailing payload arg. */
+/** TOML/JSON array value for Codex's `notify` config — a shell wrapper that ignores the trailing payload arg. */
 function codexNotifyValue(hookPath: string): string {
   return JSON.stringify(['bash', '-c', codexHookCommand(hookPath, 'ready')]);
 }
 
-/** JSON value for Codex's `hooks` config table. */
-function codexHooksValue(hookPath: string): string {
-  const group = (status: 'thinking' | 'ready') => ({
-    hooks: [{ type: 'command', command: codexHookCommand(hookPath, status) }],
-  });
-  return JSON.stringify({
-    UserPromptSubmit: [group('thinking')],
-    PostToolUse: [group('thinking')],
-    Stop: [group('ready')],
-    PermissionRequest: [group('ready')],
-  });
-}
-
-/** Bash wrapper that shadows `codex` and injects hooks + CLI reference via `-c` overrides. */
+/** Bash wrapper that shadows `codex` and injects the CLI reference + status notifier via `-c` overrides. */
 export const CODEX_WRAPPER = [
   '#!/bin/bash',
   '# Ouijit codex wrapper — mirrors the claude wrapper. Removes its own',
   '# directory from PATH to find the real codex binary, then re-exports it',
-  '# so the ouijit CLI is available inside Codex. Injects status hooks and the',
-  '# Ouijit CLI reference via `-c` config overrides (Codex has no --settings).',
+  '# so the ouijit CLI is available inside Codex. Injects the Ouijit CLI',
+  '# reference and a status notifier via `-c` config overrides (Codex has no',
+  '# --settings flag).',
   'WRAPPER_DIR="$(cd "$(dirname "$0")" && pwd)"',
   'CLEAN_PATH=":$PATH:"',
   'CLEAN_PATH="${CLEAN_PATH//:$WRAPPER_DIR:/:}"',
@@ -534,7 +521,7 @@ export const CODEX_WRAPPER = [
   '# Re-export PATH with wrapper dir so ouijit CLI works inside Codex',
   'export PATH="$WRAPPER_DIR:$CLEAN_PATH"',
   '',
-  '# Ouijit CLI reference file — appended as developer instructions',
+  '# Ouijit CLI reference file — surfaced via developer_instructions',
   'REFERENCE_FILE="$HOME/.config/Ouijit/ouijit-cli-reference.md"',
   '',
   '# If ouijit is not running, just exec the real codex with CLI awareness',
@@ -542,14 +529,12 @@ export const CODEX_WRAPPER = [
   '  exec "$REAL_CODEX" -c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"',
   'fi',
   '',
-  '# Launch-time status=thinking ping (the lifecycle hooks below only fire if',
-  "# the user has Codex's experimental hooks engine enabled).",
+  '# Launch-time status=thinking ping (pairs with notify→ready below).',
   '"$HOME/.config/Ouijit/bin/ouijit-hook" status status=thinking &',
   '',
   'exec "$REAL_CODEX" \\',
   '  -c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)" \\',
   `  -c 'notify=${codexNotifyValue(CODEX_OUIJIT_HOOK)}' \\`,
-  `  -c 'hooks=${codexHooksValue(CODEX_OUIJIT_HOOK)}' \\`,
   '  "$@"',
   '',
 ].join('\n');

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -481,8 +481,10 @@ export const CLAUDE_WRAPPER = [
 //     lifecycle-hook engine (stable, on by default). UserPromptSubmit /
 //     PostToolUse → thinking; Stop / PermissionRequest → ready. Same status
 //     mapping as the claude wrapper. The values are TOML arrays of inline
-//     tables; commands run via the user's shell, so $HOME stays literal, and
-//     `async = true` keeps them off Codex's hot path.
+//     tables; commands run via the user's shell, so $HOME stays literal.
+//     (We can't mark these `async = true` — Codex skips async hooks with a
+//     warning today. ouijit-hook itself backgrounds its `curl` and exits in
+//     milliseconds, so sync is fine.)
 //   • notify — Codex's older, always-on turn-complete notifier; also mapped
 //     to status=ready (a harmless fallback if the hooks engine is disabled).
 //     Codex runs `notify[0] notify[1..] <json>` with no shell, so we wrap it
@@ -504,9 +506,9 @@ function codexHookCommand(hookPath: string, status: 'thinking' | 'ready'): strin
   return `${hookPath} status status=${status}`;
 }
 
-/** TOML array-of-one-inline-table value for a single Codex `hooks.<Event>` entry (one async command hook). */
+/** TOML array-of-one-inline-table value for a single Codex `hooks.<Event>` entry (one command hook). */
 function codexHookEventValue(hookPath: string, status: 'thinking' | 'ready'): string {
-  return `[{hooks=[{type="command",command="${codexHookCommand(hookPath, status)}",async=true}]}]`;
+  return `[{hooks=[{type="command",command="${codexHookCommand(hookPath, status)}"}]}]`;
 }
 
 /** TOML/JSON array value for Codex's `notify` config — a shell wrapper that ignores the trailing payload arg. */

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -471,25 +471,42 @@ export const CLAUDE_WRAPPER = [
 
 // ── Codex wrapper ────────────────────────────────────────────────────
 // Codex has no `--settings` / `--append-system-prompt-file` flags, so the
-// wrapper injects what it can via `codex -c key=value` config overrides:
+// wrapper injects everything via `codex -c key=value` config overrides
+// (where the value is parsed as TOML, falling back to a raw string):
 //   • developer_instructions — the Ouijit CLI reference, surfaced as a
 //     `developer` role message (appends; does NOT replace base instructions
-//     like model_instructions_file would). A `-c` value that fails TOML
-//     parsing is kept as a string, which is exactly the type this key wants.
-//   • notify — Codex's stable, always-on turn-complete notifier; mapped to
-//     status=ready. Codex runs `notify[0] notify[1..] <json>` with no shell,
-//     so we wrap it as ["bash","-c","<cmd>"] — bash expands $HOME and the
-//     trailing JSON payload becomes $0 (ignored). The value is a TOML array.
-// A launch-time status=thinking ping pairs with notify→ready to give the dot
-// a launch → ready transition. (Codex's richer lifecycle-hook engine isn't
-// wired here: it can't be configured via `-c` — the value would have to be a
-// TOML inline table — and writing into the user's ~/.codex/ is out of scope.)
+//     like model_instructions_file would). The markdown isn't valid TOML, so
+//     it's kept as a string — exactly the type this key wants.
+//   • hooks.{UserPromptSubmit,PostToolUse,Stop,PermissionRequest} — Codex's
+//     lifecycle-hook engine (stable, on by default). UserPromptSubmit /
+//     PostToolUse → thinking; Stop / PermissionRequest → ready. Same status
+//     mapping as the claude wrapper. The values are TOML arrays of inline
+//     tables; commands run via the user's shell, so $HOME stays literal, and
+//     `async = true` keeps them off Codex's hot path.
+//   • notify — Codex's older, always-on turn-complete notifier; also mapped
+//     to status=ready (a harmless fallback if the hooks engine is disabled).
+//     Codex runs `notify[0] notify[1..] <json>` with no shell, so we wrap it
+//     as ["bash","-c","<cmd>"] — bash expands $HOME and the trailing JSON
+//     payload becomes $0 (ignored).
 
 /** Path to ouijit-hook with literal $HOME (expanded by whatever shell runs it). */
 const CODEX_OUIJIT_HOOK = '$HOME/.config/Ouijit/bin/ouijit-hook';
 
+/** Lifecycle hook events Codex exposes that we map to a status, in `[event, status]` pairs. */
+const CODEX_STATUS_HOOKS: ReadonlyArray<readonly [event: string, status: 'thinking' | 'ready']> = [
+  ['UserPromptSubmit', 'thinking'],
+  ['PostToolUse', 'thinking'],
+  ['Stop', 'ready'],
+  ['PermissionRequest', 'ready'],
+];
+
 function codexHookCommand(hookPath: string, status: 'thinking' | 'ready'): string {
   return `${hookPath} status status=${status}`;
+}
+
+/** TOML array-of-one-inline-table value for a single Codex `hooks.<Event>` entry (one async command hook). */
+function codexHookEventValue(hookPath: string, status: 'thinking' | 'ready'): string {
+  return `[{hooks=[{type="command",command="${codexHookCommand(hookPath, status)}",async=true}]}]`;
 }
 
 /** TOML/JSON array value for Codex's `notify` config — a shell wrapper that ignores the trailing payload arg. */
@@ -497,13 +514,13 @@ function codexNotifyValue(hookPath: string): string {
   return JSON.stringify(['bash', '-c', codexHookCommand(hookPath, 'ready')]);
 }
 
-/** Bash wrapper that shadows `codex` and injects the CLI reference + status notifier via `-c` overrides. */
+/** Bash wrapper that shadows `codex` and injects the CLI reference + status hooks via `-c` overrides. */
 export const CODEX_WRAPPER = [
   '#!/bin/bash',
   '# Ouijit codex wrapper — mirrors the claude wrapper. Removes its own',
   '# directory from PATH to find the real codex binary, then re-exports it',
   '# so the ouijit CLI is available inside Codex. Injects the Ouijit CLI',
-  '# reference and a status notifier via `-c` config overrides (Codex has no',
+  '# reference and status hooks via `-c` config overrides (Codex has no',
   '# --settings flag).',
   'WRAPPER_DIR="$(cd "$(dirname "$0")" && pwd)"',
   'CLEAN_PATH=":$PATH:"',
@@ -529,11 +546,11 @@ export const CODEX_WRAPPER = [
   '  exec "$REAL_CODEX" -c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"',
   'fi',
   '',
-  '# Launch-time status=thinking ping (pairs with notify→ready below).',
-  '"$HOME/.config/Ouijit/bin/ouijit-hook" status status=thinking &',
-  '',
   'exec "$REAL_CODEX" \\',
   '  -c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)" \\',
+  ...CODEX_STATUS_HOOKS.map(
+    ([event, status]) => `  -c 'hooks.${event}=${codexHookEventValue(CODEX_OUIJIT_HOOK, status)}' \\`,
+  ),
   `  -c 'notify=${codexNotifyValue(CODEX_OUIJIT_HOOK)}' \\`,
   '  "$@"',
   '',
@@ -728,12 +745,17 @@ export function buildVmHookSettings(): string {
 
 /**
  * Build the TOML content for the VM's ~/.codex/config.toml. There is no `codex`
- * wrapper inside the sandbox, so Codex's turn-complete notifier is wired via the
- * config file instead. Only the stable `notify` channel is used (mapped to
- * status=ready); the CLI reference is deliberately omitted — the ouijit CLI is
- * not installed in the sandbox. $HOME stays literal so the in-VM shell expands it.
+ * wrapper inside the sandbox, so the lifecycle hooks + turn-complete notifier
+ * are wired via the config file instead. The CLI reference is deliberately
+ * omitted — the ouijit CLI is not installed in the sandbox. $HOME stays
+ * literal so the in-VM shell expands it.
  */
 export function buildVmCodexConfig(): string {
-  const readyCmd = codexHookCommand('$HOME/ouijit-hook', 'ready');
-  return [`notify = ["bash", "-c", "${readyCmd}"]`, ''].join('\n');
+  const hookPath = '$HOME/ouijit-hook';
+  const lines = [`notify = ["bash", "-c", "${codexHookCommand(hookPath, 'ready')}"]`];
+  for (const [event, status] of CODEX_STATUS_HOOKS) {
+    lines.push(`hooks.${event} = ${codexHookEventValue(hookPath, status)}`);
+  }
+  lines.push('');
+  return lines.join('\n');
 }

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -4,7 +4,7 @@ import type { PtySpawnOptions, PtySpawnResult, PtyId } from '../types';
 import { registerSandboxPty, unregisterSandboxPty, type ActiveSession } from '../ptyManager';
 import { generateId } from '../utils/ids';
 import { buildLimactlHostEnv, ensureRunning, getLimactlPath } from './manager';
-import { getApiPort, HELPER_SCRIPT, buildVmHookSettings } from '../hookServer';
+import { getApiPort, HELPER_SCRIPT, buildVmHookSettings, buildVmCodexConfig } from '../hookServer';
 import { issueToken, revokeToken } from '../apiAuth';
 import { getTaskByNumber } from '../db';
 import { startSandboxView, watchSandboxRef, ffMergeSandboxToUser } from './sandboxSync';
@@ -51,9 +51,9 @@ function handleOutput(ptyId: PtyId, channel: string, data: string): void {
 }
 
 /**
- * Build bash commands that inject the ouijit-hook script and Claude settings
- * into the VM's ephemeral home directory. Runs once per shell spawn so hooks
- * are always fresh (never stale).
+ * Build bash commands that inject the ouijit-hook script, Claude settings, and
+ * Codex config into the VM's ephemeral home directory. Runs once per shell spawn
+ * so hooks are always fresh (never stale).
  *
  * The ouijit CLI reference file is deliberately not written into the
  * sandbox VM. The CLI would give an agent inside the VM task-management
@@ -63,6 +63,7 @@ function handleOutput(ptyId: PtyId, channel: string, data: string): void {
 function buildVmHookSetup(): string {
   const hookScript = HELPER_SCRIPT;
   const hookSettings = buildVmHookSettings();
+  const codexConfig = buildVmCodexConfig();
   return [
     // Write hook script using quoted heredoc (prevents $VAR expansion at write time)
     `cat > ~/ouijit-hook <<'OUIJIT_HOOK_EOF'`,
@@ -74,6 +75,11 @@ function buildVmHookSetup(): string {
     `cat > ~/.claude/settings.json <<'OUIJIT_SETTINGS_EOF'`,
     hookSettings,
     'OUIJIT_SETTINGS_EOF',
+    // Write Codex config (turn-complete notifier → status; CLI reference omitted)
+    'mkdir -p ~/.codex',
+    `cat > ~/.codex/config.toml <<'OUIJIT_CODEX_EOF'`,
+    codexConfig,
+    'OUIJIT_CODEX_EOF',
     '',
   ].join('\n');
 }

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -4,7 +4,13 @@ import type { PtySpawnOptions, PtySpawnResult, PtyId } from '../types';
 import { registerSandboxPty, unregisterSandboxPty, type ActiveSession } from '../ptyManager';
 import { generateId } from '../utils/ids';
 import { buildLimactlHostEnv, ensureRunning, getLimactlPath } from './manager';
-import { getApiPort, HELPER_SCRIPT, buildVmHookSettings, buildVmCodexConfig } from '../hookServer';
+import {
+  getApiPort,
+  HELPER_SCRIPT,
+  buildVmHookSettings,
+  buildVmCodexConfig,
+  buildVmCodexTrustState,
+} from '../hookServer';
 import { issueToken, revokeToken } from '../apiAuth';
 import { getTaskByNumber } from '../db';
 import { startSandboxView, watchSandboxRef, ffMergeSandboxToUser } from './sandboxSync';
@@ -75,11 +81,17 @@ function buildVmHookSetup(): string {
     `cat > ~/.claude/settings.json <<'OUIJIT_SETTINGS_EOF'`,
     hookSettings,
     'OUIJIT_SETTINGS_EOF',
-    // Write Codex config (turn-complete notifier → status; CLI reference omitted)
+    // Write Codex config (lifecycle hooks + notify; CLI reference omitted).
+    // Quoted heredoc → $HOME in hook commands stays literal for the agent's shell.
     'mkdir -p ~/.codex',
     `cat > ~/.codex/config.toml <<'OUIJIT_CODEX_EOF'`,
     codexConfig,
     'OUIJIT_CODEX_EOF',
+    // Append pre-trust state — unquoted heredoc so the VM's bash expands $HOME
+    // in the persisted hook key (Codex uses the resolved absolute path).
+    `cat >> ~/.codex/config.toml <<OUIJIT_CODEX_TRUST_EOF`,
+    buildVmCodexTrustState(),
+    'OUIJIT_CODEX_TRUST_EOF',
     '',
   ].join('\n');
 }

--- a/src/taskLifecycle.ts
+++ b/src/taskLifecycle.ts
@@ -62,13 +62,13 @@ export async function beginTask(
     }
   }
 
-  // Surface a non-fatal warning if Claude Code is not on PATH. The kanban / open
-  // terminal handlers route these to a one-time toast.
+  // Surface a non-fatal warning if no supported coding agent is on PATH. The
+  // kanban / open terminal handlers route these to a one-time toast.
   const health = getCachedHealth();
-  if (health && !health.claude) {
+  if (health && !health.claude && !health.codex) {
     result.warnings = [
       ...(result.warnings ?? []),
-      'Claude Code not found on PATH. Install from claude.com/claude-code to use AI workflows in this terminal.',
+      'No coding agent found on PATH. Install Claude Code (claude.com/claude-code) or Codex to use AI workflows in this terminal.',
     ];
   }
 


### PR DESCRIPTION
## Summary

- Install a `codex` wrapper alongside the `claude` one so Ouijit terminals can run Codex with the same status-dot / CLI-reference integration. Both wrappers ship in `installWrapper()`; no DB or UI changes, users opt in by writing `codex "\$OUIJIT_TASK_PROMPT"` in their start/continue hook.
- Surface the Ouijit CLI reference to the agent via `codex -c "developer_instructions=$(cat …)"` (appends a developer-role message; doesn't replace base instructions like `model_instructions_file` would).
- Wire the per-terminal status dot through Codex's lifecycle-hook engine — `UserPromptSubmit` / `PostToolUse` → `thinking`, `Stop` / `PermissionRequest` → `ready` — passed via `-c hooks.<Event>=…` (TOML array of inline tables; values are parsed as TOML, falling back to raw string). `notify` is kept as a stable fallback for users who disable the hooks engine.
- Pre-trust each hook via `-c hooks.state."<key>".trusted_hash="sha256:…"` so Codex doesn't gate them behind the `/hooks` review prompt. The hash mirrors `command_hook_hash` in `codex-rs/hooks/src/engine/discovery.rs` (sha256 of canonical JSON of the normalized hook identity). If a future Codex changes the normalization, the trust check downgrades to `Modified` and the user falls back to the same one-time `/hooks` approval — no hard error.
- Add `detectCodex()` to the health probe; the "no agent on PATH" warning now fires only when neither `claude` nor `codex` is found.
- Mirror the same hook + trust state into the sandbox VM's `~/.codex/config.toml` (the CLI reference stays out — same lateral-movement reasoning as the existing Claude path).