### PR TITLE
Persist terminal renames and focus across restore/reconnect

### DIFF
--- a/src/__tests__/renderer/sessionRestore.test.tsx
+++ b/src/__tests__/renderer/sessionRestore.test.tsx
@@ -1,0 +1,96 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('electron-log/renderer', () => ({
+  default: { scope: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
+}));
+
+// restoreSession only needs addProjectTerminal as a spy and the snapshot-save
+// suspend/resume hooks as no-ops — both pull xterm in for real otherwise.
+vi.mock('../../components/terminal/terminalActions', () => ({
+  addProjectTerminal: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('../../components/terminal/sessionSnapshot', () => ({
+  suspendSnapshotSaves: vi.fn(),
+  resumeSnapshotSaves: vi.fn(),
+}));
+
+import { restoreSession } from '../../components/terminal/sessionRestore';
+import { addProjectTerminal } from '../../components/terminal/terminalActions';
+import type { LastSessionSnapshot, Project, SnapshotTerminal } from '../../types';
+import type { RestorableEntry } from '../../components/terminal/sessionRestore';
+
+const PROJECT = '/project';
+const project: Project = { path: PROJECT, name: 'Project' } as Project;
+
+function snapTerminal(over: Partial<SnapshotTerminal>): SnapshotTerminal {
+  return {
+    ptyId: 'p',
+    projectPath: PROJECT,
+    taskNumber: null,
+    worktreePath: null,
+    worktreeBranch: null,
+    sandboxed: false,
+    label: null,
+    ordinalInProject: 0,
+    isActiveInProject: false,
+    ui: { planPath: null, webPreview: null, runner: null },
+    ...over,
+  };
+}
+
+function entry(over: Partial<RestorableEntry> & { source: SnapshotTerminal }): RestorableEntry {
+  return {
+    project,
+    taskNumber: over.source.taskNumber,
+    taskName: null,
+    taskStatus: null,
+    label: over.source.label,
+    ordinalInProject: over.source.ordinalInProject,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('restoreSession', () => {
+  test('passes the persisted custom label and active flag through to addProjectTerminal', async () => {
+    const a = snapTerminal({ ptyId: 'a', label: 'Build', ordinalInProject: 0, isActiveInProject: false });
+    const b = snapTerminal({
+      ptyId: 'b',
+      label: 'My Renamed Tab',
+      taskNumber: 7,
+      ordinalInProject: 1,
+      isActiveInProject: true,
+    });
+    const snapshot: LastSessionSnapshot = {
+      version: 1,
+      capturedAt: new Date().toISOString(),
+      activeProjectPath: null,
+      terminals: [a, b],
+    };
+
+    await restoreSession(snapshot, [entry({ source: a }), entry({ source: b })]);
+
+    expect(addProjectTerminal).toHaveBeenCalledTimes(2);
+    const calls = vi.mocked(addProjectTerminal).mock.calls;
+    // Spawned in ordinal order: 'Build' (background, not active) then the renamed task tab (foreground).
+    expect(calls[0][2]).toMatchObject({ label: 'Build', background: true });
+    expect(calls[1][2]).toMatchObject({ label: 'My Renamed Tab', taskId: 7, background: false });
+  });
+
+  test('a terminal that was never renamed restores without a label override', async () => {
+    const a = snapTerminal({ ptyId: 'a', label: null, taskNumber: 3, ordinalInProject: 0, isActiveInProject: true });
+    const snapshot: LastSessionSnapshot = {
+      version: 1,
+      capturedAt: new Date().toISOString(),
+      activeProjectPath: null,
+      terminals: [a],
+    };
+
+    await restoreSession(snapshot, [entry({ source: a })]);
+
+    expect(vi.mocked(addProjectTerminal).mock.calls[0][2]).toMatchObject({ label: undefined, taskId: 3 });
+  });
+});

--- a/src/__tests__/renderer/sessionSnapshot.test.tsx
+++ b/src/__tests__/renderer/sessionSnapshot.test.tsx
@@ -1,0 +1,137 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+// electron-log/renderer expects an Electron host; stub it to a no-op logger.
+vi.mock('electron-log/renderer', () => ({
+  default: { scope: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
+}));
+
+// Replace terminalReact (xterm under the hood) with a thin stand-in. Both
+// sessionSnapshot.ts and terminalActions.ts import from it; the test reaches
+// the same `terminalInstances` map they do.
+vi.mock('../../components/terminal/terminalReact', () => ({
+  terminalInstances: new Map(),
+  OuijitTerminal: class {},
+  resolveTerminalLabel: (taskName?: string | null, branch?: string, fallback?: string) =>
+    taskName || branch || fallback || 'Shell',
+}));
+
+import { gatherSnapshot } from '../../components/terminal/sessionSnapshot';
+import { renameTerminal } from '../../components/terminal/terminalActions';
+import { terminalInstances } from '../../components/terminal/terminalReact';
+import { useTerminalStore } from '../../stores/terminalStore';
+import { useAppStore } from '../../stores/appStore';
+import type { OuijitTerminal } from '../../components/terminal/terminalReact';
+
+const PROJECT = '/project';
+
+interface FakeTermOpts {
+  ptyId: string;
+  label?: string;
+  isRunner?: boolean;
+  taskId?: number | null;
+  worktreePath?: string | null;
+  worktreeBranch?: string | null;
+  planPath?: string | null;
+  planPanelOpen?: boolean;
+  diffPanelOpen?: boolean;
+}
+
+function makeFakeTerm(opts: FakeTermOpts): OuijitTerminal {
+  return {
+    ptyId: opts.ptyId,
+    label: opts.label ?? 'Shell',
+    isRunner: opts.isRunner ?? false,
+    sandboxed: false,
+    taskId: opts.taskId ?? null,
+    worktreePath: opts.worktreePath ?? undefined,
+    worktreeBranch: opts.worktreeBranch ?? undefined,
+    planPath: opts.planPath ?? null,
+    planPanelOpen: opts.planPanelOpen ?? false,
+    diffPanelOpen: opts.diffPanelOpen ?? false,
+    webPreviewUrl: null,
+    webPreviewUrlAutoDetected: false,
+    webPreviewPanelOpen: false,
+    webPreviewFullWidth: true,
+    webPreviewSplitRatio: 0.5,
+    runnerScript: null,
+    runnerPanelOpen: false,
+    runnerFullWidth: true,
+  } as unknown as OuijitTerminal;
+}
+
+function register(projectPath: string, term: OuijitTerminal): void {
+  terminalInstances.set(term.ptyId, term);
+  const cur = useTerminalStore.getState().terminalsByProject[projectPath] ?? [];
+  useTerminalStore.setState({
+    terminalsByProject: { ...useTerminalStore.getState().terminalsByProject, [projectPath]: [...cur, term.ptyId] },
+    displayStates: {
+      ...useTerminalStore.getState().displayStates,
+      [term.ptyId]: { ptyId: term.ptyId, projectPath, label: term.label } as never,
+    },
+  });
+}
+
+beforeEach(() => {
+  terminalInstances.clear();
+  useTerminalStore.setState({ terminalsByProject: {}, displayStates: {}, activeIndices: {} });
+  useAppStore.setState({ activeProjectPath: PROJECT });
+  vi.clearAllMocks();
+});
+
+describe('gatherSnapshot', () => {
+  test('captures ptyId, the (renamed) label, panel state and which card is active', () => {
+    register(PROJECT, makeFakeTerm({ ptyId: 'a', label: 'Build' }));
+    register(
+      PROJECT,
+      makeFakeTerm({ ptyId: 'b', label: 'My Renamed Tab', taskId: 7, planPath: '/plan.md', planPanelOpen: true }),
+    );
+    register(PROJECT, makeFakeTerm({ ptyId: 'c', label: 'shell', diffPanelOpen: true }));
+    useTerminalStore.getState().setActiveIndex(PROJECT, 1);
+
+    const snap = gatherSnapshot();
+    expect(snap.activeProjectPath).toBe(PROJECT);
+    expect(snap.terminals).toHaveLength(3);
+
+    const [t0, t1, t2] = snap.terminals;
+    expect(t0).toMatchObject({ ptyId: 'a', label: 'Build', isActiveInProject: false });
+    expect(t1).toMatchObject({ ptyId: 'b', label: 'My Renamed Tab', taskNumber: 7, isActiveInProject: true });
+    expect(t1.ui).toMatchObject({ planPath: '/plan.md', planPanelOpen: true });
+    expect(t2).toMatchObject({ ptyId: 'c', isActiveInProject: false });
+    expect(t2.ui.diffPanelOpen).toBe(true);
+  });
+
+  test('skips runner instances', () => {
+    register(PROJECT, makeFakeTerm({ ptyId: 'main', label: 'Shell' }));
+    register(PROJECT, makeFakeTerm({ ptyId: 'runner', label: 'npm run dev', isRunner: true }));
+
+    const snap = gatherSnapshot();
+    expect(snap.terminals.map((t) => t.ptyId)).toEqual(['main']);
+  });
+});
+
+describe('renameTerminal', () => {
+  test('writes through to display state, the terminal instance, and the PTY record', () => {
+    const term = makeFakeTerm({ ptyId: 'x', label: 'old-branch-name' });
+    register(PROJECT, term);
+
+    renameTerminal('x', '  Auth refactor  ');
+
+    expect(term.label).toBe('Auth refactor');
+    expect(useTerminalStore.getState().displayStates['x'].label).toBe('Auth refactor');
+    expect(window.api.pty.setLabel).toHaveBeenCalledWith('x', 'Auth refactor');
+
+    // …and the rename survives a snapshot.
+    expect(gatherSnapshot().terminals[0]).toMatchObject({ ptyId: 'x', label: 'Auth refactor' });
+  });
+
+  test('ignores an empty/whitespace name', () => {
+    const term = makeFakeTerm({ ptyId: 'x', label: 'keep-me' });
+    register(PROJECT, term);
+
+    renameTerminal('x', '   ');
+
+    expect(term.label).toBe('keep-me');
+    expect(useTerminalStore.getState().displayStates['x'].label).toBe('keep-me');
+    expect(window.api.pty.setLabel).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/renderer/setup.ts
+++ b/src/__tests__/renderer/setup.ts
@@ -51,6 +51,7 @@ const mockApi = {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(),
+    setLabel: vi.fn(),
     onData: vi.fn().mockReturnValue(() => {}),
     onExit: vi.fn().mockReturnValue(() => {}),
     getActiveSessions: vi.fn().mockResolvedValue([]),

--- a/src/components/ResumeBanner.tsx
+++ b/src/components/ResumeBanner.tsx
@@ -32,6 +32,24 @@ export function ResumeBanner() {
     (async () => {
       const snap = await readSnapshot();
       if (cancelled || !snap || snap.terminals.length === 0) return;
+
+      // If PTYs from this snapshot are still alive, the renderer reloaded
+      // rather than the app restarting — reconnectOrphanedSessions will bring
+      // those terminals back as the user navigates, so offering to spawn fresh
+      // copies would just duplicate them. Stay silent; leave the snapshot in
+      // place so the reconnect path can still read its UI/focus state.
+      try {
+        const live = await window.api.pty.getActiveSessions();
+        if (cancelled) return;
+        const snapPtyIds = new Set(snap.terminals.map((t) => t.ptyId).filter(Boolean));
+        if (live.some((s) => snapPtyIds.has(s.ptyId))) {
+          setDismissed(true);
+          return;
+        }
+      } catch {
+        /* fall through and offer the banner */
+      }
+
       const list = await listRestorable(snap);
       if (cancelled) return;
       if (list.length === 0) {

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -4,7 +4,7 @@ import { useProjectStore } from '../../stores/projectStore';
 import { useUIStore } from '../../stores/uiStore';
 import { useShallow } from 'zustand/react/shallow';
 import { terminalInstances } from './terminalReact';
-import { addProjectTerminal, closeProjectTerminal } from './terminalActions';
+import { addProjectTerminal, closeProjectTerminal, renameTerminal } from './terminalActions';
 import { findOtherTaskTerminals } from './findOtherTaskTerminals';
 
 const EMPTY_TAGS: string[] = [];
@@ -271,9 +271,7 @@ export const TerminalHeader = memo(function TerminalHeader({
 
   const commitRename = useCallback(() => {
     const value = renameInputRef.current?.value.trim();
-    if (value) {
-      useTerminalStore.getState().updateDisplay(ptyId, { label: value });
-    }
+    if (value) renameTerminal(ptyId, value);
     setRenaming(false);
   }, [ptyId]);
 

--- a/src/components/terminal/XTermContainer.tsx
+++ b/src/components/terminal/XTermContainer.tsx
@@ -26,9 +26,17 @@ export function XTermContainer({ ptyId, className, style }: XTermContainerProps)
     containerRef.current.appendChild(viewport);
     instance.reattach();
 
-    // Defer fit to next frame — container may not have layout dimensions yet
+    // Defer fit to next frame — container may not have layout dimensions yet —
+    // and grab keyboard focus. This component only renders for the active card,
+    // so mounting here means a terminal just became visible (card switch, page
+    // nav, project re-entry, session restore) and should be ready to type into.
     const raf = requestAnimationFrame(() => {
       instance.fit();
+      const focused = document.activeElement;
+      const editingElsewhere =
+        focused instanceof HTMLElement &&
+        (focused.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(focused.tagName));
+      if (!editingElsewhere) instance.xterm.focus();
     });
 
     return () => {

--- a/src/components/terminal/sessionRestore.ts
+++ b/src/components/terminal/sessionRestore.ts
@@ -108,6 +108,9 @@ export async function restoreSession(snapshot: LastSessionSnapshot, entries: Res
               : undefined,
             taskId: source.taskNumber ?? undefined,
             sandboxed: source.sandboxed,
+            // Carry through a user rename so a restored card keeps its name
+            // instead of snapping back to the task name.
+            label: source.label ?? undefined,
             // Don't fire start/continue hooks on resume — that'd kick off a new
             // claude session. Restored terminals come back as plain shells.
             skipAutoHook: true,

--- a/src/components/terminal/sessionSnapshot.ts
+++ b/src/components/terminal/sessionSnapshot.ts
@@ -40,6 +40,8 @@ function uiFor(term: OuijitTerminal): SnapshotTerminalUi {
 
   return {
     planPath: term.planPath,
+    planPanelOpen: term.planPanelOpen,
+    diffPanelOpen: term.diffPanelOpen,
     webPreview,
     runner,
   };
@@ -60,6 +62,7 @@ export function gatherSnapshot(): LastSessionSnapshot {
       if (term.isRunner) return; // runners are restored as state on their parent
 
       terminals.push({
+        ptyId: term.ptyId,
         projectPath,
         taskNumber: term.taskId,
         worktreePath: term.worktreePath ?? null,

--- a/src/components/terminal/terminalActions.ts
+++ b/src/components/terminal/terminalActions.ts
@@ -16,6 +16,7 @@ import { useTerminalStore, type TerminalDisplayState } from '../../stores/termin
 import { useCanvasStore, persistCanvas } from '../../stores/canvasStore';
 import { useAppStore, staleGuard } from '../../stores/appStore';
 import { OuijitTerminal, terminalInstances, resolveTerminalLabel, type SummaryType } from './terminalReact';
+import { readSnapshot } from './sessionSnapshot';
 import { detectDevServerUrl } from '../webPreview/urlHelpers';
 import log from 'electron-log/renderer';
 
@@ -41,6 +42,9 @@ export interface AddProjectTerminalOptions {
   taskId?: number;
   skipAutoHook?: boolean;
   background?: boolean;
+  /** Overrides the auto-derived card label (e.g. a user-renamed terminal being
+   *  restored from a session snapshot). */
+  label?: string;
   /** Apply persisted UI state (plan, web preview, runner panel) after spawn — for session restore. */
   initialUiState?: SnapshotTerminalUi;
   /** If set, the new terminal takes this loading slot's place via
@@ -51,11 +55,23 @@ export interface AddProjectTerminalOptions {
 
 // ── Apply persisted UI state from a session snapshot ────────────────
 
-async function applyInitialUiState(term: OuijitTerminal, ui: SnapshotTerminalUi): Promise<void> {
+/**
+ * Re-apply per-terminal UI state captured in a session snapshot. Shared by
+ * the cross-launch restore path (fresh shells) and the renderer-reload
+ * reconnect path (live PTYs), so the two stay in lockstep.
+ */
+export async function applyInitialUiState(term: OuijitTerminal, ui: SnapshotTerminalUi): Promise<void> {
   if (ui.planPath) {
     term.planPath = ui.planPath;
-    term.planPanelOpen = true;
-    term.pushDisplayState({ planPath: ui.planPath, planPanelOpen: true });
+    // Older snapshots had no planPanelOpen flag and always re-opened the panel
+    // when a plan was attached — preserve that as the fallback.
+    term.planPanelOpen = ui.planPanelOpen ?? true;
+    term.pushDisplayState({ planPath: ui.planPath, planPanelOpen: term.planPanelOpen });
+  }
+
+  if (ui.diffPanelOpen) {
+    term.diffPanelOpen = true;
+    term.pushDisplayState({ diffPanelOpen: true });
   }
 
   if (ui.webPreview?.url) {
@@ -74,10 +90,11 @@ async function applyInitialUiState(term: OuijitTerminal, ui: SnapshotTerminalUi)
   if (ui.runner) {
     // Don't auto-respawn the previously-running script. A user's `npm run dev`
     // is benign to re-run, but a `Reset DB` or similar destructive script
-    // would silently fire on Resume. Preserve the panel layout so the slot
-    // is recognizable, and pre-load the script so one click on Run re-launches it.
+    // would silently fire on Resume. Pre-load the script so one click on Run
+    // re-launches it, and surface its name in the header.
     term.runnerFullWidth = ui.runner.fullWidth;
     term.runnerScript = { name: ui.runner.scriptName ?? '', command: ui.runner.scriptCommand };
+    term.pushDisplayState({ runnerScriptName: ui.runner.scriptName ?? null });
   }
 }
 
@@ -151,7 +168,7 @@ export async function addProjectTerminal(
 
   if (isStale()) return false;
 
-  const label = resolveTerminalLabel(taskName, worktreeInfo?.branch, runConfig?.name);
+  const label = options?.label ?? resolveTerminalLabel(taskName, worktreeInfo?.branch, runConfig?.name);
   const command = runConfig?.command;
 
   // Determine command to run
@@ -295,6 +312,24 @@ export async function addProjectTerminal(
   }
 }
 
+// ── Rename a terminal ────────────────────────────────────────────────
+
+/**
+ * Apply a user rename. Writes through to (1) the display state the card reads
+ * from, (2) the OuijitTerminal instance — which `gatherSnapshot` persists, so
+ * the rename survives a cross-launch restore — and (3) the main-process PTY
+ * record, so a renderer-reload reconnect comes back with the renamed label
+ * rather than the original. Empty/whitespace names are ignored.
+ */
+export function renameTerminal(ptyId: string, label: string): void {
+  const trimmed = label.trim();
+  if (!trimmed) return;
+  const instance = terminalInstances.get(ptyId);
+  if (instance) instance.label = trimmed;
+  useTerminalStore.getState().updateDisplay(ptyId, { label: trimmed });
+  window.api.pty.setLabel(ptyId, trimmed);
+}
+
 // ── Close a terminal ─────────────────────────────────────────────────
 
 export function closeProjectTerminal(ptyId: string): void {
@@ -316,13 +351,14 @@ export function closeProjectTerminal(ptyId: string): void {
 
 export async function reconnectTerminal(
   session: ActiveSession,
-  opts: { worktreeBranch?: string; mergeTarget?: string; initialStatus?: SummaryType } = {},
+  opts: { worktreeBranch?: string; mergeTarget?: string; initialStatus?: SummaryType; label?: string } = {},
 ): Promise<OuijitTerminal | null> {
+  const label = opts.label ?? session.label;
   const term = new OuijitTerminal({
     ptyId: session.ptyId,
     projectPath: session.projectPath,
     command: session.command,
-    label: session.label,
+    label,
     sandboxed: !!session.sandboxed,
     taskId: session.taskId ?? null,
     worktreePath: session.worktreePath,
@@ -349,14 +385,21 @@ export async function reconnectTerminal(
   // Bind to PTY (wires data, input, exit, resize)
   term.bind(session.ptyId);
 
-  // Register in store
-  registerTerminal(term, session.projectPath, {
-    label: session.label,
-    sandboxed: !!session.sandboxed,
-    taskId: session.taskId ?? null,
-    worktreeBranch: opts.worktreeBranch ?? null,
-    summaryType: opts.initialStatus ?? 'ready',
-  });
+  // Register in store as a background terminal — focus is restored explicitly
+  // by reconnectOrphanedSessions once every PTY for the project is back, so the
+  // last-reconnected one doesn't steal it.
+  registerTerminal(
+    term,
+    session.projectPath,
+    {
+      label,
+      sandboxed: !!session.sandboxed,
+      taskId: session.taskId ?? null,
+      worktreeBranch: opts.worktreeBranch ?? null,
+      summaryType: opts.initialStatus ?? 'ready',
+    },
+    /* background */ true,
+  );
 
   // Load tags and git status
   term.loadTags();
@@ -539,6 +582,16 @@ export async function reconnectOrphanedSessions(projectPath: string): Promise<vo
   const projectSessions = sessions.filter((s) => s.projectPath === projectPath);
   if (projectSessions.length === 0) return;
 
+  // The session snapshot from the same launch (PTYs survive a renderer reload)
+  // carries per-terminal UI state and which card was focused. Match its rows to
+  // live sessions by ptyId.
+  const snapshot = await readSnapshot();
+  const snapByPtyId = new Map(
+    (snapshot?.terminals ?? [])
+      .filter((t) => t.projectPath === projectPath && t.ptyId)
+      .map((t) => [t.ptyId as string, t] as const),
+  );
+
   const mainSessions = projectSessions.filter((s) => !s.isRunner);
   const runnerSessions = projectSessions.filter((s) => s.isRunner);
 
@@ -558,10 +611,36 @@ export async function reconnectOrphanedSessions(projectPath: string): Promise<vo
     ]);
     const initialStatus: SummaryType = hookStatus?.status === 'thinking' ? 'thinking' : 'ready';
 
-    const term = await reconnectTerminal(session, { worktreeBranch, mergeTarget, initialStatus });
-    if (term && planPath) {
-      term.planPath = planPath;
-      term.pushDisplayState({ planPath });
+    const snapEntry = snapByPtyId.get(session.ptyId);
+    const term = await reconnectTerminal(session, {
+      worktreeBranch,
+      mergeTarget,
+      initialStatus,
+      label: snapEntry?.label ?? undefined,
+    });
+    if (term) {
+      if (snapEntry) await applyInitialUiState(term, snapEntry.ui);
+      // The plan association lives in the main process — authoritative for the
+      // path; the snapshot only contributes whether the panel was open.
+      if (planPath) {
+        term.planPath = planPath;
+        term.pushDisplayState({ planPath });
+      }
+    }
+  }
+
+  // Restore the focused card. Without this, every reconnectTerminal would have
+  // run activateLast and the last PTY back would win the selection.
+  {
+    const store = useTerminalStore.getState();
+    const activeEntry = (snapshot?.terminals ?? []).find(
+      (t) => t.projectPath === projectPath && t.isActiveInProject && t.ptyId,
+    );
+    const idx = activeEntry ? (store.terminalsByProject[projectPath] ?? []).indexOf(activeEntry.ptyId as string) : -1;
+    if (idx >= 0) {
+      store.setActiveIndex(projectPath, idx);
+    } else {
+      store.activateLast(projectPath);
     }
   }
 

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -205,6 +205,7 @@ export interface IpcSendContract {
   'pty:write': { args: [ptyId: string, data: string] };
   'pty:resize': { args: [ptyId: string, cols: number, rows: number] };
   'pty:kill': { args: [ptyId: string] };
+  'pty:set-label': { args: [ptyId: string, label: string] };
   'pty:set-window': { args: [] };
 }
 

--- a/src/ipc/handlers/pty.ts
+++ b/src/ipc/handlers/pty.ts
@@ -1,6 +1,15 @@
 import { BrowserWindow } from 'electron';
 import { typedHandle, typedOn } from '../helpers';
-import { spawnPty, reconnectPty, getActiveSessions, setWindow, writeToPty, resizePty, killPty } from '../../ptyManager';
+import {
+  spawnPty,
+  reconnectPty,
+  getActiveSessions,
+  setWindow,
+  writeToPty,
+  resizePty,
+  killPty,
+  setPtyLabel,
+} from '../../ptyManager';
 import * as limaPlugin from '../../lima';
 
 export function registerPtyHandlers(mainWindow: BrowserWindow): void {
@@ -41,6 +50,14 @@ export function registerPtyHandlers(mainWindow: BrowserWindow): void {
       return limaPlugin.reconnectSandboxPty(ptyId, mainWindow);
     }
     return reconnectPty(ptyId, mainWindow);
+  });
+
+  typedOn('pty:set-label', (ptyId, label) => {
+    if (limaPlugin.isSandboxPty(ptyId)) {
+      limaPlugin.setSandboxPtyLabel(ptyId, label);
+    } else {
+      setPtyLabel(ptyId, label);
+    }
   });
 
   typedOn('pty:set-window', () => {

--- a/src/lima/index.ts
+++ b/src/lima/index.ts
@@ -7,6 +7,7 @@ export {
   writeSandboxPty,
   resizeSandboxPty,
   killSandboxPty,
+  setSandboxPtyLabel,
   getActiveSandboxSessions,
   reconnectSandboxPty,
 } from './spawn';

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -311,6 +311,14 @@ export function killSandboxPty(ptyId: PtyId): void {
 }
 
 /**
+ * Update a sandbox PTY's display label (mirror of setPtyLabel for host PTYs).
+ */
+export function setSandboxPtyLabel(ptyId: PtyId, label: string): void {
+  const managed = activeSandboxPtys.get(ptyId);
+  if (managed) managed.label = label;
+}
+
+/**
  * Get active sandbox sessions (for restoration after renderer reload)
  */
 export function getActiveSandboxSessions(): ActiveSession[] {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -67,6 +67,7 @@ contextBridge.exposeInMainWorld('api', {
     write: (ptyId: PtyId, data: string) => typedSend('pty:write', ptyId, data),
     resize: (ptyId: PtyId, cols: number, rows: number) => typedSend('pty:resize', ptyId, cols, rows),
     kill: (ptyId: PtyId) => typedSend('pty:kill', ptyId),
+    setLabel: (ptyId: PtyId, label: string) => typedSend('pty:set-label', ptyId, label),
     getActiveSessions: () => typedInvoke('pty:get-active-sessions'),
     reconnect: (ptyId: PtyId) => typedInvoke('pty:reconnect', ptyId),
     setWindow: () => typedSend('pty:set-window'),

--- a/src/ptyManager.ts
+++ b/src/ptyManager.ts
@@ -363,6 +363,16 @@ export function getActiveSessionCount(): number {
 }
 
 /**
+ * Update a PTY's display label (user renamed the terminal card). Keeps the
+ * managed record in sync so `getActiveSessions` — and therefore the reconnect
+ * path after a renderer reload — restores the renamed label, not the original.
+ */
+export function setPtyLabel(ptyId: PtyId, label: string): void {
+  const managed = activePtys.get(ptyId);
+  if (managed) managed.label = label;
+}
+
+/**
  * Sandbox PTYs are tracked in src/lima/spawn.ts in their own map — they never
  * enter `activePtys`. But hookServer / setPlanPath / `task current` need a
  * single source of truth for "is this ptyId live?" and "what task does this

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,11 @@ export type LastActiveView = { type: 'home' } | { type: 'project'; path: string 
  */
 export interface SnapshotTerminalUi {
   planPath: string | null;
+  /** Whether the plan panel was open. Older snapshots omit this — treat as the
+   *  legacy "open if a plan was attached" behaviour when undefined. */
+  planPanelOpen?: boolean;
+  /** Whether the diff panel was open. Older snapshots omit this. */
+  diffPanelOpen?: boolean;
   webPreview: {
     url: string | null;
     panelOpen: boolean;
@@ -64,6 +69,9 @@ export interface SnapshotTerminalUi {
 }
 
 export interface SnapshotTerminal {
+  /** Live PTY id at capture time. Useful only for a renderer-reload reconnect
+   *  (PTYs survive); meaningless across a full quit. Older snapshots omit it. */
+  ptyId?: string;
   projectPath: string;
   taskNumber: number | null;
   worktreePath: string | null;
@@ -257,6 +265,8 @@ export interface PtyAPI {
   write(ptyId: PtyId, data: string): void;
   resize(ptyId: PtyId, cols: number, rows: number): void;
   kill(ptyId: PtyId): void;
+  /** Update a terminal's display label after a user rename */
+  setLabel(ptyId: PtyId, label: string): void;
   onData(ptyId: PtyId, callback: (data: string) => void): () => void;
   onExit(ptyId: PtyId, callback: (exitCode: number) => void): () => void;
   /** Get list of active sessions (for reconnection after reload) */


### PR DESCRIPTION
## Summary

- Persist user terminal renames so they survive both a renderer reload and a full app restart: a new `renameTerminal()` writes through to the display state, the `OuijitTerminal` instance (captured by `gatherSnapshot`), and the main-process PTY record via a new `pty:set-label` IPC. Covers host and Lima sandbox PTYs.
- Restore the previously-focused terminal card on reconnect instead of letting the last-reconnected PTY win: `reconnectTerminal` now registers terminals as background, and `reconnectOrphanedSessions` explicitly re-selects the card that was active (matched by `ptyId`).
- `XTermContainer` grabs keyboard focus when a terminal becomes visible, unless an input/textarea/contentEditable is focused elsewhere.
- Capture more per-terminal UI state in the session snapshot: `ptyId`, `planPanelOpen`, and `diffPanelOpen`, with backward-compatible fallbacks for older snapshots.
- `ResumeBanner` stays silent when the snapshot's PTYs are still alive (renderer reload) so it doesn't offer to spawn duplicate terminals; the reconnect path handles those.
- Add renderer tests for snapshot capture, rename write-through, and label pass-through on restore.