### PR TITLE
Attachments: paste/drop in the new task form, any file type, robust paths

### DIFF
--- a/src/__tests__/attachments.test.ts
+++ b/src/__tests__/attachments.test.ts
@@ -72,6 +72,13 @@ describe('extractAttachmentPaths', () => {
     const text = 'one ![](/a.png) two ![](/b.png) one again ![](/a.png)';
     expect(extractAttachmentPaths(text)).toEqual(['/a.png', '/b.png']);
   });
+
+  test('decodes encoded characters so backend cleanup matches the chip path', () => {
+    // The renderer stores parens as `%28` / `%29`; the cleanup pass must see
+    // the same path the chip's `data-attachment-path` holds.
+    const text = '![](/Users/me/Doc %281%29.pdf)';
+    expect(extractAttachmentPaths(text)).toEqual(['/Users/me/Doc (1).pdf']);
+  });
 });
 
 describe('deleteOrphanedAttachments', () => {

--- a/src/__tests__/descriptionAttachments.test.ts
+++ b/src/__tests__/descriptionAttachments.test.ts
@@ -5,6 +5,8 @@ import {
   serializeDescriptionDOM,
   createAttachmentChip,
   descriptionToHookPrompt,
+  encodeAttachmentPath,
+  decodeAttachmentPath,
 } from '../utils/descriptionAttachments';
 
 describe('parseDescription', () => {
@@ -95,5 +97,56 @@ describe('round-trip', () => {
       else editor.appendChild(createAttachmentChip(seg.path));
     }
     expect(serializeDescriptionDOM(editor)).toBe(input);
+  });
+});
+
+describe('encodeAttachmentPath / decodeAttachmentPath', () => {
+  test('passes a path with no reserved characters through unchanged', () => {
+    expect(encodeAttachmentPath('/tmp/a.png')).toBe('/tmp/a.png');
+    expect(decodeAttachmentPath('/tmp/a.png')).toBe('/tmp/a.png');
+  });
+
+  test('escapes parens that would terminate the marker early', () => {
+    expect(encodeAttachmentPath('/Users/me/Document (1).pdf')).toBe('/Users/me/Document %281%29.pdf');
+    expect(decodeAttachmentPath('/Users/me/Document %281%29.pdf')).toBe('/Users/me/Document (1).pdf');
+  });
+
+  test('round-trips a literal % already present in the path', () => {
+    const original = '/tmp/100%25-coverage.png';
+    expect(decodeAttachmentPath(encodeAttachmentPath(original))).toBe(original);
+    // And a path that literally contains %28 / %29 shouldn't be mis-decoded.
+    expect(decodeAttachmentPath(encodeAttachmentPath('/tmp/file %28keep%29.png'))).toBe('/tmp/file %28keep%29.png');
+  });
+});
+
+describe('parser with encoded paths', () => {
+  test('parseDescription decodes parens out of the storage form', () => {
+    expect(parseDescription('here ![](/Users/me/Doc %281%29.pdf) ok')).toEqual([
+      { type: 'text', value: 'here ' },
+      { type: 'image', path: '/Users/me/Doc (1).pdf' },
+      { type: 'text', value: ' ok' },
+    ]);
+  });
+
+  test('serializeDescriptionDOM encodes parens back into the storage form', () => {
+    const editor = document.createElement('div');
+    editor.appendChild(createAttachmentChip('/Users/me/Doc (1).pdf'));
+    expect(serializeDescriptionDOM(editor)).toBe('![](/Users/me/Doc %281%29.pdf)');
+  });
+});
+
+describe('descriptionToHookPrompt with special characters', () => {
+  test('decodes the storage form before quoting', () => {
+    expect(descriptionToHookPrompt('see ![](/Users/me/Doc %281%29.pdf)')).toBe('see "/Users/me/Doc (1).pdf"');
+  });
+
+  test('escapes a literal double quote so it does not collapse the surrounding quotes', () => {
+    // `data-attachment-path` happens to be `/tmp/a "real" name.png` (rare but legal).
+    // After serialization that becomes `![](/tmp/a "real" name.png)`.
+    expect(descriptionToHookPrompt('![](/tmp/a "real" name.png)')).toBe('"/tmp/a \\"real\\" name.png"');
+  });
+
+  test('escapes a literal backslash to keep escape sequences unambiguous', () => {
+    expect(descriptionToHookPrompt('![](/tmp/a\\b.png)')).toBe('"/tmp/a\\\\b.png"');
   });
 });

--- a/src/__tests__/renderer/descriptionChipEditor.test.tsx
+++ b/src/__tests__/renderer/descriptionChipEditor.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Behavior tests for the shared chip editor. Covers the paths that aren't
+ * exercised through the kanban add-form test: chip-aware Backspace/Delete,
+ * imperative reset, drop-with-files, and onAttachFile being consulted before
+ * the editor inserts a chip.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRef } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { DescriptionChipEditor, type DescriptionChipEditorHandle } from '../../components/kanban/DescriptionChipEditor';
+
+/** Place the caret adjacent to `node`. `before=true` → just before it, else just after. */
+function placeCaretAdjacentTo(node: Node, before: boolean): void {
+  const parent = node.parentNode;
+  if (!parent) throw new Error('Node has no parent');
+  const index = Array.from(parent.childNodes).indexOf(node as ChildNode);
+  const range = document.createRange();
+  range.setStart(parent, before ? index : index + 1);
+  range.collapse(true);
+  const sel = window.getSelection();
+  sel?.removeAllRanges();
+  sel?.addRange(range);
+}
+
+describe('DescriptionChipEditor', () => {
+  it('renders initial value with chips at the marker positions', () => {
+    const { container } = render(<DescriptionChipEditor initialValue="before ![](/Users/a/p.png) after" />);
+    const editor = container.querySelector('.kanban-description-editor')!;
+    const chips = editor.querySelectorAll('.description-attachment-chip');
+    expect(chips.length).toBe(1);
+    expect(chips[0].getAttribute('data-attachment-path')).toBe('/Users/a/p.png');
+    expect(editor.textContent).toBe('before  after');
+  });
+
+  it('fires onChange with the serialized value on input events', () => {
+    const onChange = vi.fn();
+    const { container } = render(<DescriptionChipEditor initialValue="hi" onChange={onChange} />);
+    const editor = container.querySelector('.kanban-description-editor') as HTMLDivElement;
+    editor.textContent = 'hi there';
+    fireEvent.input(editor);
+    expect(onChange).toHaveBeenLastCalledWith('hi there');
+    // The CSS placeholder selector keys off data-empty, kept in sync by emitChange.
+    expect(editor.dataset.empty).toBe('false');
+  });
+
+  it('reports data-empty=true when the value becomes empty so the placeholder shows', () => {
+    const { container } = render(<DescriptionChipEditor initialValue="hi" placeholder="Type here" />);
+    const editor = container.querySelector('.kanban-description-editor') as HTMLDivElement;
+    expect(editor.dataset.empty).toBe('false');
+    editor.textContent = '';
+    fireEvent.input(editor);
+    expect(editor.dataset.empty).toBe('true');
+    expect(editor.getAttribute('data-placeholder')).toBe('Type here');
+  });
+
+  it('removes a chip on Backspace when the caret is immediately after it', () => {
+    const onChange = vi.fn();
+    const { container } = render(<DescriptionChipEditor initialValue="![](/p.png) tail" onChange={onChange} />);
+    const editor = container.querySelector('.kanban-description-editor') as HTMLDivElement;
+    const chip = editor.querySelector('.description-attachment-chip')!;
+    placeCaretAdjacentTo(chip, /* before */ false);
+    fireEvent.keyDown(editor, { key: 'Backspace' });
+    // The serializer trims, so the leading space disappears after the chip is gone.
+    expect(onChange).toHaveBeenLastCalledWith('tail');
+    expect(editor.querySelector('.description-attachment-chip')).toBeNull();
+  });
+
+  it('removes a chip on Delete when the caret is immediately before it', () => {
+    const onChange = vi.fn();
+    const { container } = render(<DescriptionChipEditor initialValue="head ![](/p.png)" onChange={onChange} />);
+    const editor = container.querySelector('.kanban-description-editor') as HTMLDivElement;
+    const chip = editor.querySelector('.description-attachment-chip')!;
+    placeCaretAdjacentTo(chip, /* before */ true);
+    fireEvent.keyDown(editor, { key: 'Delete' });
+    expect(onChange).toHaveBeenLastCalledWith('head');
+    expect(editor.querySelector('.description-attachment-chip')).toBeNull();
+  });
+
+  it('falls through Backspace to the parent onKeyDown when no chip is adjacent', () => {
+    const parentKeyDown = vi.fn();
+    const { container } = render(<DescriptionChipEditor initialValue="plain text" onKeyDown={parentKeyDown} />);
+    const editor = container.querySelector('.kanban-description-editor') as HTMLDivElement;
+    fireEvent.keyDown(editor, { key: 'Backspace' });
+    expect(parentKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onAttachFile on paste and inserts a chip for the returned path', async () => {
+    const onAttachFile = vi.fn().mockResolvedValue('/saved/img.png');
+    const onChange = vi.fn();
+    const { container } = render(
+      <DescriptionChipEditor initialValue="" onAttachFile={onAttachFile} onChange={onChange} />,
+    );
+    const editor = container.querySelector('.kanban-description-editor') as HTMLDivElement;
+    const file = new File([new Uint8Array([1])], 'paste.png', { type: 'image/png' });
+    const dataTransfer = {
+      items: [{ kind: 'file', type: 'image/png', getAsFile: () => file }],
+    } as unknown as DataTransfer;
+    fireEvent.paste(editor, { clipboardData: dataTransfer });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(onAttachFile).toHaveBeenCalledTimes(1);
+    expect(onAttachFile).toHaveBeenCalledWith(file);
+    expect(editor.querySelector('.description-attachment-chip')!.getAttribute('data-attachment-path')).toBe(
+      '/saved/img.png',
+    );
+    expect(onChange).toHaveBeenLastCalledWith('![](/saved/img.png)');
+  });
+
+  it('calls onAttachFile for each dropped file and appends chips in order', async () => {
+    const onAttachFile = vi.fn().mockResolvedValueOnce('/Users/a/one.txt').mockResolvedValueOnce('/Users/a/two.pdf');
+    const onChange = vi.fn();
+    const { container } = render(
+      <DescriptionChipEditor initialValue="" onAttachFile={onAttachFile} onChange={onChange} />,
+    );
+    const editor = container.querySelector('.kanban-description-editor') as HTMLDivElement;
+    const f1 = new File([new Uint8Array([1])], 'one.txt', { type: 'text/plain' });
+    const f2 = new File([new Uint8Array([1])], 'two.pdf', { type: 'application/pdf' });
+    const dataTransfer = {
+      items: [
+        { kind: 'file', type: 'text/plain' },
+        { kind: 'file', type: 'application/pdf' },
+      ],
+      files: [f1, f2],
+    } as unknown as DataTransfer;
+    fireEvent.drop(editor, { dataTransfer, clientX: 0, clientY: 0 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(onAttachFile).toHaveBeenCalledTimes(2);
+    expect(onAttachFile).toHaveBeenNthCalledWith(1, f1);
+    expect(onAttachFile).toHaveBeenNthCalledWith(2, f2);
+    expect(onChange).toHaveBeenLastCalledWith('![](/Users/a/one.txt)![](/Users/a/two.pdf)');
+  });
+
+  it('skips files for which onAttachFile returns null', async () => {
+    const onAttachFile = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce('/Users/a/ok.png');
+    const onChange = vi.fn();
+    const { container } = render(
+      <DescriptionChipEditor initialValue="" onAttachFile={onAttachFile} onChange={onChange} />,
+    );
+    const editor = container.querySelector('.kanban-description-editor') as HTMLDivElement;
+    const f1 = new File([new Uint8Array([1])], 'skipped.bin', { type: 'application/octet-stream' });
+    const f2 = new File([new Uint8Array([1])], 'ok.png', { type: 'image/png' });
+    const dataTransfer = {
+      items: [
+        { kind: 'file', type: 'application/octet-stream' },
+        { kind: 'file', type: 'image/png' },
+      ],
+      files: [f1, f2],
+    } as unknown as DataTransfer;
+    fireEvent.drop(editor, { dataTransfer, clientX: 0, clientY: 0 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(onChange).toHaveBeenLastCalledWith('![](/Users/a/ok.png)');
+    expect(editor.querySelectorAll('.description-attachment-chip').length).toBe(1);
+  });
+
+  it('resets the DOM via the imperative setValue handle', () => {
+    const ref = createRef<DescriptionChipEditorHandle>();
+    const { container } = render(<DescriptionChipEditor ref={ref} initialValue="![](/a.png) hi" />);
+    const editor = container.querySelector('.kanban-description-editor') as HTMLDivElement;
+    expect(editor.querySelectorAll('.description-attachment-chip').length).toBe(1);
+    ref.current!.setValue('');
+    expect(editor.querySelector('.description-attachment-chip')).toBeNull();
+    expect(editor.textContent).toBe('');
+    expect(editor.dataset.empty).toBe('true');
+  });
+});

--- a/src/__tests__/renderer/kanbanAddInput.test.tsx
+++ b/src/__tests__/renderer/kanbanAddInput.test.tsx
@@ -8,9 +8,20 @@ import { render, fireEvent, screen } from '@testing-library/react';
 import { KanbanAddInput } from '../../components/kanban/KanbanAddInput';
 
 const getTitle = () => screen.getByPlaceholderText('New task...') as HTMLInputElement;
-const getDescription = () => screen.queryByPlaceholderText('Description (optional)') as HTMLTextAreaElement | null;
+/** Description is a contentEditable div — query by its stable class. */
+const getDescription = () => document.querySelector('.kanban-add-description') as HTMLDivElement | null;
 const getCreateButton = () => screen.queryByRole('button', { name: 'Create' }) as HTMLButtonElement | null;
 const getCancelButton = () => screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement;
+
+/** Set the editor's text content and fire the input event the editor listens
+ *  for. Mirrors what a user typing produces, minus chip insertion. */
+function typeDescription(text: string): void {
+  const el = getDescription();
+  if (!el) throw new Error('Description editor not in DOM');
+  el.innerHTML = '';
+  if (text) el.appendChild(document.createTextNode(text));
+  fireEvent.input(el);
+}
 
 describe('KanbanAddInput', () => {
   it('hides the description field and buttons until the title is focused', () => {
@@ -40,7 +51,7 @@ describe('KanbanAddInput', () => {
 
     fireEvent.focus(getTitle());
     fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    fireEvent.change(getDescription()!, { target: { value: 'Sessions expire too early' } });
+    typeDescription('Sessions expire too early');
     fireEvent.click(getCreateButton()!);
 
     expect(onAdd).toHaveBeenCalledWith('Fix login', 'Sessions expire too early');
@@ -65,9 +76,8 @@ describe('KanbanAddInput', () => {
 
     fireEvent.focus(getTitle());
     fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    const description = getDescription()!;
-    fireEvent.change(description, { target: { value: 'Details' } });
-    fireEvent.keyDown(description, { key: 'Enter', metaKey: true });
+    typeDescription('Details');
+    fireEvent.keyDown(getDescription()!, { key: 'Enter', metaKey: true });
 
     expect(onAdd).toHaveBeenCalledWith('Fix login', 'Details');
   });
@@ -78,9 +88,8 @@ describe('KanbanAddInput', () => {
 
     fireEvent.focus(getTitle());
     fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    const description = getDescription()!;
-    fireEvent.change(description, { target: { value: 'Details' } });
-    fireEvent.keyDown(description, { key: 'Enter', ctrlKey: true });
+    typeDescription('Details');
+    fireEvent.keyDown(getDescription()!, { key: 'Enter', ctrlKey: true });
 
     expect(onAdd).toHaveBeenCalledWith('Fix login', 'Details');
   });
@@ -113,14 +122,14 @@ describe('KanbanAddInput', () => {
     const title = getTitle();
     fireEvent.focus(title);
     fireEvent.change(title, { target: { value: 'Fix login' } });
-    fireEvent.change(getDescription()!, { target: { value: 'Details' } });
+    typeDescription('Details');
     fireEvent.keyDown(title, { key: 'Enter' });
 
     // Fields are cleared, but the form stays expanded so the next task can
     // be entered without clicking back in.
     expect(getTitle().value).toBe('');
     expect(getDescription()).not.toBeNull();
-    expect(getDescription()!.value).toBe('');
+    expect(getDescription()!.textContent).toBe('');
     expect(getCreateButton()).not.toBeNull();
   });
 
@@ -169,9 +178,43 @@ describe('KanbanAddInput', () => {
     const title = getTitle();
     fireEvent.focus(title);
     fireEvent.change(title, { target: { value: 'Fix login' } });
-    fireEvent.change(getDescription()!, { target: { value: '   ' } });
+    typeDescription('   ');
     fireEvent.keyDown(title, { key: 'Enter' });
 
     expect(onAdd).toHaveBeenCalledWith('Fix login', undefined);
+  });
+
+  it('saves an image attachment as a markdown marker in the description on paste', async () => {
+    const onAdd = vi.fn();
+    const saveAttachment = vi.fn().mockResolvedValue({ success: true, path: '/tmp/img-test.png' });
+    // Stub the IPC the editor calls on image paste.
+    const original = (window as unknown as { api?: unknown }).api;
+    (window as unknown as { api: { task: { saveAttachment: typeof saveAttachment } } }).api = {
+      task: { saveAttachment },
+    };
+
+    render(<KanbanAddInput onAdd={onAdd} />);
+    fireEvent.focus(getTitle());
+    fireEvent.change(getTitle(), { target: { value: 'With image' } });
+
+    const editor = getDescription()!;
+    // Simulate a clipboard paste with one image item.
+    const file = new File([new Uint8Array([1, 2, 3])], 'paste.png', { type: 'image/png' });
+    const dataTransfer = {
+      items: [{ kind: 'file', type: 'image/png', getAsFile: () => file }],
+    } as unknown as DataTransfer;
+    fireEvent.paste(editor, { clipboardData: dataTransfer });
+    // Wait a tick for the async save to resolve and the chip to land.
+    await new Promise((r) => setTimeout(r, 0));
+
+    fireEvent.click(getCreateButton()!);
+    expect(saveAttachment).toHaveBeenCalledTimes(1);
+    expect(onAdd).toHaveBeenCalledWith('With image', '![](/tmp/img-test.png)');
+
+    if (original !== undefined) {
+      (window as unknown as { api: unknown }).api = original;
+    } else {
+      delete (window as unknown as { api?: unknown }).api;
+    }
   });
 });

--- a/src/__tests__/renderer/kanbanAddInput.test.tsx
+++ b/src/__tests__/renderer/kanbanAddInput.test.tsx
@@ -184,13 +184,14 @@ describe('KanbanAddInput', () => {
     expect(onAdd).toHaveBeenCalledWith('Fix login', undefined);
   });
 
-  it('saves an image attachment as a markdown marker in the description on paste', async () => {
+  it('saves an image attachment from clipboard paste with no source path', async () => {
     const onAdd = vi.fn();
     const saveAttachment = vi.fn().mockResolvedValue({ success: true, path: '/tmp/img-test.png' });
-    // Stub the IPC the editor calls on image paste.
+    const getPathForFile = vi.fn().mockReturnValue('');
     const original = (window as unknown as { api?: unknown }).api;
-    (window as unknown as { api: { task: { saveAttachment: typeof saveAttachment } } }).api = {
+    (window as unknown as { api: unknown }).api = {
       task: { saveAttachment },
+      getPathForFile,
     };
 
     render(<KanbanAddInput onAdd={onAdd} />);
@@ -198,23 +199,51 @@ describe('KanbanAddInput', () => {
     fireEvent.change(getTitle(), { target: { value: 'With image' } });
 
     const editor = getDescription()!;
-    // Simulate a clipboard paste with one image item.
     const file = new File([new Uint8Array([1, 2, 3])], 'paste.png', { type: 'image/png' });
     const dataTransfer = {
       items: [{ kind: 'file', type: 'image/png', getAsFile: () => file }],
     } as unknown as DataTransfer;
     fireEvent.paste(editor, { clipboardData: dataTransfer });
-    // Wait a tick for the async save to resolve and the chip to land.
     await new Promise((r) => setTimeout(r, 0));
 
     fireEvent.click(getCreateButton()!);
+    expect(getPathForFile).toHaveBeenCalledTimes(1);
     expect(saveAttachment).toHaveBeenCalledTimes(1);
     expect(onAdd).toHaveBeenCalledWith('With image', '![](/tmp/img-test.png)');
 
-    if (original !== undefined) {
-      (window as unknown as { api: unknown }).api = original;
-    } else {
-      delete (window as unknown as { api?: unknown }).api;
-    }
+    if (original !== undefined) (window as unknown as { api: unknown }).api = original;
+    else delete (window as unknown as { api?: unknown }).api;
+  });
+
+  it('uses the original file path on drop, with no copy and any extension', async () => {
+    const onAdd = vi.fn();
+    const saveAttachment = vi.fn().mockResolvedValue({ success: false, error: 'should not be called' });
+    const getPathForFile = vi.fn().mockReturnValue('/Users/me/notes/agenda.txt');
+    const original = (window as unknown as { api?: unknown }).api;
+    (window as unknown as { api: unknown }).api = {
+      task: { saveAttachment },
+      getPathForFile,
+    };
+
+    render(<KanbanAddInput onAdd={onAdd} />);
+    fireEvent.focus(getTitle());
+    fireEvent.change(getTitle(), { target: { value: 'With file' } });
+
+    const editor = getDescription()!;
+    const file = new File([new Uint8Array([1])], 'agenda.txt', { type: 'text/plain' });
+    const dataTransfer = {
+      items: [{ kind: 'file', type: 'text/plain' }],
+      files: [file],
+    } as unknown as DataTransfer;
+    fireEvent.drop(editor, { dataTransfer, clientX: 0, clientY: 0 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    fireEvent.click(getCreateButton()!);
+    expect(getPathForFile).toHaveBeenCalledTimes(1);
+    expect(saveAttachment).not.toHaveBeenCalled();
+    expect(onAdd).toHaveBeenCalledWith('With file', '![](/Users/me/notes/agenda.txt)');
+
+    if (original !== undefined) (window as unknown as { api: unknown }).api = original;
+    else delete (window as unknown as { api?: unknown }).api;
   });
 });

--- a/src/__tests__/renderer/views.test.tsx
+++ b/src/__tests__/renderer/views.test.tsx
@@ -84,6 +84,43 @@ describe('KanbanCardView', () => {
     expect(onCommit).toHaveBeenCalledWith(7, 'Renamed');
     expect(onCancel).not.toHaveBeenCalled();
   });
+
+  it('commits a description drop while not editing through onUpdateDescription', async () => {
+    const onUpdateDescription = vi.fn();
+    const onAttachFile = vi.fn().mockResolvedValue('/Users/a/notes.txt');
+    const { container } = render(
+      <KanbanCardView task={baseTask} onUpdateDescription={onUpdateDescription} onAttachFile={onAttachFile} />,
+    );
+    // Expand the card so the description editor is rendered.
+    fireEvent.click(container.querySelector('button')!);
+    const editor = container.querySelector('.kanban-description-editor') as HTMLDivElement;
+
+    const file = new File([new Uint8Array([1])], 'notes.txt', { type: 'text/plain' });
+    const dataTransfer = {
+      items: [{ kind: 'file', type: 'text/plain' }],
+      files: [file],
+    } as unknown as DataTransfer;
+    fireEvent.drop(editor, { dataTransfer, clientX: 0, clientY: 0 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(onAttachFile).toHaveBeenCalledTimes(1);
+    expect(onUpdateDescription).toHaveBeenCalledWith(7, '![](/Users/a/notes.txt)');
+  });
+
+  it('commits the description on Enter while editing', () => {
+    const onUpdateDescription = vi.fn();
+    const taskWithPrompt = { ...baseTask, prompt: 'old' };
+    const { container } = render(<KanbanCardView task={taskWithPrompt} onUpdateDescription={onUpdateDescription} />);
+    // Expand and click into the editor to enter edit mode.
+    fireEvent.click(container.querySelector('button')!);
+    const editor = container.querySelector('.kanban-description-editor') as HTMLDivElement;
+    fireEvent.click(editor);
+    editor.textContent = 'new value';
+    fireEvent.input(editor);
+    fireEvent.keyDown(editor, { key: 'Enter' });
+
+    expect(onUpdateDescription).toHaveBeenCalledWith(7, 'new value');
+  });
 });
 
 describe('KanbanBadgeView', () => {

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -10,6 +10,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { getUserDataPath } from './paths';
 import { generateId } from './utils/ids';
+import { decodeAttachmentPath } from './utils/descriptionAttachments';
 import log from './log';
 
 const attachmentsLog = log.scope('attachments');
@@ -41,11 +42,13 @@ export function getAttachmentsDir(): string {
 /** Markdown image markers `![](path)` — pulls out the absolute path tokens. */
 const ATTACHMENT_PATH_REGEX = /!\[\]\(([^)]+)\)/g;
 
-/** Extract the set of unique attachment paths referenced by a description. */
+/** Extract the set of unique attachment paths referenced by a description.
+ *  Paths are decoded from the storage format so the returned values match the
+ *  chip's `data-attachment-path` and the on-disk file name. */
 export function extractAttachmentPaths(text: string | null | undefined): string[] {
   if (!text) return [];
   const seen = new Set<string>();
-  for (const match of text.matchAll(ATTACHMENT_PATH_REGEX)) seen.add(match[1]);
+  for (const match of text.matchAll(ATTACHMENT_PATH_REGEX)) seen.add(decodeAttachmentPath(match[1]));
   return [...seen];
 }
 

--- a/src/components/kanban/DescriptionChipEditor.tsx
+++ b/src/components/kanban/DescriptionChipEditor.tsx
@@ -18,10 +18,12 @@ export interface DescriptionChipEditorProps {
   /** Fires on every edit with the current serialized value. */
   onChange?: (value: string) => void;
   /**
-   * Persists a pasted/dropped image and resolves to its absolute file path
-   * (or null on failure). Without this prop, images are ignored.
+   * Resolve a pasted/dropped file to the absolute path that goes into the
+   * prompt as a chip. The caller decides whether to use the file's existing
+   * on-disk path (drag-drop from the filesystem) or save the bytes somewhere
+   * first (clipboard paste of raw image data). Returning null skips the file.
    */
-  onSaveImage?: (data: Uint8Array, ext: string) => Promise<string | null>;
+  onAttachFile?: (file: File) => Promise<string | null>;
   placeholder?: string;
   className?: string;
   style?: React.CSSProperties;
@@ -46,7 +48,7 @@ export const DescriptionChipEditor = forwardRef<DescriptionChipEditorHandle, Des
     {
       initialValue = '',
       onChange,
-      onSaveImage,
+      onAttachFile,
       placeholder,
       className,
       style,
@@ -121,43 +123,39 @@ export const DescriptionChipEditor = forwardRef<DescriptionChipEditorHandle, Des
 
     const handlePaste = useCallback(
       async (e: React.ClipboardEvent<HTMLDivElement>) => {
-        if (!onSaveImage) return;
+        if (!onAttachFile) return;
         const items = e.clipboardData?.items;
         if (!items) return;
-        const imageItem = Array.from(items).find((it) => it.kind === 'file' && it.type.startsWith('image/'));
-        if (!imageItem) return;
+        const fileItem = Array.from(items).find((it) => it.kind === 'file');
+        if (!fileItem) return;
         // Block default paste — contentEditable would embed an <img>, and
         // we own placement of the chip element instead.
         e.preventDefault();
 
-        const file = imageItem.getAsFile();
+        const file = fileItem.getAsFile();
         if (!file) return;
-        const ext = imageItem.type.split('/')[1] || 'png';
-        const data = new Uint8Array(await file.arrayBuffer());
-        const savedPath = await onSaveImage(data, ext);
-        if (!savedPath) return;
+        const path = await onAttachFile(file);
+        if (!path) return;
 
         const sel = window.getSelection();
         const range =
           sel && sel.rangeCount > 0 && editorRef.current?.contains(sel.anchorNode) ? sel.getRangeAt(0) : null;
-        insertChipAtRange(createAttachmentChip(savedPath), range);
+        insertChipAtRange(createAttachmentChip(path), range);
       },
-      [onSaveImage, insertChipAtRange],
+      [onAttachFile, insertChipAtRange],
     );
 
     const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-      const hasImage = Array.from(e.dataTransfer.items ?? []).some(
-        (it) => it.kind === 'file' && it.type.startsWith('image/'),
-      );
-      if (!hasImage) return;
+      const hasFile = Array.from(e.dataTransfer.items ?? []).some((it) => it.kind === 'file');
+      if (!hasFile) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = 'copy';
     }, []);
 
     const handleDrop = useCallback(
       async (e: React.DragEvent<HTMLDivElement>) => {
-        if (!onSaveImage) return;
-        const files = Array.from(e.dataTransfer.files ?? []).filter((f) => f.type.startsWith('image/'));
+        if (!onAttachFile) return;
+        const files = Array.from(e.dataTransfer.files ?? []);
         if (files.length === 0) return;
         e.preventDefault();
         e.stopPropagation();
@@ -179,18 +177,16 @@ export const DescriptionChipEditor = forwardRef<DescriptionChipEditorHandle, Des
           dropRange = document.caretRangeFromPoint(e.clientX, e.clientY);
         }
 
-        const savedPaths: string[] = [];
+        const paths: string[] = [];
         for (const file of files) {
-          const ext = file.type.split('/')[1] || 'png';
-          const data = new Uint8Array(await file.arrayBuffer());
-          const savedPath = await onSaveImage(data, ext);
-          if (savedPath) savedPaths.push(savedPath);
+          const path = await onAttachFile(file);
+          if (path) paths.push(path);
         }
-        for (const path of savedPaths) {
+        for (const path of paths) {
           insertChipAtRange(createAttachmentChip(path), dropRange);
         }
       },
-      [onSaveImage, insertChipAtRange],
+      [onAttachFile, insertChipAtRange],
     );
 
     const handleKeyDown = useCallback(

--- a/src/components/kanban/DescriptionChipEditor.tsx
+++ b/src/components/kanban/DescriptionChipEditor.tsx
@@ -1,0 +1,247 @@
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from 'react';
+import {
+  createAttachmentChip,
+  isAttachmentChip,
+  parseDescription,
+  serializeDescriptionDOM,
+} from '../../utils/descriptionAttachments';
+
+export interface DescriptionChipEditorHandle {
+  getValue: () => string;
+  setValue: (value: string) => void;
+  focus: () => void;
+}
+
+export interface DescriptionChipEditorProps {
+  /** Initial storage-format value (text + `![](path)` markers). */
+  initialValue?: string;
+  /** Fires on every edit with the current serialized value. */
+  onChange?: (value: string) => void;
+  /**
+   * Persists a pasted/dropped image and resolves to its absolute file path
+   * (or null on failure). Without this prop, images are ignored.
+   */
+  onSaveImage?: (data: Uint8Array, ext: string) => Promise<string | null>;
+  placeholder?: string;
+  className?: string;
+  style?: React.CSSProperties;
+  /** Defaults to true. */
+  editable?: boolean;
+  autoFocus?: boolean;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
+  onFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
+  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+/**
+ * Uncontrolled contentEditable that renders task descriptions with inline
+ * image attachment chips. The DOM is the source of truth between explicit
+ * resets via the imperative handle; `onChange` mirrors every edit so a parent
+ * holding the value in state stays in sync. Re-render is safe because no
+ * children are passed to the editable div — React never touches its content.
+ */
+export const DescriptionChipEditor = forwardRef<DescriptionChipEditorHandle, DescriptionChipEditorProps>(
+  function DescriptionChipEditor(
+    {
+      initialValue = '',
+      onChange,
+      onSaveImage,
+      placeholder,
+      className,
+      style,
+      editable = true,
+      autoFocus = false,
+      onKeyDown,
+      onBlur,
+      onFocus,
+      onClick,
+    },
+    ref,
+  ) {
+    const editorRef = useRef<HTMLDivElement>(null);
+
+    const populate = useCallback((value: string) => {
+      const el = editorRef.current;
+      if (!el) return;
+      el.innerHTML = '';
+      for (const seg of parseDescription(value)) {
+        if (seg.type === 'text') el.appendChild(document.createTextNode(seg.value));
+        else el.appendChild(createAttachmentChip(seg.path));
+      }
+      el.dataset.empty = value.length === 0 ? 'true' : 'false';
+    }, []);
+
+    // Initial populate on mount. The editor is uncontrolled afterwards —
+    // external resets go through the imperative `setValue` handle.
+    useEffect(() => {
+      populate(initialValue);
+      if (autoFocus) editorRef.current?.focus();
+      // Intentionally only on mount: subsequent prop changes don't repopulate.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const emitChange = useCallback(() => {
+      const el = editorRef.current;
+      if (!el) return;
+      const serialized = serializeDescriptionDOM(el);
+      el.dataset.empty = serialized.length === 0 ? 'true' : 'false';
+      onChange?.(serialized);
+    }, [onChange]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        getValue: () => (editorRef.current ? serializeDescriptionDOM(editorRef.current) : ''),
+        setValue: (value: string) => populate(value),
+        focus: () => editorRef.current?.focus(),
+      }),
+      [populate],
+    );
+
+    const insertChipAtRange = useCallback(
+      (chip: HTMLElement, range: Range | null) => {
+        const editor = editorRef.current;
+        if (!editor) return;
+        if (range && editor.contains(range.startContainer)) {
+          range.deleteContents();
+          range.insertNode(chip);
+          range.setStartAfter(chip);
+          range.collapse(true);
+          const sel = window.getSelection();
+          sel?.removeAllRanges();
+          sel?.addRange(range);
+        } else {
+          editor.appendChild(chip);
+        }
+        emitChange();
+      },
+      [emitChange],
+    );
+
+    const handlePaste = useCallback(
+      async (e: React.ClipboardEvent<HTMLDivElement>) => {
+        if (!onSaveImage) return;
+        const items = e.clipboardData?.items;
+        if (!items) return;
+        const imageItem = Array.from(items).find((it) => it.kind === 'file' && it.type.startsWith('image/'));
+        if (!imageItem) return;
+        // Block default paste — contentEditable would embed an <img>, and
+        // we own placement of the chip element instead.
+        e.preventDefault();
+
+        const file = imageItem.getAsFile();
+        if (!file) return;
+        const ext = imageItem.type.split('/')[1] || 'png';
+        const data = new Uint8Array(await file.arrayBuffer());
+        const savedPath = await onSaveImage(data, ext);
+        if (!savedPath) return;
+
+        const sel = window.getSelection();
+        const range =
+          sel && sel.rangeCount > 0 && editorRef.current?.contains(sel.anchorNode) ? sel.getRangeAt(0) : null;
+        insertChipAtRange(createAttachmentChip(savedPath), range);
+      },
+      [onSaveImage, insertChipAtRange],
+    );
+
+    const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+      const hasImage = Array.from(e.dataTransfer.items ?? []).some(
+        (it) => it.kind === 'file' && it.type.startsWith('image/'),
+      );
+      if (!hasImage) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+    }, []);
+
+    const handleDrop = useCallback(
+      async (e: React.DragEvent<HTMLDivElement>) => {
+        if (!onSaveImage) return;
+        const files = Array.from(e.dataTransfer.files ?? []).filter((f) => f.type.startsWith('image/'));
+        if (files.length === 0) return;
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Resolve the drop point to a caret range *before* the await — the
+        // hit-test API needs the live layout from the drop event.
+        const docWithCaret = document as Document & {
+          caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
+        };
+        let dropRange: Range | null = null;
+        if (docWithCaret.caretPositionFromPoint) {
+          const pos = docWithCaret.caretPositionFromPoint(e.clientX, e.clientY);
+          if (pos) {
+            dropRange = document.createRange();
+            dropRange.setStart(pos.offsetNode, pos.offset);
+            dropRange.collapse(true);
+          }
+        } else if (document.caretRangeFromPoint) {
+          dropRange = document.caretRangeFromPoint(e.clientX, e.clientY);
+        }
+
+        const savedPaths: string[] = [];
+        for (const file of files) {
+          const ext = file.type.split('/')[1] || 'png';
+          const data = new Uint8Array(await file.arrayBuffer());
+          const savedPath = await onSaveImage(data, ext);
+          if (savedPath) savedPaths.push(savedPath);
+        }
+        for (const path of savedPaths) {
+          insertChipAtRange(createAttachmentChip(path), dropRange);
+        }
+      },
+      [onSaveImage, insertChipAtRange],
+    );
+
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        // Chip-aware Backspace/Delete: remove the whole chip in one keypress
+        // instead of the browser's two-step "select then delete" behaviour.
+        if (e.key === 'Backspace' || e.key === 'Delete') {
+          const sel = window.getSelection();
+          if (sel && sel.rangeCount > 0 && sel.isCollapsed) {
+            const range = sel.getRangeAt(0);
+            const { startContainer: sc, startOffset: so } = range;
+            let adjacent: Node | null = null;
+            if (e.key === 'Backspace') {
+              if (sc.nodeType === Node.TEXT_NODE && so === 0) adjacent = sc.previousSibling;
+              else if (sc.nodeType === Node.ELEMENT_NODE) adjacent = (sc as Element).childNodes[so - 1] ?? null;
+            } else {
+              const len = sc.nodeType === Node.TEXT_NODE ? (sc.textContent?.length ?? 0) : 0;
+              if (sc.nodeType === Node.TEXT_NODE && so === len) adjacent = sc.nextSibling;
+              else if (sc.nodeType === Node.ELEMENT_NODE) adjacent = (sc as Element).childNodes[so] ?? null;
+            }
+            if (isAttachmentChip(adjacent)) {
+              e.preventDefault();
+              adjacent.remove();
+              emitChange();
+              return;
+            }
+          }
+        }
+        onKeyDown?.(e);
+      },
+      [onKeyDown, emitChange],
+    );
+
+    return (
+      <div
+        ref={editorRef}
+        className={`kanban-description-editor ${className ?? ''}`}
+        style={style}
+        contentEditable={editable}
+        suppressContentEditableWarning
+        data-placeholder={placeholder ?? ''}
+        data-empty={initialValue.length === 0 ? 'true' : 'false'}
+        onInput={emitChange}
+        onPaste={handlePaste}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        onKeyDown={handleKeyDown}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        onClick={onClick}
+      />
+    );
+  },
+);

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -83,7 +83,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     // No source path — bytes only (typically a clipboard-pasted screenshot).
     // Save those to userData so CLI agents have a stable path to read.
     if (!file.type.startsWith('image/')) {
-      useProjectStore.getState().addToast('Attachment skipped: no source path', 'error');
+      useProjectStore.getState().addToast('Only image clipboard content can be attached', 'error');
       return null;
     }
     const ext = file.type.split('/')[1] || 'png';

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -73,7 +73,21 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     [name, description],
   );
 
-  const handleSaveImage = useCallback(async (data: Uint8Array, ext: string): Promise<string | null> => {
+  const handleAttachFile = useCallback(async (file: File): Promise<string | null> => {
+    // Prefer the file's existing on-disk path — drag-drop from Finder and
+    // most clipboard file pastes already have one. Skipping the copy keeps
+    // the user's file under their control and works for any extension.
+    const existingPath = window.api.getPathForFile(file);
+    if (existingPath) return existingPath;
+
+    // No source path — bytes only (typically a clipboard-pasted screenshot).
+    // Save those to userData so CLI agents have a stable path to read.
+    if (!file.type.startsWith('image/')) {
+      useProjectStore.getState().addToast('Attachment skipped: no source path', 'error');
+      return null;
+    }
+    const ext = file.type.split('/')[1] || 'png';
+    const data = new Uint8Array(await file.arrayBuffer());
     const result = await window.api.task.saveAttachment(data, ext);
     if (result.success && result.path) return result.path;
     useProjectStore.getState().addToast(result.error || 'Failed to attach image', 'error');
@@ -99,7 +113,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
             ref={editorRef}
             initialValue=""
             onChange={setDescription}
-            onSaveImage={handleSaveImage}
+            onAttachFile={handleAttachFile}
             placeholder="Description (optional)"
             onKeyDown={handleDescriptionKeyDown}
             className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none focus:bg-white/[0.04]"

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -1,4 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
+import { DescriptionChipEditor, type DescriptionChipEditorHandle } from './DescriptionChipEditor';
+import { useProjectStore } from '../../stores/projectStore';
 
 interface KanbanAddInputProps {
   onAdd: (name: string, description?: string) => void;
@@ -9,10 +11,12 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
   const [description, setDescription] = useState('');
   const [active, setActive] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const editorRef = useRef<DescriptionChipEditorHandle>(null);
 
   const reset = useCallback(() => {
     setName('');
     setDescription('');
+    editorRef.current?.setValue('');
     setActive(false);
   }, []);
 
@@ -27,6 +31,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     // can be typed immediately without clicking back in.
     setName('');
     setDescription('');
+    editorRef.current?.setValue('');
     inputRef.current?.focus();
   }, [name, description, onAdd]);
 
@@ -46,8 +51,8 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
 
   const handleDescriptionKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      // Enter inserts a newline so multi-line prompts can be typed; the
-      // Create button (or Cmd/Ctrl+Enter) submits.
+      // Cmd/Ctrl+Enter submits; plain Enter falls through to contentEditable's
+      // native line-break handling. Escape resets the form.
       if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         submit();
@@ -68,6 +73,13 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     [name, description],
   );
 
+  const handleSaveImage = useCallback(async (data: Uint8Array, ext: string): Promise<string | null> => {
+    const result = await window.api.task.saveAttachment(data, ext);
+    if (result.success && result.path) return result.path;
+    useProjectStore.getState().addToast(result.error || 'Failed to attach image', 'error');
+    return null;
+  }, []);
+
   return (
     <div className="kanban-add-form" onBlur={handleBlur}>
       <input
@@ -83,13 +95,15 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
       />
       {active && (
         <>
-          <textarea
-            className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none resize-none focus:bg-white/[0.04]"
+          <DescriptionChipEditor
+            ref={editorRef}
+            initialValue=""
+            onChange={setDescription}
+            onSaveImage={handleSaveImage}
             placeholder="Description (optional)"
-            rows={3}
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
             onKeyDown={handleDescriptionKeyDown}
+            className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none focus:bg-white/[0.04]"
+            style={{ minHeight: '4.5rem', whiteSpace: 'pre-wrap', wordWrap: 'break-word', lineHeight: 1.5 }}
           />
           <div
             className="flex items-center justify-end gap-4 px-3 py-2"

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -342,7 +342,7 @@ export const KanbanCard = memo(function KanbanCard({
     // No source path — bytes only (typically a clipboard-pasted screenshot).
     // Save those to userData so CLI agents have a stable path to read.
     if (!file.type.startsWith('image/')) {
-      useProjectStore.getState().addToast('Attachment skipped: no source path', 'error');
+      useProjectStore.getState().addToast('Only image clipboard content can be attached', 'error');
       return null;
     }
     const ext = file.type.split('/')[1] || 'png';

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -332,7 +332,21 @@ export const KanbanCard = memo(function KanbanCard({
     handleStartRenameTask,
   ]);
 
-  const handleSaveImage = useCallback(async (data: Uint8Array, ext: string): Promise<string | null> => {
+  const handleAttachFile = useCallback(async (file: File): Promise<string | null> => {
+    // Prefer the file's existing on-disk path — drag-drop from Finder and
+    // most clipboard file pastes already have one. Skipping the copy keeps
+    // the user's file under their control and works for any extension.
+    const existingPath = window.api.getPathForFile(file);
+    if (existingPath) return existingPath;
+
+    // No source path — bytes only (typically a clipboard-pasted screenshot).
+    // Save those to userData so CLI agents have a stable path to read.
+    if (!file.type.startsWith('image/')) {
+      useProjectStore.getState().addToast('Attachment skipped: no source path', 'error');
+      return null;
+    }
+    const ext = file.type.split('/')[1] || 'png';
+    const data = new Uint8Array(await file.arrayBuffer());
     const result = await window.api.task.saveAttachment(data, ext);
     if (result.success && result.path) return result.path;
     useProjectStore.getState().addToast(result.error || 'Failed to attach image', 'error');
@@ -360,7 +374,7 @@ export const KanbanCard = memo(function KanbanCard({
         onPlainClick={handlePlainClick}
         onContextMenu={(e) => setContextMenu({ x: e.clientX, y: e.clientY })}
         onUpdateDescription={onUpdateDescription}
-        onSaveImage={handleSaveImage}
+        onAttachFile={handleAttachFile}
         onSwitchToTerminal={onSwitchToTerminal}
         onTerminalContextMenu={(ptyId, e) => setTerminalContextMenu({ x: e.clientX, y: e.clientY, ptyId })}
         isRenamingTask={isRenamingTask}

--- a/src/components/kanban/KanbanCardView.tsx
+++ b/src/components/kanban/KanbanCardView.tsx
@@ -3,14 +3,7 @@ import type { TaskWithWorkspace } from '../../types';
 import type { TerminalDisplayState } from '../../stores/terminalStore';
 import { Icon } from '../terminal/Icon';
 import { StatusDot } from '../terminal/StatusDot';
-import {
-  createAttachmentChip,
-  isAttachmentChip,
-  parseDescription,
-  serializeDescriptionDOM,
-} from '../../utils/descriptionAttachments';
-
-const DESCRIPTION_PLACEHOLDER = 'Add description…';
+import { DescriptionChipEditor, type DescriptionChipEditorHandle } from './DescriptionChipEditor';
 
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
 
@@ -94,8 +87,12 @@ export const KanbanCardView = memo(function KanbanCardView({
   const [expanded, setExpanded] = useState(false);
   const [editingDesc, setEditingDesc] = useState(false);
   const nameInputRef = useRef<HTMLTextAreaElement>(null);
-  const descInputRef = useRef<HTMLSpanElement>(null);
+  const descEditorRef = useRef<DescriptionChipEditorHandle>(null);
   const terminalRenameRef = useRef<HTMLInputElement>(null);
+  /** Last prompt value pushed into the editor — guards against repopulating
+   *  the DOM (and stomping the user's caret) when our own onChange triggers
+   *  a server round-trip that returns the same string. */
+  const lastSyncedPromptRef = useRef<string>(task.prompt ?? '');
 
   const isDone = task.status === 'done';
 
@@ -135,193 +132,53 @@ export const KanbanCardView = memo(function KanbanCardView({
   );
 
   const commitDescription = useCallback(() => {
-    if (!descInputRef.current) return;
-    const desc = serializeDescriptionDOM(descInputRef.current);
-    onUpdateDescription?.(task.taskNumber, desc);
+    const value = descEditorRef.current?.getValue() ?? '';
+    lastSyncedPromptRef.current = value;
+    onUpdateDescription?.(task.taskNumber, value);
     setEditingDesc(false);
   }, [task.taskNumber, onUpdateDescription]);
 
   /**
-   * Sync the contentEditable DOM with `task.prompt`. Fires when the prompt
-   * changes or when the editor (re-)mounts via the expand toggle — the span
-   * only exists while the card is expanded, so the ref is null on the first
-   * render and we need this effect to run again when it actually attaches.
-   * Attachments are rendered as inline chips at the paste positions.
+   * Sync the editor with `task.prompt` when an external change arrives — but
+   * skip the case where the change is just our own commit round-tripping back
+   * (otherwise we'd repopulate the DOM and stomp the caret). While editing,
+   * we never replay external changes; the user's in-flight edits win.
    */
   useEffect(() => {
-    const el = descInputRef.current;
-    if (!el) return;
-    el.innerHTML = '';
-    for (const seg of parseDescription(task.prompt ?? '')) {
-      if (seg.type === 'text') {
-        el.appendChild(document.createTextNode(seg.value));
-      } else {
-        el.appendChild(createAttachmentChip(seg.path));
-      }
-    }
-    if (!task.prompt) el.textContent = DESCRIPTION_PLACEHOLDER;
-  }, [task.prompt, expanded]);
+    if (editingDesc) return;
+    const next = task.prompt ?? '';
+    if (next === lastSyncedPromptRef.current) return;
+    descEditorRef.current?.setValue(next);
+    lastSyncedPromptRef.current = next;
+  }, [task.prompt, editingDesc, expanded]);
 
-  /**
-   * Toggle the placeholder text on edit-state changes. Kept narrow so it never
-   * touches user-authored content — only swaps between empty and the
-   * placeholder string when the prompt itself is empty.
-   */
+  /** Focus the editor when the user enters edit mode. */
   useEffect(() => {
-    const el = descInputRef.current;
-    if (!el || task.prompt) return;
-    if (editingDesc) {
-      if (el.textContent === DESCRIPTION_PLACEHOLDER) el.textContent = '';
-    } else if (!el.textContent || el.textContent === '') {
-      el.textContent = DESCRIPTION_PLACEHOLDER;
-    }
-  }, [editingDesc, task.prompt]);
-
-  /** Insert a chip into the editor at a given range, or append if no range. */
-  const insertChipAtRange = useCallback((chip: HTMLElement, range: Range | null) => {
-    const editor = descInputRef.current;
-    if (!editor) return;
-    if (range && editor.contains(range.startContainer)) {
-      range.deleteContents();
-      range.insertNode(chip);
-      range.setStartAfter(chip);
-      range.collapse(true);
-      const sel = window.getSelection();
-      sel?.removeAllRanges();
-      sel?.addRange(range);
-    } else {
-      editor.appendChild(chip);
-    }
-  }, []);
+    if (!editingDesc) return;
+    requestAnimationFrame(() => descEditorRef.current?.focus());
+  }, [editingDesc]);
 
   /**
-   * Intercept pasted images. The bytes are saved to disk and a chip element is
-   * inserted at the caret. The chip survives serialization as an inline
-   * `![](path)` marker — that path is what the CLI agent reads when the task
-   * runs, so the image stays positional within the prompt.
+   * Drop-in-view-mode: the editor still fires onChange when an image is
+   * dropped (the chip is added imperatively). Commit immediately so the
+   * server learns about it. During edit mode, blur/Enter commits — ignore
+   * intermediate input events.
    */
-  const handleDescPaste = useCallback(
-    async (e: React.ClipboardEvent<HTMLSpanElement>) => {
-      if (!onSaveImage) return;
-      const items = e.clipboardData?.items;
-      if (!items) return;
-      const imageItem = Array.from(items).find((it) => it.kind === 'file' && it.type.startsWith('image/'));
-      if (!imageItem) return;
-
-      // Block the default paste: contentEditable would embed an <img>, and
-      // we own placement of the chip element instead.
-      e.preventDefault();
-
-      const file = imageItem.getAsFile();
-      if (!file) return;
-      const ext = imageItem.type.split('/')[1] || 'png';
-      const data = new Uint8Array(await file.arrayBuffer());
-      const savedPath = await onSaveImage(data, ext);
-      if (!savedPath) return;
-
-      const sel = window.getSelection();
-      const range =
-        sel && sel.rangeCount > 0 && descInputRef.current?.contains(sel.anchorNode) ? sel.getRangeAt(0) : null;
-      insertChipAtRange(createAttachmentChip(savedPath), range);
+  const handleEditorChange = useCallback(
+    (next: string) => {
+      if (editingDesc) return;
+      lastSyncedPromptRef.current = next;
+      onUpdateDescription?.(task.taskNumber, next);
     },
-    [onSaveImage, insertChipAtRange],
+    [editingDesc, onUpdateDescription, task.taskNumber],
   );
 
-  /**
-   * Accept image files dragged onto the description. If the user hasn't yet
-   * entered edit mode we update the description through the normal commit
-   * channel — the populate effect repaints the chip on re-render. When
-   * already editing, the chip is inserted at the drop point.
-   */
-  const handleDescDragOver = useCallback((e: React.DragEvent<HTMLSpanElement>) => {
-    const hasImage = Array.from(e.dataTransfer.items ?? []).some(
-      (it) => it.kind === 'file' && it.type.startsWith('image/'),
-    );
-    if (!hasImage) return;
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'copy';
-  }, []);
-
-  const handleDescDrop = useCallback(
-    async (e: React.DragEvent<HTMLSpanElement>) => {
-      if (!onSaveImage) return;
-      const files = Array.from(e.dataTransfer.files ?? []).filter((f) => f.type.startsWith('image/'));
-      if (files.length === 0) return;
-      e.preventDefault();
-      e.stopPropagation();
-
-      // Resolve the drop point to a caret range *before* the await — the
-      // hit-test API needs the live layout from the drop event.
-      const docWithCaret = document as Document & {
-        caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
-      };
-      let dropRange: Range | null = null;
-      if (editingDesc) {
-        if (docWithCaret.caretPositionFromPoint) {
-          const pos = docWithCaret.caretPositionFromPoint(e.clientX, e.clientY);
-          if (pos) {
-            dropRange = document.createRange();
-            dropRange.setStart(pos.offsetNode, pos.offset);
-            dropRange.collapse(true);
-          }
-        } else if (document.caretRangeFromPoint) {
-          dropRange = document.caretRangeFromPoint(e.clientX, e.clientY);
-        }
-      }
-
-      const savedPaths: string[] = [];
-      for (const file of files) {
-        const ext = file.type.split('/')[1] || 'png';
-        const data = new Uint8Array(await file.arrayBuffer());
-        const savedPath = await onSaveImage(data, ext);
-        if (savedPath) savedPaths.push(savedPath);
-      }
-      if (savedPaths.length === 0) return;
-
-      if (editingDesc) {
-        for (const path of savedPaths) {
-          insertChipAtRange(createAttachmentChip(path), dropRange);
-        }
-      } else {
-        const prev = task.prompt ?? '';
-        const appended = savedPaths.map((p) => `![](${p})`).join('');
-        const next = prev ? `${prev} ${appended}` : appended;
-        onUpdateDescription?.(task.taskNumber, next);
-      }
-    },
-    [editingDesc, insertChipAtRange, onSaveImage, onUpdateDescription, task.prompt, task.taskNumber],
-  );
-
-  /**
-   * Key handling for the description editor. Enter commits; Backspace/Delete
-   * adjacent to a chip removes the entire chip in one keypress instead of
-   * relying on the browser's two-step "select then delete" behaviour.
-   */
-  const handleDescKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLSpanElement>) => {
+  /** Enter (without shift) commits the description. */
+  const handleEditorKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         commitDescription();
-        return;
-      }
-      if (e.key !== 'Backspace' && e.key !== 'Delete') return;
-      const sel = window.getSelection();
-      if (!sel || sel.rangeCount === 0 || !sel.isCollapsed) return;
-      const range = sel.getRangeAt(0);
-      const { startContainer: sc, startOffset: so } = range;
-
-      let adjacent: Node | null = null;
-      if (e.key === 'Backspace') {
-        if (sc.nodeType === Node.TEXT_NODE && so === 0) adjacent = sc.previousSibling;
-        else if (sc.nodeType === Node.ELEMENT_NODE) adjacent = (sc as Element).childNodes[so - 1] ?? null;
-      } else {
-        const len = sc.nodeType === Node.TEXT_NODE ? (sc.textContent?.length ?? 0) : 0;
-        if (sc.nodeType === Node.TEXT_NODE && so === len) adjacent = sc.nextSibling;
-        else if (sc.nodeType === Node.ELEMENT_NODE) adjacent = (sc as Element).childNodes[so] ?? null;
-      }
-      if (isAttachmentChip(adjacent)) {
-        e.preventDefault();
-        adjacent.remove();
       }
     },
     [commitDescription],
@@ -480,27 +337,21 @@ export const KanbanCardView = memo(function KanbanCardView({
       {expanded && (
         <div className="grid mt-2 pt-2 border-t border-white/[0.04] gap-2">
           <div className="flex flex-col gap-1 text-sm">
-            <span
-              ref={descInputRef}
-              className={`kanban-description-editor text-text-secondary cursor-text break-words${editingDesc ? ' outline-none' : ' line-clamp-3'}${!task.prompt && !editingDesc ? ' text-text-tertiary italic transition-colors duration-150 ease-out hover:text-text-secondary' : ''}`}
-              style={editingDesc ? { whiteSpace: 'pre-wrap', wordWrap: 'break-word', lineHeight: 1.5 } : undefined}
-              contentEditable={editingDesc}
-              suppressContentEditableWarning
+            <DescriptionChipEditor
+              ref={descEditorRef}
+              initialValue={task.prompt ?? ''}
+              onChange={handleEditorChange}
+              onSaveImage={onSaveImage}
+              placeholder="Add description…"
+              editable={editingDesc}
+              onKeyDown={handleEditorKeyDown}
+              onBlur={editingDesc ? commitDescription : undefined}
               onClick={() => {
-                if (!editingDesc) {
-                  setEditingDesc(true);
-                  requestAnimationFrame(() => descInputRef.current?.focus());
-                }
+                if (!editingDesc) setEditingDesc(true);
               }}
-              onBlur={commitDescription}
-              onPaste={handleDescPaste}
-              onDragOver={handleDescDragOver}
-              onDrop={handleDescDrop}
-              onKeyDown={handleDescKeyDown}
+              className={`text-text-secondary cursor-text break-words${editingDesc ? ' outline-none' : ' line-clamp-3'}`}
+              style={editingDesc ? { whiteSpace: 'pre-wrap', wordWrap: 'break-word', lineHeight: 1.5 } : undefined}
             />
-            {/* Content is populated imperatively in useEffect from `task.prompt` so
-                the contentEditable DOM (text + attachment chips) survives unrelated
-                parent re-renders without being stomped by React reconciliation. */}
           </div>
           {task.branch && (
             <div className="flex items-center gap-1 font-mono text-[13px] text-white/50 min-w-0 overflow-hidden [&>svg]:w-3 [&>svg]:h-3 [&>svg]:shrink-0">

--- a/src/components/kanban/KanbanCardView.tsx
+++ b/src/components/kanban/KanbanCardView.tsx
@@ -23,11 +23,12 @@ export interface KanbanCardViewProps {
   onContextMenu?: (event: MouseEvent) => void;
   onUpdateDescription?: (taskNumber: number, description: string) => void;
   /**
-   * Persists a pasted image and resolves to its absolute file path (or null on
-   * failure). The path is inserted into the description so CLI agents can read
-   * the image when the task runs.
+   * Resolves a pasted/dropped file to the absolute path that goes into the
+   * description as a chip. Drag-drop hands back the file's existing path;
+   * clipboard image bytes get saved to disk first. Returning null skips the
+   * file.
    */
-  onSaveImage?: (data: Uint8Array, ext: string) => Promise<string | null>;
+  onAttachFile?: (file: File) => Promise<string | null>;
   onSwitchToTerminal?: (ptyId: string) => void;
   onTerminalContextMenu?: (ptyId: string, event: MouseEvent) => void;
 
@@ -72,7 +73,7 @@ export const KanbanCardView = memo(function KanbanCardView({
   onPlainClick,
   onContextMenu,
   onUpdateDescription,
-  onSaveImage,
+  onAttachFile,
   onSwitchToTerminal,
   onTerminalContextMenu,
   isRenamingTask = false,
@@ -341,7 +342,7 @@ export const KanbanCardView = memo(function KanbanCardView({
               ref={descEditorRef}
               initialValue={task.prompt ?? ''}
               onChange={handleEditorChange}
-              onSaveImage={onSaveImage}
+              onAttachFile={onAttachFile}
               placeholder="Add description…"
               editable={editingDesc}
               onKeyDown={handleEditorKeyDown}

--- a/src/index.css
+++ b/src/index.css
@@ -735,6 +735,13 @@ textarea,
   counter-reset: img-counter;
 }
 
+.kanban-description-editor[data-empty='true']::before {
+  content: attr(data-placeholder);
+  color: var(--color-text-tertiary);
+  font-style: italic;
+  pointer-events: none;
+}
+
 .description-attachment-chip {
   display: inline-block;
   padding: 0 5px;

--- a/src/utils/descriptionAttachments.ts
+++ b/src/utils/descriptionAttachments.ts
@@ -22,6 +22,26 @@ export const ATTACHMENT_CHIP_CLASS = 'description-attachment-chip';
 export const ATTACHMENT_PATH_ATTR = 'data-attachment-path';
 
 /**
+ * Round-trip-safe escape for paths stored inside `![](...)` markers. The
+ * marker terminates at the first `)`, so any literal `(` or `)` in the path
+ * has to be escaped; `%` is escaped first/decoded last to make a path that
+ * already contains `%28` / `%29` round-trip cleanly. Other characters
+ * (including spaces and quotes) are left alone — they don't break the marker.
+ */
+export function encodeAttachmentPath(path: string): string {
+  return path.replace(/%/g, '%25').replace(/\(/g, '%28').replace(/\)/g, '%29');
+}
+
+export function decodeAttachmentPath(encoded: string): string {
+  return encoded.replace(/%29/g, ')').replace(/%28/g, '(').replace(/%25/g, '%');
+}
+
+/** Escape `"` and `\` so a path can be safely embedded inside `"..."`. */
+function escapeForDoubleQuotes(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
  * Split a description string into a flat list of text and image segments,
  * preserving the order in which they appeared.
  */
@@ -36,7 +56,7 @@ export function parseDescription(text: string): DescriptionSegment[] {
     if (start > cursor) {
       segments.push({ type: 'text', value: text.slice(cursor, start) });
     }
-    segments.push({ type: 'image', path: match[1] });
+    segments.push({ type: 'image', path: decodeAttachmentPath(match[1]) });
     cursor = start + match[0].length;
   }
   if (cursor < text.length) {
@@ -69,7 +89,7 @@ export function serializeDescriptionDOM(root: Node): string {
     const el = node as HTMLElement;
     const attachmentPath = el.getAttribute(ATTACHMENT_PATH_ATTR);
     if (attachmentPath) {
-      out += `![](${attachmentPath})`;
+      out += `![](${encodeAttachmentPath(attachmentPath)})`;
       return;
     }
     if (el.tagName === 'BR') {
@@ -114,9 +134,13 @@ export function isAttachmentChip(node: Node | null | undefined): node is HTMLEle
  * Convert the stored description to the form a CLI agent sees. The `![](path)`
  * marker is an internal sentinel for our chip renderer — agents like Claude
  * Code or Codex parse file paths from the prompt directly, so we strip the
- * markdown noise and leave a quoted absolute path in its place.
+ * markdown noise and leave a quoted absolute path in its place. Paths are
+ * decoded from the storage format and escaped so a `"` or `\` in the path
+ * doesn't collapse the surrounding quotes.
  */
 export function descriptionToHookPrompt(text: string): string {
   if (!text) return text;
-  return text.replace(/!\[\]\(([^)]+)\)/g, (_, path) => `"${path}"`);
+  return text.replace(/!\[\]\(([^)]+)\)/g, (_, encoded) => {
+    return `"${escapeForDoubleQuotes(decodeAttachmentPath(encoded))}"`;
+  });
 }


### PR DESCRIPTION
## Summary
- Fixes the reported bug: paste and drag-drop did nothing in the new-task form description field. Extracts the contentEditable chip editor into a shared `DescriptionChipEditor` (uncontrolled, imperative handle) used by both `KanbanAddInput` and `KanbanCardView`; the card view sheds ~150 LOC of duplicated chip handling.
- Drag-drop now accepts any file type and references the file's existing on-disk path (no copy, no cleanup) — same shape as Codex CLI's clipboard file-reference path. Paste keeps the copy behavior for clipboard image bytes that have no source path; non-image bytes-only pastes are rejected with a toast.
- Encodes `(`, `)`, `%` as `%28` / `%29` / `%25` in the `![](...)` storage marker so paths like `Document (1).pdf` round-trip through serialize → parse. `descriptionToHookPrompt` decodes the marker and escapes `"` / `\` inside the wrapping quotes so a quote in the path no longer collapses them. Paths with no special characters round-trip identically — existing stored prompts remain valid.
- Adds renderer-side regression tests for the shared editor (paste, drop, chip-aware Backspace/Delete, fall-through, imperative reset) and card view (drop-in-view-mode commit, Enter commits), plus unit tests for the encode/decode round-trip and shell escape.