### PR TITLE
Fix OUIJIT_* values being shell-evaluated in hook commands

### DIFF
--- a/src/__tests__/buildCommandString.test.ts
+++ b/src/__tests__/buildCommandString.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { buildCommandString, buildCommandShellArgs } from '../ptyManager';
+
+/**
+ * Regression: OUIJIT_* values must not be textually interpolated into the
+ * hook/start command string. They are passed to the PTY as real environment
+ * variables, so the shell expands $VAR itself. Pre-substituting raw values
+ * splices shell metacharacters (backticks, $(), quotes) into the command,
+ * which the shell then re-evaluates.
+ *
+ * Proven case (Keith, Signal): task name `Add `.DS_Store` in .gitignore`
+ * with start command `codex "$OUIJIT_TASK_NAME"` produced
+ * `zsh: command not found: .DS_Store` — the backticks were executed.
+ */
+describe('buildCommandString', () => {
+  it('returns an empty string when no command is given', () => {
+    expect(buildCommandString(undefined, undefined)).toBe('');
+    expect(buildCommandString(undefined, { OUIJIT_TASK_NAME: 'x' })).toBe('');
+  });
+
+  it('does not substitute $OUIJIT_* tokens — the shell expands them as real env vars', () => {
+    const command = 'codex "$OUIJIT_TASK_NAME"';
+    const env = { OUIJIT_TASK_NAME: 'Add `.DS_Store` in .gitignore' };
+
+    const result = buildCommandString(command, env);
+
+    // The token must survive verbatim so the shell expands the env var.
+    expect(result).toBe('codex "$OUIJIT_TASK_NAME"');
+    // The raw value (with backticks) must never appear in the command text.
+    expect(result).not.toContain('.DS_Store');
+    expect(result).not.toContain('`');
+  });
+
+  it('does not splice values containing $() command substitution', () => {
+    const command = 'run "$OUIJIT_TASK_NAME"';
+    const env = { OUIJIT_TASK_NAME: 'fix $(rm -rf /) bug' };
+
+    const result = buildCommandString(command, env);
+
+    expect(result).toBe('run "$OUIJIT_TASK_NAME"');
+    expect(result).not.toContain('$(rm');
+  });
+
+  it('does not splice values containing quotes', () => {
+    const command = 'echo "$OUIJIT_TASK_NAME"';
+    const env = { OUIJIT_TASK_NAME: `it's a "quoted" name` };
+
+    const result = buildCommandString(command, env);
+
+    expect(result).toBe('echo "$OUIJIT_TASK_NAME"');
+  });
+
+  it('leaves commands without OUIJIT_* tokens untouched', () => {
+    expect(buildCommandString('npm run dev', { OUIJIT_TASK_NAME: 'x' })).toBe('npm run dev');
+  });
+});
+
+/**
+ * The startup command is spliced into the shell's `-c` script as shell *code*
+ * the shell must parse — not a data string. It must NOT be quote-escaped:
+ * `'\''`-escaping (an idiom only valid inside an enclosing single-quoted
+ * string) corrupts any command containing a single quote into an unterminated
+ * quote, since the command is interpolated unquoted.
+ */
+describe('buildCommandShellArgs', () => {
+  it('splices the command into the zsh -c script verbatim', () => {
+    const args = buildCommandShellArgs("echo 'hello world'", '/bin/zsh', '/tmp/integration');
+
+    expect(args[0]).toBe('-ic');
+    expect(args[1]).toContain("echo 'hello world'");
+    // The `'\''` escape idiom must never appear — it is invalid here.
+    expect(args[1]).not.toContain("'\\''");
+  });
+
+  it('splices the command into the bash -c script verbatim', () => {
+    const args = buildCommandShellArgs("echo 'hi'", '/bin/bash', '/tmp/integration');
+
+    expect(args[0]).toBe('-ic');
+    expect(args[1]).toContain("echo 'hi'");
+    expect(args[1]).not.toContain("'\\''");
+  });
+
+  it('preserves a $OUIJIT_* token so the shell expands it as a real env var', () => {
+    const args = buildCommandShellArgs('codex "$OUIJIT_TASK_NAME"', '/bin/zsh', '/tmp/integration');
+
+    expect(args[1]).toContain('codex "$OUIJIT_TASK_NAME"');
+  });
+
+  it('keeps the command intact for non-zsh/bash shells', () => {
+    const args = buildCommandShellArgs("fish_cmd 'arg'", '/usr/bin/fish', '/tmp/integration');
+
+    expect(args[0]).toBe('-ic');
+    expect(args[1]).toContain("fish_cmd 'arg'");
+    expect(args[1]).toContain('exec /usr/bin/fish');
+  });
+});

--- a/src/ptyManager.ts
+++ b/src/ptyManager.ts
@@ -16,6 +16,56 @@ import { issueToken, revokeToken, revokeAllTokens } from './apiAuth';
 
 const ptyLog = getLogger().scope('pty');
 
