### PR TITLE
Fix done column hook icon not activating when done hook is populated

### DIFF
--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -685,7 +685,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
             const hookActive =
               (col.status === 'in_progress' && !!(configuredHooks.start || configuredHooks.continue)) ||
               (col.status === 'in_review' && !!configuredHooks.review) ||
-              (col.status === 'done' && !!configuredHooks.cleanup);
+              (col.status === 'done' && !!configuredHooks.done);
 
             return (
               <KanbanColumn


### PR DESCRIPTION
## Summary
- Done column webhook icon now lights up when a `done` hook is configured. The check still referenced the old `cleanup` key (renamed to `done` in #165 / migration 009), so it was always falsy.