### PR TITLE
Fix plan unset not clearing UI when main-process map is empty

### DIFF
--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -34,6 +34,9 @@ import {
   startHookServer,
   stopHookServer,
   getApiPort,
+  setPlanPath,
+  clearPlanPath,
+  getPlanPath,
   installWrapper,
   migrateFromSettingsHooks,
   buildVmHookSettings,
@@ -270,6 +273,38 @@ describe('status action', () => {
     port = getApiPort();
 
     await post(port, { action: 'status', ptyId: 'pty-123', status: 'thinking' });
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+});
+
+describe('clearPlanPath', () => {
+  beforeEach(async () => {
+    await startHookServer(createMockWindow());
+  });
+
+  test('notifies renderer and returns true when a plan was set', () => {
+    setPlanPath('pty-plan-1', '/tmp/plan.md');
+    mockSend.mockClear();
+
+    const had = clearPlanPath('pty-plan-1');
+
+    expect(had).toBe(true);
+    expect(getPlanPath('pty-plan-1')).toBeNull();
+    expect(mockSend).toHaveBeenCalledWith('claude-plan-detected', 'pty-plan-1', null);
+  });
+
+  test('still notifies renderer when the map has no entry (stale renderer state)', () => {
+    const had = clearPlanPath('pty-never-set');
+
+    expect(had).toBe(false);
+    expect(mockSend).toHaveBeenCalledWith('claude-plan-detected', 'pty-never-set', null);
+  });
+
+  test('does not throw when window is destroyed', async () => {
+    await stopHookServer();
+    await startHookServer(createMockWindow(true));
+
+    expect(() => clearPlanPath('pty-destroyed')).not.toThrow();
     expect(mockSend).not.toHaveBeenCalled();
   });
 });

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -76,15 +76,21 @@ export function setPlanPath(ptyId: string, planPath: string): boolean {
   return true;
 }
 
-/** Clear the plan file path for a pty and notify the renderer. */
+/**
+ * Clear the plan file path for a pty and notify the renderer.
+ *
+ * Always notifies the renderer, even when planPathMap has no entry: the map is
+ * in-memory only, so after an app restart it is empty while the renderer may
+ * still display a previously-set plan. Notifying unconditionally lets a stale
+ * renderer plan state get cleared.
+ */
 export function clearPlanPath(ptyId: string): boolean {
-  if (!planPathMap.has(ptyId)) return false;
-  planPathMap.delete(ptyId);
-  hookServerLog.info('plan cleared', { ptyId });
+  const had = planPathMap.delete(ptyId);
+  hookServerLog.info('plan cleared', { ptyId, had });
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send('claude-plan-detected', ptyId, null);
   }
-  return true;
+  return had;
 }
 
 // ── Action handlers ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `clearPlanPath` returned early without notifying the renderer when `planPathMap` had no entry for the ptyId. Since the map is in-memory only, it is empty after an app restart while the renderer may still display a previously-set plan, so `ouijit plan unset` reported success but left the plan visible.
- `clearPlanPath` now always sends the null `claude-plan-detected` event so stale renderer plan state is cleared; the return value still reflects whether an entry existed.
- Added tests covering the set+clear path, the empty-map (stale renderer) case, and the destroyed-window case.