+/**
+ * Builds the command string to run in the spawned shell.
+ *
+ * Env vars (OUIJIT_* and any custom vars from the caller) are passed to the
+ * PTY process as real environment variables, so the shell expands $VAR /
+ * ${VAR} references itself when it parses the command.
+ *
+ * The command must NOT be pre-substituted with the raw env values. Splicing a
+ * value into the command text lets the shell re-parse and re-evaluate any
+ * shell metacharacters it contains (backticks, $(), quotes) — e.g. a task
+ * named ``Add `.DS_Store` in .gitignore`` would have its backticks executed
+ * as a command. Genuine env-var expansion inside double quotes keeps such
+ * characters literal.
+ *
+ * `env` is accepted (and ignored) so callers can document that those values
+ * reach the shell as environment variables rather than as command text.
+ */
+export function buildCommandString(command: string | undefined, _env?: Record<string, string> | undefined): string {
+  return command || '';
+}
+
+/**
+ * Builds the argv for the spawned shell when a startup command is present.
+ *
+ * The command runs via `-ic` then the shell execs into an interactive
+ * session, which avoids the double-echo from writing to stdin.
+ *
+ * The command is spliced into the `-c` script verbatim: it is shell *code*
+ * the shell must parse (so $VAR expands and the user's own quotes apply), not
+ * a data string. It must NOT be quote-escaped — the `'\''` idiom is only
+ * valid inside an enclosing single-quoted string, and here the command is
+ * interpolated unquoted, so escaping it would corrupt any command containing
+ * a single quote into an unterminated quote.
+ */
+export function buildCommandShellArgs(command: string, shell: string, shellIntegrationDir: string): string[] {
+  const isZsh = shell.endsWith('/zsh') || shell === 'zsh';
+  const isBash = shell.endsWith('/bash') || shell === 'bash';
+  const prefix = 'export PATH="$OUIJIT_WRAPPER_DIR:$PATH"';
+
+  if (isZsh) {
+    return ['-ic', `${prefix}; ${command}; ZDOTDIR="$OUIJIT_SHELL_INTEGRATION_DIR/zsh" exec ${shell}`];
+  }
+  if (isBash) {
+    const rcfile = path.join(shellIntegrationDir, 'ouijit-bash-integration.bash');
+    return ['-ic', `${prefix}; ${command}; exec bash --rcfile ${rcfile}`];
+  }
+  // Fallback for other shells
+  return ['-ic', `${prefix}; ${command}; exec ${shell}`];
+}
+
 interface ManagedPty {
   process: pty.IPty;
   projectPath: string;
@@ -193,17 +243,10 @@ export async function spawnPty(options: PtySpawnOptions, window: BrowserWindow):
     const cliPath = getCliPath();
     if (cliPath) finalEnv['OUIJIT_CLI_PATH'] = cliPath;
 
-    // Expand environment variables in the command if provided
-    let expandedCommand = options.command || '';
-    if (options.command && options.env) {
-      for (const [key, value] of Object.entries(options.env)) {
-        // Replace $VAR and ${VAR} patterns
-        expandedCommand = expandedCommand.replace(new RegExp(`\\$\\{${key}\\}|\\$${key}\\b`, 'g'), value);
-      }
-    }
+    // Build the command string to run in the spawned shell
+    const expandedCommand = buildCommandString(options.command, options.env);
 
     // If there's a command, run it via shell -c then exec into interactive shell
-    // This avoids the double-echo issue from writing to stdin
     let shellArgs: string[] = [];
 
     const isZsh = shell.endsWith('/zsh') || shell === 'zsh';
@@ -217,27 +260,18 @@ export async function spawnPty(options: PtySpawnOptions, window: BrowserWindow):
       finalEnv['ZDOTDIR'] = path.join(shellIntegrationDir, 'zsh');
 
       if (expandedCommand) {
-        const escapedCmd = expandedCommand.replace(/'/g, "'\\''");
-        shellArgs = [
-          '-ic',
-          `export PATH="$OUIJIT_WRAPPER_DIR:$PATH"; ${escapedCmd}; ZDOTDIR="$OUIJIT_SHELL_INTEGRATION_DIR/zsh" exec ${shell}`,
-        ];
+        shellArgs = buildCommandShellArgs(expandedCommand, shell, shellIntegrationDir);
       }
     } else if (isBash) {
       // --rcfile/--init-file: bash sources this instead of ~/.bashrc.
       // Our integration script sources .bashrc first, then fixes PATH.
-      const rcfile = path.join(shellIntegrationDir, 'ouijit-bash-integration.bash');
-
       if (expandedCommand) {
-        const escapedCmd = expandedCommand.replace(/'/g, "'\\''");
-        shellArgs = ['-ic', `export PATH="$OUIJIT_WRAPPER_DIR:$PATH"; ${escapedCmd}; exec bash --rcfile ${rcfile}`];
+        shellArgs = buildCommandShellArgs(expandedCommand, shell, shellIntegrationDir);
       } else {
-        shellArgs = ['--init-file', rcfile];
+        shellArgs = ['--init-file', path.join(shellIntegrationDir, 'ouijit-bash-integration.bash')];
       }
     } else if (expandedCommand) {
-      // Fallback for other shells
-      const escapedCmd = expandedCommand.replace(/'/g, "'\\''");
-      shellArgs = ['-ic', `export PATH="$OUIJIT_WRAPPER_DIR:$PATH"; ${escapedCmd}; exec ${shell}`];
+      shellArgs = buildCommandShellArgs(expandedCommand, shell, shellIntegrationDir);
     }
 
     const ptyProcess = pty.spawn(shell, shellArgs, {


### PR DESCRIPTION
## Summary

- `$OUIJIT_*` tokens were textually interpolated into the start/hook command string instead of being expanded by the shell as environment variables. A value with shell metacharacters (e.g. a task named ``Add `.DS_Store` in .gitignore``) got re-evaluated by the shell, producing errors like `zsh: command not found: .DS_Store`.
- Stop pre-substituting tokens: the values already reach the PTY as real environment variables, so the shell expands `$VAR` itself and metacharacters in the value stay literal.
- Remove the `'\''` quote-escaping applied to the command. The command is spliced into the shell's `-c` script verbatim as shell code; the escape idiom is only valid inside an enclosing single-quoted string, so it corrupted any command containing a single quote into an unterminated quote.
- Extract `buildCommandString` and `buildCommandShellArgs` as pure functions; cover both fixes with tests that fail against the old behavior.