### PR TITLE
Polish the new-task form: plain-text paste, tighter footer, shortcut hints

### DIFF
--- a/src/__tests__/renderer/descriptionChipEditor.test.tsx
+++ b/src/__tests__/renderer/descriptionChipEditor.test.tsx
@@ -84,6 +84,31 @@ describe('DescriptionChipEditor', () => {
     expect(parentKeyDown).toHaveBeenCalledTimes(1);
   });
 
+  it('strips formatting from text pastes by routing through insertText', () => {
+    // jsdom doesn't implement execCommand at all, so install a fake before spying.
+    const docWithExec = document as Document & { execCommand?: (cmd: string, ui?: boolean, val?: string) => boolean };
+    const original = docWithExec.execCommand;
+    const exec = vi.fn().mockReturnValue(true);
+    docWithExec.execCommand = exec;
+    try {
+      const { container } = render(<DescriptionChipEditor initialValue="" />);
+      const editor = container.querySelector('.kanban-description-editor') as HTMLDivElement;
+      editor.focus();
+      const dataTransfer = {
+        items: [{ kind: 'string', type: 'text/plain' }],
+        getData: (type: string) => (type === 'text/plain' ? 'OUIJIT_API_URL' : ''),
+      } as unknown as DataTransfer;
+      const evt = new Event('paste', { bubbles: true, cancelable: true });
+      Object.defineProperty(evt, 'clipboardData', { value: dataTransfer });
+      const prevented = !editor.dispatchEvent(evt);
+      expect(prevented).toBe(true);
+      expect(exec).toHaveBeenCalledWith('insertText', false, 'OUIJIT_API_URL');
+    } finally {
+      if (original) docWithExec.execCommand = original;
+      else delete docWithExec.execCommand;
+    }
+  });
+
   it('calls onAttachFile on paste and inserts a chip for the returned path', async () => {
     const onAttachFile = vi.fn().mockResolvedValue('/saved/img.png');
     const onChange = vi.fn();

--- a/src/__tests__/renderer/kanbanAddInput.test.tsx
+++ b/src/__tests__/renderer/kanbanAddInput.test.tsx
@@ -1,8 +1,8 @@
 /**
  * Behavior tests for the kanban add form. Users can enter a short title and,
  * by tabbing into the revealed description field, a full prompt before the
- * task is created. The form is keyboard-driven: Cmd/Ctrl+Enter creates,
- * Escape cancels, and a hint row in the footer surfaces those shortcuts.
+ * task is created. The footer exposes Cancel and Create as clickable buttons
+ * that also advertise their keyboard shortcuts (Esc / Cmd|Ctrl+Enter).
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent, screen } from '@testing-library/react';
@@ -11,8 +11,8 @@ import { KanbanAddInput } from '../../components/kanban/KanbanAddInput';
 const getTitle = () => screen.getByPlaceholderText('New task...') as HTMLInputElement;
 /** Description is a contentEditable div — query by its stable class. */
 const getDescription = () => document.querySelector('.kanban-add-description') as HTMLDivElement | null;
-const getCreateHint = () => (screen.queryByText('to create')?.closest('span') ?? null) as HTMLSpanElement | null;
-const getCancelHint = () => (screen.queryByText('to cancel')?.closest('span') ?? null) as HTMLSpanElement | null;
+const getCreateButton = () => screen.queryByRole('button', { name: /Create/ }) as HTMLButtonElement | null;
+const getCancelButton = () => screen.queryByRole('button', { name: /Cancel/ }) as HTMLButtonElement | null;
 
 /** Set the editor's text content and fire the input event the editor listens
  *  for. Mirrors what a user typing produces, minus chip insertion. */
@@ -25,16 +25,16 @@ function typeDescription(text: string): void {
 }
 
 describe('KanbanAddInput', () => {
-  it('hides the description field and shortcut hints until the title is focused', () => {
+  it('hides the description field and footer buttons until the title is focused', () => {
     render(<KanbanAddInput onAdd={vi.fn()} />);
     expect(getDescription()).toBeNull();
-    expect(getCreateHint()).toBeNull();
-    expect(getCancelHint()).toBeNull();
+    expect(getCreateButton()).toBeNull();
+    expect(getCancelButton()).toBeNull();
 
     fireEvent.focus(getTitle());
     expect(getDescription()).not.toBeNull();
-    expect(getCreateHint()).not.toBeNull();
-    expect(getCancelHint()).not.toBeNull();
+    expect(getCreateButton()).not.toBeNull();
+    expect(getCancelButton()).not.toBeNull();
   });
 
   it('creates a title-only task when Enter is pressed in the title field', () => {
@@ -48,17 +48,40 @@ describe('KanbanAddInput', () => {
     expect(onAdd).toHaveBeenCalledWith('Fix login', undefined);
   });
 
-  it('dims the create hint until the title has content', () => {
+  it('disables the Create button until the title has content', () => {
     render(<KanbanAddInput onAdd={vi.fn()} />);
 
     fireEvent.focus(getTitle());
-    expect(getCreateHint()!.className).toContain('opacity-50');
+    expect(getCreateButton()!.disabled).toBe(true);
 
     fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    expect(getCreateHint()!.className).not.toContain('opacity-50');
+    expect(getCreateButton()!.disabled).toBe(false);
 
     fireEvent.change(getTitle(), { target: { value: '   ' } });
-    expect(getCreateHint()!.className).toContain('opacity-50');
+    expect(getCreateButton()!.disabled).toBe(true);
+  });
+
+  it('creates the task when the Create button is clicked', () => {
+    const onAdd = vi.fn();
+    render(<KanbanAddInput onAdd={onAdd} />);
+
+    fireEvent.focus(getTitle());
+    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
+    typeDescription('Details');
+    fireEvent.click(getCreateButton()!);
+
+    expect(onAdd).toHaveBeenCalledWith('Fix login', 'Details');
+  });
+
+  it('clears and collapses the form when the Cancel button is clicked', () => {
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+
+    fireEvent.focus(getTitle());
+    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
+    fireEvent.click(getCancelButton()!);
+
+    expect(getTitle().value).toBe('');
+    expect(getDescription()).toBeNull();
   });
 
   it('creates with Cmd+Enter from the description field', () => {
@@ -121,7 +144,7 @@ describe('KanbanAddInput', () => {
     expect(getTitle().value).toBe('');
     expect(getDescription()).not.toBeNull();
     expect(getDescription()!.textContent).toBe('');
-    expect(getCreateHint()).not.toBeNull();
+    expect(getCreateButton()).not.toBeNull();
   });
 
   it('can create a second task in a row without re-focusing the form', () => {

--- a/src/__tests__/renderer/kanbanAddInput.test.tsx
+++ b/src/__tests__/renderer/kanbanAddInput.test.tsx
@@ -1,7 +1,8 @@
 /**
  * Behavior tests for the kanban add form. Users can enter a short title and,
  * by tabbing into the revealed description field, a full prompt before the
- * task is created. A Create button is the primary, always-visible action.
+ * task is created. The form is keyboard-driven: Cmd/Ctrl+Enter creates,
+ * Escape cancels, and a hint row in the footer surfaces those shortcuts.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent, screen } from '@testing-library/react';
@@ -10,8 +11,8 @@ import { KanbanAddInput } from '../../components/kanban/KanbanAddInput';
 const getTitle = () => screen.getByPlaceholderText('New task...') as HTMLInputElement;
 /** Description is a contentEditable div — query by its stable class. */
 const getDescription = () => document.querySelector('.kanban-add-description') as HTMLDivElement | null;
-const getCreateButton = () => screen.queryByRole('button', { name: 'Create' }) as HTMLButtonElement | null;
-const getCancelButton = () => screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement;
+const getCreateHint = () => (screen.queryByText('to create')?.closest('span') ?? null) as HTMLSpanElement | null;
+const getCancelHint = () => (screen.queryByText('to cancel')?.closest('span') ?? null) as HTMLSpanElement | null;
 
 /** Set the editor's text content and fire the input event the editor listens
  *  for. Mirrors what a user typing produces, minus chip insertion. */
@@ -24,14 +25,16 @@ function typeDescription(text: string): void {
 }
 
 describe('KanbanAddInput', () => {
-  it('hides the description field and buttons until the title is focused', () => {
+  it('hides the description field and shortcut hints until the title is focused', () => {
     render(<KanbanAddInput onAdd={vi.fn()} />);
     expect(getDescription()).toBeNull();
-    expect(getCreateButton()).toBeNull();
+    expect(getCreateHint()).toBeNull();
+    expect(getCancelHint()).toBeNull();
 
     fireEvent.focus(getTitle());
     expect(getDescription()).not.toBeNull();
-    expect(getCreateButton()).not.toBeNull();
+    expect(getCreateHint()).not.toBeNull();
+    expect(getCancelHint()).not.toBeNull();
   });
 
   it('creates a title-only task when Enter is pressed in the title field', () => {
@@ -45,29 +48,17 @@ describe('KanbanAddInput', () => {
     expect(onAdd).toHaveBeenCalledWith('Fix login', undefined);
   });
 
-  it('creates a task with title and description when the Create button is clicked', () => {
-    const onAdd = vi.fn();
-    render(<KanbanAddInput onAdd={onAdd} />);
-
-    fireEvent.focus(getTitle());
-    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    typeDescription('Sessions expire too early');
-    fireEvent.click(getCreateButton()!);
-
-    expect(onAdd).toHaveBeenCalledWith('Fix login', 'Sessions expire too early');
-  });
-
-  it('disables the Create button until the title has content', () => {
+  it('dims the create hint until the title has content', () => {
     render(<KanbanAddInput onAdd={vi.fn()} />);
 
     fireEvent.focus(getTitle());
-    expect(getCreateButton()!.disabled).toBe(true);
+    expect(getCreateHint()!.className).toContain('opacity-50');
 
     fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    expect(getCreateButton()!.disabled).toBe(false);
+    expect(getCreateHint()!.className).not.toContain('opacity-50');
 
     fireEvent.change(getTitle(), { target: { value: '   ' } });
-    expect(getCreateButton()!.disabled).toBe(true);
+    expect(getCreateHint()!.className).toContain('opacity-50');
   });
 
   it('creates with Cmd+Enter from the description field', () => {
@@ -130,7 +121,7 @@ describe('KanbanAddInput', () => {
     expect(getTitle().value).toBe('');
     expect(getDescription()).not.toBeNull();
     expect(getDescription()!.textContent).toBe('');
-    expect(getCreateButton()).not.toBeNull();
+    expect(getCreateHint()).not.toBeNull();
   });
 
   it('can create a second task in a row without re-focusing the form', () => {
@@ -149,23 +140,24 @@ describe('KanbanAddInput', () => {
     expect(onAdd).toHaveBeenNthCalledWith(2, 'Second task', undefined);
   });
 
-  it('clears and collapses the form when Cancel is clicked', () => {
-    render(<KanbanAddInput onAdd={vi.fn()} />);
-
-    fireEvent.focus(getTitle());
-    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    fireEvent.click(getCancelButton());
-
-    expect(getTitle().value).toBe('');
-    expect(getDescription()).toBeNull();
-  });
-
-  it('clears and collapses the form on Escape', () => {
+  it('clears and collapses the form on Escape from the title field', () => {
     render(<KanbanAddInput onAdd={vi.fn()} />);
 
     const title = getTitle();
     fireEvent.change(title, { target: { value: 'Fix login' } });
     fireEvent.keyDown(title, { key: 'Escape' });
+
+    expect(getTitle().value).toBe('');
+    expect(getDescription()).toBeNull();
+  });
+
+  it('clears and collapses the form on Escape from the description field', () => {
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+
+    fireEvent.focus(getTitle());
+    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
+    typeDescription('Details');
+    fireEvent.keyDown(getDescription()!, { key: 'Escape' });
 
     expect(getTitle().value).toBe('');
     expect(getDescription()).toBeNull();
@@ -206,7 +198,7 @@ describe('KanbanAddInput', () => {
     fireEvent.paste(editor, { clipboardData: dataTransfer });
     await new Promise((r) => setTimeout(r, 0));
 
-    fireEvent.click(getCreateButton()!);
+    fireEvent.keyDown(editor, { key: 'Enter', metaKey: true });
     expect(getPathForFile).toHaveBeenCalledTimes(1);
     expect(saveAttachment).toHaveBeenCalledTimes(1);
     expect(onAdd).toHaveBeenCalledWith('With image', '![](/tmp/img-test.png)');
@@ -238,7 +230,7 @@ describe('KanbanAddInput', () => {
     fireEvent.drop(editor, { dataTransfer, clientX: 0, clientY: 0 });
     await new Promise((r) => setTimeout(r, 0));
 
-    fireEvent.click(getCreateButton()!);
+    fireEvent.keyDown(editor, { key: 'Enter', metaKey: true });
     expect(getPathForFile).toHaveBeenCalledTimes(1);
     expect(saveAttachment).not.toHaveBeenCalled();
     expect(onAdd).toHaveBeenCalledWith('With file', '![](/Users/me/notes/agenda.txt)');

--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -332,7 +332,7 @@ export function HomeView() {
           >
             <div className="text-sm">No tasks yet.</div>
             <div className="flex items-center gap-2 text-xs">
-              <span className="font-mono text-[13px]">{isMac ? '⌘ I' : 'Ctrl+I'}</span>
+              <span className="font-mono text-[13px]">{isMac ? '⌘ I' : '⌃ I'}</span>
               <span>to open a terminal</span>
             </div>
           </div>

--- a/src/components/kanban/DescriptionChipEditor.tsx
+++ b/src/components/kanban/DescriptionChipEditor.tsx
@@ -123,18 +123,33 @@ export const DescriptionChipEditor = forwardRef<DescriptionChipEditorHandle, Des
 
     const handlePaste = useCallback(
       async (e: React.ClipboardEvent<HTMLDivElement>) => {
-        if (!onAttachFile) return;
-        const items = e.clipboardData?.items;
-        if (!items) return;
-        const fileItem = Array.from(items).find((it) => it.kind === 'file');
-        if (!fileItem) return;
+        const clipboard = e.clipboardData;
+        if (!clipboard) return;
+        const fileItem = onAttachFile ? Array.from(clipboard.items).find((it) => it.kind === 'file') : undefined;
+
+        // Always strip formatting: the description is plain text, and the
+        // browser's default rich-HTML paste drags in fonts, colors, and code
+        // backgrounds from styled sources (e.g. an `OUIJIT_*` env var copied
+        // from a docs code block) that look broken in the editor.
+        if (!fileItem) {
+          const text = clipboard.getData('text/plain');
+          if (!text) return;
+          e.preventDefault();
+          // execCommand is deprecated but is the only API that produces a
+          // single, undoable insertion at the current selection in a
+          // contentEditable. The modern alternative (manual Range surgery)
+          // breaks browser undo.
+          document.execCommand('insertText', false, text);
+          return;
+        }
+
         // Block default paste — contentEditable would embed an <img>, and
         // we own placement of the chip element instead.
         e.preventDefault();
 
         const file = fileItem.getAsFile();
         if (!file) return;
-        const path = await onAttachFile(file);
+        const path = await onAttachFile!(file);
         if (!path) return;
 
         const sel = window.getSelection();

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -5,14 +5,10 @@ import { useProjectStore } from '../../stores/projectStore';
 
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
 
-function SubmitHint() {
+function SubmitHint({ withModifier }: { withModifier: boolean }) {
   return (
     <span className="kanban-add-button-hint">
-      {isMac ? (
-        <Icon name="command" className="kanban-add-button-hint-icon" />
-      ) : (
-        <span className="kanban-add-button-hint-text">Ctrl</span>
-      )}
+      {withModifier && <Icon name={isMac ? 'command' : 'control'} className="kanban-add-button-hint-icon" />}
       <Icon name="arrow-elbow-down-left" className="kanban-add-button-hint-icon" />
     </span>
   );
@@ -30,6 +26,9 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [active, setActive] = useState(false);
+  // Which input owns focus right now — drives the submit hint, since plain
+  // Enter creates from the title field but the description needs ⌘/Ctrl+↵.
+  const [focusedField, setFocusedField] = useState<'title' | 'description'>('title');
   const inputRef = useRef<HTMLInputElement>(null);
   const editorRef = useRef<DescriptionChipEditorHandle>(null);
 
@@ -38,6 +37,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     setDescription('');
     editorRef.current?.setValue('');
     setActive(false);
+    setFocusedField('title');
   }, []);
 
   const canSubmit = name.trim().length > 0;
@@ -83,6 +83,12 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     [submit, reset],
   );
 
+  const handleDescriptionFocus = useCallback(() => setFocusedField('description'), []);
+  const handleNameFocus = useCallback(() => {
+    setActive(true);
+    setFocusedField('title');
+  }, []);
+
   // Collapse only when focus leaves the whole form and nothing was entered.
   const handleBlur = useCallback(
     (e: React.FocusEvent) => {
@@ -125,7 +131,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
         value={name}
         onChange={(e) => setName(e.target.value)}
         onKeyDown={handleNameKeyDown}
-        onFocus={() => setActive(true)}
+        onFocus={handleNameFocus}
       />
       {active && (
         <>
@@ -136,21 +142,16 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
             onAttachFile={handleAttachFile}
             placeholder="Description (optional)"
             onKeyDown={handleDescriptionKeyDown}
+            onFocus={handleDescriptionFocus}
             className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none focus:bg-white/[0.04]"
             style={{ minHeight: '4.5rem', whiteSpace: 'pre-wrap', wordWrap: 'break-word', lineHeight: 1.5 }}
           />
+          {/* DOM order is [Create, Cancel] so Tab from the description lands
+              on Create first; flex-row-reverse keeps Cancel on the visual left. */}
           <div
-            className="flex items-center justify-end gap-2 px-2 py-1.5"
+            className="flex flex-row-reverse items-center justify-start gap-2 px-2 py-1.5"
             style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
           >
-            <button
-              type="button"
-              onClick={reset}
-              className="kanban-add-button text-text-tertiary hover:text-text-primary hover:bg-white/[0.04]"
-            >
-              Cancel
-              <CancelHint />
-            </button>
             <button
               type="button"
               onClick={submit}
@@ -158,7 +159,15 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
               className="kanban-add-button text-accent hover:bg-accent/10 disabled:text-text-tertiary"
             >
               Create
-              <SubmitHint />
+              <SubmitHint withModifier={focusedField === 'description'} />
+            </button>
+            <button
+              type="button"
+              onClick={reset}
+              className="kanban-add-button text-text-tertiary hover:text-text-primary hover:bg-white/[0.04]"
+            >
+              Cancel
+              <CancelHint />
             </button>
           </div>
         </>

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -1,10 +1,26 @@
 import { useState, useRef, useCallback } from 'react';
 import { DescriptionChipEditor, type DescriptionChipEditorHandle } from './DescriptionChipEditor';
+import { Icon } from '../terminal/Icon';
 import { useProjectStore } from '../../stores/projectStore';
 
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
-const SUBMIT_HINT = isMac ? '⌘↵' : 'Ctrl+↵';
-const CANCEL_HINT = 'Esc';
+
+function SubmitHint() {
+  return (
+    <span className="kanban-add-button-hint">
+      {isMac ? (
+        <Icon name="command" className="kanban-add-button-hint-icon" />
+      ) : (
+        <span className="kanban-add-button-hint-text">Ctrl</span>
+      )}
+      <Icon name="arrow-elbow-down-left" className="kanban-add-button-hint-icon" />
+    </span>
+  );
+}
+
+function CancelHint() {
+  return <span className="kanban-add-button-hint kanban-add-button-hint-text">Esc</span>;
+}
 
 interface KanbanAddInputProps {
   onAdd: (name: string, description?: string) => void;
@@ -133,7 +149,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
               className="kanban-add-button text-text-tertiary hover:text-text-primary hover:bg-white/[0.04]"
             >
               Cancel
-              <kbd className="kanban-add-button-kbd">{CANCEL_HINT}</kbd>
+              <CancelHint />
             </button>
             <button
               type="button"
@@ -142,7 +158,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
               className="kanban-add-button text-accent hover:bg-accent/10 disabled:text-text-tertiary"
             >
               Create
-              <kbd className="kanban-add-button-kbd">{SUBMIT_HINT}</kbd>
+              <SubmitHint />
             </button>
           </div>
         </>

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -124,15 +124,26 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
             style={{ minHeight: '4.5rem', whiteSpace: 'pre-wrap', wordWrap: 'break-word', lineHeight: 1.5 }}
           />
           <div
-            className="flex items-center justify-end gap-3 px-3 py-2 text-[11px] text-text-tertiary select-none"
+            className="flex items-center justify-end gap-2 px-2 py-1.5"
             style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
           >
-            <span>
-              <kbd className="font-mono">{CANCEL_HINT}</kbd> to cancel
-            </span>
-            <span className={canSubmit ? 'text-text-secondary' : 'opacity-50'}>
-              <kbd className="font-mono">{SUBMIT_HINT}</kbd> to create
-            </span>
+            <button
+              type="button"
+              onClick={reset}
+              className="kanban-add-button text-text-tertiary hover:text-text-primary hover:bg-white/[0.04]"
+            >
+              Cancel
+              <kbd className="kanban-add-button-kbd">{CANCEL_HINT}</kbd>
+            </button>
+            <button
+              type="button"
+              onClick={submit}
+              disabled={!canSubmit}
+              className="kanban-add-button text-accent hover:bg-accent/10 disabled:text-text-tertiary"
+            >
+              Create
+              <kbd className="kanban-add-button-kbd">{SUBMIT_HINT}</kbd>
+            </button>
           </div>
         </>
       )}

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -2,6 +2,10 @@ import { useState, useRef, useCallback } from 'react';
 import { DescriptionChipEditor, type DescriptionChipEditorHandle } from './DescriptionChipEditor';
 import { useProjectStore } from '../../stores/projectStore';
 
+const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
+const SUBMIT_HINT = isMac ? '⌘↵' : 'Ctrl+↵';
+const CANCEL_HINT = 'Esc';
+
 interface KanbanAddInputProps {
   onAdd: (name: string, description?: string) => void;
 }
@@ -120,25 +124,15 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
             style={{ minHeight: '4.5rem', whiteSpace: 'pre-wrap', wordWrap: 'break-word', lineHeight: 1.5 }}
           />
           <div
-            className="flex items-center justify-end gap-4 px-3 py-2"
+            className="flex items-center justify-end gap-3 px-3 py-2 text-[11px] text-text-tertiary select-none"
             style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
           >
-            <button
-              type="button"
-              onClick={reset}
-              className="text-[11px] text-text-tertiary hover:text-text-secondary transition-colors duration-100"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={submit}
-              disabled={!canSubmit}
-              title="Create task (⌘↵)"
-              className="text-[11px] font-medium text-accent hover:text-accent-hover transition-colors duration-100 disabled:text-text-tertiary disabled:opacity-50"
-            >
-              Create
-            </button>
+            <span>
+              <kbd className="font-mono">{CANCEL_HINT}</kbd> to cancel
+            </span>
+            <span className={canSubmit ? 'text-text-secondary' : 'opacity-50'}>
+              <kbd className="font-mono">{SUBMIT_HINT}</kbd> to create
+            </span>
           </div>
         </>
       )}

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -181,10 +181,9 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
         if (selectedTaskNumbers.size > 0) {
           e.preventDefault();
           clearSelection();
-          return; // First Escape deselects; second closes board
         }
-        e.preventDefault();
-        onHide();
+        // Otherwise let Escape fall through — board/stack toggling is owned by
+        // Cmd/Ctrl+T, never Escape, so it doesn't fight with form-level resets.
         return;
       }
       const mod = isMac ? e.metaKey : e.ctrlKey;
@@ -195,7 +194,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
     };
     document.addEventListener('keydown', handler, true);
     return () => document.removeEventListener('keydown', handler, true);
-  }, [onHide, hasOpenDialog]);
+  }, [hasOpenDialog]);
 
   // Track Option/Alt key for showing standalone badges
   useEffect(() => {

--- a/src/components/terminal/TerminalCardStack.tsx
+++ b/src/components/terminal/TerminalCardStack.tsx
@@ -60,10 +60,10 @@ function EmptyState() {
         >
           <span
             className="inline-flex items-center font-mono"
-            style={{ fontSize: isMac ? 16 : 13, color: 'rgba(255, 255, 255, 0.25)' }}
+            style={{ fontSize: 16, color: 'rgba(255, 255, 255, 0.25)' }}
           >
-            {isMac ? '⌘' : 'Ctrl+'}
-            <span className={isMac ? 'text-xs' : 'text-[13px]'}>N</span>
+            {isMac ? '⌘' : '⌃'}
+            <span className="text-xs">N</span>
           </span>
           New Task
         </span>
@@ -73,10 +73,10 @@ function EmptyState() {
         >
           <span
             className="inline-flex items-center font-mono"
-            style={{ fontSize: isMac ? 16 : 13, color: 'rgba(255, 255, 255, 0.25)' }}
+            style={{ fontSize: 16, color: 'rgba(255, 255, 255, 0.25)' }}
           >
-            {isMac ? '⌘' : 'Ctrl+'}
-            <span className={isMac ? 'text-xs' : 'text-[13px]'}>T</span>
+            {isMac ? '⌘' : '⌃'}
+            <span className="text-xs">T</span>
           </span>
           Board
         </span>

--- a/src/components/terminal/TerminalHeaderView.tsx
+++ b/src/components/terminal/TerminalHeaderView.tsx
@@ -71,7 +71,7 @@ export function TerminalHeaderView({
             <StatusDot summaryType={summaryType} sandboxed={sandboxed} />
             {!isActive && stackPosition != null && stackPosition <= 9 && (
               <kbd className="inline-flex items-center font-mono text-base text-white/40 shrink-0">
-                {isMac ? '⌘' : 'Ctrl+'}
+                {isMac ? '⌘' : '⌃'}
                 <span className="text-xs">{stackPosition}</span>
               </kbd>
             )}

--- a/src/index.css
+++ b/src/index.css
@@ -756,11 +756,23 @@ textarea,
 }
 
 .kanban-add-button-kbd {
+  display: inline-flex;
+  align-items: center;
+  min-width: 18px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text-secondary);
   font-family: 'Iosevka Term Extended', ui-monospace, monospace;
   font-size: 10px;
-  font-weight: 400;
-  color: currentColor;
-  opacity: 0.5;
+  font-weight: 500;
+  line-height: 1;
+  justify-content: center;
+}
+
+.kanban-add-button:disabled .kanban-add-button-kbd {
+  background: rgba(255, 255, 255, 0.04);
 }
 
 /* ── Task description attachment chip ─────────────────────────────── */

--- a/src/index.css
+++ b/src/index.css
@@ -729,6 +729,40 @@ textarea,
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
+/* ── Kanban add-task form buttons ─────────────────────────────────── */
+
+.kanban-add-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  transition:
+    color 100ms ease-out,
+    background-color 100ms ease-out;
+}
+
+.kanban-add-button:disabled {
+  opacity: 0.5;
+}
+
+.kanban-add-button:disabled:hover {
+  background: transparent;
+}
+
+.kanban-add-button-kbd {
+  font-family: 'Iosevka Term Extended', ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 400;
+  color: currentColor;
+  opacity: 0.5;
+}
+
 /* ── Task description attachment chip ─────────────────────────────── */
 
 .kanban-description-editor {

--- a/src/index.css
+++ b/src/index.css
@@ -734,12 +734,12 @@ textarea,
 .kanban-add-button {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 4px 8px;
-  border-radius: 4px;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 5px;
   border: none;
   background: transparent;
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   line-height: 1;
   transition:
@@ -755,24 +755,23 @@ textarea,
   background: transparent;
 }
 
-.kanban-add-button-kbd {
+.kanban-add-button-hint {
   display: inline-flex;
   align-items: center;
-  min-width: 18px;
-  height: 16px;
-  padding: 0 4px;
-  border-radius: 3px;
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--color-text-secondary);
-  font-family: 'Iosevka Term Extended', ui-monospace, monospace;
-  font-size: 10px;
-  font-weight: 500;
-  line-height: 1;
-  justify-content: center;
+  gap: 2px;
+  opacity: 0.65;
 }
 
-.kanban-add-button:disabled .kanban-add-button-kbd {
-  background: rgba(255, 255, 255, 0.04);
+.kanban-add-button-hint-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.kanban-add-button-hint-text {
+  font-family: 'Iosevka Term Extended', ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
 }
 
 /* ── Task description attachment chip ─────────────────────────────── */

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -21,7 +21,9 @@ import arrowsOut from '@phosphor-icons/core/assets/regular/arrows-out.svg?raw';
 import arrowsOutLineHorizontal from '@phosphor-icons/core/assets/regular/arrows-out-line-horizontal.svg?raw';
 import arrowsOutLineVertical from '@phosphor-icons/core/assets/regular/arrows-out-line-vertical.svg?raw';
 import bug from '@phosphor-icons/core/assets/regular/bug.svg?raw';
+import arrowElbowDownLeft from '@phosphor-icons/core/assets/regular/arrow-elbow-down-left.svg?raw';
 import caretDown from '@phosphor-icons/core/assets/regular/caret-down.svg?raw';
+import command from '@phosphor-icons/core/assets/regular/command.svg?raw';
 import dotsSixVertical from '@phosphor-icons/core/assets/regular/dots-six-vertical.svg?raw';
 import caretLeft from '@phosphor-icons/core/assets/regular/caret-left.svg?raw';
 import caretRight from '@phosphor-icons/core/assets/regular/caret-right.svg?raw';
@@ -88,7 +90,9 @@ export const iconMap: Record<string, string> = {
   'arrows-out-line-horizontal': arrowsOutLineHorizontal,
   'arrows-out-line-vertical': arrowsOutLineVertical,
   bug: bug,
+  'arrow-elbow-down-left': arrowElbowDownLeft,
   'caret-down': caretDown,
+  command: command,
   'dots-six-vertical': dotsSixVertical,
   'caret-left': caretLeft,
   'caret-right': caretRight,

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -24,6 +24,7 @@ import bug from '@phosphor-icons/core/assets/regular/bug.svg?raw';
 import arrowElbowDownLeft from '@phosphor-icons/core/assets/regular/arrow-elbow-down-left.svg?raw';
 import caretDown from '@phosphor-icons/core/assets/regular/caret-down.svg?raw';
 import command from '@phosphor-icons/core/assets/regular/command.svg?raw';
+import control from '@phosphor-icons/core/assets/regular/control.svg?raw';
 import dotsSixVertical from '@phosphor-icons/core/assets/regular/dots-six-vertical.svg?raw';
 import caretLeft from '@phosphor-icons/core/assets/regular/caret-left.svg?raw';
 import caretRight from '@phosphor-icons/core/assets/regular/caret-right.svg?raw';
@@ -93,6 +94,7 @@ export const iconMap: Record<string, string> = {
   'arrow-elbow-down-left': arrowElbowDownLeft,
   'caret-down': caretDown,
   command: command,
+  control: control,
   'dots-six-vertical': dotsSixVertical,
   'caret-left': caretLeft,
   'caret-right': caretRight,


### PR DESCRIPTION
## Summary
- Strip rich formatting on text pastes into the task description editor so styled `OUIJIT_*` env vars (or anything else copied from a code block) come in as plain text instead of carrying fonts, colors, and backgrounds.
- Replace the new-task footer's plain-text Cancel/Create with compact buttons that surface their shortcuts inline (Esc, ⌘↵ / ⌃↵) via Phosphor command, control, and arrow-elbow-down-left icons.
- Make the create-button shortcut hint field-aware: plain ↵ while the title is focused, ⌘↵ / ⌃↵ while the description is focused.
- Reorder the footer so Tab from the description lands on Create first while Cancel stays visually on the left.
- Stop Escape from toggling the kanban board; Cmd/Ctrl+T is the only board toggle, so it no longer fights the new-task form's Escape reset.
- Swap the wider Linux "Ctrl+" text for the ⌃ glyph in the terminal header stack-position chip, the empty-stack New Task / Board hints, and the home-view "open a terminal" hint.