### PR TITLE
Fix dead status dot on home view

### DIFF
--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -241,12 +241,12 @@ describe('status action', () => {
 
   test('sends IPC for valid thinking status', async () => {
     await post(port, { action: 'status', ptyId: 'pty-123', status: 'thinking' });
-    expect(mockSend).toHaveBeenCalledWith('claude-hook-status', 'pty-123', 'thinking');
+    expect(mockSend).toHaveBeenCalledWith('agent-hook-status', 'pty-123', 'thinking');
   });
 
   test('sends IPC for valid ready status', async () => {
     await post(port, { action: 'status', ptyId: 'pty-789', status: 'ready' });
-    expect(mockSend).toHaveBeenCalledWith('claude-hook-status', 'pty-789', 'ready');
+    expect(mockSend).toHaveBeenCalledWith('agent-hook-status', 'pty-789', 'ready');
   });
 
   test('rejects invalid status values', async () => {
@@ -606,7 +606,7 @@ describe('ouijit-hook script → hook server integration', () => {
     });
 
     await waitForIpc();
-    expect(mockSend).toHaveBeenCalledWith('claude-hook-status', 'pty-integration-1', 'thinking');
+    expect(mockSend).toHaveBeenCalledWith('agent-hook-status', 'pty-integration-1', 'thinking');
   });
 
   test('ready status reaches hook server and triggers IPC', async () => {
@@ -618,7 +618,7 @@ describe('ouijit-hook script → hook server integration', () => {
     });
 
     await waitForIpc();
-    expect(mockSend).toHaveBeenCalledWith('claude-hook-status', 'pty-integration-2', 'ready');
+    expect(mockSend).toHaveBeenCalledWith('agent-hook-status', 'pty-integration-2', 'ready');
   });
 
   test('script exits silently when OUIJIT_API_URL is unset', async () => {
@@ -730,7 +730,7 @@ describe('wrapper → ouijit-hook → hook server (end-to-end)', () => {
     });
 
     await waitForIpc();
-    expect(mockSend).toHaveBeenCalledWith('claude-hook-status', 'pty-e2e-1', 'thinking');
+    expect(mockSend).toHaveBeenCalledWith('agent-hook-status', 'pty-e2e-1', 'thinking');
   });
 
   test('hooks fire even when shell init prepends paths before wrapper dir', async () => {
@@ -769,7 +769,7 @@ describe('wrapper → ouijit-hook → hook server (end-to-end)', () => {
     });
 
     await waitForIpc();
-    expect(mockSend).toHaveBeenCalledWith('claude-hook-status', 'pty-e2e-2', 'thinking');
+    expect(mockSend).toHaveBeenCalledWith('agent-hook-status', 'pty-e2e-2', 'thinking');
   });
 
   test.skipIf(!hasZsh)('hooks fire in zsh after start hook runs and exec drops into interactive shell', async () => {
@@ -828,7 +828,7 @@ describe('wrapper → ouijit-hook → hook server (end-to-end)', () => {
     );
 
     await waitForIpc();
-    expect(mockSend).toHaveBeenCalledWith('claude-hook-status', 'pty-e2e-zsh-hook', 'thinking');
+    expect(mockSend).toHaveBeenCalledWith('agent-hook-status', 'pty-e2e-zsh-hook', 'thinking');
   });
 });
 

--- a/src/__tests__/renderer/setup.ts
+++ b/src/__tests__/renderer/setup.ts
@@ -98,7 +98,7 @@ const mockApi = {
     removeFromTask: vi.fn().mockResolvedValue(undefined),
     setTaskTags: vi.fn().mockResolvedValue([]),
   },
-  claudeHooks: {
+  agentHooks: {
     onStatus: vi.fn().mockReturnValue(() => {}),
     getStatus: vi.fn().mockResolvedValue(null),
   },

--- a/src/__tests__/renderer/useHookStatusListener.test.tsx
+++ b/src/__tests__/renderer/useHookStatusListener.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Regression coverage for T-378: the home view was missing the
+ * agentHooks.onStatus subscription, so its status dot never updated after
+ * the initial seed.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// The hook imports terminalInstances from terminalReact, which transitively
+// pulls in xterm and other browser-only modules. Stub the module surface we
+// actually use so the test stays focused on the hook's logic.
+vi.mock('../../components/terminal/terminalReact', () => ({
+  terminalInstances: new Map<string, { handleHookStatus: ReturnType<typeof vi.fn> }>(),
+}));
+
+import { useHookStatusListener } from '../../hooks/useHookStatusListener';
+import { useTerminalStore } from '../../stores/terminalStore';
+import { terminalInstances } from '../../components/terminal/terminalReact';
+
+type FakeTerminal = { handleHookStatus: ReturnType<typeof vi.fn> };
+
+function makeFakeTerminal(): FakeTerminal {
+  return { handleHookStatus: vi.fn() };
+}
+
+/** Insert fake terminals into the registry + store and return them. */
+function seedTerminals(map: Record<string, string[]>): Record<string, FakeTerminal> {
+  const fakes: Record<string, FakeTerminal> = {};
+  for (const ptyIds of Object.values(map)) {
+    for (const ptyId of ptyIds) {
+      const fake = makeFakeTerminal();
+      fakes[ptyId] = fake;
+      (terminalInstances as Map<string, FakeTerminal>).set(ptyId, fake);
+    }
+  }
+  useTerminalStore.setState({ terminalsByProject: map });
+  return fakes;
+}
+
+describe('useHookStatusListener', () => {
+  beforeEach(() => {
+    (terminalInstances as Map<string, FakeTerminal>).clear();
+    useTerminalStore.setState({ terminalsByProject: {} });
+    vi.mocked(window.api.agentHooks.onStatus)
+      .mockReset()
+      .mockReturnValue(() => {});
+    vi.mocked(window.api.agentHooks.getStatus).mockReset().mockResolvedValue(null);
+  });
+
+  it('subscribes to agentHooks.onStatus and dispatches events to the matching terminal', () => {
+    const fakes = seedTerminals({ '/proj/a': ['pty-1'] });
+
+    let captured: ((ptyId: string, status: string) => void) | null = null;
+    vi.mocked(window.api.agentHooks.onStatus).mockImplementation((cb) => {
+      captured = cb;
+      return () => {};
+    });
+
+    renderHook(() => useHookStatusListener('/proj/a'));
+
+    expect(captured).not.toBeNull();
+    captured!('pty-1', 'thinking');
+    expect(fakes['pty-1'].handleHookStatus).toHaveBeenCalledWith('thinking');
+  });
+
+  it('ignores events for ptyIds without a matching terminal instance', () => {
+    seedTerminals({ '/proj/a': ['pty-1'] });
+
+    let captured: ((ptyId: string, status: string) => void) | null = null;
+    vi.mocked(window.api.agentHooks.onStatus).mockImplementation((cb) => {
+      captured = cb;
+      return () => {};
+    });
+
+    renderHook(() => useHookStatusListener('/proj/a'));
+
+    // Should not throw; the optional chain in the hook silently no-ops.
+    expect(() => captured!('pty-unknown', 'thinking')).not.toThrow();
+  });
+
+  it("with projectPath set, seeds only that project's terminals", async () => {
+    const fakes = seedTerminals({
+      '/proj/a': ['pty-a1', 'pty-a2'],
+      '/proj/b': ['pty-b1'],
+    });
+    vi.mocked(window.api.agentHooks.getStatus).mockResolvedValue({
+      status: 'thinking',
+      thinkingCount: 1,
+      readyCount: 0,
+      lastUpdate: Date.now(),
+    });
+
+    renderHook(() => useHookStatusListener('/proj/a'));
+    // Flush the two getStatus promises for project A.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(window.api.agentHooks.getStatus).toHaveBeenCalledWith('pty-a1');
+    expect(window.api.agentHooks.getStatus).toHaveBeenCalledWith('pty-a2');
+    expect(window.api.agentHooks.getStatus).not.toHaveBeenCalledWith('pty-b1');
+
+    expect(fakes['pty-a1'].handleHookStatus).toHaveBeenCalledWith('thinking');
+    expect(fakes['pty-a2'].handleHookStatus).toHaveBeenCalledWith('thinking');
+    expect(fakes['pty-b1'].handleHookStatus).not.toHaveBeenCalled();
+  });
+
+  it('with projectPath null, seeds terminals across every project (home view)', async () => {
+    const fakes = seedTerminals({
+      '/proj/a': ['pty-a1'],
+      '/proj/b': ['pty-b1', 'pty-b2'],
+    });
+    vi.mocked(window.api.agentHooks.getStatus).mockResolvedValue({
+      status: 'thinking',
+      thinkingCount: 2,
+      readyCount: 0,
+      lastUpdate: Date.now(),
+    });
+
+    renderHook(() => useHookStatusListener(null));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(window.api.agentHooks.getStatus).toHaveBeenCalledWith('pty-a1');
+    expect(window.api.agentHooks.getStatus).toHaveBeenCalledWith('pty-b1');
+    expect(window.api.agentHooks.getStatus).toHaveBeenCalledWith('pty-b2');
+
+    expect(fakes['pty-a1'].handleHookStatus).toHaveBeenCalledWith('thinking');
+    expect(fakes['pty-b1'].handleHookStatus).toHaveBeenCalledWith('thinking');
+    expect(fakes['pty-b2'].handleHookStatus).toHaveBeenCalledWith('thinking');
+  });
+
+  it('does not seed terminals whose status is ready or has thinkingCount of 0', async () => {
+    const fakes = seedTerminals({ '/proj/a': ['pty-1'] });
+    vi.mocked(window.api.agentHooks.getStatus).mockResolvedValue({
+      status: 'ready',
+      thinkingCount: 0,
+      readyCount: 5,
+      lastUpdate: Date.now(),
+    });
+
+    renderHook(() => useHookStatusListener('/proj/a'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fakes['pty-1'].handleHookStatus).not.toHaveBeenCalled();
+  });
+
+  it('calls the cleanup returned by onStatus on unmount', () => {
+    seedTerminals({ '/proj/a': ['pty-1'] });
+    const cleanup = vi.fn();
+    vi.mocked(window.api.agentHooks.onStatus).mockReturnValue(cleanup);
+
+    const { unmount } = renderHook(() => useHookStatusListener('/proj/a'));
+    expect(cleanup).not.toHaveBeenCalled();
+    unmount();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -8,6 +8,7 @@ import { TerminalHeader } from './terminal/TerminalHeader';
 import { TerminalBody } from './terminal/TerminalBody';
 import { XTermContainer } from './terminal/XTermContainer';
 import { useTerminalPanels } from './terminal/useTerminalPanels';
+import { useHookStatusListener } from '../hooks/useHookStatusListener';
 import { Icon } from './terminal/Icon';
 import { stringToColor, getInitials } from '../utils/projectIcon';
 import { OuijitLogotype } from './OuijitLogotype';
@@ -52,6 +53,8 @@ export function HomeView() {
   const [activePtyId, setActivePtyId] = useState<string | null>(null);
   const reconnectedRef = useRef(false);
 
+  useHookStatusListener(null);
+
   // Keep activePtyId valid: if the active terminal was removed, fall back
   useEffect(() => {
     if (allPtyIds.length === 0) {
@@ -92,7 +95,7 @@ export function HomeView() {
           worktreeBranch = task?.branch;
         }
         const [hookStatus, planPath] = await Promise.all([
-          window.api.claudeHooks.getStatus(session.ptyId),
+          window.api.agentHooks.getStatus(session.ptyId),
           window.api.plan.getForPty(session.ptyId),
         ]);
         const initialStatus = hookStatus?.status === 'thinking' ? ('thinking' as const) : ('ready' as const);

--- a/src/components/ProjectViewReact.tsx
+++ b/src/components/ProjectViewReact.tsx
@@ -17,6 +17,7 @@ import {
   spawnRunner,
 } from './terminal/terminalActions';
 import { terminalInstances, refreshAllTerminalGitStatus } from './terminal/terminalReact';
+import { useHookStatusListener } from '../hooks/useHookStatusListener';
 
 const isMac = navigator.platform.toLowerCase().includes('mac');
 const GIT_STATUS_PERIODIC_INTERVAL = 30000;
@@ -293,31 +294,7 @@ export function ProjectView() {
   }, [projectPath]);
 
   // Hook status: register ongoing listener + seed existing terminals
-  useEffect(() => {
-    if (!projectPath) return;
-
-    // Ongoing listener for hook status events
-    const cleanup = window.api.claudeHooks.onStatus((ptyId, status) => {
-      const instance = terminalInstances.get(ptyId);
-      if (instance) {
-        instance.handleHookStatus(status as 'thinking' | 'ready');
-      }
-    });
-
-    // Seed existing terminals with current hook status
-    const terms = useTerminalStore.getState().terminalsByProject[projectPath] ?? [];
-    for (const ptyId of terms) {
-      const instance = terminalInstances.get(ptyId);
-      if (!instance) continue;
-      window.api.claudeHooks.getStatus(ptyId).then((hookStatus) => {
-        if (hookStatus?.status === 'thinking' && hookStatus.thinkingCount > 0) {
-          instance.handleHookStatus('thinking');
-        }
-      });
-    }
-
-    return cleanup;
-  }, [projectPath]);
+  useHookStatusListener(projectPath);
 
   // Plan detection: register listeners + seed existing terminals
   useEffect(() => {

--- a/src/components/terminal/terminalActions.ts
+++ b/src/components/terminal/terminalActions.ts
@@ -553,7 +553,7 @@ export async function reconnectOrphanedSessions(projectPath: string): Promise<vo
     }
 
     const [hookStatus, planPath] = await Promise.all([
-      window.api.claudeHooks.getStatus(session.ptyId),
+      window.api.agentHooks.getStatus(session.ptyId),
       window.api.plan.getForPty(session.ptyId),
     ]);
     const initialStatus: SummaryType = hookStatus?.status === 'thinking' ? 'thinking' : 'ready';

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -117,7 +117,7 @@ const actionHandlers: Record<string, ActionHandler> = {
 
     // Forward to renderer for real-time UI updates
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('claude-hook-status', ptyId, status);
+      mainWindow.webContents.send('agent-hook-status', ptyId, status);
     }
   },
 

--- a/src/hooks/useHookStatusListener.ts
+++ b/src/hooks/useHookStatusListener.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { useTerminalStore } from '../stores/terminalStore';
+import { terminalInstances } from '../components/terminal/terminalReact';
+
+/**
+ * Subscribes to CLI agent hook status events (claude / codex / pi) and dispatches
+ * them to the matching terminal instance. On mount, seeds existing terminals
+ * with their current status so the dot reflects state captured before the
+ * listener was registered.
+ *
+ * Pass `projectPath` to seed only that project's terminals (project view).
+ * Pass `null` to seed every known terminal (home view, which shows them all).
+ */
+export function useHookStatusListener(projectPath: string | null): void {
+  useEffect(() => {
+    const cleanup = window.api.agentHooks.onStatus((ptyId, status) => {
+      terminalInstances.get(ptyId)?.handleHookStatus(status as 'thinking' | 'ready');
+    });
+
+    const { terminalsByProject } = useTerminalStore.getState();
+    const ptyIds =
+      projectPath === null ? Object.values(terminalsByProject).flat() : (terminalsByProject[projectPath] ?? []);
+
+    for (const ptyId of ptyIds) {
+      const instance = terminalInstances.get(ptyId);
+      if (!instance) continue;
+      window.api.agentHooks.getStatus(ptyId).then((hookStatus) => {
+        if (hookStatus?.status === 'thinking' && hookStatus.thinkingCount > 0) {
+          instance.handleHookStatus('thinking');
+        }
+      });
+    }
+
+    return cleanup;
+  }, [projectPath]);
+}

--- a/src/hooks/useIPCListeners.ts
+++ b/src/hooks/useIPCListeners.ts
@@ -49,8 +49,9 @@ async function spawnTerminalForCliStart(projectPath: string, start: PendingCliSt
  * Per-terminal listeners (pty:data, pty:exit) remain in OuijitTerminal.bind()
  * and are NOT registered here — they are imperative, not React-managed.
  *
- * Claude hook status listener is registered in useHookStatusListener()
- * to avoid pulling in terminal module at top-level.
+ * Agent hook status listener lives in useHookStatusListener() so both the
+ * home and project views can mount it independently without pulling the
+ * terminal module in at top level here.
  */
 export function useIPCListeners() {
   useEffect(() => {

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -217,7 +217,7 @@ export interface IpcSendContract {
  */
 export interface IpcPushContract {
   'fullscreen-change': { args: [isFullscreen: boolean] };
-  'claude-hook-status': { args: [ptyId: string, status: import('../hookServer').HookStatus] };
+  'agent-hook-status': { args: [ptyId: string, status: import('../hookServer').HookStatus] };
   'claude-plan-detected': { args: [ptyId: string, planPath: string] };
   'claude-plan-ready': { args: [ptyId: string] };
   'plan:content-changed': { args: [planPath: string, content: string] };

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -168,8 +168,8 @@ contextBridge.exposeInMainWorld('api', {
 
   onFullscreenChange: (callback: (isFullscreen: boolean) => void) => typedListen('fullscreen-change', callback),
 
-  claudeHooks: {
-    onStatus: (callback: (ptyId: string, status: string) => void) => typedListen('claude-hook-status', callback),
+  agentHooks: {
+    onStatus: (callback: (ptyId: string, status: string) => void) => typedListen('agent-hook-status', callback),
     getStatus: (ptyId: string) => typedInvoke('hooks:get-status', ptyId),
   },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -497,8 +497,8 @@ export interface ElectronAPI {
   tags: TagsAPI;
   /** Ad-hoc scripts API */
   scripts: ScriptsAPI;
-  /** Claude Code hook events */
-  claudeHooks: ClaudeHooksAPI;
+  /** CLI agent hook events (claude/codex/pi) */
+  agentHooks: AgentHooksAPI;
   /** Plan file detection and viewing */
   plan: PlanAPI;
   /** Get file path from a dropped File object */
@@ -531,9 +531,9 @@ export interface CaptureAPI {
 }
 
 /**
- * Claude Code hook events API exposed to the renderer
+ * CLI agent hook events API exposed to the renderer. Shared by claude / codex / pi.
  */
-export interface ClaudeHooksAPI {
+export interface AgentHooksAPI {
   onStatus(callback: (ptyId: PtyId, status: HookStatus) => void): () => void;
   getStatus(ptyId: PtyId): Promise<HookStatusEntry | null>;
 }


### PR DESCRIPTION
## Summary
- Extract `useHookStatusListener` and call it from both `HomeViewReact` and `ProjectViewReact`; previously only the project view subscribed to push events, so terminals viewed from home only ever showed their seeded status.
- Rename the renderer-facing surface from `claudeHooks` / `claude-hook-status` to `agentHooks` / `agent-hook-status` to reflect that the pipeline is shared by claude, codex, and pi (internal types were already CLI-agnostic).
- Add regression tests covering the new hook's subscribe, dispatch, project-scoped vs all-projects seeding, and unmount cleanup behavior.