### PR TITLE
Improve left sidebar discoverability

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"d825a418-60ba-4076-9294-cde259b42cb1","pid":96661,"procStart":"Fri May 22 02:20:26 2026","acquiredAt":1779424135707}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,10 +94,11 @@ export function App() {
     hydrateTerminalFont();
   }, []);
 
-  // Hydrate persisted sidebar-pinned preference.
+  // Hydrate persisted sidebar-pinned preference. Defaults to pinned (see the
+  // store initial state) — only an explicit '0' from a prior session unpins it.
   useEffect(() => {
     window.api.globalSettings.get('ui:sidebar-pinned').then((value) => {
-      if (value === '1') useUIStore.setState({ sidebarPinned: true });
+      if (value === '0') useUIStore.setState({ sidebarPinned: false });
     });
   }, []);
 

--- a/src/components/SidebarReact.tsx
+++ b/src/components/SidebarReact.tsx
@@ -108,6 +108,28 @@ export function Sidebar({ onProjectSelect, onHomeSelect, onAddExisting, onCreate
     return () => document.removeEventListener('show-sidebar', handler);
   }, [showSidebar]);
 
+  // Listen for toggle-sidebar events from the titlebar project icon. Toggling
+  // drives the pinned state so the choice persists; when unpinning we collapse
+  // immediately since the cursor isn't over the sidebar to trigger mouse-leave.
+  useEffect(() => {
+    const handler = () => {
+      const ui = useUIStore.getState();
+      if (ui.sidebarPinned) {
+        ui.setSidebarPinned(false);
+        if (showTimeoutRef.current) clearTimeout(showTimeoutRef.current);
+        if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
+        showTimeoutRef.current = null;
+        hideTimeoutRef.current = null;
+        setVisible(false);
+        document.documentElement.style.setProperty('--sidebar-offset', '0px');
+      } else {
+        ui.setSidebarPinned(true);
+      }
+    };
+    document.addEventListener('toggle-sidebar', handler);
+    return () => document.removeEventListener('toggle-sidebar', handler);
+  }, []);
+
   // Sidebar starts visible (see initial useState above) — match the layout
   // offset to that on mount so content doesn't render under the sidebar
   // before the first show/hide tick.

