### PR TITLE
Fix stale OUIJIT_TASK_PROMPT after editing a task description

### DIFF
--- a/src/__tests__/buildWorktreeStartEnv.test.ts
+++ b/src/__tests__/buildWorktreeStartEnv.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from 'vitest';
+
+import { buildWorktreeStartEnv } from '../components/terminal/terminalActions';
+import type { TaskWithWorkspace, WorktreeInfo } from '../types';
+
+const PROJECT = '/path/to/project';
+
+function makeWorktree(patch: Partial<WorktreeInfo & { prompt?: string }> = {}): WorktreeInfo & { prompt?: string } {
+  return {
+    path: '/path/to/project/worktrees/T-1',
+    branch: 'feat-1234567890',
+    ...patch,
+  } as WorktreeInfo & { prompt?: string };
+}
+
+function makeTask(patch: Partial<TaskWithWorkspace> = {}): TaskWithWorkspace {
+  return {
+    taskNumber: 1,
+    name: 'Add Hello World to footer of README',
+    status: 'in_progress',
+    createdAt: new Date().toISOString(),
+    ...patch,
+  };
+}
+
+describe('buildWorktreeStartEnv', () => {
+  test('always sets the base worktree env vars', () => {
+    const env = buildWorktreeStartEnv({
+      hookType: 'continue',
+      projectPath: PROJECT,
+      worktreeInfo: makeWorktree(),
+      label: 'My Task',
+      task: makeTask(),
+    });
+
+    expect(env.OUIJIT_HOOK_TYPE).toBe('continue');
+    expect(env.OUIJIT_PROJECT_PATH).toBe(PROJECT);
+    expect(env.OUIJIT_WORKTREE_PATH).toBe('/path/to/project/worktrees/T-1');
+    expect(env.OUIJIT_TASK_BRANCH).toBe('feat-1234567890');
+    expect(env.OUIJIT_TASK_NAME).toBe('My Task');
+  });
+
+  // The bug (T-387): editing a task's description after its worktree exists
+  // left OUIJIT_TASK_PROMPT stale, because the prompt was sourced from the
+  // worktree snapshot captured at creation time. The prompt must come from the
+  // live task instead.
+  test('sources the prompt from the live task, not the stale worktree snapshot', () => {
+    const env = buildWorktreeStartEnv({
+      hookType: 'continue',
+      projectPath: PROJECT,
+      // Stale snapshot prompt from worktree-creation time.
+      worktreeInfo: makeWorktree({ prompt: 'original description' }),
+      label: 'My Task',
+      // Description edited live after the worktree was created.
+      task: makeTask({ prompt: 'edited description' }),
+    });
+
+    expect(env.OUIJIT_TASK_PROMPT).toBe('edited description');
+  });
+
+  test('exposes OUIJIT_TASK_DESCRIPTION as an alias of OUIJIT_TASK_PROMPT', () => {
+    const env = buildWorktreeStartEnv({
+      hookType: 'continue',
+      projectPath: PROJECT,
+      worktreeInfo: makeWorktree(),
+      label: 'My Task',
+      task: makeTask({ prompt: 'a description' }),
+    });
+
+    expect(env.OUIJIT_TASK_DESCRIPTION).toBe('a description');
+    expect(env.OUIJIT_TASK_DESCRIPTION).toBe(env.OUIJIT_TASK_PROMPT);
+  });
+
+  test('omits the prompt vars entirely when the live task has no description', () => {
+    const env = buildWorktreeStartEnv({
+      hookType: 'continue',
+      projectPath: PROJECT,
+      worktreeInfo: makeWorktree(),
+      label: 'My Task',
+      task: makeTask({ prompt: undefined }),
+    });
+
+    expect('OUIJIT_TASK_PROMPT' in env).toBe(false);
+    expect('OUIJIT_TASK_DESCRIPTION' in env).toBe(false);
+  });
+});

