### PR TITLE
Allow entering a description before task creation

### DIFF
--- a/src/__tests__/renderer/kanbanAddInput.test.tsx
+++ b/src/__tests__/renderer/kanbanAddInput.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Behavior tests for the kanban add form. Users can enter a short title and,
+ * by tabbing into the revealed description field, a full prompt before the
+ * task is created.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { KanbanAddInput } from '../../components/kanban/KanbanAddInput';
+
+const getTitle = () => screen.getByPlaceholderText('New task...') as HTMLInputElement;
+const getDescription = () => screen.queryByPlaceholderText(/Description \(optional\)/) as HTMLTextAreaElement | null;
+
+describe('KanbanAddInput', () => {
+  it('hides the description field until the title is focused', () => {
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+    expect(getDescription()).toBeNull();
+
+    fireEvent.focus(getTitle());
+    expect(getDescription()).not.toBeNull();
+  });
+
+  it('creates a title-only task when Enter is pressed in the title field', () => {
+    const onAdd = vi.fn();
+    render(<KanbanAddInput onAdd={onAdd} />);
+
+    const title = getTitle();
+    fireEvent.change(title, { target: { value: 'Fix login' } });
+    fireEvent.keyDown(title, { key: 'Enter' });
+
+    expect(onAdd).toHaveBeenCalledWith('Fix login', undefined);
+  });
+
+  it('creates a task with title and description on Cmd+Enter in the description field', () => {
+    const onAdd = vi.fn();
+    render(<KanbanAddInput onAdd={onAdd} />);
+
+    const title = getTitle();
+    fireEvent.focus(title);
+    fireEvent.change(title, { target: { value: 'Fix login' } });
+
+    const description = getDescription();
+    expect(description).not.toBeNull();
+    fireEvent.change(description!, { target: { value: 'Sessions expire too early' } });
+    fireEvent.keyDown(description!, { key: 'Enter', metaKey: true });
+
+    expect(onAdd).toHaveBeenCalledWith('Fix login', 'Sessions expire too early');
+  });
+
+  it('creates with Ctrl+Enter as well', () => {
+    const onAdd = vi.fn();
+    render(<KanbanAddInput onAdd={onAdd} />);
+
+    fireEvent.focus(getTitle());
+    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
+    const description = getDescription()!;
+    fireEvent.change(description, { target: { value: 'Details' } });
+    fireEvent.keyDown(description, { key: 'Enter', ctrlKey: true });
+
+    expect(onAdd).toHaveBeenCalledWith('Fix login', 'Details');
+  });
+
+  it('does not create on a bare Enter in the description field', () => {
+    const onAdd = vi.fn();
+    render(<KanbanAddInput onAdd={onAdd} />);
+
+    fireEvent.focus(getTitle());
+    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
+    fireEvent.keyDown(getDescription()!, { key: 'Enter' });
+
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it('does not create when the title is empty or whitespace', () => {
+    const onAdd = vi.fn();
+    render(<KanbanAddInput onAdd={onAdd} />);
+
+    const title = getTitle();
+    fireEvent.change(title, { target: { value: '   ' } });
+    fireEvent.keyDown(title, { key: 'Enter' });
+
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it('clears both fields after a successful create', () => {
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+
+    const title = getTitle();
+    fireEvent.focus(title);
+    fireEvent.change(title, { target: { value: 'Fix login' } });
+    fireEvent.change(getDescription()!, { target: { value: 'Details' } });
+    fireEvent.keyDown(title, { key: 'Enter' });
+
+    expect(getTitle().value).toBe('');
+    expect(getDescription()).toBeNull();
+  });
+
+  it('clears and collapses the form on Escape', () => {
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+
+    const title = getTitle();
+    fireEvent.change(title, { target: { value: 'Fix login' } });
+    fireEvent.keyDown(title, { key: 'Escape' });
+
+    expect(getTitle().value).toBe('');
+    expect(getDescription()).toBeNull();
+  });
+
+  it('omits an empty description from the create call', () => {
+    const onAdd = vi.fn();
+    render(<KanbanAddInput onAdd={onAdd} />);
+
+    const title = getTitle();
+    fireEvent.focus(title);
+    fireEvent.change(title, { target: { value: 'Fix login' } });
+    fireEvent.change(getDescription()!, { target: { value: '   ' } });
+    fireEvent.keyDown(title, { key: 'Enter' });
+
+    expect(onAdd).toHaveBeenCalledWith('Fix login', undefined);
+  });
+});

--- a/src/__tests__/renderer/kanbanAddInput.test.tsx
+++ b/src/__tests__/renderer/kanbanAddInput.test.tsx
@@ -107,7 +107,7 @@ describe('KanbanAddInput', () => {
     expect(onAdd).not.toHaveBeenCalled();
   });
 
-  it('clears both fields after a successful create', () => {
+  it('clears the fields but keeps the form open for the next task after a create', () => {
     render(<KanbanAddInput onAdd={vi.fn()} />);
 
     const title = getTitle();
@@ -116,8 +116,28 @@ describe('KanbanAddInput', () => {
     fireEvent.change(getDescription()!, { target: { value: 'Details' } });
     fireEvent.keyDown(title, { key: 'Enter' });
 
+    // Fields are cleared, but the form stays expanded so the next task can
+    // be entered without clicking back in.
     expect(getTitle().value).toBe('');
-    expect(getDescription()).toBeNull();
+    expect(getDescription()).not.toBeNull();
+    expect(getDescription()!.value).toBe('');
+    expect(getCreateButton()).not.toBeNull();
+  });
+
+  it('can create a second task in a row without re-focusing the form', () => {
+    const onAdd = vi.fn();
+    render(<KanbanAddInput onAdd={onAdd} />);
+
+    const title = getTitle();
+    fireEvent.focus(title);
+    fireEvent.change(title, { target: { value: 'First task' } });
+    fireEvent.keyDown(title, { key: 'Enter' });
+
+    fireEvent.change(title, { target: { value: 'Second task' } });
+    fireEvent.keyDown(title, { key: 'Enter' });
+
+    expect(onAdd).toHaveBeenNthCalledWith(1, 'First task', undefined);
+    expect(onAdd).toHaveBeenNthCalledWith(2, 'Second task', undefined);
   });
 
   it('clears and collapses the form when Cancel is clicked', () => {

--- a/src/__tests__/renderer/kanbanAddInput.test.tsx
+++ b/src/__tests__/renderer/kanbanAddInput.test.tsx
@@ -1,22 +1,26 @@
 /**
  * Behavior tests for the kanban add form. Users can enter a short title and,
  * by tabbing into the revealed description field, a full prompt before the
- * task is created.
+ * task is created. A Create button is the primary, always-visible action.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent, screen } from '@testing-library/react';
 import { KanbanAddInput } from '../../components/kanban/KanbanAddInput';
 
 const getTitle = () => screen.getByPlaceholderText('New task...') as HTMLInputElement;
-const getDescription = () => screen.queryByPlaceholderText(/Description \(optional\)/) as HTMLTextAreaElement | null;
+const getDescription = () => screen.queryByPlaceholderText('Description (optional)') as HTMLTextAreaElement | null;
+const getCreateButton = () => screen.queryByRole('button', { name: 'Create' }) as HTMLButtonElement | null;
+const getCancelButton = () => screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement;
 
 describe('KanbanAddInput', () => {
-  it('hides the description field until the title is focused', () => {
+  it('hides the description field and buttons until the title is focused', () => {
     render(<KanbanAddInput onAdd={vi.fn()} />);
     expect(getDescription()).toBeNull();
+    expect(getCreateButton()).toBeNull();
 
     fireEvent.focus(getTitle());
     expect(getDescription()).not.toBeNull();
+    expect(getCreateButton()).not.toBeNull();
   });
 
   it('creates a title-only task when Enter is pressed in the title field', () => {
@@ -30,23 +34,45 @@ describe('KanbanAddInput', () => {
     expect(onAdd).toHaveBeenCalledWith('Fix login', undefined);
   });
 
-  it('creates a task with title and description on Cmd+Enter in the description field', () => {
+  it('creates a task with title and description when the Create button is clicked', () => {
     const onAdd = vi.fn();
     render(<KanbanAddInput onAdd={onAdd} />);
 
-    const title = getTitle();
-    fireEvent.focus(title);
-    fireEvent.change(title, { target: { value: 'Fix login' } });
-
-    const description = getDescription();
-    expect(description).not.toBeNull();
-    fireEvent.change(description!, { target: { value: 'Sessions expire too early' } });
-    fireEvent.keyDown(description!, { key: 'Enter', metaKey: true });
+    fireEvent.focus(getTitle());
+    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
+    fireEvent.change(getDescription()!, { target: { value: 'Sessions expire too early' } });
+    fireEvent.click(getCreateButton()!);
 
     expect(onAdd).toHaveBeenCalledWith('Fix login', 'Sessions expire too early');
   });
 
-  it('creates with Ctrl+Enter as well', () => {
+  it('disables the Create button until the title has content', () => {
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+
+    fireEvent.focus(getTitle());
+    expect(getCreateButton()!.disabled).toBe(true);
+
+    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
+    expect(getCreateButton()!.disabled).toBe(false);
+
+    fireEvent.change(getTitle(), { target: { value: '   ' } });
+    expect(getCreateButton()!.disabled).toBe(true);
+  });
+
+  it('creates with Cmd+Enter from the description field', () => {
+    const onAdd = vi.fn();
+    render(<KanbanAddInput onAdd={onAdd} />);
+
+    fireEvent.focus(getTitle());
+    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
+    const description = getDescription()!;
+    fireEvent.change(description, { target: { value: 'Details' } });
+    fireEvent.keyDown(description, { key: 'Enter', metaKey: true });
+
+    expect(onAdd).toHaveBeenCalledWith('Fix login', 'Details');
+  });
+
+  it('creates with Ctrl+Enter from the description field', () => {
     const onAdd = vi.fn();
     render(<KanbanAddInput onAdd={onAdd} />);
 
@@ -89,6 +115,17 @@ describe('KanbanAddInput', () => {
     fireEvent.change(title, { target: { value: 'Fix login' } });
     fireEvent.change(getDescription()!, { target: { value: 'Details' } });
     fireEvent.keyDown(title, { key: 'Enter' });
+
+    expect(getTitle().value).toBe('');
+    expect(getDescription()).toBeNull();
+  });
+
+  it('clears and collapses the form when Cancel is clicked', () => {
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+
+    fireEvent.focus(getTitle());
+    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
+    fireEvent.click(getCancelButton());
 
     expect(getTitle().value).toBe('');
     expect(getDescription()).toBeNull();

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -88,13 +88,13 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
             onKeyDown={handleDescriptionKeyDown}
           />
           <div
-            className="flex items-center justify-end gap-2 px-3 py-2"
-            style={{ borderTop: '1px solid rgba(255, 255, 255, 0.06)' }}
+            className="flex items-center justify-end gap-4 px-3 py-2"
+            style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
           >
             <button
               type="button"
               onClick={reset}
-              className="px-3 py-1 text-xs text-text-secondary rounded-full hover:bg-white/[0.04] transition-colors"
+              className="text-[11px] text-text-tertiary hover:text-text-secondary transition-colors duration-100"
             >
               Cancel
             </button>
@@ -103,7 +103,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
               onClick={submit}
               disabled={!canSubmit}
               title="Create task (⌘↵)"
-              className="px-3 py-1 text-xs font-medium text-white bg-accent rounded-full hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 disabled:opacity-40"
+              className="text-[11px] font-medium text-accent hover:text-accent-hover transition-colors duration-100 disabled:text-text-tertiary disabled:opacity-50"
             >
               Create
             </button>

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -23,8 +23,12 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     if (!trimmedName) return;
     const trimmedDescription = description.trim();
     onAdd(trimmedName, trimmedDescription || undefined);
-    reset();
-  }, [name, description, onAdd, reset]);
+    // Clear the fields but keep the form open and focused so the next task
+    // can be typed immediately without clicking back in.
+    setName('');
+    setDescription('');
+    inputRef.current?.focus();
+  }, [name, description, onAdd]);
 
   const handleNameKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -1,41 +1,96 @@
 import { useState, useRef, useCallback } from 'react';
 
 interface KanbanAddInputProps {
-  onAdd: (name: string) => void;
+  onAdd: (name: string, description?: string) => void;
 }
 
 export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
-  const [value, setValue] = useState('');
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [active, setActive] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleKeyDown = useCallback(
+  const reset = useCallback(() => {
+    setName('');
+    setDescription('');
+    setActive(false);
+  }, []);
+
+  const submit = useCallback(() => {
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    const trimmedDescription = description.trim();
+    onAdd(trimmedName, trimmedDescription || undefined);
+    reset();
+  }, [name, description, onAdd, reset]);
+
+  const handleNameKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter') {
         e.preventDefault();
-        const name = value.trim();
-        if (name) {
-          onAdd(name);
-          setValue('');
-        }
+        submit();
       } else if (e.key === 'Escape') {
-        setValue('');
+        reset();
         inputRef.current?.blur();
       }
+      // Tab falls through to native focus handling, moving into the description field.
     },
-    [value, onAdd],
+    [submit, reset],
   );
 
+  const handleDescriptionKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        submit();
+      } else if (e.key === 'Escape') {
+        reset();
+        textareaRef.current?.blur();
+      }
+      // A bare Enter inserts a newline so multi-line prompts can be typed.
+    },
+    [submit, reset],
+  );
+
+  const handleBlur = useCallback(() => {
+    // Collapse the description field only when nothing has been entered.
+    if (!name.trim() && !description.trim()) {
+      setActive(false);
+    }
+  }, [name, description]);
+
+  const showDescription = active || description.length > 0;
+
   return (
-    <input
-      ref={inputRef}
-      type="text"
-      className="kanban-add-input w-full font-mono text-sm font-medium text-text-primary bg-transparent px-3 py-3.5 outline-none transition-all duration-150 ease-out border-none focus:bg-white/[0.04]"
-      style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
-      placeholder="New task..."
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      onKeyDown={handleKeyDown}
-    />
+    <div className="kanban-add-form">
+      <input
+        ref={inputRef}
+        type="text"
+        className="kanban-add-input w-full font-mono text-sm font-medium text-text-primary bg-transparent px-3 py-3.5 outline-none transition-all duration-150 ease-out border-none focus:bg-white/[0.04]"
+        style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
+        placeholder="New task..."
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={handleNameKeyDown}
+        onFocus={() => setActive(true)}
+        onBlur={handleBlur}
+      />
+      {showDescription && (
+        <textarea
+          ref={textareaRef}
+          className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none resize-none focus:bg-white/[0.04]"
+          style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
+          placeholder="Description (optional) — ⌘↵ to create"
+          rows={3}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          onKeyDown={handleDescriptionKeyDown}
+          onFocus={() => setActive(true)}
+          onBlur={handleBlur}
+        />
+      )}
+    </div>
   );
 }
 

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -9,13 +9,14 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
   const [description, setDescription] = useState('');
   const [active, setActive] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const reset = useCallback(() => {
     setName('');
     setDescription('');
     setActive(false);
   }, []);
+
+  const canSubmit = name.trim().length > 0;
 
   const submit = useCallback(() => {
     const trimmedName = name.trim();
@@ -41,29 +42,30 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
 
   const handleDescriptionKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // Enter inserts a newline so multi-line prompts can be typed; the
+      // Create button (or Cmd/Ctrl+Enter) submits.
       if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         submit();
       } else if (e.key === 'Escape') {
         reset();
-        textareaRef.current?.blur();
       }
-      // A bare Enter inserts a newline so multi-line prompts can be typed.
     },
     [submit, reset],
   );
 
-  const handleBlur = useCallback(() => {
-    // Collapse the description field only when nothing has been entered.
-    if (!name.trim() && !description.trim()) {
-      setActive(false);
-    }
-  }, [name, description]);
-
-  const showDescription = active || description.length > 0;
+  // Collapse only when focus leaves the whole form and nothing was entered.
+  const handleBlur = useCallback(
+    (e: React.FocusEvent) => {
+      const nextFocus = e.relatedTarget as Node | null;
+      if (nextFocus && e.currentTarget.contains(nextFocus)) return;
+      if (!name.trim() && !description.trim()) setActive(false);
+    },
+    [name, description],
+  );
 
   return (
-    <div className="kanban-add-form">
+    <div className="kanban-add-form" onBlur={handleBlur}>
       <input
         ref={inputRef}
         type="text"
@@ -74,21 +76,39 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
         onChange={(e) => setName(e.target.value)}
         onKeyDown={handleNameKeyDown}
         onFocus={() => setActive(true)}
-        onBlur={handleBlur}
       />
-      {showDescription && (
-        <textarea
-          ref={textareaRef}
-          className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none resize-none focus:bg-white/[0.04]"
-          style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
-          placeholder="Description (optional). ⌘↵ to create"
-          rows={3}
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          onKeyDown={handleDescriptionKeyDown}
-          onFocus={() => setActive(true)}
-          onBlur={handleBlur}
-        />
+      {active && (
+        <>
+          <textarea
+            className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none resize-none focus:bg-white/[0.04]"
+            placeholder="Description (optional)"
+            rows={3}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            onKeyDown={handleDescriptionKeyDown}
+          />
+          <div
+            className="flex items-center justify-end gap-2 px-3 py-2"
+            style={{ borderTop: '1px solid rgba(255, 255, 255, 0.06)' }}
+          >
+            <button
+              type="button"
+              onClick={reset}
+              className="px-3 py-1 text-xs text-text-secondary rounded-full hover:bg-white/[0.04] transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={submit}
+              disabled={!canSubmit}
+              title="Create task (⌘↵)"
+              className="px-3 py-1 text-xs font-medium text-white bg-accent rounded-full hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 disabled:opacity-40"
+            >
+              Create
+            </button>
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -81,7 +81,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
           ref={textareaRef}
           className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none resize-none focus:bg-white/[0.04]"
           style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
-          placeholder="Description (optional) — ⌘↵ to create"
+          placeholder="Description (optional). ⌘↵ to create"
           rows={3}
           value={description}
           onChange={(e) => setDescription(e.target.value)}

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -514,8 +514,8 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
 
   // Task CRUD
   const handleAddTask = useCallback(
-    async (name: string) => {
-      await window.api.task.create(projectPath, name);
+    async (name: string, description?: string) => {
+      await window.api.task.create(projectPath, name, description);
       useProjectStore.getState().loadTasks(projectPath);
     },
     [projectPath],

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -23,7 +23,7 @@ interface KanbanColumnProps {
   tasks: TaskWithWorkspace[];
   projectPath: string;
   settingUpTaskNumbers?: ReadonlySet<number>;
-  onAddTask?: (name: string) => void;
+  onAddTask?: (name: string, description?: string) => void;
   onRenameTask: (taskNumber: number, newName: string) => void;
   onUpdateDescription: (taskNumber: number, description: string) => void;
   onOpenTerminal: (task: TaskWithWorkspace, sandboxed?: boolean) => void;


### PR DESCRIPTION
## Summary
- The kanban add form now reveals a description field once the title input is focused, so a full prompt can be entered before the task is created.
- Tab moves from the title into the visible description textarea; the field is also directly clickable.
- Explicit Cancel and Create buttons replace the previous cryptic key hint. Create is disabled until the title has content.
- Keyboard accelerators: Enter in the title creates, Cmd/Ctrl+Enter in the description creates, Escape cancels.
- After a create the form stays open and refocused for rapid back-to-back task entry.
- The footer uses flat ghost buttons to match the column's minimal aesthetic.
- The description flows through `task.create` to `createTodoTask`, which already persisted a `prompt`.
- Adds 13 renderer tests covering create paths, the disabled state, reset, and consecutive creates.