--- a/src/components/TitleBarReact.tsx
+++ b/src/components/TitleBarReact.tsx
@@ -95,32 +95,30 @@ export function TitleBar({ mode }: TitleBarProps) {
       >
         {activeView === 'project' && activeProjectData && activeProjectPath ? (
           <div key="project-header" className="flex items-center gap-3 flex-1 pl-2 pr-4 min-w-0">
-            <Tooltip text="Toggle sidebar" placement="bottom-start">
-              <button
-                className={`w-8 h-8 shrink-0 [-webkit-app-region:no-drag] transition-opacity duration-150 ease-out hover:opacity-70 active:opacity-50 ${activeProjectData.iconDataUrl ? '' : 'overflow-hidden rounded-md'}`}
-                aria-label="Toggle sidebar"
-                onClick={() => document.dispatchEvent(new CustomEvent('toggle-sidebar'))}
-              >
-                {activeProjectData.iconDataUrl ? (
-                  <img
-                    src={activeProjectData.iconDataUrl}
-                    alt={activeProjectData.name}
-                    className="w-full h-full object-cover"
-                    draggable={false}
-                  />
-                ) : (
-                  <div
-                    className="w-full h-full flex items-center justify-center text-xs font-bold text-white"
-                    style={{
-                      backgroundColor: stringToColor(activeProjectData.name),
-                      textShadow: '0 1px 2px rgba(0, 0, 0, 0.2)',
-                    }}
-                  >
-                    {getInitials(activeProjectData.name)}
-                  </div>
-                )}
-              </button>
-            </Tooltip>
+            <button
+              className={`w-8 h-8 shrink-0 [-webkit-app-region:no-drag] transition-opacity duration-150 ease-out hover:opacity-70 active:opacity-50 ${activeProjectData.iconDataUrl ? '' : 'overflow-hidden rounded-md'}`}
+              aria-label="Toggle sidebar"
+              onClick={() => document.dispatchEvent(new CustomEvent('toggle-sidebar'))}
+            >
+              {activeProjectData.iconDataUrl ? (
+                <img
+                  src={activeProjectData.iconDataUrl}
+                  alt={activeProjectData.name}
+                  className="w-full h-full object-cover"
+                  draggable={false}
+                />
+              ) : (
+                <div
+                  className="w-full h-full flex items-center justify-center text-xs font-bold text-white"
+                  style={{
+                    backgroundColor: stringToColor(activeProjectData.name),
+                    textShadow: '0 1px 2px rgba(0, 0, 0, 0.2)',
+                  }}
+                >
+                  {getInitials(activeProjectData.name)}
+                </div>
+              )}
+            </button>
             <div className="flex flex-col gap-[2px] min-w-0">
               <span className="text-[15px] font-semibold text-text-primary leading-none tracking-tight truncate">
                 {activeProjectData.name}

--- a/src/components/TitleBarReact.tsx
+++ b/src/components/TitleBarReact.tsx
@@ -95,26 +95,32 @@ export function TitleBar({ mode }: TitleBarProps) {
       >
         {activeView === 'project' && activeProjectData && activeProjectPath ? (
           <div key="project-header" className="flex items-center gap-3 flex-1 pl-2 pr-4 min-w-0">
-            <div className={`w-8 h-8 shrink-0 ${activeProjectData.iconDataUrl ? '' : 'overflow-hidden rounded-md'}`}>
-              {activeProjectData.iconDataUrl ? (
-                <img
-                  src={activeProjectData.iconDataUrl}
-                  alt={activeProjectData.name}
-                  className="w-full h-full object-cover"
-                  draggable={false}
-                />
-              ) : (
-                <div
-                  className="w-full h-full flex items-center justify-center text-xs font-bold text-white"
-                  style={{
-                    backgroundColor: stringToColor(activeProjectData.name),
-                    textShadow: '0 1px 2px rgba(0, 0, 0, 0.2)',
-                  }}
-                >
-                  {getInitials(activeProjectData.name)}
-                </div>
-              )}
-            </div>
+            <Tooltip text="Toggle sidebar" placement="bottom-start">
+              <button
+                className={`w-8 h-8 shrink-0 [-webkit-app-region:no-drag] transition-opacity duration-150 ease-out hover:opacity-70 active:opacity-50 ${activeProjectData.iconDataUrl ? '' : 'overflow-hidden rounded-md'}`}
+                aria-label="Toggle sidebar"
+                onClick={() => document.dispatchEvent(new CustomEvent('toggle-sidebar'))}
+              >
+                {activeProjectData.iconDataUrl ? (
+                  <img
+                    src={activeProjectData.iconDataUrl}
+                    alt={activeProjectData.name}
+                    className="w-full h-full object-cover"
+                    draggable={false}
+                  />
+                ) : (
+                  <div
+                    className="w-full h-full flex items-center justify-center text-xs font-bold text-white"
+                    style={{
+                      backgroundColor: stringToColor(activeProjectData.name),
+                      textShadow: '0 1px 2px rgba(0, 0, 0, 0.2)',
+                    }}
+                  >
+                    {getInitials(activeProjectData.name)}
+                  </div>
+                )}
+              </button>
+            </Tooltip>
             <div className="flex flex-col gap-[2px] min-w-0">
               <span className="text-[15px] font-semibold text-text-primary leading-none tracking-tight truncate">
                 {activeProjectData.name}

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -4,7 +4,10 @@ export type HomeGroupMode = 'project' | 'tag';
 
 interface UIStoreState {
   sidebarVisible: boolean;
-  /** When true, sidebar stays open regardless of hover. Persisted in global settings. */
+  /**
+   * When true, sidebar stays open regardless of hover. Persisted in global
+   * settings; defaults to pinned so the sidebar is discoverable on first launch.
+   */
   sidebarPinned: boolean;
   gitDropdownVisible: boolean;
   scriptDropdownVisible: boolean;
@@ -28,7 +31,7 @@ type UIStore = UIStoreState & UIStoreActions;
 
 export const useUIStore = create<UIStore>()((set, get) => ({
   sidebarVisible: false,
-  sidebarPinned: false,
+  sidebarPinned: true,
   gitDropdownVisible: false,
   scriptDropdownVisible: false,
   scriptDropdownPtyId: null,


### PR DESCRIPTION
## Summary

- Default the sidebar to pinned so it stays open on first launch instead of relying on hover near the screen edge; an explicit unpin from a prior session still persists.
- Make clicking the project icon in the titlebar toggle the sidebar open/closed via the pinned state.