### PR TITLE
Add Pi CLI support

### DIFF
--- a/src/__tests__/healthCheck.test.ts
+++ b/src/__tests__/healthCheck.test.ts
@@ -45,7 +45,7 @@ describe('healthCheck', () => {
 
     const { checkHealth } = await import('../healthCheck');
     const status = await checkHealth();
-    expect(status).toEqual({ git: true, claude: true, codex: true, lima: true, gitVersion: '2.39.5' });
+    expect(status).toEqual({ git: true, claude: true, codex: true, pi: true, lima: true, gitVersion: '2.39.5' });
   });
 
   test('reports git missing when execFile rejects', async () => {
@@ -58,7 +58,7 @@ describe('healthCheck', () => {
 
     const { checkHealth } = await import('../healthCheck');
     const status = await checkHealth();
-    expect(status).toEqual({ git: false, claude: false, codex: false, lima: false, gitVersion: undefined });
+    expect(status).toEqual({ git: false, claude: false, codex: false, pi: false, lima: false, gitVersion: undefined });
   });
 
   test('detects codex independently of claude', async () => {
@@ -72,7 +72,21 @@ describe('healthCheck', () => {
 
     const { checkHealth } = await import('../healthCheck');
     const status = await checkHealth();
-    expect(status).toEqual({ git: true, claude: false, codex: true, lima: false, gitVersion: '2.41.0' });
+    expect(status).toEqual({ git: true, claude: false, codex: true, pi: false, lima: false, gitVersion: '2.41.0' });
+  });
+
+  test('detects pi independently of claude and codex', async () => {
+    execFileMock.mockImplementation((cmd: string, args: string[], cb: Function) => {
+      if (cmd === 'git') cb(null, 'git version 2.42.0\n', '');
+      else if (cmd === 'which' && args[0] === 'pi') cb(null, '/opt/homebrew/bin/pi\n', '');
+      else if (cmd === 'which') cb(new Error('not found'));
+      else cb(new Error(`unexpected ${cmd}`));
+    });
+    isLimaInstalledMock.mockResolvedValue(false);
+
+    const { checkHealth } = await import('../healthCheck');
+    const status = await checkHealth();
+    expect(status).toEqual({ git: true, claude: false, codex: false, pi: true, lima: false, gitVersion: '2.42.0' });
   });
 
   test('caches result and exposes via getCachedHealth', async () => {
@@ -86,6 +100,13 @@ describe('healthCheck', () => {
     const { checkHealth, getCachedHealth } = await import('../healthCheck');
     expect(getCachedHealth()).toBeNull();
     await checkHealth();
-    expect(getCachedHealth()).toEqual({ git: true, claude: false, codex: false, lima: true, gitVersion: '2.40.0' });
+    expect(getCachedHealth()).toEqual({
+      git: true,
+      claude: false,
+      codex: false,
+      pi: false,
+      lima: true,
+      gitVersion: '2.40.0',
+    });
   });
 });

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -363,7 +363,6 @@ describe('installWrapper', () => {
   test('creates pi wrapper and extension on first install', () => {
     installWrapper();
 
-    // Wrapper exists, shadows pi, exec lines look right
     const wrapperPath = path.join(tmpHome, '.config', 'Ouijit', 'bin', 'pi');
     const wrapper = fs.readFileSync(wrapperPath, 'utf-8');
     expect(wrapper).toContain('#!/bin/bash');
@@ -371,13 +370,10 @@ describe('installWrapper', () => {
     expect(wrapper).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
     expect(wrapper).toContain('--append-system-prompt "$(cat "$REFERENCE_FILE" 2>/dev/null)"');
     expect(wrapper).toContain('--extension "$EXTENSION_FILE"');
-    // OUIJIT_HOOK_BIN crosses into the Pi process so the extension can find ouijit-hook
     expect(wrapper).toContain('OUIJIT_HOOK_BIN="$HOOK_BIN" exec "$REAL_PI"');
-    // No-API fallthrough — just the CLI reference, no extension
     expect(wrapper).toContain('if [ -z "$OUIJIT_API_URL" ]; then');
     expect(wrapper).toContain('exec "$REAL_PI" --append-system-prompt "$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"');
 
-    // Extension file dropped outside `bin/` so it's never on PATH
     const extPath = path.join(tmpHome, '.config', 'Ouijit', 'pi', 'ouijit-extension.ts');
     expect(fs.existsSync(extPath)).toBe(true);
     const ext = fs.readFileSync(extPath, 'utf-8');
@@ -1031,18 +1027,12 @@ describe('PI_WRAPPER', () => {
     expect(PI_WRAPPER).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
   });
 
-  test('uses --append-system-prompt for the CLI reference (not Codex-style -c)', () => {
-    // Pi has no `-c key=value` config overrides — `-c` is `--continue`.
-    // The wrapper MUST inject the CLI reference via --append-system-prompt
-    // or Pi will treat the next arg as the prompt and clobber session state.
+  test('uses --append-system-prompt for the CLI reference (Pi has no `-c` overrides)', () => {
     expect(PI_WRAPPER).toContain('--append-system-prompt "$(cat "$REFERENCE_FILE" 2>/dev/null)"');
-    // No stray `-c key=value` overrides
     expect(PI_WRAPPER).not.toMatch(/-c '[a-z_]+=/);
   });
 
   test('loads the extension via --extension and bridges OUIJIT_HOOK_BIN', () => {
-    // The extension runs in Pi's Node process and reads OUIJIT_HOOK_BIN
-    // to find ouijit-hook. Both bits have to land on the same exec line.
     expect(PI_WRAPPER).toMatch(/OUIJIT_HOOK_BIN="\$HOOK_BIN" exec "\$REAL_PI" \\/);
     expect(PI_WRAPPER).toContain('--extension "$EXTENSION_FILE"');
     expect(PI_WRAPPER).toContain('HOOK_BIN="$HOME/.config/Ouijit/bin/ouijit-hook"');
@@ -1050,11 +1040,9 @@ describe('PI_WRAPPER', () => {
   });
 
   test('falls through with just --append-system-prompt when OUIJIT_API_URL is unset', () => {
-    // A bare `pi` invocation (no Ouijit env) shouldn't carry the extension
-    // or the hook env var — those depend on a live hook server.
     expect(PI_WRAPPER).toContain('if [ -z "$OUIJIT_API_URL" ]; then');
     expect(PI_WRAPPER).toContain('exec "$REAL_PI" --append-system-prompt "$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"');
-    // The fallthrough line must NOT include --extension or OUIJIT_HOOK_BIN
+    // Fallthrough must not carry the extension or hook env var.
     const fallthroughLine = PI_WRAPPER.split('\n').find(
       (l) => l.includes('exec "$REAL_PI" --append-system-prompt') && !l.endsWith('\\'),
     );
@@ -1068,34 +1056,23 @@ describe('PI_WRAPPER', () => {
 
 describe('PI_EXTENSION', () => {
   test('is a TypeScript module with a default-export factory', () => {
-    // Pi's extension loader expects `export default <factory>`. Anything
-    // else (named export, CommonJS) silently no-ops.
     expect(PI_EXTENSION).toMatch(/export default async \(pi: \w+\) =>/);
   });
 
   test('subscribes turn_start → thinking and turn_end → ready exactly once each', () => {
-    // The two events are the minimal turn-boundary signal; subscribing more
-    // (tool_call etc) would just thrash the status dot mid-turn.
-    const turnStart = PI_EXTENSION.match(/pi\.on\('turn_start'/g);
-    const turnEnd = PI_EXTENSION.match(/pi\.on\('turn_end'/g);
-    expect(turnStart).toHaveLength(1);
-    expect(turnEnd).toHaveLength(1);
+    expect(PI_EXTENSION.match(/pi\.on\('turn_start'/g)).toHaveLength(1);
+    expect(PI_EXTENSION.match(/pi\.on\('turn_end'/g)).toHaveLength(1);
     expect(PI_EXTENSION).toContain("ping('thinking')");
     expect(PI_EXTENSION).toContain("ping('ready')");
   });
 
   test('no-ops when OUIJIT_HOOK_BIN is unset (safe outside Ouijit)', () => {
-    // The same file can land in a user's ~/.pi/agent/extensions/ if they
-    // copy it manually. Without the env var it must do nothing.
     expect(PI_EXTENSION).toMatch(/const hookBin = process\.env\.OUIJIT_HOOK_BIN/);
     expect(PI_EXTENSION).toMatch(/if \(!hookBin\) return/);
   });
 
-  test('shells out to ouijit-hook via pi.exec with a timeout', () => {
-    // pi.exec runs sync from the extension's perspective; the timeout is a
-    // belt-and-braces upper bound. ouijit-hook itself backgrounds its curl.
+  test('shells out to ouijit-hook via pi.exec with a timeout and swallows errors', () => {
     expect(PI_EXTENSION).toMatch(/pi\.exec\(hookBin, \['status', .* \{ timeout: 2000 \}\)/);
-    // Errors are swallowed — a missed status ping is not worth a UI error.
     expect(PI_EXTENSION).toContain('.catch(() => {})');
   });
 });
@@ -1103,13 +1080,12 @@ describe('PI_EXTENSION', () => {
 // ── buildVmPiExtension ───────────────────────────────────────────────
 
 describe('buildVmPiExtension', () => {
-  test('matches the host-side extension exactly (one source, two install sites)', () => {
+  test('matches the host-side extension exactly', () => {
     expect(buildVmPiExtension()).toBe(PI_EXTENSION);
   });
 
   test('omits any reference to the host-only CLI reference file', () => {
-    // Same lateral-movement reasoning as the Claude/Codex VM configs: an
-    // agent inside the sandbox must not get task-management powers.
+    // Lateral-movement: agent in sandbox must not get the CLI.
     const ext = buildVmPiExtension();
     expect(ext).not.toContain('ouijit-cli-reference');
     expect(ext).not.toContain('.config/Ouijit');

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -39,8 +39,11 @@ import {
   buildVmHookSettings,
   buildVmCodexConfig,
   buildVmCodexTrustState,
+  buildVmPiExtension,
   CLAUDE_WRAPPER,
   CODEX_WRAPPER,
+  PI_WRAPPER,
+  PI_EXTENSION,
 } from '../hookServer';
 import { issueToken, revokeAllTokens } from '../apiAuth';
 
@@ -355,6 +358,33 @@ describe('installWrapper', () => {
     expect(wrapper).toContain(
       'exec "$REAL_CODEX" -c "developer_instructions=$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"',
     );
+  });
+
+  test('creates pi wrapper and extension on first install', () => {
+    installWrapper();
+
+    // Wrapper exists, shadows pi, exec lines look right
+    const wrapperPath = path.join(tmpHome, '.config', 'Ouijit', 'bin', 'pi');
+    const wrapper = fs.readFileSync(wrapperPath, 'utf-8');
+    expect(wrapper).toContain('#!/bin/bash');
+    expect(wrapper).toContain('REAL_PI=');
+    expect(wrapper).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
+    expect(wrapper).toContain('--append-system-prompt "$(cat "$REFERENCE_FILE" 2>/dev/null)"');
+    expect(wrapper).toContain('--extension "$EXTENSION_FILE"');
+    // OUIJIT_HOOK_BIN crosses into the Pi process so the extension can find ouijit-hook
+    expect(wrapper).toContain('OUIJIT_HOOK_BIN="$HOOK_BIN" exec "$REAL_PI"');
+    // No-API fallthrough — just the CLI reference, no extension
+    expect(wrapper).toContain('if [ -z "$OUIJIT_API_URL" ]; then');
+    expect(wrapper).toContain('exec "$REAL_PI" --append-system-prompt "$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"');
+
+    // Extension file dropped outside `bin/` so it's never on PATH
+    const extPath = path.join(tmpHome, '.config', 'Ouijit', 'pi', 'ouijit-extension.ts');
+    expect(fs.existsSync(extPath)).toBe(true);
+    const ext = fs.readFileSync(extPath, 'utf-8');
+    expect(ext).toContain('export default');
+    expect(ext).toContain("pi.on('turn_start'");
+    expect(ext).toContain("pi.on('turn_end'");
+    expect(ext).toContain('OUIJIT_HOOK_BIN');
   });
 
   test('creates CLI reference file with command documentation', () => {
@@ -989,5 +1019,99 @@ describe('buildVmCodexTrustState', () => {
       );
       expect(toml).toMatch(re);
     }
+  });
+});
+
+// ── PI_WRAPPER constant ──────────────────────────────────────────────
+
+describe('PI_WRAPPER', () => {
+  test('resolves real pi and re-exports wrapper dir on PATH', () => {
+    expect(PI_WRAPPER).toContain('WRAPPER_DIR=');
+    expect(PI_WRAPPER).toContain('REAL_PI=');
+    expect(PI_WRAPPER).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
+  });
+
+  test('uses --append-system-prompt for the CLI reference (not Codex-style -c)', () => {
+    // Pi has no `-c key=value` config overrides — `-c` is `--continue`.
+    // The wrapper MUST inject the CLI reference via --append-system-prompt
+    // or Pi will treat the next arg as the prompt and clobber session state.
+    expect(PI_WRAPPER).toContain('--append-system-prompt "$(cat "$REFERENCE_FILE" 2>/dev/null)"');
+    // No stray `-c key=value` overrides
+    expect(PI_WRAPPER).not.toMatch(/-c '[a-z_]+=/);
+  });
+
+  test('loads the extension via --extension and bridges OUIJIT_HOOK_BIN', () => {
+    // The extension runs in Pi's Node process and reads OUIJIT_HOOK_BIN
+    // to find ouijit-hook. Both bits have to land on the same exec line.
+    expect(PI_WRAPPER).toMatch(/OUIJIT_HOOK_BIN="\$HOOK_BIN" exec "\$REAL_PI" \\/);
+    expect(PI_WRAPPER).toContain('--extension "$EXTENSION_FILE"');
+    expect(PI_WRAPPER).toContain('HOOK_BIN="$HOME/.config/Ouijit/bin/ouijit-hook"');
+    expect(PI_WRAPPER).toContain('EXTENSION_FILE="$HOME/.config/Ouijit/pi/ouijit-extension.ts"');
+  });
+
+  test('falls through with just --append-system-prompt when OUIJIT_API_URL is unset', () => {
+    // A bare `pi` invocation (no Ouijit env) shouldn't carry the extension
+    // or the hook env var — those depend on a live hook server.
+    expect(PI_WRAPPER).toContain('if [ -z "$OUIJIT_API_URL" ]; then');
+    expect(PI_WRAPPER).toContain('exec "$REAL_PI" --append-system-prompt "$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"');
+    // The fallthrough line must NOT include --extension or OUIJIT_HOOK_BIN
+    const fallthroughLine = PI_WRAPPER.split('\n').find(
+      (l) => l.includes('exec "$REAL_PI" --append-system-prompt') && !l.endsWith('\\'),
+    );
+    expect(fallthroughLine).toBeDefined();
+    expect(fallthroughLine).not.toContain('--extension');
+    expect(fallthroughLine).not.toContain('OUIJIT_HOOK_BIN');
+  });
+});
+
+// ── PI_EXTENSION constant ────────────────────────────────────────────
+
+describe('PI_EXTENSION', () => {
+  test('is a TypeScript module with a default-export factory', () => {
+    // Pi's extension loader expects `export default <factory>`. Anything
+    // else (named export, CommonJS) silently no-ops.
+    expect(PI_EXTENSION).toMatch(/export default async \(pi: \w+\) =>/);
+  });
+
+  test('subscribes turn_start → thinking and turn_end → ready exactly once each', () => {
+    // The two events are the minimal turn-boundary signal; subscribing more
+    // (tool_call etc) would just thrash the status dot mid-turn.
+    const turnStart = PI_EXTENSION.match(/pi\.on\('turn_start'/g);
+    const turnEnd = PI_EXTENSION.match(/pi\.on\('turn_end'/g);
+    expect(turnStart).toHaveLength(1);
+    expect(turnEnd).toHaveLength(1);
+    expect(PI_EXTENSION).toContain("ping('thinking')");
+    expect(PI_EXTENSION).toContain("ping('ready')");
+  });
+
+  test('no-ops when OUIJIT_HOOK_BIN is unset (safe outside Ouijit)', () => {
+    // The same file can land in a user's ~/.pi/agent/extensions/ if they
+    // copy it manually. Without the env var it must do nothing.
+    expect(PI_EXTENSION).toMatch(/const hookBin = process\.env\.OUIJIT_HOOK_BIN/);
+    expect(PI_EXTENSION).toMatch(/if \(!hookBin\) return/);
+  });
+
+  test('shells out to ouijit-hook via pi.exec with a timeout', () => {
+    // pi.exec runs sync from the extension's perspective; the timeout is a
+    // belt-and-braces upper bound. ouijit-hook itself backgrounds its curl.
+    expect(PI_EXTENSION).toMatch(/pi\.exec\(hookBin, \['status', .* \{ timeout: 2000 \}\)/);
+    // Errors are swallowed — a missed status ping is not worth a UI error.
+    expect(PI_EXTENSION).toContain('.catch(() => {})');
+  });
+});
+
+// ── buildVmPiExtension ───────────────────────────────────────────────
+
+describe('buildVmPiExtension', () => {
+  test('matches the host-side extension exactly (one source, two install sites)', () => {
+    expect(buildVmPiExtension()).toBe(PI_EXTENSION);
+  });
+
+  test('omits any reference to the host-only CLI reference file', () => {
+    // Same lateral-movement reasoning as the Claude/Codex VM configs: an
+    // agent inside the sandbox must not get task-management powers.
+    const ext = buildVmPiExtension();
+    expect(ext).not.toContain('ouijit-cli-reference');
+    expect(ext).not.toContain('.config/Ouijit');
   });
 });

--- a/src/healthCheck.ts
+++ b/src/healthCheck.ts
@@ -11,6 +11,7 @@ export interface HealthStatus {
   git: boolean;
   claude: boolean;
   codex: boolean;
+  pi: boolean;
   lima: boolean;
   gitVersion?: string;
 }
@@ -45,13 +46,29 @@ async function detectCodex(): Promise<boolean> {
   }
 }
 
+async function detectPi(): Promise<boolean> {
+  try {
+    await execFileAsync('which', ['pi']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function checkHealth(): Promise<HealthStatus> {
-  const [git, claude, codex, lima] = await Promise.all([detectGit(), detectClaude(), detectCodex(), isLimaInstalled()]);
-  cached = { git: git.ok, claude, codex, lima, gitVersion: git.version };
+  const [git, claude, codex, pi, lima] = await Promise.all([
+    detectGit(),
+    detectClaude(),
+    detectCodex(),
+    detectPi(),
+    isLimaInstalled(),
+  ]);
+  cached = { git: git.ok, claude, codex, pi, lima, gitVersion: git.version };
   healthLog.info('health probe', {
     git: cached.git,
     claude: cached.claude,
     codex: cached.codex,
+    pi: cached.pi,
     lima: cached.lima,
     gitVersion: cached.gitVersion,
   });

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -621,6 +621,123 @@ export const CODEX_WRAPPER = [
   '',
 ].join('\n');
 
+// ── Pi wrapper ───────────────────────────────────────────────────────
+// Pi (pi.dev — `@earendil-works/pi-coding-agent`) is a third coding-agent
+// harness. Unlike Claude's `--settings` or Codex's `-c hooks.<Event>=…`,
+// Pi has no declarative way to register shell-command hooks. Its lifecycle
+// events (`turn_start`, `turn_end`, …) are exposed only to *TypeScript
+// extensions* — a default-export factory that subscribes via `pi.on(...)`.
+//
+// So we ship a tiny ouijit extension at install time and pass it to every
+// wrapped invocation via `pi --extension <path>`. The same extension source
+// is dropped into `~/.pi/agent/extensions/ouijit/index.ts` inside the
+// sandbox VM (no wrapper there) and Pi auto-discovers it.
+//
+// The CLI reference is injected via `--append-system-prompt "$(cat …)"` —
+// the analog of Codex's `developer_instructions`. Pi has no `…-file`
+// variant, so we read the file in the wrapper.
+//
+// The extension reaches `ouijit-hook` via the `OUIJIT_HOOK_BIN` env var
+// the wrapper (and the VM's shell init) sets. Keeping the path in an env
+// var means the same extension source works on host and sandbox without
+// branching.
+
+/** Where the host-side Pi extension lives (passed to `pi --extension`). */
+export function getPiExtensionPath(): string {
+  return path.join(os.homedir(), '.config', 'Ouijit', 'pi', 'ouijit-extension.ts');
+}
+
+/**
+ * Source of the Pi extension. The same string is dropped into
+ * ~/.config/Ouijit/pi/ on the host (loaded via `--extension`) and into
+ * ~/.pi/agent/extensions/ouijit/index.ts in the sandbox VM (auto-loaded).
+ *
+ * Pi loads this via its own TS runtime, so the type annotations are local
+ * to the file and never seen by Ouijit's tsc. Kept minimal so the
+ * extension surface we depend on (`pi.on`, `pi.exec`, `process.env`) is
+ * obvious from one screen.
+ */
+export const PI_EXTENSION = `// Ouijit Pi extension — bridges Pi's lifecycle events to the Ouijit
+// per-terminal status indicator. Auto-installed by the Ouijit app; safe to
+// delete (Ouijit will recreate it on next launch).
+//
+// turn_start  → status=thinking
+// turn_end    → status=ready
+//
+// The hook binary path comes from OUIJIT_HOOK_BIN, set by the Ouijit pi
+// wrapper on the host and by the Lima VM's shell init in the sandbox. If
+// it's unset the extension no-ops, so a user running \`pi\` outside Ouijit
+// (e.g. by copying this file into their own extensions dir) is unaffected.
+
+type OuijitStatus = 'thinking' | 'ready';
+
+interface OuijitPiApi {
+  on(event: string, handler: () => void): void;
+  exec(command: string, args: string[], options?: { timeout?: number }): Promise<unknown>;
+}
+
+export default async (pi: OuijitPiApi) => {
+  const hookBin = process.env.OUIJIT_HOOK_BIN;
+  if (!hookBin) return;
+
+  const ping = (status: OuijitStatus) => {
+    // Pi may reject if the hook binary is missing or slow; ouijit-hook
+    // backgrounds its curl and exits in milliseconds, so the 2s timeout
+    // is just an upper bound. Swallow errors — a missed status ping is
+    // not worth surfacing to the user inside the agent's UI.
+    pi.exec(hookBin, ['status', \`status=\${status}\`], { timeout: 2000 }).catch(() => {});
+  };
+
+  pi.on('turn_start', () => ping('thinking'));
+  pi.on('turn_end', () => ping('ready'));
+};
+`;
+
+/** Bash wrapper that shadows `pi` and injects the CLI reference + Ouijit extension. */
+export const PI_WRAPPER = [
+  '#!/bin/bash',
+  '# Ouijit pi wrapper — mirrors the claude/codex wrappers. Removes its own',
+  '# directory from PATH to find the real pi binary, then re-exports it so',
+  '# the ouijit CLI is available inside Pi. Injects the Ouijit CLI reference',
+  '# via --append-system-prompt and the status-dot bridge via --extension.',
+  'WRAPPER_DIR="$(cd "$(dirname "$0")" && pwd)"',
+  'CLEAN_PATH=":$PATH:"',
+  'CLEAN_PATH="${CLEAN_PATH//:$WRAPPER_DIR:/:}"',
+  'CLEAN_PATH="${CLEAN_PATH#:}"',
+  'CLEAN_PATH="${CLEAN_PATH%:}"',
+  '',
+  '# Resolve the real pi binary from the clean PATH',
+  'REAL_PI="$(PATH="$CLEAN_PATH" command -v pi)"',
+  'if [ -z "$REAL_PI" ]; then',
+  '  echo "ouijit: pi not found on PATH" >&2',
+  '  exit 1',
+  'fi',
+  '',
+  '# Re-export PATH with wrapper dir so ouijit CLI works inside Pi',
+  'export PATH="$WRAPPER_DIR:$CLEAN_PATH"',
+  '',
+  '# Ouijit CLI reference file — surfaced via --append-system-prompt',
+  'REFERENCE_FILE="$HOME/.config/Ouijit/ouijit-cli-reference.md"',
+  '# Ouijit Pi extension — loaded via --extension; bridges Pi events to',
+  '# the per-terminal status indicator. Reads OUIJIT_HOOK_BIN at runtime.',
+  'EXTENSION_FILE="$HOME/.config/Ouijit/pi/ouijit-extension.ts"',
+  'HOOK_BIN="$HOME/.config/Ouijit/bin/ouijit-hook"',
+  '',
+  '# If ouijit is not running, just exec the real pi with CLI awareness',
+  'if [ -z "$OUIJIT_API_URL" ]; then',
+  '  exec "$REAL_PI" --append-system-prompt "$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"',
+  'fi',
+  '',
+  '# OUIJIT_HOOK_BIN crosses into the Pi process so the extension can shell',
+  '# out to ouijit-hook. Kept as an env var (not a flag) so the same',
+  '# extension source works on host and in the sandbox VM.',
+  'OUIJIT_HOOK_BIN="$HOOK_BIN" exec "$REAL_PI" \\',
+  '  --append-system-prompt "$(cat "$REFERENCE_FILE" 2>/dev/null)" \\',
+  '  --extension "$EXTENSION_FILE" \\',
+  '  "$@"',
+  '',
+].join('\n');
+
 // ── Shell integration scripts ────────────────────────────────────────
 // These scripts ensure the wrapper dir stays first in PATH even after
 // shell init files (.zshrc, .bashrc) prepend other directories.
@@ -704,6 +821,16 @@ export function installWrapper(): void {
 
     // Write codex wrapper script (shadows `codex` to inject -c config overrides)
     fs.writeFileSync(path.join(binDir, 'codex'), CODEX_WRAPPER, { mode: 0o755 });
+
+    // Write pi wrapper script (shadows `pi` to inject --append-system-prompt + --extension)
+    fs.writeFileSync(path.join(binDir, 'pi'), PI_WRAPPER, { mode: 0o755 });
+
+    // Write the Pi extension the wrapper passes via --extension. Lives
+    // outside `bin/` so it never appears on PATH, and outside Pi's
+    // auto-discovery roots so a non-Ouijit `pi` invocation isn't affected.
+    const piExtPath = getPiExtensionPath();
+    fs.mkdirSync(path.dirname(piExtPath), { recursive: true });
+    fs.writeFileSync(piExtPath, PI_EXTENSION, { mode: 0o644 });
 
     // Write ouijit CLI wrapper (delegates to the bundled CLI JS via env vars set by PTY manager)
     fs.writeFileSync(
@@ -845,4 +972,15 @@ export function buildVmCodexTrustState(): string {
   });
   lines.push('');
   return lines.join('\n');
+}
+
+/**
+ * Pi extension source for the sandbox VM. Identical to the host-side
+ * extension because the only context-dependent value (the hook binary
+ * path) is supplied via the OUIJIT_HOOK_BIN env var, which lima/spawn
+ * exports inside the VM. Wrapping the constant in a function keeps the
+ * lima/spawn import list consistent with the buildVm…() siblings.
+ */
+export function buildVmPiExtension(): string {
+  return PI_EXTENSION;
 }

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -622,52 +622,19 @@ export const CODEX_WRAPPER = [
 ].join('\n');
 
 // ── Pi wrapper ───────────────────────────────────────────────────────
-// Pi (pi.dev — `@earendil-works/pi-coding-agent`) is a third coding-agent
-// harness. Unlike Claude's `--settings` or Codex's `-c hooks.<Event>=…`,
-// Pi has no declarative way to register shell-command hooks. Its lifecycle
-// events (`turn_start`, `turn_end`, …) are exposed only to *TypeScript
-// extensions* — a default-export factory that subscribes via `pi.on(...)`.
-//
-// So we ship a tiny ouijit extension at install time and pass it to every
-// wrapped invocation via `pi --extension <path>`. The same extension source
-// is dropped into `~/.pi/agent/extensions/ouijit/index.ts` inside the
-// sandbox VM (no wrapper there) and Pi auto-discovers it.
-//
-// The CLI reference is injected via `--append-system-prompt "$(cat …)"` —
-// the analog of Codex's `developer_instructions`. Pi has no `…-file`
-// variant, so we read the file in the wrapper.
-//
-// The extension reaches `ouijit-hook` via the `OUIJIT_HOOK_BIN` env var
-// the wrapper (and the VM's shell init) sets. Keeping the path in an env
-// var means the same extension source works on host and sandbox without
-// branching.
+// Pi exposes lifecycle events only to TypeScript extensions, not as
+// shell-command hooks. We ship a tiny extension and load it via
+// `pi --extension <path>`; the same source auto-discovers in the sandbox
+// VM. OUIJIT_HOOK_BIN (set by the wrapper / VM init) carries the path to
+// ouijit-hook so the extension source is identical in both contexts.
 
-/** Where the host-side Pi extension lives (passed to `pi --extension`). */
 export function getPiExtensionPath(): string {
   return path.join(os.homedir(), '.config', 'Ouijit', 'pi', 'ouijit-extension.ts');
 }
 
-/**
- * Source of the Pi extension. The same string is dropped into
- * ~/.config/Ouijit/pi/ on the host (loaded via `--extension`) and into
- * ~/.pi/agent/extensions/ouijit/index.ts in the sandbox VM (auto-loaded).
- *
- * Pi loads this via its own TS runtime, so the type annotations are local
- * to the file and never seen by Ouijit's tsc. Kept minimal so the
- * extension surface we depend on (`pi.on`, `pi.exec`, `process.env`) is
- * obvious from one screen.
- */
-export const PI_EXTENSION = `// Ouijit Pi extension — bridges Pi's lifecycle events to the Ouijit
-// per-terminal status indicator. Auto-installed by the Ouijit app; safe to
-// delete (Ouijit will recreate it on next launch).
-//
-// turn_start  → status=thinking
-// turn_end    → status=ready
-//
-// The hook binary path comes from OUIJIT_HOOK_BIN, set by the Ouijit pi
-// wrapper on the host and by the Lima VM's shell init in the sandbox. If
-// it's unset the extension no-ops, so a user running \`pi\` outside Ouijit
-// (e.g. by copying this file into their own extensions dir) is unaffected.
+export const PI_EXTENSION = `// Ouijit Pi extension — bridges Pi turn events to the per-terminal
+// status indicator. Auto-installed; safe to delete (Ouijit recreates it).
+// No-ops when OUIJIT_HOOK_BIN is unset, so it's harmless outside Ouijit.
 
 type OuijitStatus = 'thinking' | 'ready';
 
@@ -681,10 +648,6 @@ export default async (pi: OuijitPiApi) => {
   if (!hookBin) return;
 
   const ping = (status: OuijitStatus) => {
-    // Pi may reject if the hook binary is missing or slow; ouijit-hook
-    // backgrounds its curl and exits in milliseconds, so the 2s timeout
-    // is just an upper bound. Swallow errors — a missed status ping is
-    // not worth surfacing to the user inside the agent's UI.
     pi.exec(hookBin, ['status', \`status=\${status}\`], { timeout: 2000 }).catch(() => {});
   };
 
@@ -693,44 +656,32 @@ export default async (pi: OuijitPiApi) => {
 };
 `;
 
-/** Bash wrapper that shadows `pi` and injects the CLI reference + Ouijit extension. */
 export const PI_WRAPPER = [
   '#!/bin/bash',
-  '# Ouijit pi wrapper — mirrors the claude/codex wrappers. Removes its own',
-  '# directory from PATH to find the real pi binary, then re-exports it so',
-  '# the ouijit CLI is available inside Pi. Injects the Ouijit CLI reference',
-  '# via --append-system-prompt and the status-dot bridge via --extension.',
+  '# Ouijit pi wrapper — mirrors the claude/codex wrappers.',
   'WRAPPER_DIR="$(cd "$(dirname "$0")" && pwd)"',
   'CLEAN_PATH=":$PATH:"',
   'CLEAN_PATH="${CLEAN_PATH//:$WRAPPER_DIR:/:}"',
   'CLEAN_PATH="${CLEAN_PATH#:}"',
   'CLEAN_PATH="${CLEAN_PATH%:}"',
   '',
-  '# Resolve the real pi binary from the clean PATH',
   'REAL_PI="$(PATH="$CLEAN_PATH" command -v pi)"',
   'if [ -z "$REAL_PI" ]; then',
   '  echo "ouijit: pi not found on PATH" >&2',
   '  exit 1',
   'fi',
   '',
-  '# Re-export PATH with wrapper dir so ouijit CLI works inside Pi',
   'export PATH="$WRAPPER_DIR:$CLEAN_PATH"',
   '',
-  '# Ouijit CLI reference file — surfaced via --append-system-prompt',
   'REFERENCE_FILE="$HOME/.config/Ouijit/ouijit-cli-reference.md"',
-  '# Ouijit Pi extension — loaded via --extension; bridges Pi events to',
-  '# the per-terminal status indicator. Reads OUIJIT_HOOK_BIN at runtime.',
   'EXTENSION_FILE="$HOME/.config/Ouijit/pi/ouijit-extension.ts"',
   'HOOK_BIN="$HOME/.config/Ouijit/bin/ouijit-hook"',
   '',
-  '# If ouijit is not running, just exec the real pi with CLI awareness',
   'if [ -z "$OUIJIT_API_URL" ]; then',
   '  exec "$REAL_PI" --append-system-prompt "$(cat "$REFERENCE_FILE" 2>/dev/null)" "$@"',
   'fi',
   '',
-  '# OUIJIT_HOOK_BIN crosses into the Pi process so the extension can shell',
-  '# out to ouijit-hook. Kept as an env var (not a flag) so the same',
-  '# extension source works on host and in the sandbox VM.',
+  '# OUIJIT_HOOK_BIN is read by the extension to shell out to ouijit-hook.',
   'OUIJIT_HOOK_BIN="$HOOK_BIN" exec "$REAL_PI" \\',
   '  --append-system-prompt "$(cat "$REFERENCE_FILE" 2>/dev/null)" \\',
   '  --extension "$EXTENSION_FILE" \\',
@@ -822,12 +773,10 @@ export function installWrapper(): void {
     // Write codex wrapper script (shadows `codex` to inject -c config overrides)
     fs.writeFileSync(path.join(binDir, 'codex'), CODEX_WRAPPER, { mode: 0o755 });
 
-    // Write pi wrapper script (shadows `pi` to inject --append-system-prompt + --extension)
+    // Write pi wrapper and the extension it loads via --extension. The
+    // extension lives outside bin/ (not on PATH) and outside Pi's
+    // auto-discovery roots (no effect on un-wrapped `pi` invocations).
     fs.writeFileSync(path.join(binDir, 'pi'), PI_WRAPPER, { mode: 0o755 });
-
-    // Write the Pi extension the wrapper passes via --extension. Lives
-    // outside `bin/` so it never appears on PATH, and outside Pi's
-    // auto-discovery roots so a non-Ouijit `pi` invocation isn't affected.
     const piExtPath = getPiExtensionPath();
     fs.mkdirSync(path.dirname(piExtPath), { recursive: true });
     fs.writeFileSync(piExtPath, PI_EXTENSION, { mode: 0o644 });
@@ -974,13 +923,7 @@ export function buildVmCodexTrustState(): string {
   return lines.join('\n');
 }
 
-/**
- * Pi extension source for the sandbox VM. Identical to the host-side
- * extension because the only context-dependent value (the hook binary
- * path) is supplied via the OUIJIT_HOOK_BIN env var, which lima/spawn
- * exports inside the VM. Wrapping the constant in a function keeps the
- * lima/spawn import list consistent with the buildVm…() siblings.
- */
+/** Pi extension for the sandbox VM. Identical to the host-side source. */
 export function buildVmPiExtension(): string {
   return PI_EXTENSION;
 }

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -10,6 +10,7 @@ import {
   buildVmHookSettings,
   buildVmCodexConfig,
   buildVmCodexTrustState,
+  buildVmPiExtension,
 } from '../hookServer';
 import { issueToken, revokeToken } from '../apiAuth';
 import { getTaskByNumber } from '../db';
@@ -57,9 +58,9 @@ function handleOutput(ptyId: PtyId, channel: string, data: string): void {
 }
 
 /**
- * Build bash commands that inject the ouijit-hook script, Claude settings, and
- * Codex config into the VM's ephemeral home directory. Runs once per shell spawn
- * so hooks are always fresh (never stale).
+ * Build bash commands that inject the ouijit-hook script, Claude settings,
+ * Codex config, and the Pi extension into the VM's ephemeral home directory.
+ * Runs once per shell spawn so hooks are always fresh (never stale).
  *
  * The ouijit CLI reference file is deliberately not written into the
  * sandbox VM. The CLI would give an agent inside the VM task-management
@@ -70,6 +71,7 @@ function buildVmHookSetup(): string {
   const hookScript = HELPER_SCRIPT;
   const hookSettings = buildVmHookSettings();
   const codexConfig = buildVmCodexConfig();
+  const piExtension = buildVmPiExtension();
   return [
     // Write hook script using quoted heredoc (prevents $VAR expansion at write time)
     `cat > ~/ouijit-hook <<'OUIJIT_HOOK_EOF'`,
@@ -92,6 +94,14 @@ function buildVmHookSetup(): string {
     `cat >> ~/.codex/config.toml <<OUIJIT_CODEX_TRUST_EOF`,
     buildVmCodexTrustState(),
     'OUIJIT_CODEX_TRUST_EOF',
+    // Drop the Pi extension into Pi's auto-discovery path. No host-side
+    // wrapper exists in the VM, so we rely on auto-discovery instead of
+    // passing `--extension` per-invocation. CLI reference is omitted for
+    // the same lateral-movement reason as the Claude / Codex paths.
+    'mkdir -p ~/.pi/agent/extensions/ouijit',
+    `cat > ~/.pi/agent/extensions/ouijit/index.ts <<'OUIJIT_PI_EXT_EOF'`,
+    piExtension,
+    'OUIJIT_PI_EXT_EOF',
     '',
   ].join('\n');
 }
@@ -180,6 +190,10 @@ export async function spawnSandboxedPty(options: PtySpawnOptions, window: Browse
     envExports += `export OUIJIT_PTY_ID='${ptyId}'\n`;
     envExports += `export OUIJIT_API_URL='http://host.lima.internal:${getApiPort()}'\n`;
     envExports += `export OUIJIT_API_TOKEN='${apiToken}'\n`;
+    // OUIJIT_HOOK_BIN is read by the Pi extension to shell out to
+    // ouijit-hook. Same role here as in the host wrapper; needed because
+    // Pi's auto-discovered extension runs in the sandbox without a wrapper.
+    envExports += `export OUIJIT_HOOK_BIN="$HOME/ouijit-hook"\n`;
 
     // Inject hook script + Claude settings into VM's ephemeral home dir
     const hookSetup = buildVmHookSetup();

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -94,10 +94,7 @@ function buildVmHookSetup(): string {
     `cat >> ~/.codex/config.toml <<OUIJIT_CODEX_TRUST_EOF`,
     buildVmCodexTrustState(),
     'OUIJIT_CODEX_TRUST_EOF',
-    // Drop the Pi extension into Pi's auto-discovery path. No host-side
-    // wrapper exists in the VM, so we rely on auto-discovery instead of
-    // passing `--extension` per-invocation. CLI reference is omitted for
-    // the same lateral-movement reason as the Claude / Codex paths.
+    // Pi extension lands in its auto-discovery path (no wrapper in the VM).
     'mkdir -p ~/.pi/agent/extensions/ouijit',
     `cat > ~/.pi/agent/extensions/ouijit/index.ts <<'OUIJIT_PI_EXT_EOF'`,
     piExtension,
@@ -190,9 +187,7 @@ export async function spawnSandboxedPty(options: PtySpawnOptions, window: Browse
     envExports += `export OUIJIT_PTY_ID='${ptyId}'\n`;
     envExports += `export OUIJIT_API_URL='http://host.lima.internal:${getApiPort()}'\n`;
     envExports += `export OUIJIT_API_TOKEN='${apiToken}'\n`;
-    // OUIJIT_HOOK_BIN is read by the Pi extension to shell out to
-    // ouijit-hook. Same role here as in the host wrapper; needed because
-    // Pi's auto-discovered extension runs in the sandbox without a wrapper.
+    // Read by the Pi extension to shell out to ouijit-hook.
     envExports += `export OUIJIT_HOOK_BIN="$HOME/ouijit-hook"\n`;
 
     // Inject hook script + Claude settings into VM's ephemeral home dir

--- a/src/taskLifecycle.ts
+++ b/src/taskLifecycle.ts
@@ -65,10 +65,10 @@ export async function beginTask(
   // Surface a non-fatal warning if no supported coding agent is on PATH. The
   // kanban / open terminal handlers route these to a one-time toast.
   const health = getCachedHealth();
-  if (health && !health.claude && !health.codex) {
+  if (health && !health.claude && !health.codex && !health.pi) {
     result.warnings = [
       ...(result.warnings ?? []),
-      'No coding agent found on PATH. Install Claude Code (claude.com/claude-code) or Codex to use AI workflows in this terminal.',
+      'No coding agent found on PATH. Install Claude Code (claude.com/claude-code), Codex, or Pi (pi.dev) to use AI workflows in this terminal.',
     ];
   }
 


### PR DESCRIPTION
## Summary

- Install a `pi` wrapper alongside the `claude` and `codex` ones. The wrapper injects the Ouijit CLI reference via `pi --append-system-prompt "$(cat …)"` (Pi has no `…-file` variant) and loads a small ouijit extension via `pi --extension <path>`.
- Pi exposes lifecycle events only to TypeScript extensions, so the status-dot wiring lives in an extension file the wrapper points at: `turn_start` → `thinking`, `turn_end` → `ready`. The extension shells out to `ouijit-hook` via `pi.exec()`. Its path comes from a new `OUIJIT_HOOK_BIN` env var the wrapper exports, so the same extension source works on host and sandbox without branching.
- Drop the extension at `~/.config/Ouijit/pi/ouijit-extension.ts` on the host (outside Pi's auto-discovery roots, only loaded via `--extension` in wrapped sessions) and at `~/.pi/agent/extensions/ouijit/index.ts` in the sandbox VM (no wrapper there, so auto-discovery picks it up). The sandbox shell also exports `OUIJIT_HOOK_BIN=$HOME/ouijit-hook`.
- Add `detectPi()` to the health probe; the "no agent on PATH" warning now fires only when none of `claude` / `codex` / `pi` is found.
- Mirror the same source on host and in the VM via `buildVmPiExtension`. The CLI reference stays out of the sandbox — same lateral-movement reasoning as the Claude / Codex paths.