--- a/src/components/dialogs/CombinedHookConfigDialog.tsx
+++ b/src/components/dialogs/CombinedHookConfigDialog.tsx
@@ -10,6 +10,7 @@ const ENV_VARS = [
   '$OUIJIT_TASK_BRANCH',
   '$OUIJIT_TASK_NAME',
   '$OUIJIT_TASK_PROMPT',
+  '$OUIJIT_TASK_DESCRIPTION',
 ];
 
 interface CombinedHookConfigDialogProps {

--- a/src/components/dialogs/HookConfigDialog.tsx
+++ b/src/components/dialogs/HookConfigDialog.tsx
@@ -48,6 +48,7 @@ const ENV_VARS = [
   '$OUIJIT_TASK_BRANCH',
   '$OUIJIT_TASK_NAME',
   '$OUIJIT_TASK_PROMPT',
+  '$OUIJIT_TASK_DESCRIPTION',
 ];
 
 interface HookConfigDialogProps {

--- a/src/components/dialogs/RunHookDialog.tsx
+++ b/src/components/dialogs/RunHookDialog.tsx
@@ -17,6 +17,7 @@ const ENV_VARS = [
   '$OUIJIT_TASK_BRANCH',
   '$OUIJIT_TASK_NAME',
   '$OUIJIT_TASK_PROMPT',
+  '$OUIJIT_TASK_DESCRIPTION',
 ];
 
 export interface RunHookResult {

--- a/src/components/terminal/terminalActions.ts
+++ b/src/components/terminal/terminalActions.ts
@@ -11,6 +11,7 @@ import type {
   ActiveSession,
   RunnerScript,
   SnapshotTerminalUi,
+  TaskWithWorkspace,
 } from '../../types';
 import { useTerminalStore, type TerminalDisplayState } from '../../stores/terminalStore';
 import { useCanvasStore, persistCanvas } from '../../stores/canvasStore';
@@ -139,6 +140,45 @@ function registerTerminal(
   }
 }
 
+// ── Worktree hook environment ────────────────────────────────────────
+
+/**
+ * Build the env vars handed to a worktree-backed terminal's hook.
+ *
+ * The task prompt MUST come from `task` — a live DB fetch — and never from the
+ * worktree snapshot in `AddProjectTerminalOptions.existingWorktree`. That
+ * snapshot is captured when the worktree is created and never refreshed, so
+ * sourcing the prompt from it leaves OUIJIT_TASK_PROMPT stale (or absent
+ * entirely, since the var is only set when the prompt is truthy) after a task's
+ * description is edited.
+ *
+ * OUIJIT_TASK_DESCRIPTION is set as an alias of OUIJIT_TASK_PROMPT: the UI
+ * labels this field "description", so a hook reaching for the var name that
+ * matches the label gets the same value.
+ */
+export function buildWorktreeStartEnv(params: {
+  hookType: string;
+  projectPath: string;
+  worktreeInfo: WorktreeInfo;
+  label: string;
+  task: TaskWithWorkspace | null;
+}): Record<string, string> {
+  const { hookType, projectPath, worktreeInfo, label, task } = params;
+  const env: Record<string, string> = {
+    OUIJIT_HOOK_TYPE: hookType,
+    OUIJIT_PROJECT_PATH: projectPath,
+    OUIJIT_WORKTREE_PATH: worktreeInfo.path,
+    OUIJIT_TASK_BRANCH: worktreeInfo.branch,
+    OUIJIT_TASK_NAME: label,
+  };
+  const prompt = task?.prompt;
+  if (prompt) {
+    env.OUIJIT_TASK_PROMPT = prompt;
+    env.OUIJIT_TASK_DESCRIPTION = prompt;
+  }
+  return env;
+}
+
 // ── Spawn a new project terminal ─────────────────────────────────────
 
 export async function addProjectTerminal(
@@ -151,20 +191,21 @@ export async function addProjectTerminal(
 
   let terminalCwd = projectPath;
   const worktreeInfo: (WorktreeInfo & { prompt?: string }) | undefined = options?.existingWorktree;
-  const taskPrompt: string | undefined = options?.existingWorktree?.prompt;
 
   if (worktreeInfo) {
     terminalCwd = worktreeInfo.path;
   }
 
-  // Look up current task name and merge target
-  let taskName: string | undefined;
-  let mergeTarget: string | undefined;
+  // Look up the current task. Name, merge target AND prompt all come from this
+  // live fetch — the worktree snapshot's prompt is a stale copy from worktree
+  // creation time and would not reflect a description edited afterwards.
+  let task: TaskWithWorkspace | null = null;
   if (options?.taskId != null) {
-    const task = await window.api.task.getByNumber(projectPath, options.taskId);
-    taskName = task?.name;
-    mergeTarget = task?.mergeTarget;
+    task = await window.api.task.getByNumber(projectPath, options.taskId);
   }
+  const taskName = task?.name;
+  const mergeTarget = task?.mergeTarget;
+  const taskPrompt = task?.prompt;
 
   if (isStale()) return false;
 
@@ -176,18 +217,13 @@ export async function addProjectTerminal(
   let startEnv: Record<string, string> | undefined;
 
   if (worktreeInfo) {
-    const hookType = 'continue';
-
-    startEnv = {
-      OUIJIT_HOOK_TYPE: hookType,
-      OUIJIT_PROJECT_PATH: projectPath,
-      OUIJIT_WORKTREE_PATH: worktreeInfo.path,
-      OUIJIT_TASK_BRANCH: worktreeInfo.branch,
-      OUIJIT_TASK_NAME: label,
-    };
-    if (taskPrompt) {
-      startEnv.OUIJIT_TASK_PROMPT = taskPrompt;
-    }
+    startEnv = buildWorktreeStartEnv({
+      hookType: 'continue',
+      projectPath,
+      worktreeInfo,
+      label,
+      task,
+    });
 
     if (!runConfig && !options?.skipAutoHook) {
       const hooks = await window.api.hooks.get(projectPath);
@@ -495,7 +531,10 @@ async function _spawnRunnerInner(instance: OuijitTerminal, script?: RunnerScript
       ...(instance.worktreePath && { OUIJIT_WORKTREE_PATH: instance.worktreePath }),
       ...(instance.worktreeBranch && { OUIJIT_TASK_BRANCH: instance.worktreeBranch }),
       ...(instance.label && { OUIJIT_TASK_NAME: instance.label }),
-      ...(instance.taskPrompt && { OUIJIT_TASK_PROMPT: instance.taskPrompt }),
+      ...(instance.taskPrompt && {
+        OUIJIT_TASK_PROMPT: instance.taskPrompt,
+        OUIJIT_TASK_DESCRIPTION: instance.taskPrompt,
+      }),
     },
   };
 

--- a/src/hookRunner.ts
+++ b/src/hookRunner.ts
@@ -68,6 +68,8 @@ export async function executeHook(
     }
     if (env?.taskPrompt) {
       hookEnv.OUIJIT_TASK_PROMPT = env.taskPrompt;
+      // Alias matching the "description" label used in the UI.
+      hookEnv.OUIJIT_TASK_DESCRIPTION = env.taskPrompt;
     }
 
     // Spawn the process


### PR DESCRIPTION
## Summary

- `addProjectTerminal` sourced `OUIJIT_TASK_PROMPT` from the worktree snapshot frozen at creation time, while task name and merge target came from a live fetch; editing a task's description afterwards never propagated, and the truthiness guard omitted the var entirely
- Extracted `buildWorktreeStartEnv` and route the prompt through the live `task.getByNumber` fetch alongside name and merge target
- Added `OUIJIT_TASK_DESCRIPTION` as a non-breaking alias of `OUIJIT_TASK_PROMPT` (continue env, runner env, `hookRunner.ts`) to match the UI's "description" label; surfaced it in the hook config dialogs
- Added `buildWorktreeStartEnv.test.ts` covering the stale-prompt bug, the alias, and prompt-absent behavior