### PR TITLE
Fix Pi integration repeated audio notifications

### DIFF
--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -1096,8 +1096,6 @@ describe('PI_EXTENSION', () => {
   });
 
   test('subscribes agent_start → thinking and agent_end → ready exactly once each', () => {
-    // agent_start/agent_end fire once per user prompt; turn_start/turn_end
-    // fire once per LLM round-trip, which replayed the notification (#169).
     expect(PI_EXTENSION.match(/pi\.on\('agent_start'/g)).toHaveLength(1);
     expect(PI_EXTENSION.match(/pi\.on\('agent_end'/g)).toHaveLength(1);
     expect(PI_EXTENSION).not.toContain("pi.on('turn_end'");
@@ -1116,9 +1114,8 @@ describe('PI_EXTENSION', () => {
   });
 
   test('pings ready once per prompt regardless of turn count when the factory runs', async () => {
-    // Pi fires turn_start/turn_end once per LLM round-trip but agent_start/
-    // agent_end exactly once per user prompt. Subscribing to agent_* means a
-    // multi-turn prompt produces a single 'ready' ping (issue #169).
+    // agent_* events fire once per prompt, so a multi-turn prompt should
+    // still produce exactly one 'ready' ping.
     const handlers: Record<string, () => void> = {};
     const pings: string[] = [];
     const pi = {

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { execFileSync } from 'node:child_process';
+import * as ts from 'typescript';
 import type { BrowserWindow } from 'electron';
 
 const hasZsh = (() => {
@@ -413,8 +414,8 @@ describe('installWrapper', () => {
     expect(fs.existsSync(extPath)).toBe(true);
     const ext = fs.readFileSync(extPath, 'utf-8');
     expect(ext).toContain('export default');
-    expect(ext).toContain("pi.on('turn_start'");
-    expect(ext).toContain("pi.on('turn_end'");
+    expect(ext).toContain("pi.on('agent_start'");
+    expect(ext).toContain("pi.on('agent_end'");
     expect(ext).toContain('OUIJIT_HOOK_BIN');
   });
 
@@ -1094,9 +1095,12 @@ describe('PI_EXTENSION', () => {
     expect(PI_EXTENSION).toMatch(/export default async \(pi: \w+\) =>/);
   });
 
-  test('subscribes turn_start → thinking and turn_end → ready exactly once each', () => {
-    expect(PI_EXTENSION.match(/pi\.on\('turn_start'/g)).toHaveLength(1);
-    expect(PI_EXTENSION.match(/pi\.on\('turn_end'/g)).toHaveLength(1);
+  test('subscribes agent_start → thinking and agent_end → ready exactly once each', () => {
+    // agent_start/agent_end fire once per user prompt; turn_start/turn_end
+    // fire once per LLM round-trip, which replayed the notification (#169).
+    expect(PI_EXTENSION.match(/pi\.on\('agent_start'/g)).toHaveLength(1);
+    expect(PI_EXTENSION.match(/pi\.on\('agent_end'/g)).toHaveLength(1);
+    expect(PI_EXTENSION).not.toContain("pi.on('turn_end'");
     expect(PI_EXTENSION).toContain("ping('thinking')");
     expect(PI_EXTENSION).toContain("ping('ready')");
   });
@@ -1110,7 +1114,52 @@ describe('PI_EXTENSION', () => {
     expect(PI_EXTENSION).toMatch(/pi\.exec\(hookBin, \['status', .* \{ timeout: 2000 \}\)/);
     expect(PI_EXTENSION).toContain('.catch(() => {})');
   });
+
+  test('pings ready once per prompt regardless of turn count when the factory runs', async () => {
+    // Pi fires turn_start/turn_end once per LLM round-trip but agent_start/
+    // agent_end exactly once per user prompt. Subscribing to agent_* means a
+    // multi-turn prompt produces a single 'ready' ping (issue #169).
+    const handlers: Record<string, () => void> = {};
+    const pings: string[] = [];
+    const pi = {
+      on: (event: string, handler: () => void) => {
+        handlers[event] = handler;
+      },
+      exec: async (_cmd: string, args: string[]) => {
+        pings.push(args[1].replace('status=', ''));
+      },
+    };
+    const factory = compilePiExtension(PI_EXTENSION);
+    process.env.OUIJIT_HOOK_BIN = '/fake/ouijit-hook';
+    try {
+      await factory(pi);
+
+      // One prompt, three internal turns.
+      handlers.agent_start();
+      handlers.turn_start?.();
+      handlers.turn_end?.();
+      handlers.turn_start?.();
+      handlers.turn_end?.();
+      handlers.turn_start?.();
+      handlers.turn_end?.();
+      handlers.agent_end();
+
+      expect(pings).toEqual(['thinking', 'ready']);
+    } finally {
+      delete process.env.OUIJIT_HOOK_BIN;
+    }
+  });
 });
+
+/** Strips type annotations from the PI_EXTENSION TS string into a runnable factory. */
+function compilePiExtension(src: string): (pi: unknown) => Promise<void> {
+  const transpiled = ts.transpileModule(src, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+  }).outputText;
+  const moduleExports: { exports: { default?: unknown } } = { exports: {} };
+  new Function('exports', 'module', 'process', transpiled)(moduleExports.exports, moduleExports, process);
+  return moduleExports.exports.default as (pi: unknown) => Promise<void>;
+}
 
 // ── buildVmPiExtension ───────────────────────────────────────────────
 

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -657,10 +657,6 @@ export default async (pi: OuijitPiApi) => {
     pi.exec(hookBin, ['status', \`status=\${status}\`], { timeout: 2000 }).catch(() => {});
   };
 
-  // agent_start / agent_end fire exactly once per user prompt. turn_start /
-  // turn_end fire once per LLM round-trip, so a single prompt produces many
-  // of them — subscribing to those replayed the done notification on every
-  // turn while Pi was still working (issue #169).
   pi.on('agent_start', () => ping('thinking'));
   pi.on('agent_end', () => ping('ready'));
 };

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -657,8 +657,12 @@ export default async (pi: OuijitPiApi) => {
     pi.exec(hookBin, ['status', \`status=\${status}\`], { timeout: 2000 }).catch(() => {});
   };
 
-  pi.on('turn_start', () => ping('thinking'));
-  pi.on('turn_end', () => ping('ready'));
+  // agent_start / agent_end fire exactly once per user prompt. turn_start /
+  // turn_end fire once per LLM round-trip, so a single prompt produces many
+  // of them — subscribing to those replayed the done notification on every
+  // turn while Pi was still working (issue #169).
+  pi.on('agent_start', () => ping('thinking'));
+  pi.on('agent_end', () => ping('ready'));
 };
 `;
 


### PR DESCRIPTION
## Summary

- The Ouijit Pi extension subscribed to `turn_start`/`turn_end`, which Pi's extension API fires once per LLM round-trip — so a multi-turn prompt replayed the done notification sound on every turn while Pi was still working (issue #169).
- Switched to `agent_start`/`agent_end`, which the Pi docs document as firing exactly once per user prompt (`agent_end` after all turns complete). No debounce heuristic needed.
- Updated `hookServer` tests to expect the `agent_*` events and added a functional test that runs the extension factory through a multi-turn prompt and asserts a single `ready` ping.