### PR TITLE
Polish first-run onboarding: unified opt-in, stuck recovery, simpler state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,6 +219,17 @@ export function App() {
     setShowNewProject(true);
   }, []);
 
+  useEffect(() => {
+    const onAddExisting = () => handleAddExisting();
+    const onCreateNew = () => handleCreateNew();
+    document.addEventListener('add-existing-project', onAddExisting);
+    document.addEventListener('create-new-project', onCreateNew);
+    return () => {
+      document.removeEventListener('add-existing-project', onAddExisting);
+      document.removeEventListener('create-new-project', onCreateNew);
+    };
+  }, [handleAddExisting, handleCreateNew]);
+
   const handleNewProjectClose = useCallback(
     async (result: { created: boolean; projectName?: string; projectPath?: string } | null) => {
       setShowNewProject(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -205,10 +205,15 @@ export function App() {
   const handleAddExisting = useCallback(async () => {
     const result = await window.api.showFolderPicker();
     if (!result.canceled && result.filePaths.length > 0) {
-      const addResult = await window.api.addProject(result.filePaths[0]);
+      const addedPath = result.filePaths[0];
+      const addResult = await window.api.addProject(addedPath);
       if (addResult.success) {
         const projects = await window.api.refreshProjects();
         useAppStore.getState().setProjects(projects);
+        const project = projects.find((p) => p.path === addedPath);
+        if (project) {
+          useAppStore.getState().navigateToProject(addedPath, project);
+        }
       } else if (addResult.error) {
         useProjectStore.getState().addToast(addResult.error, 'error');
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { ProjectView } from './components/ProjectViewReact';
 import { ToastContainer } from './components/ui/ToastContainer';
 import { NewProjectDialog } from './components/dialogs/NewProjectDialog';
 import { WhatsNewDialog } from './components/dialogs/WhatsNewDialog';
+import { HelpDialog } from './components/dialogs/HelpDialog';
 import { installCaptureNavigator } from './capture/navigator';
 import { hydrateTerminalFont } from './components/terminal/terminalReact';
 import { installSessionAutoSave } from './components/terminal/sessionSnapshot';
@@ -62,6 +63,7 @@ export function App() {
   const activeView = useAppStore((s) => s.activeView);
   const activeProjectPath = useAppStore((s) => s.activeProjectPath);
   const whatsNew = useAppStore((s) => s.whatsNew);
+  const helpDialogOpen = useAppStore((s) => s.helpDialogOpen);
   const homeActivePanel = useAppStore((s) => s.homeActivePanel);
   const [showNewProject, setShowNewProject] = useState(false);
   const [initialized, setInitialized] = useState(false);
@@ -270,6 +272,7 @@ export function App() {
           onClose={() => useAppStore.getState().setWhatsNew(null)}
         />
       )}
+      {helpDialogOpen && <HelpDialog onClose={() => useAppStore.getState().setHelpDialogOpen(false)} />}
     </div>
   );
 }

--- a/src/__tests__/onboardingState.test.ts
+++ b/src/__tests__/onboardingState.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ONBOARDING_STATE_KEY,
+  ONBOARDING_STATE_VERSION,
+  mergeOnboardingPatch,
+  normalizeOnboardingState,
+  patchOnboardingState,
+  readOnboardingState,
+  serializeOnboardingState,
+  type OnboardingStorageIO,
+} from '../onboardingState';
+import type { OnboardingState } from '../types';
+
+const VALID_STATE: OnboardingState = {
+  version: ONBOARDING_STATE_VERSION,
+  firstProjectPath: '/some/path',
+  source: 'created',
+  seededTaskNumber: 42,
+  dismissed: false,
+};
+
+describe('normalizeOnboardingState', () => {
+  it('returns null for missing input', () => {
+    expect(normalizeOnboardingState(null)).toBeNull();
+    expect(normalizeOnboardingState(undefined)).toBeNull();
+    expect(normalizeOnboardingState('')).toBeNull();
+  });
+
+  it('returns null for non-JSON input', () => {
+    expect(normalizeOnboardingState('not-json')).toBeNull();
+    expect(normalizeOnboardingState('{')).toBeNull();
+  });
+
+  it('returns null for non-object JSON', () => {
+    expect(normalizeOnboardingState('null')).toBeNull();
+    expect(normalizeOnboardingState('42')).toBeNull();
+    expect(normalizeOnboardingState('"a string"')).toBeNull();
+  });
+
+  it('fills missing fields with defaults', () => {
+    const result = normalizeOnboardingState('{}');
+    expect(result).toEqual({
+      version: ONBOARDING_STATE_VERSION,
+      firstProjectPath: '',
+      source: 'added',
+      seededTaskNumber: null,
+      dismissed: false,
+    });
+  });
+
+  it('coerces an invalid source to the default', () => {
+    const result = normalizeOnboardingState(JSON.stringify({ source: 'garbage' }));
+    expect(result?.source).toBe('added');
+  });
+
+  it('coerces a non-number seededTaskNumber to null', () => {
+    expect(normalizeOnboardingState(JSON.stringify({ seededTaskNumber: '42' }))?.seededTaskNumber).toBeNull();
+    expect(normalizeOnboardingState(JSON.stringify({ seededTaskNumber: null }))?.seededTaskNumber).toBeNull();
+  });
+
+  it('treats a non-true dismissed as false', () => {
+    expect(normalizeOnboardingState(JSON.stringify({ dismissed: 1 }))?.dismissed).toBe(false);
+    expect(normalizeOnboardingState(JSON.stringify({ dismissed: 'yes' }))?.dismissed).toBe(false);
+    expect(normalizeOnboardingState(JSON.stringify({ dismissed: true }))?.dismissed).toBe(true);
+  });
+
+  it('round-trips a valid state', () => {
+    const result = normalizeOnboardingState(serializeOnboardingState(VALID_STATE));
+    expect(result).toEqual(VALID_STATE);
+  });
+
+  it('overwrites a stale version with the current one', () => {
+    const result = normalizeOnboardingState(JSON.stringify({ ...VALID_STATE, version: 999 }));
+    expect(result?.version).toBe(ONBOARDING_STATE_VERSION);
+  });
+});
+
+describe('mergeOnboardingPatch', () => {
+  it('merges over a null current with defaults', () => {
+    const result = mergeOnboardingPatch(null, { firstProjectPath: '/x' });
+    expect(result.firstProjectPath).toBe('/x');
+    expect(result.source).toBe('added');
+    expect(result.dismissed).toBe(false);
+  });
+
+  it('preserves untouched fields from the current state', () => {
+    const result = mergeOnboardingPatch(VALID_STATE, { dismissed: true });
+    expect(result.firstProjectPath).toBe(VALID_STATE.firstProjectPath);
+    expect(result.seededTaskNumber).toBe(VALID_STATE.seededTaskNumber);
+    expect(result.dismissed).toBe(true);
+  });
+
+  it('always stamps the current version even if patch tries to override it', () => {
+    const result = mergeOnboardingPatch(VALID_STATE, { version: 999 as number });
+    expect(result.version).toBe(ONBOARDING_STATE_VERSION);
+  });
+});
+
+function makeFakeIO(initial: Record<string, string> = {}): OnboardingStorageIO & { store: Record<string, string> } {
+  const store: Record<string, string> = { ...initial };
+  return {
+    store,
+    get: async (key) => store[key],
+    set: async (key, value) => {
+      store[key] = value;
+      return { success: true };
+    },
+  };
+}
+
+describe('readOnboardingState', () => {
+  it('returns null when nothing is stored', async () => {
+    const io = makeFakeIO();
+    expect(await readOnboardingState(io)).toBeNull();
+  });
+
+  it('returns the parsed state when stored', async () => {
+    const io = makeFakeIO({ [ONBOARDING_STATE_KEY]: serializeOnboardingState(VALID_STATE) });
+    expect(await readOnboardingState(io)).toEqual(VALID_STATE);
+  });
+
+  it('returns null for invalid stored JSON', async () => {
+    const io = makeFakeIO({ [ONBOARDING_STATE_KEY]: 'not-json' });
+    expect(await readOnboardingState(io)).toBeNull();
+  });
+});
+
+describe('patchOnboardingState', () => {
+  it('initializes state from defaults when none exists', async () => {
+    const io = makeFakeIO();
+    const next = await patchOnboardingState(io, { firstProjectPath: '/p', source: 'created' });
+    expect(next.firstProjectPath).toBe('/p');
+    expect(next.source).toBe('created');
+    expect(next.dismissed).toBe(false);
+    // Persisted under the right key
+    expect(io.store[ONBOARDING_STATE_KEY]).toBeDefined();
+  });
+
+  it('merges patches into existing state', async () => {
+    const io = makeFakeIO({ [ONBOARDING_STATE_KEY]: serializeOnboardingState(VALID_STATE) });
+    const next = await patchOnboardingState(io, { dismissed: true });
+    expect(next.dismissed).toBe(true);
+    expect(next.firstProjectPath).toBe(VALID_STATE.firstProjectPath);
+    expect(next.seededTaskNumber).toBe(VALID_STATE.seededTaskNumber);
+  });
+
+  it('persists the merged state back to storage', async () => {
+    const io = makeFakeIO();
+    await patchOnboardingState(io, { seededTaskNumber: 7 });
+    const reparsed = normalizeOnboardingState(io.store[ONBOARDING_STATE_KEY]);
+    expect(reparsed?.seededTaskNumber).toBe(7);
+  });
+});

--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -11,7 +11,6 @@ import { useTerminalPanels } from './terminal/useTerminalPanels';
 import { useHookStatusListener } from '../hooks/useHookStatusListener';
 import { Icon } from './terminal/Icon';
 import { stringToColor, getInitials } from '../utils/projectIcon';
-import { OuijitLogotype } from './OuijitLogotype';
 import { RecentTasksPanel } from './RecentTasksPanel';
 import { ResumeBanner } from './ResumeBanner';
 import type { Project } from '../types';
@@ -311,18 +310,25 @@ export function HomeView() {
             className="absolute inset-0 flex flex-col items-center justify-center rounded-[14px] border border-dashed border-white/10"
             style={{ background: 'var(--color-terminal-bg)' }}
           >
-            <div className="flex flex-col items-center text-center px-8 max-w-[28rem]">
-              <OuijitLogotype className="h-12 w-[14rem] mb-6" />
-              <p className="text-[15px] text-text-secondary leading-relaxed">
-                A local parallel agent terminal manager.
+            <div className="flex flex-col px-8 max-w-[32rem]">
+              <h1 className="text-[22px] font-semibold text-text-primary tracking-tight mb-2">Start a project</h1>
+              <p className="text-[13px] text-text-secondary leading-relaxed mb-7">
+                A project is a folder on your machine. Ouijit tracks its tasks and gives each one its own git worktree.
               </p>
-              <button
-                type="button"
-                className="mt-10 inline-flex items-center justify-center px-6 py-2 font-sans text-sm font-medium border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
-                onClick={() => document.dispatchEvent(new Event('open-add-menu'))}
-              >
-                Add your first project
-              </button>
+              <div className="flex flex-col">
+                <EmptyStateChoice
+                  verb="Open"
+                  noun="a folder you already have"
+                  detail="Stays where it is on disk. Ouijit just starts tracking tasks against it."
+                  onClick={() => document.dispatchEvent(new Event('add-existing-project'))}
+                />
+                <EmptyStateChoice
+                  verb="Create"
+                  noun="a new project"
+                  detail="A fresh folder with git initialized, ready for tasks and agent runs."
+                  onClick={() => document.dispatchEvent(new Event('create-new-project'))}
+                />
+              </div>
             </div>
           </div>
         ) : noRecents ? (
@@ -525,5 +531,32 @@ export function HomeView() {
         );
       })}
     </div>
+  );
+}
+
+interface EmptyStateChoiceProps {
+  verb: string;
+  noun: string;
+  detail: string;
+  onClick: () => void;
+}
+
+function EmptyStateChoice({ verb, noun, detail, onClick }: EmptyStateChoiceProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex items-baseline gap-3 w-full text-left py-3 transition-colors duration-150 ease-out focus-visible:ring-2 focus-visible:ring-accent-light rounded-sm outline-none [-webkit-app-region:no-drag]"
+    >
+      <span className="text-[15px] text-text-tertiary group-hover:text-text-primary transition-colors w-3 shrink-0">
+        →
+      </span>
+      <span className="flex-1 min-w-0">
+        <span className="text-[14px] text-text-primary">
+          <span className="font-semibold">{verb}</span> <span className="text-text-secondary">{noun}.</span>
+        </span>
+        <span className="block text-[12px] text-text-tertiary mt-0.5 leading-relaxed">{detail}</span>
+      </span>
+    </button>
   );
 }

--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -311,21 +311,18 @@ export function HomeView() {
             style={{ background: 'var(--color-terminal-bg)' }}
           >
             <div className="flex flex-col px-8 max-w-[32rem]">
-              <h1 className="text-[22px] font-semibold text-text-primary tracking-tight mb-2">Start a project</h1>
-              <p className="text-[13px] text-text-secondary leading-relaxed mb-7">
-                A project is a folder on your machine. Ouijit tracks its tasks and gives each one its own git worktree.
-              </p>
+              <h1 className="text-[22px] font-semibold text-text-primary tracking-tight mb-6">Start a project</h1>
               <div className="flex flex-col">
                 <EmptyStateChoice
                   verb="Open"
                   noun="a folder you already have"
-                  detail="Stays where it is on disk. Ouijit just starts tracking tasks against it."
+                  detail="Brings an existing folder into Ouijit as a project."
                   onClick={() => document.dispatchEvent(new Event('add-existing-project'))}
                 />
                 <EmptyStateChoice
                   verb="Create"
                   noun="a new project"
-                  detail="A fresh folder with git initialized, ready for tasks and agent runs."
+                  detail="Creates a new folder, initialized as a git repo."
                   onClick={() => document.dispatchEvent(new Event('create-new-project'))}
                 />
               </div>

--- a/src/components/TitleBarReact.tsx
+++ b/src/components/TitleBarReact.tsx
@@ -168,12 +168,20 @@ export function TitleBar({ mode }: TitleBarProps) {
                 <Icon name="terminal" />
               </button>
             </Tooltip>
-            <Tooltip text="New task" placement="bottom-end">
+            <Tooltip text="New task" placement="bottom">
               <button
                 className="w-9 h-9 flex items-center justify-center bg-background-secondary glass-bevel relative border border-black/60 rounded-[14px] text-text-secondary transition-all duration-150 ease-out ml-3 [-webkit-app-region:no-drag] hover:bg-background-tertiary hover:text-text-primary [&>svg]:w-5 [&>svg]:h-5"
                 onClick={handleNewTask}
               >
                 <Icon name="plus" />
+              </button>
+            </Tooltip>
+            <Tooltip text="Help &amp; setup" placement="bottom-end">
+              <button
+                className="w-9 h-9 flex items-center justify-center bg-background-secondary glass-bevel relative border border-black/60 rounded-[14px] text-text-secondary transition-all duration-150 ease-out ml-3 [-webkit-app-region:no-drag] hover:bg-background-tertiary hover:text-text-primary [&>svg]:w-5 [&>svg]:h-5"
+                onClick={() => useAppStore.getState().setHelpDialogOpen(true)}
+              >
+                <Icon name="question" />
               </button>
             </Tooltip>
           </div>

--- a/src/components/TitleBarReact.tsx
+++ b/src/components/TitleBarReact.tsx
@@ -168,20 +168,12 @@ export function TitleBar({ mode }: TitleBarProps) {
                 <Icon name="terminal" />
               </button>
             </Tooltip>
-            <Tooltip text="New task" placement="bottom">
+            <Tooltip text="New task" placement="bottom-end">
               <button
                 className="w-9 h-9 flex items-center justify-center bg-background-secondary glass-bevel relative border border-black/60 rounded-[14px] text-text-secondary transition-all duration-150 ease-out ml-3 [-webkit-app-region:no-drag] hover:bg-background-tertiary hover:text-text-primary [&>svg]:w-5 [&>svg]:h-5"
                 onClick={handleNewTask}
               >
                 <Icon name="plus" />
-              </button>
-            </Tooltip>
-            <Tooltip text="Help &amp; setup" placement="bottom-end">
-              <button
-                className="w-9 h-9 flex items-center justify-center bg-background-secondary glass-bevel relative border border-black/60 rounded-[14px] text-text-secondary transition-all duration-150 ease-out ml-3 [-webkit-app-region:no-drag] hover:bg-background-tertiary hover:text-text-primary [&>svg]:w-5 [&>svg]:h-5"
-                onClick={() => useAppStore.getState().setHelpDialogOpen(true)}
-              >
-                <Icon name="question" />
               </button>
             </Tooltip>
           </div>

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -69,6 +69,7 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
               />
               <HealthRow ok={health.claude} label="claude" hint="not on PATH" />
               <HealthRow ok={health.codex} label="codex" hint="not on PATH" />
+              <HealthRow ok={health.pi} label="pi" hint="not on PATH" />
             </div>
           ) : (
             <div className="text-xs text-text-tertiary">Checking…</div>

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -1,0 +1,119 @@
+import { useState, useEffect, useCallback } from 'react';
+import { DialogOverlay } from './DialogOverlay';
+import { Icon } from '../terminal/Icon';
+import type { HealthStatus } from '../../healthCheck';
+
+interface HelpDialogProps {
+  onClose: () => void;
+}
+
+interface CliExample {
+  command: string;
+  desc: string;
+}
+
+const CLI_EXAMPLES: CliExample[] = [
+  { command: 'ouijit task current', desc: 'Show the task this terminal owns' },
+  { command: 'ouijit task list', desc: 'List all tasks' },
+  { command: 'ouijit task set-status <n> in_review', desc: 'Move a task to In Review' },
+  { command: 'ouijit task create "<name>"', desc: 'Create a new task' },
+  { command: 'ouijit tag add <n> <tag>', desc: 'Tag a task' },
+  { command: 'ouijit hook list', desc: 'Show configured project hooks' },
+];
+
+function HealthRow({ ok, label, hint }: { ok: boolean; label: string; hint?: string }) {
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span
+        className="shrink-0 w-2 h-2 rounded-full"
+        style={{ background: ok ? 'rgb(48, 209, 88)' : 'rgb(255, 159, 10)' }}
+      />
+      <span className="text-text-primary font-medium w-20 shrink-0">{label}</span>
+      <span className="text-text-secondary">{ok ? 'installed' : hint || 'not found'}</span>
+    </div>
+  );
+}
+
+export function HelpDialog({ onClose }: HelpDialogProps) {
+  const [visible, setVisible] = useState(false);
+  const [health, setHealth] = useState<HealthStatus | null>(null);
+
+  useEffect(() => {
+    requestAnimationFrame(() => setVisible(true));
+    window.api.health.check().then(setHealth);
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setVisible(false);
+    setTimeout(() => onClose(), 200);
+  }, [onClose]);
+
+  return (
+    <DialogOverlay visible={visible} onDismiss={dismiss} maxWidth={520}>
+      <div className="flex items-center gap-2 mb-1">
+        <div className="w-7 h-7 rounded-full flex items-center justify-center text-text-secondary [&>svg]:w-4 [&>svg]:h-4 bg-white/5">
+          <Icon name="question" />
+        </div>
+        <h2 className="text-lg font-semibold text-text-primary">Help &amp; Setup</h2>
+      </div>
+
+      <div className="max-h-[65vh] overflow-y-auto pr-1 -mr-1">
+        <section className="mt-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-text-tertiary mb-2">Environment</h3>
+          {health ? (
+            <div className="flex flex-col gap-1.5">
+              <HealthRow
+                ok={health.git}
+                label="git"
+                hint="install via `xcode-select --install` (macOS) or your package manager"
+              />
+              <HealthRow ok={health.claude} label="claude" hint="not on PATH" />
+              <HealthRow ok={health.codex} label="codex" hint="not on PATH" />
+            </div>
+          ) : (
+            <div className="text-xs text-text-tertiary">Checking…</div>
+          )}
+        </section>
+
+        <section className="mt-5">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-text-tertiary mb-2">Connect a CLI agent</h3>
+          <p className="text-xs text-text-secondary leading-relaxed">
+            Configure a <span className="text-text-primary font-medium">start hook</span> on the kanban board (the chip
+            on the In Progress column). When you drag a task to In Progress, Ouijit creates a git worktree and runs your
+            hook script with <code className="px-1 py-0.5 rounded bg-white/5 font-mono">OUIJIT_TASK_PROMPT</code> set to
+            the task description. A typical hook just launches your agent:{' '}
+            <code className="px-1 py-0.5 rounded bg-white/5 font-mono">claude</code> or{' '}
+            <code className="px-1 py-0.5 rounded bg-white/5 font-mono">codex</code>.
+          </p>
+        </section>
+
+        <section className="mt-5">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-text-tertiary mb-2">The ouijit CLI</h3>
+          <p className="text-xs text-text-secondary leading-relaxed mb-2">
+            Every task terminal has <code className="px-1 py-0.5 rounded bg-white/5 font-mono">OUIJIT_API_URL</code> and{' '}
+            <code className="px-1 py-0.5 rounded bg-white/5 font-mono">OUIJIT_PTY_ID</code> pre-set, so the{' '}
+            <code className="px-1 py-0.5 rounded bg-white/5 font-mono">ouijit</code> CLI works without setup. Your agent
+            can use it to drive the board.
+          </p>
+          <div className="flex flex-col gap-1.5 mt-3 font-mono text-[11px]">
+            {CLI_EXAMPLES.map((ex) => (
+              <div key={ex.command} className="flex items-baseline gap-3">
+                <code className="px-1.5 py-0.5 rounded bg-white/5 text-text-primary shrink-0">{ex.command}</code>
+                <span className="text-text-tertiary text-xs">{ex.desc}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      <div className="flex justify-end mt-5">
+        <button
+          className="inline-flex items-center justify-center gap-2 px-5 py-1.5 font-sans text-sm font-medium border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
+          onClick={dismiss}
+        >
+          Got it
+        </button>
+      </div>
+    </DialogOverlay>
+  );
+}

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -80,21 +80,18 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
           <h3 className="text-xs font-semibold uppercase tracking-wide text-text-tertiary mb-2">Connect a CLI agent</h3>
           <p className="text-xs text-text-secondary leading-relaxed">
             Configure a <span className="text-text-primary font-medium">start hook</span> on the kanban board (the chip
-            on the In Progress column). When you drag a task to In Progress, Ouijit creates a git worktree and runs your
-            hook script with <code className="px-1 py-0.5 rounded bg-white/5 font-mono">OUIJIT_TASK_PROMPT</code> set to
-            the task description. A typical hook just launches your agent:{' '}
-            <code className="px-1 py-0.5 rounded bg-white/5 font-mono">claude</code> or{' '}
-            <code className="px-1 py-0.5 rounded bg-white/5 font-mono">codex</code>.
+            on the In Progress column). A start hook is the command that runs when you drag a task to In Progress.
+            Usually it&apos;s just your agent: <code className="px-1 py-0.5 rounded bg-white/5 font-mono">claude</code>{' '}
+            or <code className="px-1 py-0.5 rounded bg-white/5 font-mono">codex</code>. The task description is passed
+            in as the prompt, and the agent figures out the rest using the{' '}
+            <code className="px-1 py-0.5 rounded bg-white/5 font-mono">ouijit</code> CLI.
           </p>
         </section>
 
         <section className="mt-5">
           <h3 className="text-xs font-semibold uppercase tracking-wide text-text-tertiary mb-2">The ouijit CLI</h3>
           <p className="text-xs text-text-secondary leading-relaxed mb-2">
-            Every task terminal has <code className="px-1 py-0.5 rounded bg-white/5 font-mono">OUIJIT_API_URL</code> and{' '}
-            <code className="px-1 py-0.5 rounded bg-white/5 font-mono">OUIJIT_PTY_ID</code> pre-set, so the{' '}
-            <code className="px-1 py-0.5 rounded bg-white/5 font-mono">ouijit</code> CLI works without setup. Your agent
-            can use it to drive the board.
+            Available in every task terminal. Your agent uses it to read and update the board.
           </p>
           <div className="flex flex-col gap-1.5 mt-3 font-mono text-[11px]">
             {CLI_EXAMPLES.map((ex) => (

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -22,7 +22,9 @@ import { beginTransition, bulkTransitionTasks, surfaceStartWarnings } from '../.
 import { completeTask } from '../../services/taskCompletion';
 import { KanbanColumn } from './KanbanColumn';
 import { BulkActionBar } from './BulkActionBar';
+import { OnboardingPanel } from './OnboardingPanel';
 import { focusKanbanAddInput } from './KanbanAddInput';
+import { useAppStore } from '../../stores/appStore';
 import { HookConfigDialog } from '../dialogs/HookConfigDialog';
 import { CombinedHookConfigDialog } from '../dialogs/CombinedHookConfigDialog';
 import { MissingWorktreeDialog } from '../dialogs/MissingWorktreeDialog';
@@ -699,6 +701,11 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
             onClose={handleHookDialogClose}
           />
         )}
+        <OnboardingPanel
+          projectPath={projectPath}
+          onConfigureCliAgent={() => handleConfigureHook(['start', 'continue'])}
+          onOpenHelp={() => useAppStore.getState().setHelpDialogOpen(true)}
+        />
         <div className="flex flex-1 min-h-0" style={{ overflowX: 'auto', overflowY: 'hidden' }}>
           {COLUMNS.map((col) => {
             const hookActive =

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState, useMemo } from 'react';
+import { Icon } from '../terminal/Icon';
+import { useProjectStore } from '../../stores/projectStore';
+
+interface OnboardingPanelProps {
+  projectPath: string;
+  onConfigureCliAgent: () => void;
+  onOpenHelp: () => void;
+}
+
+const SEEDED_KEY = 'onboarding:seededProject';
+const DISMISSED_KEY = 'onboarding:dismissed';
+
+/**
+ * First-run onboarding banner shown above the kanban columns on the single
+ * project that received the seeded tutorial task. Disappears once the user
+ * dismisses or once any task is in progress.
+ */
+export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }: OnboardingPanelProps) {
+  const tasks = useProjectStore((s) => s.tasks);
+  const [seededProject, setSeededProject] = useState<string | undefined>(undefined);
+  const [dismissed, setDismissed] = useState<boolean | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([window.api.globalSettings.get(SEEDED_KEY), window.api.globalSettings.get(DISMISSED_KEY)]).then(
+      ([seeded, dismissedVal]) => {
+        if (cancelled) return;
+        setSeededProject(seeded ?? undefined);
+        setDismissed(dismissedVal === '1');
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hasStartedAnyTask = useMemo(
+    () => tasks.some((t) => t.status === 'in_progress' || t.status === 'in_review' || t.status === 'done'),
+    [tasks],
+  );
+
+  if (seededProject === undefined || dismissed === undefined) return null;
+  if (seededProject !== projectPath) return null;
+  if (dismissed) return null;
+  if (hasStartedAnyTask) return null;
+
+  const handleDismiss = async () => {
+    setDismissed(true);
+    await window.api.globalSettings.set(DISMISSED_KEY, '1');
+  };
+
+  return (
+    <div
+      className="mx-3 mt-3 mb-2 px-4 py-3 rounded-[12px] border border-white/10 flex items-start gap-3"
+      style={{ background: 'rgba(255, 255, 255, 0.03)' }}
+    >
+      <div
+        className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center text-accent [&>svg]:w-5 [&>svg]:h-5"
+        style={{ background: 'rgba(10, 132, 255, 0.12)' }}
+      >
+        <Icon name="rocket" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-text-primary mb-1">Welcome to Ouijit</div>
+        <div className="text-xs text-text-secondary leading-relaxed mb-3">
+          We seeded a tutorial task below. Set up a start hook to launch your CLI agent (Claude, Codex, etc.), then drag
+          the tutorial card to In Progress. The agent will use the{' '}
+          <code className="px-1 py-0.5 rounded bg-white/5 font-mono">ouijit</code> CLI to drive the board itself. Watch
+          the card move across columns live.
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <button
+            className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
+            onClick={onConfigureCliAgent}
+          >
+            <Icon name="terminal" className="w-3.5 h-3.5" />
+            Set up your CLI agent
+          </button>
+          <button
+            className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
+            onClick={onOpenHelp}
+          >
+            <Icon name="question" className="w-3.5 h-3.5" />
+            Need help?
+          </button>
+        </div>
+      </div>
+      <button
+        className="shrink-0 w-7 h-7 flex items-center justify-center rounded-full text-text-tertiary hover:text-text-primary hover:bg-white/10 transition-colors [&>svg]:w-4 [&>svg]:h-4"
+        onClick={handleDismiss}
+        aria-label="Dismiss onboarding"
+      >
+        <Icon name="x" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -9,11 +9,14 @@ interface OnboardingPanelProps {
 }
 
 const FIRST_PROJECT_KEY = 'onboarding:firstProjectPath';
+const FIRST_PROJECT_SOURCE_KEY = 'onboarding:firstProjectSource';
 const SEEDED_TASK_NUMBER_KEY = 'onboarding:seededTaskNumber';
-const SEEDED_ON_DEMAND_KEY = 'onboarding:seededOnDemand';
 const DISMISSED_KEY = 'onboarding:dismissed';
 
+const EXAMPLE_START_HOOK_COMMAND = `claude "complete the current task and move it to in-review"`;
+
 type Stage = 'intro' | 'setup' | 'in-flight' | 'complete';
+type FirstProjectSource = 'created' | 'added';
 
 /**
  * First-run onboarding banner. Walks the user through configuring a start
@@ -25,23 +28,28 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
   const tasks = useProjectStore((s) => s.tasks);
   const startHookConfigured = useProjectStore((s) => !!s.configuredHooks.start);
   const [firstProject, setFirstProject] = useState<string | undefined>(undefined);
+  const [firstProjectSource, setFirstProjectSource] = useState<FirstProjectSource | undefined>(undefined);
   const [seededTaskNumber, setSeededTaskNumber] = useState<number | undefined>(undefined);
-  const [seededOnDemand, setSeededOnDemand] = useState(false);
   const [dismissed, setDismissed] = useState<boolean | undefined>(undefined);
+  // Session-only soft dismiss: used when the user hits X at intro. Hides the
+  // panel for this mount but doesn't write to global settings, so the panel
+  // reappears on next app launch / project switch. Only the intro stage uses
+  // this; later stages set the persisted `dismissed` flag.
+  const [softDismissed, setSoftDismissed] = useState(false);
   const [seeding, setSeeding] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     Promise.all([
       window.api.globalSettings.get(FIRST_PROJECT_KEY),
+      window.api.globalSettings.get(FIRST_PROJECT_SOURCE_KEY),
       window.api.globalSettings.get(SEEDED_TASK_NUMBER_KEY),
-      window.api.globalSettings.get(SEEDED_ON_DEMAND_KEY),
       window.api.globalSettings.get(DISMISSED_KEY),
-    ]).then(([first, taskNum, onDemand, dismissedVal]) => {
+    ]).then(([first, source, taskNum, dismissedVal]) => {
       if (cancelled) return;
       setFirstProject(first ?? undefined);
+      setFirstProjectSource(source === 'created' || source === 'added' ? source : undefined);
       setSeededTaskNumber(taskNum ? Number(taskNum) : undefined);
-      setSeededOnDemand(onDemand === '1');
       setDismissed(dismissedVal === '1');
     });
     return () => {
@@ -62,12 +70,34 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
     return 'complete';
   }, [seededTaskNumber, seededTask]);
 
+  // "Stuck" = task entered in_progress without a start hook configured, so
+  // nothing actually fired. We latch this so re-configuring the hook after
+  // the fact doesn't silently flip the stage display — the user still needs
+  // to drag back and forward to retrigger.
+  const [stuckLatched, setStuckLatched] = useState(false);
+  useEffect(() => {
+    if (stage === 'in-flight' && !startHookConfigured && !stuckLatched) {
+      setStuckLatched(true);
+    }
+    if (stage === 'setup' || stage === 'intro' || stage === 'complete') {
+      // Task moved out of in_progress: clear the latch so a subsequent
+      // forward drag re-evaluates cleanly.
+      if (stuckLatched) setStuckLatched(false);
+    }
+  }, [stage, startHookConfigured, stuckLatched]);
+
   if (firstProject === undefined || dismissed === undefined) return null;
   if (firstProject !== projectPath) return null;
-  if (dismissed) return null;
+  if (dismissed || softDismissed) return null;
   if (stage === null) return null;
 
   const handleDismiss = async () => {
+    if (stage === 'intro') {
+      // Soft dismiss: hide for this session, but allow the panel to return on
+      // next launch so a casually-dismissed first-run user isn't stranded.
+      setSoftDismissed(true);
+      return;
+    }
     setDismissed(true);
     await window.api.globalSettings.set(DISMISSED_KEY, '1');
   };
@@ -79,24 +109,48 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
     await useProjectStore.getState().loadTasks(projectPath);
     const taskNum = await window.api.globalSettings.get(SEEDED_TASK_NUMBER_KEY);
     if (taskNum) setSeededTaskNumber(Number(taskNum));
-    setSeededOnDemand(true);
     setSeeding(false);
+  };
+
+  const handleMoveBackToTodo = async () => {
+    if (!seededTask) return;
+    await useProjectStore.getState().moveTask(projectPath, seededTask.taskNumber, 'todo', 0);
+  };
+
+  const handleUseExampleHook = async () => {
+    await window.api.hooks.save(projectPath, {
+      id: `hook-${Date.now()}`,
+      type: 'start',
+      name: 'Start Hook',
+      command: EXAMPLE_START_HOOK_COMMAND,
+    });
+    await useProjectStore.getState().loadProjectConfig(projectPath);
+    useProjectStore.getState().addToast('Start hook configured', 'success');
   };
 
   const renderStageBody = (s: Stage) => (
     <>
-      {s === 'intro' && <IntroStage />}
-      {s === 'setup' && <SetupStage configured={startHookConfigured} viaIntro={seededOnDemand} />}
-      {s === 'in-flight' && <InFlightStage />}
+      {s === 'intro' && <IntroStage source={firstProjectSource} />}
+      {s === 'setup' && <SetupStage configured={startHookConfigured} onUseExampleHook={handleUseExampleHook} />}
+      {s === 'in-flight' && (
+        <InFlightStage
+          stuck={stuckLatched}
+          startHookConfigured={startHookConfigured}
+          onConfigureCliAgent={onConfigureCliAgent}
+          onMoveBackToTodo={handleMoveBackToTodo}
+        />
+      )}
       {s === 'complete' && <CompleteStage />}
       <StageCtas
         stage={s}
         startHookConfigured={startHookConfigured}
         seeding={seeding}
+        stuck={s === 'in-flight' && stuckLatched}
         onConfigureCliAgent={onConfigureCliAgent}
         onOpenHelp={onOpenHelp}
         onDismiss={handleDismiss}
         onSeedPracticeTask={handleSeedPracticeTask}
+        onMoveBackToTodo={handleMoveBackToTodo}
       />
     </>
   );
@@ -112,7 +166,8 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
       <button
         className="shrink-0 w-7 h-7 flex items-center justify-center rounded-full text-text-tertiary hover:text-text-primary hover:bg-white/10 transition-colors [&>svg]:w-4 [&>svg]:h-4"
         onClick={handleDismiss}
-        aria-label="Dismiss onboarding"
+        aria-label={stage === 'intro' ? 'Hide onboarding for now' : 'Dismiss onboarding'}
+        title={stage === 'intro' ? 'Hide for now' : 'Dismiss'}
       >
         <Icon name="x" />
       </button>
@@ -158,20 +213,24 @@ interface StageCtasProps {
   stage: Stage;
   startHookConfigured: boolean;
   seeding: boolean;
+  stuck: boolean;
   onConfigureCliAgent: () => void;
   onOpenHelp: () => void;
   onDismiss: () => void;
   onSeedPracticeTask: () => void;
+  onMoveBackToTodo: () => void;
 }
 
 function StageCtas({
   stage,
   startHookConfigured,
   seeding,
+  stuck,
   onConfigureCliAgent,
   onOpenHelp,
   onDismiss,
   onSeedPracticeTask,
+  onMoveBackToTodo,
 }: StageCtasProps) {
   return (
     <div className="flex items-center gap-2 flex-wrap mt-4">
@@ -193,7 +252,7 @@ function StageCtas({
           Got it
         </button>
       )}
-      {(stage === 'setup' || stage === 'in-flight') && (
+      {stage === 'setup' && (
         <button
           className={`inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full active:scale-[0.98] transition-all duration-150 ease-out ${
             startHookConfigured
@@ -206,22 +265,42 @@ function StageCtas({
           {startHookConfigured ? 'Edit start hook' : 'Configure start hook'}
         </button>
       )}
+      {stage === 'in-flight' && stuck && !startHookConfigured && (
+        <button
+          className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
+          onClick={onConfigureCliAgent}
+        >
+          <Icon name="terminal" className="w-3.5 h-3.5" />
+          Configure start hook
+        </button>
+      )}
+      {stage === 'in-flight' && stuck && (
+        <button
+          className={`inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full active:scale-[0.98] transition-all duration-150 ease-out ${
+            startHookConfigured
+              ? 'text-white bg-accent hover:bg-accent-hover'
+              : 'text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary'
+          }`}
+          onClick={onMoveBackToTodo}
+        >
+          <Icon name="arrow-left" className="w-3.5 h-3.5" />
+          Move task back to To Do
+        </button>
+      )}
       <button
         className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
         onClick={onOpenHelp}
       >
         <Icon name="question" className="w-3.5 h-3.5" />
-        {stage === 'complete' || stage === 'intro' ? 'Help & setup' : 'Need help?'}
+        Help & setup
       </button>
-      {(stage === 'complete' || stage === 'intro') && (
-        <button
-          className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
-          onClick={() => window.api.openExternal('https://ouijit.com/docs')}
-        >
-          <Icon name="file-text" className="w-3.5 h-3.5" />
-          Docs
-        </button>
-      )}
+      <button
+        className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
+        onClick={() => window.api.openExternal('https://ouijit.com/docs')}
+      >
+        <Icon name="file-text" className="w-3.5 h-3.5" />
+        Docs
+      </button>
     </div>
   );
 }
@@ -259,60 +338,37 @@ function StepBadge({ done, number }: { done: boolean; number: number }) {
   );
 }
 
-function IntroStage() {
+function IntroStage({ source }: { source: FirstProjectSource | undefined }) {
+  const leadVerb = source === 'created' ? 'Created' : 'Added';
   return (
     <>
-      <div className="flex items-center gap-2 mb-3">
+      <div className="flex items-center gap-2 mb-4">
         <StepBadge done={true} number={0} />
-        <div className="text-xs text-text-primary">Added your first project</div>
+        <div className="text-xs text-text-primary">{leadVerb} your first project</div>
       </div>
-      <ul className="flex flex-col gap-1.5 text-xs text-text-secondary leading-relaxed mb-3">
-        <li className="flex gap-2">
-          <span className="text-text-tertiary shrink-0">•</span>
-          <span>Each task gets its own git worktree and branch, so multiple agents can work in parallel.</span>
+      <ol className="flex flex-col gap-3">
+        <li className="flex gap-3">
+          <StepBadge done={false} number={1} />
+          <div className="min-w-0">
+            <div className="text-xs font-medium text-text-primary mb-1">Try a practice task</div>
+            <div className="text-xs text-text-secondary leading-relaxed">
+              A dry run that shows how hooks and the{' '}
+              <code className="px-1 py-0.5 rounded bg-white/5 font-mono text-[11px]">ouijit</code> CLI work together.
+            </div>
+          </div>
         </li>
-        <li className="flex gap-2">
-          <span className="text-text-tertiary shrink-0">•</span>
-          <span>
-            Each column has a hook (start, continue, review, done) that fires on task transitions and can run any
-            command.
-          </span>
-        </li>
-        <li className="flex gap-2">
-          <span className="text-text-tertiary shrink-0">•</span>
-          <span>
-            Supported agents automatically get the{' '}
-            <code className="px-1 py-0.5 rounded bg-white/5 font-mono text-[11px]">ouijit</code> CLI in their context,
-            so they know how to see and manage tasks, hooks, tags, plans, and scripts.
-          </span>
-        </li>
-      </ul>
-      <div className="text-xs text-text-tertiary leading-relaxed">
-        A practice task adds one card with a throwaway prompt. It runs on its own branch and writes a single file you
-        can delete after.
-      </div>
+      </ol>
     </>
   );
 }
 
-function SetupStage({ configured, viaIntro }: { configured: boolean; viaIntro: boolean }) {
+function SetupStage({ configured, onUseExampleHook }: { configured: boolean; onUseExampleHook: () => void }) {
   return (
     <>
-      {viaIntro ? (
-        <>
-          <div className="flex items-center gap-2 mb-4">
-            <StepBadge done={true} number={0} />
-            <div className="text-xs text-text-primary">Practice task added to To Do</div>
-          </div>
-        </>
-      ) : (
-        <>
-          <div className="text-sm font-semibold text-text-primary mb-1">Welcome to your first project in Ouijit</div>
-          <div className="text-xs text-text-secondary leading-relaxed mb-4">
-            A tutorial task is waiting below. Complete it end to end to see how Ouijit works:
-          </div>
-        </>
-      )}
+      <div className="flex items-center gap-2 mb-4">
+        <StepBadge done={true} number={0} />
+        <div className="text-xs text-text-primary">Practice task added to To Do</div>
+      </div>
       <ol className="flex flex-col gap-3">
         <li className="flex gap-3">
           <StepBadge done={configured} number={1} />
@@ -321,14 +377,25 @@ function SetupStage({ configured, viaIntro }: { configured: boolean; viaIntro: b
             <div className="text-xs text-text-secondary leading-relaxed mb-2">
               The command Ouijit runs when a task enters In Progress. For example:
             </div>
-            <div className="flex">
+            <div className="flex items-center gap-2 flex-wrap">
               <code className="inline-block font-mono text-[12px] text-text-primary bg-white/5 rounded-md px-2.5 py-1.5 max-w-full overflow-x-auto whitespace-nowrap">
-                {`claude "complete the current task and move it to in-review"`}
+                {EXAMPLE_START_HOOK_COMMAND}
               </code>
+              {!configured && (
+                <button
+                  type="button"
+                  onClick={onUseExampleHook}
+                  className="inline-flex items-center justify-center gap-1.5 px-2.5 py-1 text-[11px] font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
+                >
+                  Use this
+                </button>
+              )}
             </div>
           </div>
         </li>
-        <li className="flex gap-3">
+        <li
+          className={`flex gap-3 transition-opacity duration-200 ease-out ${configured ? 'opacity-100' : 'opacity-50'}`}
+        >
           <StepBadge done={false} number={2} />
           <div className="min-w-0">
             <div className="text-xs font-medium text-text-primary mb-1">
@@ -344,14 +411,45 @@ function SetupStage({ configured, viaIntro }: { configured: boolean; viaIntro: b
   );
 }
 
-function InFlightStage() {
+interface InFlightStageProps {
+  stuck: boolean;
+  startHookConfigured: boolean;
+  onConfigureCliAgent: () => void;
+  onMoveBackToTodo: () => void;
+}
+
+function InFlightStage({ stuck, startHookConfigured }: InFlightStageProps) {
+  if (stuck) {
+    return (
+      <>
+        <div className="flex items-center gap-2 mb-2">
+          <span className="shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-[11px] font-semibold bg-amber-500/20 text-amber-300">
+            !
+          </span>
+          <div className="text-xs text-text-primary font-medium">
+            {startHookConfigured ? 'Start hook didn’t fire' : 'No start hook configured'}
+          </div>
+        </div>
+        <div className="text-xs text-text-secondary leading-relaxed">
+          {startHookConfigured
+            ? 'The hook was set after the task moved. Move it back to To Do and drag it forward again to run it.'
+            : 'Dragging into In Progress fires the start hook. Set one up, then move the task back to To Do and forward again.'}
+        </div>
+      </>
+    );
+  }
   return (
-    <div className="flex items-center gap-2">
-      <StepBadge done={true} number={0} />
-      <div className="text-xs text-text-primary">
-        &ldquo;Your first task&rdquo; is in <span className="font-medium">In Progress</span>
+    <>
+      <div className="flex items-center gap-2 mb-2">
+        <StepBadge done={true} number={0} />
+        <div className="text-xs text-text-primary">
+          &ldquo;Your first task&rdquo; is in <span className="font-medium">In Progress</span>
+        </div>
       </div>
-    </div>
+      <div className="text-xs text-text-secondary leading-relaxed">
+        The start hook is running. Output is in this task&rsquo;s terminal.
+      </div>
+    </>
   );
 }
 

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -55,19 +55,18 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
       className="mx-3 mt-3 mb-2 px-4 py-3 rounded-[12px] border border-white/10 flex items-start gap-3"
       style={{ background: 'rgba(255, 255, 255, 0.03)' }}
     >
-      <div
-        className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center text-accent [&>svg]:w-5 [&>svg]:h-5"
-        style={{ background: 'rgba(10, 132, 255, 0.12)' }}
-      >
-        <Icon name="rocket" />
-      </div>
       <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium text-text-primary mb-1">Welcome to Ouijit</div>
+        <div className="text-sm font-medium text-text-primary mb-1">Set up a start hook</div>
+        <div className="text-xs text-text-secondary leading-relaxed mb-2">
+          A start hook is the command Ouijit runs when a task enters In Progress. It can be as small as one line that
+          hands the task to your CLI agent. For example:
+        </div>
+        <pre className="text-[11px] font-mono text-text-primary bg-white/5 rounded-md px-2.5 py-1.5 mb-3 overflow-x-auto">
+          <code>{`claude "complete the current task and move it to in-review"`}</code>
+        </pre>
         <div className="text-xs text-text-secondary leading-relaxed mb-3">
-          We seeded a tutorial task below. Set up a start hook to launch your CLI agent (Claude, Codex, etc.), then drag
-          the tutorial card to In Progress. The agent will use the{' '}
-          <code className="px-1 py-0.5 rounded bg-white/5 font-mono">ouijit</code> CLI to drive the board itself. Watch
-          the card move across columns live.
+          We seeded a practice task below. Set up your hook, then drag the card to In Progress and watch your agent take
+          over.
         </div>
         <div className="flex items-center gap-2 flex-wrap">
           <button
@@ -75,7 +74,7 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
             onClick={onConfigureCliAgent}
           >
             <Icon name="terminal" className="w-3.5 h-3.5" />
-            Set up your CLI agent
+            Configure start hook
           </button>
           <button
             className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, useMemo, useRef } from 'react';
 import { Icon } from '../terminal/Icon';
 import { useProjectStore } from '../../stores/projectStore';
+import { type OnboardingStorageIO, patchOnboardingState, readOnboardingState } from '../../onboardingState';
+import type { FirstProjectSource, OnboardingState } from '../../types';
 
 interface OnboardingPanelProps {
   projectPath: string;
@@ -8,15 +10,14 @@ interface OnboardingPanelProps {
   onOpenHelp: () => void;
 }
 
-const FIRST_PROJECT_KEY = 'onboarding:firstProjectPath';
-const FIRST_PROJECT_SOURCE_KEY = 'onboarding:firstProjectSource';
-const SEEDED_TASK_NUMBER_KEY = 'onboarding:seededTaskNumber';
-const DISMISSED_KEY = 'onboarding:dismissed';
-
 const EXAMPLE_START_HOOK_COMMAND = `claude "complete the current task and move it to in-review"`;
 
 type Stage = 'intro' | 'setup' | 'in-flight' | 'complete';
-type FirstProjectSource = 'created' | 'added';
+
+const io: OnboardingStorageIO = {
+  get: (key) => window.api.globalSettings.get(key),
+  set: (key, value) => window.api.globalSettings.set(key, value),
+};
 
 /**
  * First-run onboarding banner. Walks the user through configuring a start
@@ -27,10 +28,8 @@ type FirstProjectSource = 'created' | 'added';
 export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }: OnboardingPanelProps) {
   const tasks = useProjectStore((s) => s.tasks);
   const startHookConfigured = useProjectStore((s) => !!s.configuredHooks.start);
-  const [firstProject, setFirstProject] = useState<string | undefined>(undefined);
-  const [firstProjectSource, setFirstProjectSource] = useState<FirstProjectSource | undefined>(undefined);
-  const [seededTaskNumber, setSeededTaskNumber] = useState<number | undefined>(undefined);
-  const [dismissed, setDismissed] = useState<boolean | undefined>(undefined);
+  // `undefined` = not yet loaded, `null` = loaded but no state exists yet.
+  const [state, setState] = useState<OnboardingState | null | undefined>(undefined);
   // Session-only soft dismiss: used when the user hits X at intro. Hides the
   // panel for this mount but doesn't write to global settings, so the panel
   // reappears on next app launch / project switch. Only the intro stage uses
@@ -40,23 +39,16 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
 
   useEffect(() => {
     let cancelled = false;
-    Promise.all([
-      window.api.globalSettings.get(FIRST_PROJECT_KEY),
-      window.api.globalSettings.get(FIRST_PROJECT_SOURCE_KEY),
-      window.api.globalSettings.get(SEEDED_TASK_NUMBER_KEY),
-      window.api.globalSettings.get(DISMISSED_KEY),
-    ]).then(([first, source, taskNum, dismissedVal]) => {
+    readOnboardingState(io).then((s) => {
       if (cancelled) return;
-      setFirstProject(first ?? undefined);
-      setFirstProjectSource(source === 'created' || source === 'added' ? source : undefined);
-      setSeededTaskNumber(taskNum ? Number(taskNum) : undefined);
-      setDismissed(dismissedVal === '1');
+      setState(s);
     });
     return () => {
       cancelled = true;
     };
   }, []);
 
+  const seededTaskNumber = state?.seededTaskNumber ?? null;
   const seededTask = useMemo(
     () => (seededTaskNumber != null ? tasks.find((t) => t.taskNumber === seededTaskNumber) : undefined),
     [tasks, seededTaskNumber],
@@ -86,9 +78,9 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
     }
   }, [stage, startHookConfigured, stuckLatched]);
 
-  if (firstProject === undefined || dismissed === undefined) return null;
-  if (firstProject !== projectPath) return null;
-  if (dismissed || softDismissed) return null;
+  if (state === undefined) return null;
+  if (!state || state.firstProjectPath !== projectPath) return null;
+  if (state.dismissed || softDismissed) return null;
   if (stage === null) return null;
 
   const handleDismiss = async () => {
@@ -98,8 +90,8 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
       setSoftDismissed(true);
       return;
     }
-    setDismissed(true);
-    await window.api.globalSettings.set(DISMISSED_KEY, '1');
+    const next = await patchOnboardingState(io, { dismissed: true });
+    setState(next);
   };
 
   const handleSeedPracticeTask = async () => {
@@ -107,8 +99,8 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
     setSeeding(true);
     await window.api.onboarding.seedTask(projectPath);
     await useProjectStore.getState().loadTasks(projectPath);
-    const taskNum = await window.api.globalSettings.get(SEEDED_TASK_NUMBER_KEY);
-    if (taskNum) setSeededTaskNumber(Number(taskNum));
+    const next = await readOnboardingState(io);
+    if (next) setState(next);
     setSeeding(false);
   };
 
@@ -130,7 +122,7 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
 
   const renderStageBody = (s: Stage) => (
     <>
-      {s === 'intro' && <IntroStage source={firstProjectSource} />}
+      {s === 'intro' && <IntroStage source={state.source} />}
       {s === 'setup' && <SetupStage configured={startHookConfigured} onUseExampleHook={handleUseExampleHook} />}
       {s === 'in-flight' && (
         <InFlightStage

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo, useRef } from 'react';
 import { Icon } from '../terminal/Icon';
 import { useProjectStore } from '../../stores/projectStore';
+import { useAppStore } from '../../stores/appStore';
 import { type OnboardingStorageIO, patchOnboardingState, readOnboardingState } from '../../onboardingState';
 import type { FirstProjectSource, OnboardingState } from '../../types';
 
@@ -30,11 +31,14 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
   const startHookConfigured = useProjectStore((s) => !!s.configuredHooks.start);
   // `undefined` = not yet loaded, `null` = loaded but no state exists yet.
   const [state, setState] = useState<OnboardingState | null | undefined>(undefined);
-  // Session-only soft dismiss: used when the user hits X at intro. Hides the
-  // panel for this mount but doesn't write to global settings, so the panel
-  // reappears on next app launch / project switch. Only the intro stage uses
-  // this; later stages set the persisted `dismissed` flag.
-  const [softDismissed, setSoftDismissed] = useState(false);
+  // Session-only flags live in the app store so they survive panel unmount
+  // (e.g., user toggles the kanban view off and back on). If these were
+  // useState they'd reset on every remount, which contradicts "Hide for now"
+  // and would lose the stuck-state context too.
+  const softDismissed = useAppStore((s) => s.onboardingSoftDismissed);
+  const stuckLatched = useAppStore((s) => s.onboardingStuckLatched);
+  const setSoftDismissed = useAppStore((s) => s.setOnboardingSoftDismissed);
+  const setStuckLatched = useAppStore((s) => s.setOnboardingStuckLatched);
   const [seeding, setSeeding] = useState(false);
 
   useEffect(() => {
@@ -74,7 +78,6 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
   // the store — startHookConfigured is briefly `false` even when the hook
   // exists. Tracking the previous stage closes that window.
   const prevStageRef = useRef<Stage | undefined>(undefined);
-  const [stuckLatched, setStuckLatched] = useState(false);
   useEffect(() => {
     const prev = prevStageRef.current;
     prevStageRef.current = stage;
@@ -86,7 +89,7 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
       // forward drag re-evaluates cleanly.
       if (stuckLatched) setStuckLatched(false);
     }
-  }, [stage, startHookConfigured, stuckLatched]);
+  }, [stage, startHookConfigured, stuckLatched, setStuckLatched]);
 
   if (state === undefined) return null;
   if (!state || state.firstProjectPath !== projectPath) return null;
@@ -123,14 +126,24 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
   };
 
   const handleUseExampleHook = async () => {
-    await window.api.hooks.save(projectPath, {
-      id: `hook-${Date.now()}`,
-      type: 'start',
-      name: 'Start Hook',
-      command: EXAMPLE_START_HOOK_COMMAND,
-    });
-    await useProjectStore.getState().loadProjectConfig(projectPath);
-    useProjectStore.getState().addToast('Start hook configured', 'success');
+    try {
+      const result = await window.api.hooks.save(projectPath, {
+        id: `hook-${Date.now()}`,
+        type: 'start',
+        name: 'Start Hook',
+        command: EXAMPLE_START_HOOK_COMMAND,
+      });
+      if (!result.success) {
+        useProjectStore.getState().addToast("Couldn't save the start hook", 'error');
+        return;
+      }
+      await useProjectStore.getState().loadProjectConfig(projectPath);
+      useProjectStore.getState().addToast('Start hook configured', 'success');
+    } catch (error) {
+      useProjectStore
+        .getState()
+        .addToast(error instanceof Error ? error.message : "Couldn't save the start hook", 'error');
+    }
   };
 
   const renderStageBody = (s: Stage) => (

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -10,6 +10,7 @@ interface OnboardingPanelProps {
 
 const FIRST_PROJECT_KEY = 'onboarding:firstProjectPath';
 const SEEDED_TASK_NUMBER_KEY = 'onboarding:seededTaskNumber';
+const SEEDED_ON_DEMAND_KEY = 'onboarding:seededOnDemand';
 const DISMISSED_KEY = 'onboarding:dismissed';
 
 type Stage = 'intro' | 'setup' | 'in-flight' | 'complete';
@@ -25,6 +26,7 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
   const startHookConfigured = useProjectStore((s) => !!s.configuredHooks.start);
   const [firstProject, setFirstProject] = useState<string | undefined>(undefined);
   const [seededTaskNumber, setSeededTaskNumber] = useState<number | undefined>(undefined);
+  const [seededOnDemand, setSeededOnDemand] = useState(false);
   const [dismissed, setDismissed] = useState<boolean | undefined>(undefined);
   const [seeding, setSeeding] = useState(false);
 
@@ -33,11 +35,13 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
     Promise.all([
       window.api.globalSettings.get(FIRST_PROJECT_KEY),
       window.api.globalSettings.get(SEEDED_TASK_NUMBER_KEY),
+      window.api.globalSettings.get(SEEDED_ON_DEMAND_KEY),
       window.api.globalSettings.get(DISMISSED_KEY),
-    ]).then(([first, taskNum, dismissedVal]) => {
+    ]).then(([first, taskNum, onDemand, dismissedVal]) => {
       if (cancelled) return;
       setFirstProject(first ?? undefined);
       setSeededTaskNumber(taskNum ? Number(taskNum) : undefined);
+      setSeededOnDemand(onDemand === '1');
       setDismissed(dismissedVal === '1');
     });
     return () => {
@@ -75,13 +79,14 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
     await useProjectStore.getState().loadTasks(projectPath);
     const taskNum = await window.api.globalSettings.get(SEEDED_TASK_NUMBER_KEY);
     if (taskNum) setSeededTaskNumber(Number(taskNum));
+    setSeededOnDemand(true);
     setSeeding(false);
   };
 
   const renderStageBody = (s: Stage) => (
     <>
       {s === 'intro' && <IntroStage />}
-      {s === 'setup' && <SetupStage configured={startHookConfigured} />}
+      {s === 'setup' && <SetupStage configured={startHookConfigured} viaIntro={seededOnDemand} />}
       {s === 'in-flight' && <InFlightStage />}
       {s === 'complete' && <CompleteStage />}
       <StageCtas
@@ -257,7 +262,10 @@ function StepBadge({ done, number }: { done: boolean; number: number }) {
 function IntroStage() {
   return (
     <>
-      <div className="text-sm font-semibold text-text-primary mb-3">How Ouijit runs tasks</div>
+      <div className="flex items-center gap-2 mb-3">
+        <StepBadge done={true} number={0} />
+        <div className="text-xs text-text-primary">Added your first project</div>
+      </div>
       <ul className="flex flex-col gap-1.5 text-xs text-text-secondary leading-relaxed mb-3">
         <li className="flex gap-2">
           <span className="text-text-tertiary shrink-0">•</span>
@@ -287,13 +295,24 @@ function IntroStage() {
   );
 }
 
-function SetupStage({ configured }: { configured: boolean }) {
+function SetupStage({ configured, viaIntro }: { configured: boolean; viaIntro: boolean }) {
   return (
     <>
-      <div className="text-sm font-semibold text-text-primary mb-1">Welcome to your first project in Ouijit</div>
-      <div className="text-xs text-text-secondary leading-relaxed mb-4">
-        A tutorial task is waiting below. Complete it end to end to see how Ouijit works:
-      </div>
+      {viaIntro ? (
+        <>
+          <div className="flex items-center gap-2 mb-4">
+            <StepBadge done={true} number={0} />
+            <div className="text-xs text-text-primary">Practice task added to To Do</div>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="text-sm font-semibold text-text-primary mb-1">Welcome to your first project in Ouijit</div>
+          <div className="text-xs text-text-secondary leading-relaxed mb-4">
+            A tutorial task is waiting below. Complete it end to end to see how Ouijit works:
+          </div>
+        </>
+      )}
       <ol className="flex flex-col gap-3">
         <li className="flex gap-3">
           <StepBadge done={configured} number={1} />
@@ -327,26 +346,12 @@ function SetupStage({ configured }: { configured: boolean }) {
 
 function InFlightStage() {
   return (
-    <>
-      <div className="text-sm font-semibold text-text-primary mb-1">Your agent is working</div>
-      <div className="text-xs text-text-secondary leading-relaxed mb-4">
-        Watch the tutorial task move across the board as your agent runs it.
+    <div className="flex items-center gap-2">
+      <StepBadge done={true} number={0} />
+      <div className="text-xs text-text-primary">
+        &ldquo;Your first task&rdquo; is in <span className="font-medium">In Progress</span>
       </div>
-      <ol className="flex flex-col gap-3">
-        <li className="flex gap-3 opacity-50">
-          <StepBadge done={true} number={1} />
-          <div className="min-w-0 pt-0.5">
-            <div className="text-xs font-medium text-text-primary">Start hook configured</div>
-          </div>
-        </li>
-        <li className="flex gap-3 opacity-50">
-          <StepBadge done={true} number={2} />
-          <div className="min-w-0 pt-0.5">
-            <div className="text-xs font-medium text-text-primary">Tutorial task started</div>
-          </div>
-        </li>
-      </ol>
-    </>
+    </div>
   );
 }
 

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -8,42 +8,58 @@ interface OnboardingPanelProps {
   onOpenHelp: () => void;
 }
 
-const SEEDED_KEY = 'onboarding:seededProject';
+const SEEDED_PROJECT_KEY = 'onboarding:seededProject';
+const SEEDED_TASK_NUMBER_KEY = 'onboarding:seededTaskNumber';
 const DISMISSED_KEY = 'onboarding:dismissed';
 
+type Stage = 'setup' | 'in-flight' | 'complete';
+
 /**
- * First-run onboarding banner shown above the kanban columns on the single
- * project that received the seeded tutorial task. Disappears once the user
- * dismisses or once any task is in progress.
+ * First-run onboarding banner. Walks the user through configuring a start
+ * hook and dragging the seeded tutorial task through the board. Mirrors the
+ * task's lifecycle: setup → in-flight (task in_progress) → complete (task in
+ * in_review or done). Dismissal is permanent via the ✕ or the final CTA.
  */
 export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }: OnboardingPanelProps) {
   const tasks = useProjectStore((s) => s.tasks);
+  const startHookConfigured = useProjectStore((s) => !!s.configuredHooks.start);
   const [seededProject, setSeededProject] = useState<string | undefined>(undefined);
+  const [seededTaskNumber, setSeededTaskNumber] = useState<number | undefined>(undefined);
   const [dismissed, setDismissed] = useState<boolean | undefined>(undefined);
 
   useEffect(() => {
     let cancelled = false;
-    Promise.all([window.api.globalSettings.get(SEEDED_KEY), window.api.globalSettings.get(DISMISSED_KEY)]).then(
-      ([seeded, dismissedVal]) => {
-        if (cancelled) return;
-        setSeededProject(seeded ?? undefined);
-        setDismissed(dismissedVal === '1');
-      },
-    );
+    Promise.all([
+      window.api.globalSettings.get(SEEDED_PROJECT_KEY),
+      window.api.globalSettings.get(SEEDED_TASK_NUMBER_KEY),
+      window.api.globalSettings.get(DISMISSED_KEY),
+    ]).then(([seeded, taskNum, dismissedVal]) => {
+      if (cancelled) return;
+      setSeededProject(seeded ?? undefined);
+      setSeededTaskNumber(taskNum ? Number(taskNum) : undefined);
+      setDismissed(dismissedVal === '1');
+    });
     return () => {
       cancelled = true;
     };
   }, []);
 
-  const hasStartedAnyTask = useMemo(
-    () => tasks.some((t) => t.status === 'in_progress' || t.status === 'in_review' || t.status === 'done'),
-    [tasks],
+  const seededTask = useMemo(
+    () => (seededTaskNumber != null ? tasks.find((t) => t.taskNumber === seededTaskNumber) : undefined),
+    [tasks, seededTaskNumber],
   );
+
+  const stage: Stage | null = useMemo(() => {
+    if (!seededTask) return 'setup';
+    if (seededTask.status === 'todo') return 'setup';
+    if (seededTask.status === 'in_progress') return 'in-flight';
+    return 'complete';
+  }, [seededTask]);
 
   if (seededProject === undefined || dismissed === undefined) return null;
   if (seededProject !== projectPath) return null;
   if (dismissed) return null;
-  if (hasStartedAnyTask) return null;
+  if (stage === null) return null;
 
   const handleDismiss = async () => {
     setDismissed(true);
@@ -56,55 +72,37 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
       style={{ background: 'rgba(255, 255, 255, 0.03)' }}
     >
       <div className="flex-1 min-w-0">
-        <div className="text-sm font-semibold text-text-primary mb-1">Welcome to your first project in Ouijit</div>
-        <div className="text-xs text-text-secondary leading-relaxed mb-4">
-          A tutorial task is waiting below. Complete it end to end to see how Ouijit works:
-        </div>
-        <ol className="flex flex-col gap-3 mb-4">
-          <li className="flex gap-3">
-            <span className="shrink-0 w-5 h-5 rounded-full bg-white/10 text-text-primary text-[11px] font-semibold flex items-center justify-center">
-              1
-            </span>
-            <div className="min-w-0">
-              <div className="text-xs font-medium text-text-primary mb-1">Configure a start hook</div>
-              <div className="text-xs text-text-secondary leading-relaxed mb-2">
-                The command Ouijit runs when a task enters In Progress. For example:
-              </div>
-              <div className="flex">
-                <code className="inline-block font-mono text-[12px] text-text-primary bg-white/5 rounded-md px-2.5 py-1.5 max-w-full overflow-x-auto whitespace-nowrap">
-                  {`claude "complete the current task and move it to in-review"`}
-                </code>
-              </div>
-            </div>
-          </li>
-          <li className="flex gap-3">
-            <span className="shrink-0 w-5 h-5 rounded-full bg-white/10 text-text-primary text-[11px] font-semibold flex items-center justify-center">
-              2
-            </span>
-            <div className="min-w-0">
-              <div className="text-xs font-medium text-text-primary mb-1">
-                Drag &ldquo;Your first task&rdquo; to In Progress
-              </div>
-              <div className="text-xs text-text-secondary leading-relaxed">
-                Your agent picks up the task and drives the board from there.
-              </div>
-            </div>
-          </li>
-        </ol>
-        <div className="flex items-center gap-2 flex-wrap">
-          <button
-            className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
-            onClick={onConfigureCliAgent}
-          >
-            <Icon name="terminal" className="w-3.5 h-3.5" />
-            Configure start hook
-          </button>
+        {stage === 'setup' && <SetupStage configured={startHookConfigured} />}
+        {stage === 'in-flight' && <InFlightStage />}
+        {stage === 'complete' && <CompleteStage />}
+
+        <div className="flex items-center gap-2 flex-wrap mt-4">
+          {stage === 'complete' ? (
+            <button
+              className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
+              onClick={handleDismiss}
+            >
+              Got it
+            </button>
+          ) : (
+            <button
+              className={`inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full active:scale-[0.98] transition-all duration-150 ease-out ${
+                startHookConfigured
+                  ? 'text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary'
+                  : 'text-white bg-accent hover:bg-accent-hover'
+              }`}
+              onClick={onConfigureCliAgent}
+            >
+              <Icon name="terminal" className="w-3.5 h-3.5" />
+              {startHookConfigured ? 'Edit start hook' : 'Configure start hook'}
+            </button>
+          )}
           <button
             className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
             onClick={onOpenHelp}
           >
             <Icon name="question" className="w-3.5 h-3.5" />
-            Need help?
+            {stage === 'complete' ? 'Help & setup' : 'Need help?'}
           </button>
         </div>
       </div>
@@ -116,5 +114,105 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
         <Icon name="x" />
       </button>
     </div>
+  );
+}
+
+function StepBadge({ done, number }: { done: boolean; number: number }) {
+  return (
+    <span
+      className={`shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-[11px] font-semibold ${
+        done ? 'bg-accent text-white [&>svg]:w-3 [&>svg]:h-3' : 'bg-white/10 text-text-primary'
+      }`}
+    >
+      {done ? <Icon name="check" /> : number}
+    </span>
+  );
+}
+
+function SetupStage({ configured }: { configured: boolean }) {
+  return (
+    <>
+      <div className="text-sm font-semibold text-text-primary mb-1">Welcome to your first project in Ouijit</div>
+      <div className="text-xs text-text-secondary leading-relaxed mb-4">
+        A tutorial task is waiting below. Complete it end to end to see how Ouijit works:
+      </div>
+      <ol className="flex flex-col gap-3">
+        <li className="flex gap-3">
+          <StepBadge done={configured} number={1} />
+          <div className={`min-w-0 ${configured ? 'opacity-50' : ''}`}>
+            <div className="text-xs font-medium text-text-primary mb-1">Configure a start hook</div>
+            <div className="text-xs text-text-secondary leading-relaxed mb-2">
+              The command Ouijit runs when a task enters In Progress. For example:
+            </div>
+            <div className="flex">
+              <code className="inline-block font-mono text-[12px] text-text-primary bg-white/5 rounded-md px-2.5 py-1.5 max-w-full overflow-x-auto whitespace-nowrap">
+                {`claude "complete the current task and move it to in-review"`}
+              </code>
+            </div>
+          </div>
+        </li>
+        <li className="flex gap-3">
+          <StepBadge done={false} number={2} />
+          <div className="min-w-0">
+            <div className="text-xs font-medium text-text-primary mb-1">
+              Drag &ldquo;Your first task&rdquo; to In Progress
+            </div>
+            <div className="text-xs text-text-secondary leading-relaxed">
+              Your agent picks up the task and drives the board from there.
+            </div>
+          </div>
+        </li>
+      </ol>
+    </>
+  );
+}
+
+function InFlightStage() {
+  return (
+    <>
+      <div className="text-sm font-semibold text-text-primary mb-1">Your agent is working</div>
+      <div className="text-xs text-text-secondary leading-relaxed mb-4">
+        Watch the tutorial task move across the board as your agent runs it.
+      </div>
+      <ol className="flex flex-col gap-3">
+        <li className="flex gap-3 opacity-50">
+          <StepBadge done={true} number={1} />
+          <div className="min-w-0 pt-0.5">
+            <div className="text-xs font-medium text-text-primary">Start hook configured</div>
+          </div>
+        </li>
+        <li className="flex gap-3 opacity-50">
+          <StepBadge done={true} number={2} />
+          <div className="min-w-0 pt-0.5">
+            <div className="text-xs font-medium text-text-primary">Tutorial task started</div>
+          </div>
+        </li>
+      </ol>
+    </>
+  );
+}
+
+function CompleteStage() {
+  return (
+    <>
+      <div className="text-sm font-semibold text-text-primary mb-3">Your agent moved the task to In Review</div>
+      <ul className="flex flex-col gap-1.5 text-xs text-text-secondary leading-relaxed">
+        <li className="flex gap-2">
+          <span className="text-text-tertiary shrink-0">•</span>
+          <span>
+            The <code className="px-1 py-0.5 rounded bg-white/5 font-mono text-[11px]">ouijit</code> CLI is how your
+            agent read this task and updated the board, and it&rsquo;s available to you in any terminal.
+          </span>
+        </li>
+        <li className="flex gap-2">
+          <span className="text-text-tertiary shrink-0">•</span>
+          <span>Each task lives in its own git worktree and branch, so multiple agents can work in parallel.</span>
+        </li>
+        <li className="flex gap-2">
+          <span className="text-text-tertiary shrink-0">•</span>
+          <span>Task descriptions support multiple lines, images, and attached files.</span>
+        </li>
+      </ul>
+    </>
   );
 }

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -8,11 +8,11 @@ interface OnboardingPanelProps {
   onOpenHelp: () => void;
 }
 
-const SEEDED_PROJECT_KEY = 'onboarding:seededProject';
+const FIRST_PROJECT_KEY = 'onboarding:firstProjectPath';
 const SEEDED_TASK_NUMBER_KEY = 'onboarding:seededTaskNumber';
 const DISMISSED_KEY = 'onboarding:dismissed';
 
-type Stage = 'setup' | 'in-flight' | 'complete';
+type Stage = 'intro' | 'setup' | 'in-flight' | 'complete';
 
 /**
  * First-run onboarding banner. Walks the user through configuring a start
@@ -23,19 +23,20 @@ type Stage = 'setup' | 'in-flight' | 'complete';
 export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }: OnboardingPanelProps) {
   const tasks = useProjectStore((s) => s.tasks);
   const startHookConfigured = useProjectStore((s) => !!s.configuredHooks.start);
-  const [seededProject, setSeededProject] = useState<string | undefined>(undefined);
+  const [firstProject, setFirstProject] = useState<string | undefined>(undefined);
   const [seededTaskNumber, setSeededTaskNumber] = useState<number | undefined>(undefined);
   const [dismissed, setDismissed] = useState<boolean | undefined>(undefined);
+  const [seeding, setSeeding] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     Promise.all([
-      window.api.globalSettings.get(SEEDED_PROJECT_KEY),
+      window.api.globalSettings.get(FIRST_PROJECT_KEY),
       window.api.globalSettings.get(SEEDED_TASK_NUMBER_KEY),
       window.api.globalSettings.get(DISMISSED_KEY),
-    ]).then(([seeded, taskNum, dismissedVal]) => {
+    ]).then(([first, taskNum, dismissedVal]) => {
       if (cancelled) return;
-      setSeededProject(seeded ?? undefined);
+      setFirstProject(first ?? undefined);
       setSeededTaskNumber(taskNum ? Number(taskNum) : undefined);
       setDismissed(dismissedVal === '1');
     });
@@ -50,14 +51,15 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
   );
 
   const stage: Stage | null = useMemo(() => {
-    if (!seededTask) return 'setup';
+    if (seededTaskNumber == null) return 'intro';
+    if (!seededTask) return 'intro';
     if (seededTask.status === 'todo') return 'setup';
     if (seededTask.status === 'in_progress') return 'in-flight';
     return 'complete';
-  }, [seededTask]);
+  }, [seededTaskNumber, seededTask]);
 
-  if (seededProject === undefined || dismissed === undefined) return null;
-  if (seededProject !== projectPath) return null;
+  if (firstProject === undefined || dismissed === undefined) return null;
+  if (firstProject !== projectPath) return null;
   if (dismissed) return null;
   if (stage === null) return null;
 
@@ -66,17 +68,30 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
     await window.api.globalSettings.set(DISMISSED_KEY, '1');
   };
 
+  const handleSeedPracticeTask = async () => {
+    if (seeding) return;
+    setSeeding(true);
+    await window.api.onboarding.seedTask(projectPath);
+    await useProjectStore.getState().loadTasks(projectPath);
+    const taskNum = await window.api.globalSettings.get(SEEDED_TASK_NUMBER_KEY);
+    if (taskNum) setSeededTaskNumber(Number(taskNum));
+    setSeeding(false);
+  };
+
   const renderStageBody = (s: Stage) => (
     <>
+      {s === 'intro' && <IntroStage />}
       {s === 'setup' && <SetupStage configured={startHookConfigured} />}
       {s === 'in-flight' && <InFlightStage />}
       {s === 'complete' && <CompleteStage />}
       <StageCtas
         stage={s}
         startHookConfigured={startHookConfigured}
+        seeding={seeding}
         onConfigureCliAgent={onConfigureCliAgent}
         onOpenHelp={onOpenHelp}
         onDismiss={handleDismiss}
+        onSeedPracticeTask={handleSeedPracticeTask}
       />
     </>
   );
@@ -137,22 +152,43 @@ function StageCrossfade({ stage, renderStage }: { stage: Stage; renderStage: (s:
 interface StageCtasProps {
   stage: Stage;
   startHookConfigured: boolean;
+  seeding: boolean;
   onConfigureCliAgent: () => void;
   onOpenHelp: () => void;
   onDismiss: () => void;
+  onSeedPracticeTask: () => void;
 }
 
-function StageCtas({ stage, startHookConfigured, onConfigureCliAgent, onOpenHelp, onDismiss }: StageCtasProps) {
+function StageCtas({
+  stage,
+  startHookConfigured,
+  seeding,
+  onConfigureCliAgent,
+  onOpenHelp,
+  onDismiss,
+  onSeedPracticeTask,
+}: StageCtasProps) {
   return (
     <div className="flex items-center gap-2 flex-wrap mt-4">
-      {stage === 'complete' ? (
+      {stage === 'intro' && (
+        <button
+          className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out disabled:opacity-60"
+          onClick={onSeedPracticeTask}
+          disabled={seeding}
+        >
+          <Icon name="plus" className="w-3.5 h-3.5" />
+          {seeding ? 'Adding…' : 'Try a practice task'}
+        </button>
+      )}
+      {stage === 'complete' && (
         <button
           className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
           onClick={onDismiss}
         >
           Got it
         </button>
-      ) : (
+      )}
+      {(stage === 'setup' || stage === 'in-flight') && (
         <button
           className={`inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full active:scale-[0.98] transition-all duration-150 ease-out ${
             startHookConfigured
@@ -170,9 +206,9 @@ function StageCtas({ stage, startHookConfigured, onConfigureCliAgent, onOpenHelp
         onClick={onOpenHelp}
       >
         <Icon name="question" className="w-3.5 h-3.5" />
-        {stage === 'complete' ? 'Help & setup' : 'Need help?'}
+        {stage === 'complete' || stage === 'intro' ? 'Help & setup' : 'Need help?'}
       </button>
-      {stage === 'complete' && (
+      {(stage === 'complete' || stage === 'intro') && (
         <button
           className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
           onClick={() => window.api.openExternal('https://ouijit.com/docs')}
@@ -215,6 +251,39 @@ function StepBadge({ done, number }: { done: boolean; number: number }) {
         <Icon name="check" />
       </span>
     </span>
+  );
+}
+
+function IntroStage() {
+  return (
+    <>
+      <div className="text-sm font-semibold text-text-primary mb-3">How Ouijit runs tasks</div>
+      <ul className="flex flex-col gap-1.5 text-xs text-text-secondary leading-relaxed mb-3">
+        <li className="flex gap-2">
+          <span className="text-text-tertiary shrink-0">•</span>
+          <span>Each task gets its own git worktree and branch, so multiple agents can work in parallel.</span>
+        </li>
+        <li className="flex gap-2">
+          <span className="text-text-tertiary shrink-0">•</span>
+          <span>
+            Each column has a hook (start, continue, review, done) that fires on task transitions and can run any
+            command.
+          </span>
+        </li>
+        <li className="flex gap-2">
+          <span className="text-text-tertiary shrink-0">•</span>
+          <span>
+            Supported agents automatically get the{' '}
+            <code className="px-1 py-0.5 rounded bg-white/5 font-mono text-[11px]">ouijit</code> CLI in their context,
+            so they know how to see and manage tasks, hooks, tags, plans, and scripts.
+          </span>
+        </li>
+      </ul>
+      <div className="text-xs text-text-tertiary leading-relaxed">
+        A practice task adds one card with a throwaway prompt. It runs on its own branch and writes a single file you
+        can delete after.
+      </div>
+    </>
   );
 }
 

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -56,18 +56,41 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
       style={{ background: 'rgba(255, 255, 255, 0.03)' }}
     >
       <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium text-text-primary mb-1">Set up a start hook</div>
-        <div className="text-xs text-text-secondary leading-relaxed mb-2">
-          A start hook is the command Ouijit runs when a task enters In Progress. It can be as small as one line that
-          hands the task to your CLI agent. For example:
+        <div className="text-sm font-semibold text-text-primary mb-1">Welcome to your first project in Ouijit</div>
+        <div className="text-xs text-text-secondary leading-relaxed mb-4">
+          A tutorial task is waiting below. Complete it end to end to see how Ouijit works:
         </div>
-        <pre className="text-[11px] font-mono text-text-primary bg-white/5 rounded-md px-2.5 py-1.5 mb-3 overflow-x-auto">
-          <code>{`claude "complete the current task and move it to in-review"`}</code>
-        </pre>
-        <div className="text-xs text-text-secondary leading-relaxed mb-3">
-          We seeded a practice task below. Set up your hook, then drag the card to In Progress and watch your agent take
-          over.
-        </div>
+        <ol className="flex flex-col gap-3 mb-4">
+          <li className="flex gap-3">
+            <span className="shrink-0 w-5 h-5 rounded-full bg-white/10 text-text-primary text-[11px] font-semibold flex items-center justify-center">
+              1
+            </span>
+            <div className="min-w-0">
+              <div className="text-xs font-medium text-text-primary mb-1">Configure a start hook</div>
+              <div className="text-xs text-text-secondary leading-relaxed mb-2">
+                The command Ouijit runs when a task enters In Progress. For example:
+              </div>
+              <div className="flex">
+                <code className="inline-block font-mono text-[12px] text-text-primary bg-white/5 rounded-md px-2.5 py-1.5 max-w-full overflow-x-auto whitespace-nowrap">
+                  {`claude "complete the current task and move it to in-review"`}
+                </code>
+              </div>
+            </div>
+          </li>
+          <li className="flex gap-3">
+            <span className="shrink-0 w-5 h-5 rounded-full bg-white/10 text-text-primary text-[11px] font-semibold flex items-center justify-center">
+              2
+            </span>
+            <div className="min-w-0">
+              <div className="text-xs font-medium text-text-primary mb-1">
+                Drag &ldquo;Your first task&rdquo; to In Progress
+              </div>
+              <div className="text-xs text-text-secondary leading-relaxed">
+                Your agent picks up the task and drives the board from there.
+              </div>
+            </div>
+          </li>
+        </ol>
         <div className="flex items-center gap-2 flex-wrap">
           <button
             className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -200,8 +200,17 @@ function CompleteStage() {
         <li className="flex gap-2">
           <span className="text-text-tertiary shrink-0">•</span>
           <span>
-            The <code className="px-1 py-0.5 rounded bg-white/5 font-mono text-[11px]">ouijit</code> CLI is how your
-            agent read this task and updated the board, and it&rsquo;s available to you in any terminal.
+            Supported agents automatically get the{' '}
+            <code className="px-1 py-0.5 rounded bg-white/5 font-mono text-[11px]">ouijit</code> CLI in their context,
+            so they know how to see and manage tasks, hooks, tags, plans, and scripts. The same commands are available
+            to you in any terminal.
+          </span>
+        </li>
+        <li className="flex gap-2">
+          <span className="text-text-tertiary shrink-0">•</span>
+          <span>
+            Each column has its own hook (start, continue, review, done) that fires on task transitions and can run any
+            command.
           </span>
         </li>
         <li className="flex gap-2">

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 import { Icon } from '../terminal/Icon';
 import { useProjectStore } from '../../stores/projectStore';
 
@@ -66,45 +66,28 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
     await window.api.globalSettings.set(DISMISSED_KEY, '1');
   };
 
+  const renderStageBody = (s: Stage) => (
+    <>
+      {s === 'setup' && <SetupStage configured={startHookConfigured} />}
+      {s === 'in-flight' && <InFlightStage />}
+      {s === 'complete' && <CompleteStage />}
+      <StageCtas
+        stage={s}
+        startHookConfigured={startHookConfigured}
+        onConfigureCliAgent={onConfigureCliAgent}
+        onOpenHelp={onOpenHelp}
+        onDismiss={handleDismiss}
+      />
+    </>
+  );
+
   return (
     <div
-      className="mx-3 mt-3 mb-2 px-4 py-3 rounded-[12px] border border-white/10 flex items-start gap-3"
+      className="mx-3 mt-3 mb-2 px-4 py-3 rounded-[12px] border border-white/10 flex items-start gap-3 onboarding-stage-enter"
       style={{ background: 'rgba(255, 255, 255, 0.03)' }}
     >
       <div className="flex-1 min-w-0">
-        {stage === 'setup' && <SetupStage configured={startHookConfigured} />}
-        {stage === 'in-flight' && <InFlightStage />}
-        {stage === 'complete' && <CompleteStage />}
-
-        <div className="flex items-center gap-2 flex-wrap mt-4">
-          {stage === 'complete' ? (
-            <button
-              className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
-              onClick={handleDismiss}
-            >
-              Got it
-            </button>
-          ) : (
-            <button
-              className={`inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full active:scale-[0.98] transition-all duration-150 ease-out ${
-                startHookConfigured
-                  ? 'text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary'
-                  : 'text-white bg-accent hover:bg-accent-hover'
-              }`}
-              onClick={onConfigureCliAgent}
-            >
-              <Icon name="terminal" className="w-3.5 h-3.5" />
-              {startHookConfigured ? 'Edit start hook' : 'Configure start hook'}
-            </button>
-          )}
-          <button
-            className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
-            onClick={onOpenHelp}
-          >
-            <Icon name="question" className="w-3.5 h-3.5" />
-            {stage === 'complete' ? 'Help & setup' : 'Need help?'}
-          </button>
-        </div>
+        <StageCrossfade stage={stage} renderStage={renderStageBody} />
       </div>
       <button
         className="shrink-0 w-7 h-7 flex items-center justify-center rounded-full text-text-tertiary hover:text-text-primary hover:bg-white/10 transition-colors [&>svg]:w-4 [&>svg]:h-4"
@@ -117,14 +100,120 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
   );
 }
 
+/**
+ * Crossfades between stages: old stage runs its exit animation while the new
+ * stage renders in the same grid cell with its entrance animation. The grid
+ * sizes the container to the max of the two children's heights during the
+ * overlap, so the parent height changes smoothly as old shrinks and new grows.
+ */
+function StageCrossfade({ stage, renderStage }: { stage: Stage; renderStage: (s: Stage) => React.ReactNode }) {
+  const [exiting, setExiting] = useState<Stage | null>(null);
+  const prevStage = useRef(stage);
+
+  useEffect(() => {
+    if (prevStage.current !== stage) {
+      const old = prevStage.current;
+      setExiting(old);
+      const t = setTimeout(() => setExiting((s) => (s === old ? null : s)), 200);
+      prevStage.current = stage;
+      return () => clearTimeout(t);
+    }
+  }, [stage]);
+
+  return (
+    <div className="grid">
+      {exiting && (
+        <div key={`exit-${exiting}`} className="[grid-area:1/1] onboarding-stage-exit">
+          {renderStage(exiting)}
+        </div>
+      )}
+      <div key={`enter-${stage}`} className="[grid-area:1/1] onboarding-stage-children-enter">
+        {renderStage(stage)}
+      </div>
+    </div>
+  );
+}
+
+interface StageCtasProps {
+  stage: Stage;
+  startHookConfigured: boolean;
+  onConfigureCliAgent: () => void;
+  onOpenHelp: () => void;
+  onDismiss: () => void;
+}
+
+function StageCtas({ stage, startHookConfigured, onConfigureCliAgent, onOpenHelp, onDismiss }: StageCtasProps) {
+  return (
+    <div className="flex items-center gap-2 flex-wrap mt-4">
+      {stage === 'complete' ? (
+        <button
+          className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
+          onClick={onDismiss}
+        >
+          Got it
+        </button>
+      ) : (
+        <button
+          className={`inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full active:scale-[0.98] transition-all duration-150 ease-out ${
+            startHookConfigured
+              ? 'text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary'
+              : 'text-white bg-accent hover:bg-accent-hover'
+          }`}
+          onClick={onConfigureCliAgent}
+        >
+          <Icon name="terminal" className="w-3.5 h-3.5" />
+          {startHookConfigured ? 'Edit start hook' : 'Configure start hook'}
+        </button>
+      )}
+      <button
+        className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
+        onClick={onOpenHelp}
+      >
+        <Icon name="question" className="w-3.5 h-3.5" />
+        {stage === 'complete' ? 'Help & setup' : 'Need help?'}
+      </button>
+      {stage === 'complete' && (
+        <button
+          className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
+          onClick={() => window.api.openExternal('https://ouijit.com/docs')}
+        >
+          <Icon name="file-text" className="w-3.5 h-3.5" />
+          Docs
+        </button>
+      )}
+    </div>
+  );
+}
+
 function StepBadge({ done, number }: { done: boolean; number: number }) {
+  const [popping, setPopping] = useState(false);
+  const prevDone = useRef(done);
+
+  useEffect(() => {
+    if (!prevDone.current && done) {
+      setPopping(true);
+      const timeout = setTimeout(() => setPopping(false), 320);
+      return () => clearTimeout(timeout);
+    }
+    prevDone.current = done;
+  }, [done]);
+
   return (
     <span
-      className={`shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-[11px] font-semibold ${
-        done ? 'bg-accent text-white [&>svg]:w-3 [&>svg]:h-3' : 'bg-white/10 text-text-primary'
-      }`}
+      className={`relative shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-[11px] font-semibold transition-colors duration-300 ease-out ${
+        done ? 'bg-accent text-white' : 'bg-white/10 text-text-primary'
+      } ${popping ? 'onboarding-badge-check' : ''}`}
     >
-      {done ? <Icon name="check" /> : number}
+      <span
+        className={`absolute inset-0 flex items-center justify-center transition-opacity duration-200 ease-out ${done ? 'opacity-0' : 'opacity-100'}`}
+      >
+        {number}
+      </span>
+      <span
+        className={`absolute inset-0 flex items-center justify-center transition-opacity duration-200 ease-out [&>svg]:w-3 [&>svg]:h-3 ${done ? 'opacity-100' : 'opacity-0'}`}
+      >
+        <Icon name="check" />
+      </span>
     </span>
   );
 }
@@ -195,15 +284,19 @@ function InFlightStage() {
 function CompleteStage() {
   return (
     <>
-      <div className="text-sm font-semibold text-text-primary mb-3">Your agent moved the task to In Review</div>
+      <div className="flex items-center gap-2 mb-4">
+        <StepBadge done={true} number={0} />
+        <div className="text-xs text-text-primary">
+          &ldquo;Your first task&rdquo; is in <span className="font-medium">In Review</span>
+        </div>
+      </div>
       <ul className="flex flex-col gap-1.5 text-xs text-text-secondary leading-relaxed">
         <li className="flex gap-2">
           <span className="text-text-tertiary shrink-0">•</span>
           <span>
             Supported agents automatically get the{' '}
             <code className="px-1 py-0.5 rounded bg-white/5 font-mono text-[11px]">ouijit</code> CLI in their context,
-            so they know how to see and manage tasks, hooks, tags, plans, and scripts. The same commands are available
-            to you in any terminal.
+            so they know how to see and manage tasks, hooks, tags, plans, and scripts.
           </span>
         </li>
         <li className="flex gap-2">
@@ -212,14 +305,6 @@ function CompleteStage() {
             Each column has its own hook (start, continue, review, done) that fires on task transitions and can run any
             command.
           </span>
-        </li>
-        <li className="flex gap-2">
-          <span className="text-text-tertiary shrink-0">•</span>
-          <span>Each task lives in its own git worktree and branch, so multiple agents can work in parallel.</span>
-        </li>
-        <li className="flex gap-2">
-          <span className="text-text-tertiary shrink-0">•</span>
-          <span>Task descriptions support multiple lines, images, and attached files.</span>
         </li>
       </ul>
     </>

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -447,7 +447,7 @@ function InFlightStage({ stuck, startHookConfigured }: InFlightStageProps) {
         </div>
       </div>
       <div className="text-xs text-text-secondary leading-relaxed">
-        The start hook is running. Output is in this task&rsquo;s terminal.
+        The start hook is running in the task&rsquo;s terminal.
       </div>
     </>
   );

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -62,13 +62,23 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
     return 'complete';
   }, [seededTaskNumber, seededTask]);
 
-  // "Stuck" = task entered in_progress without a start hook configured, so
-  // nothing actually fired. We latch this so re-configuring the hook after
-  // the fact doesn't silently flip the stage display — the user still needs
-  // to drag back and forward to retrigger.
+  // "Stuck" = task transitioned into in_progress without a start hook
+  // configured, so nothing actually fired. We latch this so re-configuring
+  // the hook after the fact doesn't silently flip the stage display — the
+  // user still needs to drag back and forward to retrigger.
+  //
+  // The latch is set only on a real stage TRANSITION into 'in-flight'.
+  // Checking just `stage === 'in-flight'` on first render would falsely
+  // latch when the panel mounts with a task already in_progress (e.g., after
+  // an app restart) before the project's configuredHooks have loaded from
+  // the store — startHookConfigured is briefly `false` even when the hook
+  // exists. Tracking the previous stage closes that window.
+  const prevStageRef = useRef<Stage | undefined>(undefined);
   const [stuckLatched, setStuckLatched] = useState(false);
   useEffect(() => {
-    if (stage === 'in-flight' && !startHookConfigured && !stuckLatched) {
+    const prev = prevStageRef.current;
+    prevStageRef.current = stage;
+    if (prev !== undefined && prev !== 'in-flight' && stage === 'in-flight' && !startHookConfigured) {
       setStuckLatched(true);
     }
     if (stage === 'setup' || stage === 'intro' || stage === 'complete') {
@@ -97,11 +107,14 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
   const handleSeedPracticeTask = async () => {
     if (seeding) return;
     setSeeding(true);
-    await window.api.onboarding.seedTask(projectPath);
-    await useProjectStore.getState().loadTasks(projectPath);
-    const next = await readOnboardingState(io);
-    if (next) setState(next);
-    setSeeding(false);
+    try {
+      await window.api.onboarding.seedTask(projectPath);
+      await useProjectStore.getState().loadTasks(projectPath);
+      const next = await readOnboardingState(io);
+      if (next) setState(next);
+    } finally {
+      setSeeding(false);
+    }
   };
 
   const handleMoveBackToTodo = async () => {

--- a/src/index.css
+++ b/src/index.css
@@ -339,6 +339,76 @@ textarea,
   }
 }
 
+@keyframes onboarding-block-enter {
+  0% {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes onboarding-stage-exit {
+  0% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes onboarding-badge-check {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.18);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* Outer panel mount: single block fades + slides in, Apple-style decelerate easing. */
+.onboarding-stage-enter {
+  animation: onboarding-block-enter 360ms cubic-bezier(0.32, 0.72, 0, 1) both;
+}
+
+/* Stage entrance: each direct child animates in sequence to give the eye a
+   top-to-bottom reading rhythm. Same easing curve as the outer panel. */
+.onboarding-stage-children-enter > * {
+  animation: onboarding-block-enter 380ms cubic-bezier(0.32, 0.72, 0, 1) both;
+}
+.onboarding-stage-children-enter > *:nth-child(1) {
+  animation-delay: 0ms;
+}
+.onboarding-stage-children-enter > *:nth-child(2) {
+  animation-delay: 70ms;
+}
+.onboarding-stage-children-enter > *:nth-child(3) {
+  animation-delay: 140ms;
+}
+.onboarding-stage-children-enter > *:nth-child(4) {
+  animation-delay: 210ms;
+}
+.onboarding-stage-children-enter > *:nth-child(5) {
+  animation-delay: 280ms;
+}
+
+/* Faster, more decisive exit. Material "accelerate" curve. */
+.onboarding-stage-exit {
+  animation: onboarding-stage-exit 150ms cubic-bezier(0.7, 0, 0.84, 0) forwards;
+  pointer-events: none;
+}
+
+.onboarding-badge-check {
+  animation: onboarding-badge-check 280ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 /* Sidebar home logo mask — CSS url() resolves relative to this file */
 .sidebar-home-logo-mask {
   -webkit-mask-image: url('./assets/ouijit-logomark.svg');

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -189,6 +189,9 @@ export interface IpcInvokeContract {
   'settings:get-global': { args: [key: string]; return: string | undefined };
   'settings:set-global': { args: [key: string, value: string]; return: { success: boolean } };
 
+  // ── Onboarding ───────────────────────────────────────────────────────
+  'onboarding:seed-task': { args: [projectPath: string]; return: { success: boolean } };
+
   // ── Health ───────────────────────────────────────────────────────────
   'health:check': { args: []; return: HealthStatus };
 

--- a/src/ipc/handlers/project.ts
+++ b/src/ipc/handlers/project.ts
@@ -4,7 +4,7 @@ import { typedHandle } from '../helpers';
 import { getProjectList } from '../../scanner';
 import { addProject, removeProject, reorderProjects, getProjectSettings, setKillExistingOnRun } from '../../db';
 import { createProject, validateProjectFolder } from '../../projectCreator';
-import { seedOnboardingTaskIfFirstProject } from '../../onboarding';
+import { recordFirstProjectIfNeeded, seedOnboardingTaskIfFirstProject } from '../../onboarding';
 import { openInEditor, openFileInEditor } from '../../editorLauncher';
 import { deleteWithCleanup } from '../../lima/manager';
 import { deleteConfig } from '../../lima/configStore';
@@ -55,7 +55,10 @@ export function registerProjectHandlers(mainWindow: BrowserWindow): void {
           error: `Project folder created at ${result.projectPath}, but registering it failed: ${message}`,
         };
       }
-      await seedOnboardingTaskIfFirstProject(result.projectPath);
+      const wasFirst = await recordFirstProjectIfNeeded(result.projectPath);
+      if (wasFirst) {
+        await seedOnboardingTaskIfFirstProject(result.projectPath);
+      }
     }
     return result;
   });
@@ -80,6 +83,7 @@ export function registerProjectHandlers(mainWindow: BrowserWindow): void {
     if (validation.ok === false) return { success: false, error: validation.error };
     try {
       await addProject(folderPath);
+      await recordFirstProjectIfNeeded(folderPath);
       return { success: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
@@ -90,6 +94,10 @@ export function registerProjectHandlers(mainWindow: BrowserWindow): void {
     await deleteWithCleanup(folderPath).catch(() => {});
     await deleteConfig(folderPath).catch(() => {});
     return removeProject(folderPath);
+  });
+  typedHandle('onboarding:seed-task', async (projectPath) => {
+    await seedOnboardingTaskIfFirstProject(projectPath);
+    return { success: true };
   });
   typedHandle('reorder-projects', (paths) => reorderProjects(paths));
   typedHandle('get-project-settings', (projectPath) => getProjectSettings(projectPath));

--- a/src/ipc/handlers/project.ts
+++ b/src/ipc/handlers/project.ts
@@ -2,9 +2,20 @@ import os from 'os';
 import { shell, BrowserWindow, dialog } from 'electron';
 import { typedHandle } from '../helpers';
 import { getProjectList } from '../../scanner';
-import { addProject, removeProject, reorderProjects, getProjectSettings, setKillExistingOnRun } from '../../db';
+import {
+  addProject,
+  removeProject,
+  reorderProjects,
+  getProjectSettings,
+  setKillExistingOnRun,
+  setGlobalSetting,
+} from '../../db';
 import { createProject, validateProjectFolder } from '../../projectCreator';
-import { recordFirstProjectIfNeeded, seedOnboardingTaskIfFirstProject } from '../../onboarding';
+import {
+  ONBOARDING_SEEDED_ON_DEMAND_KEY,
+  recordFirstProjectIfNeeded,
+  seedOnboardingTaskIfFirstProject,
+} from '../../onboarding';
 import { openInEditor, openFileInEditor } from '../../editorLauncher';
 import { deleteWithCleanup } from '../../lima/manager';
 import { deleteConfig } from '../../lima/configStore';
@@ -97,6 +108,7 @@ export function registerProjectHandlers(mainWindow: BrowserWindow): void {
   });
   typedHandle('onboarding:seed-task', async (projectPath) => {
     await seedOnboardingTaskIfFirstProject(projectPath);
+    await setGlobalSetting(ONBOARDING_SEEDED_ON_DEMAND_KEY, '1');
     return { success: true };
   });
   typedHandle('reorder-projects', (paths) => reorderProjects(paths));

--- a/src/ipc/handlers/project.ts
+++ b/src/ipc/handlers/project.ts
@@ -4,6 +4,7 @@ import { typedHandle } from '../helpers';
 import { getProjectList } from '../../scanner';
 import { addProject, removeProject, reorderProjects, getProjectSettings, setKillExistingOnRun } from '../../db';
 import { createProject, validateProjectFolder } from '../../projectCreator';
+import { seedOnboardingTaskIfFirstProject } from '../../onboarding';
 import { openInEditor, openFileInEditor } from '../../editorLauncher';
 import { deleteWithCleanup } from '../../lima/manager';
 import { deleteConfig } from '../../lima/configStore';
@@ -54,6 +55,7 @@ export function registerProjectHandlers(mainWindow: BrowserWindow): void {
           error: `Project folder created at ${result.projectPath}, but registering it failed: ${message}`,
         };
       }
+      await seedOnboardingTaskIfFirstProject(result.projectPath);
     }
     return result;
   });

--- a/src/ipc/handlers/project.ts
+++ b/src/ipc/handlers/project.ts
@@ -2,20 +2,9 @@ import os from 'os';
 import { shell, BrowserWindow, dialog } from 'electron';
 import { typedHandle } from '../helpers';
 import { getProjectList } from '../../scanner';
-import {
-  addProject,
-  removeProject,
-  reorderProjects,
-  getProjectSettings,
-  setKillExistingOnRun,
-  setGlobalSetting,
-} from '../../db';
+import { addProject, removeProject, reorderProjects, getProjectSettings, setKillExistingOnRun } from '../../db';
 import { createProject, validateProjectFolder } from '../../projectCreator';
-import {
-  ONBOARDING_SEEDED_ON_DEMAND_KEY,
-  recordFirstProjectIfNeeded,
-  seedOnboardingTaskIfFirstProject,
-} from '../../onboarding';
+import { recordFirstProjectIfNeeded, seedOnboardingTaskIfFirstProject } from '../../onboarding';
 import { openInEditor, openFileInEditor } from '../../editorLauncher';
 import { deleteWithCleanup } from '../../lima/manager';
 import { deleteConfig } from '../../lima/configStore';
@@ -66,10 +55,7 @@ export function registerProjectHandlers(mainWindow: BrowserWindow): void {
           error: `Project folder created at ${result.projectPath}, but registering it failed: ${message}`,
         };
       }
-      const wasFirst = await recordFirstProjectIfNeeded(result.projectPath);
-      if (wasFirst) {
-        await seedOnboardingTaskIfFirstProject(result.projectPath);
-      }
+      await recordFirstProjectIfNeeded(result.projectPath, 'created');
     }
     return result;
   });
@@ -94,7 +80,7 @@ export function registerProjectHandlers(mainWindow: BrowserWindow): void {
     if (validation.ok === false) return { success: false, error: validation.error };
     try {
       await addProject(folderPath);
-      await recordFirstProjectIfNeeded(folderPath);
+      await recordFirstProjectIfNeeded(folderPath, 'added');
       return { success: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
@@ -108,7 +94,6 @@ export function registerProjectHandlers(mainWindow: BrowserWindow): void {
   });
   typedHandle('onboarding:seed-task', async (projectPath) => {
     await seedOnboardingTaskIfFirstProject(projectPath);
-    await setGlobalSetting(ONBOARDING_SEEDED_ON_DEMAND_KEY, '1');
     return { success: true };
   });
   typedHandle('reorder-projects', (paths) => reorderProjects(paths));

--- a/src/ipc/handlers/settings.ts
+++ b/src/ipc/handlers/settings.ts
@@ -12,7 +12,8 @@ function isAllowedKey(key: string): boolean {
     key.startsWith('terminal:') ||
     key.startsWith('lastSession:') ||
     key.startsWith('ui:') ||
-    key.startsWith('worktree:')
+    key.startsWith('worktree:') ||
+    key.startsWith('onboarding:')
   );
 }
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,36 +1,12 @@
 import { createTodoTask } from './worktree';
 import { getGlobalSetting, setGlobalSetting } from './db';
 import { getLogger } from './logger';
+import { type OnboardingStorageIO, patchOnboardingState, readOnboardingState } from './onboardingState';
+import type { FirstProjectSource } from './types';
 
 const onboardingLog = getLogger().scope('onboarding');
 
-export const ONBOARDING_FIRST_PROJECT_KEY = 'onboarding:firstProjectPath';
-export const ONBOARDING_FIRST_PROJECT_SOURCE_KEY = 'onboarding:firstProjectSource';
-export const ONBOARDING_SEEDED_PROJECT_KEY = 'onboarding:seededProject';
-export const ONBOARDING_SEEDED_TASK_NUMBER_KEY = 'onboarding:seededTaskNumber';
-export const ONBOARDING_DISMISSED_KEY = 'onboarding:dismissed';
 export const ONBOARDING_TASK_NAME = 'Your first task';
-
-export type FirstProjectSource = 'created' | 'added';
-
-/**
- * Records the path and source of the first project the user adds (whether via
- * create-new or open-existing). The OnboardingPanel uses both to decide which
- * project gets the first-run experience and to vary copy by path. Idempotent:
- * subsequent project additions are ignored, so the panel remains anchored to
- * the original first project.
- *
- * Returns whether this call was the one that set the value — callers use this
- * to decide whether to trigger one-time side effects.
- */
-export async function recordFirstProjectIfNeeded(projectPath: string, source: FirstProjectSource): Promise<boolean> {
-  const existing = await getGlobalSetting(ONBOARDING_FIRST_PROJECT_KEY);
-  if (existing) return false;
-  await setGlobalSetting(ONBOARDING_FIRST_PROJECT_KEY, projectPath);
-  await setGlobalSetting(ONBOARDING_FIRST_PROJECT_SOURCE_KEY, source);
-  onboardingLog.info('recorded first project', { projectPath, source });
-  return true;
-}
 
 export const ONBOARDING_TASK_PROMPT = `Welcome to Ouijit. This is a practice task to show how the app works end to end.
 
@@ -38,28 +14,43 @@ Create a file named \`hello.txt\` in the project root containing the text \`hell
 
 The \`ouijit\` CLI is available in this terminal; use \`ouijit --help\` if you need it.`;
 
+const io: OnboardingStorageIO = {
+  get: getGlobalSetting,
+  set: setGlobalSetting,
+};
+
 /**
- * Seeds the onboarding tutorial task on the first project the user ever creates.
- * Subsequent project creations are no-ops. Failure to seed is non-fatal; we
- * log and let project creation succeed, since onboarding is a nice-to-have,
- * not a blocker.
+ * Records the first project (whether via create-new or open-existing).
+ * Idempotent: subsequent project additions are ignored so the panel stays
+ * anchored to the original first project. Returns whether this call was the
+ * one that set the value.
+ */
+export async function recordFirstProjectIfNeeded(projectPath: string, source: FirstProjectSource): Promise<boolean> {
+  const existing = await readOnboardingState(io);
+  if (existing?.firstProjectPath) return false;
+  await patchOnboardingState(io, { firstProjectPath: projectPath, source });
+  onboardingLog.info('recorded first project', { projectPath, source });
+  return true;
+}
+
+/**
+ * Seeds the onboarding tutorial task in the user's first project. Idempotent
+ * via the `seededTaskNumber` field — if a task has already been seeded, this
+ * is a no-op. Failure is non-fatal; we log and return.
  */
 export async function seedOnboardingTaskIfFirstProject(projectPath: string): Promise<void> {
   try {
-    const already = await getGlobalSetting(ONBOARDING_SEEDED_PROJECT_KEY);
-    if (already) return;
+    const state = await readOnboardingState(io);
+    if (state?.seededTaskNumber != null) return;
 
     const result = await createTodoTask(projectPath, ONBOARDING_TASK_NAME, ONBOARDING_TASK_PROMPT);
-    if (!result.success) {
+    if (!result.success || !result.task) {
       onboardingLog.warn('seed task creation failed', { projectPath, error: result.error });
       return;
     }
 
-    await setGlobalSetting(ONBOARDING_SEEDED_PROJECT_KEY, projectPath);
-    if (result.task) {
-      await setGlobalSetting(ONBOARDING_SEEDED_TASK_NUMBER_KEY, String(result.task.taskNumber));
-    }
-    onboardingLog.info('seeded onboarding task', { projectPath, taskNumber: result.task?.taskNumber });
+    await patchOnboardingState(io, { seededTaskNumber: result.task.taskNumber });
+    onboardingLog.info('seeded onboarding task', { projectPath, taskNumber: result.task.taskNumber });
   } catch (error) {
     onboardingLog.error('seed failed unexpectedly', {
       projectPath,

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -2,6 +2,7 @@ import { createTodoTask } from './worktree';
 import { getGlobalSetting, setGlobalSetting } from './db';
 import { getLogger } from './logger';
 import { type OnboardingStorageIO, patchOnboardingState, readOnboardingState } from './onboardingState';
+import { getProjectList } from './scanner';
 import type { FirstProjectSource } from './types';
 
 const onboardingLog = getLogger().scope('onboarding');
@@ -24,10 +25,24 @@ const io: OnboardingStorageIO = {
  * Idempotent: subsequent project additions are ignored so the panel stays
  * anchored to the original first project. Returns whether this call was the
  * one that set the value.
+ *
+ * Existing users from before this release won't have any `onboarding:state`
+ * yet, so without a guard the next project they add would re-trigger the
+ * first-run flow. We detect them by checking the project list at call time:
+ * if more than this one project is already registered, the user has used
+ * Ouijit before and should be treated as already onboarded.
  */
 export async function recordFirstProjectIfNeeded(projectPath: string, source: FirstProjectSource): Promise<boolean> {
   const existing = await readOnboardingState(io);
   if (existing?.firstProjectPath) return false;
+
+  const projects = await getProjectList();
+  if (projects.length > 1) {
+    await patchOnboardingState(io, { dismissed: true });
+    onboardingLog.info('existing user detected; suppressing onboarding', { projectCount: projects.length });
+    return false;
+  }
+
   await patchOnboardingState(io, { firstProjectPath: projectPath, source });
   onboardingLog.info('recorded first project', { projectPath, source });
   return true;

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -6,7 +6,7 @@ const onboardingLog = getLogger().scope('onboarding');
 
 export const ONBOARDING_SEEDED_PROJECT_KEY = 'onboarding:seededProject';
 export const ONBOARDING_DISMISSED_KEY = 'onboarding:dismissed';
-export const ONBOARDING_TASK_NAME = 'Your first task: meet the Ouijit CLI';
+export const ONBOARDING_TASK_NAME = 'Your first task';
 
 export const ONBOARDING_TASK_PROMPT = `Welcome to Ouijit. This is a practice task to show how the app works end to end.
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -8,15 +8,11 @@ export const ONBOARDING_SEEDED_PROJECT_KEY = 'onboarding:seededProject';
 export const ONBOARDING_DISMISSED_KEY = 'onboarding:dismissed';
 export const ONBOARDING_TASK_NAME = 'Your first task: meet the Ouijit CLI';
 
-export const ONBOARDING_TASK_PROMPT = `This is a guided practice task. Complete it by using the \`ouijit\` CLI, which is how Ouijit's board, terminals, and your agent stay in sync.
+export const ONBOARDING_TASK_PROMPT = `Welcome to Ouijit. This is a practice task to show how the app works end to end.
 
-Steps:
-1. Run \`ouijit task current\` to see this task. The CLI is pre-configured in this terminal (OUIJIT_API_URL and OUIJIT_PTY_ID are set automatically).
-2. Create a file named \`hello.txt\` in the project root containing the text \`hello world\`.
-3. Run \`ouijit task set-status <taskNumber> in_review\` using the number from step 1. Watch the card move across the board in real time.
-4. Run \`ouijit task list\` to see the full board state.
+Create a file named \`hello.txt\` in the project root containing the text \`hello world\`, then move this task to In Review.
 
-When you're done, summarize what each command did so the user understands how to drive Ouijit from the CLI.`;
+The \`ouijit\` CLI is available in this terminal; use \`ouijit --help\` if you need it.`;
 
 /**
  * Seeds the onboarding tutorial task on the first project the user ever creates.

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,0 +1,46 @@
+import { createTodoTask } from './worktree';
+import { getGlobalSetting, setGlobalSetting } from './db';
+import { getLogger } from './logger';
+
+const onboardingLog = getLogger().scope('onboarding');
+
+export const ONBOARDING_SEEDED_PROJECT_KEY = 'onboarding:seededProject';
+export const ONBOARDING_DISMISSED_KEY = 'onboarding:dismissed';
+export const ONBOARDING_TASK_NAME = 'Your first task: meet the Ouijit CLI';
+
+export const ONBOARDING_TASK_PROMPT = `This is a guided practice task. Complete it by using the \`ouijit\` CLI, which is how Ouijit's board, terminals, and your agent stay in sync.
+
+Steps:
+1. Run \`ouijit task current\` to see this task. The CLI is pre-configured in this terminal (OUIJIT_API_URL and OUIJIT_PTY_ID are set automatically).
+2. Create a file named \`hello.txt\` in the project root containing the text \`hello world\`.
+3. Run \`ouijit task set-status <taskNumber> in_review\` using the number from step 1. Watch the card move across the board in real time.
+4. Run \`ouijit task list\` to see the full board state.
+
+When you're done, summarize what each command did so the user understands how to drive Ouijit from the CLI.`;
+
+/**
+ * Seeds the onboarding tutorial task on the first project the user ever creates.
+ * Subsequent project creations are no-ops. Failure to seed is non-fatal; we
+ * log and let project creation succeed, since onboarding is a nice-to-have,
+ * not a blocker.
+ */
+export async function seedOnboardingTaskIfFirstProject(projectPath: string): Promise<void> {
+  try {
+    const already = await getGlobalSetting(ONBOARDING_SEEDED_PROJECT_KEY);
+    if (already) return;
+
+    const result = await createTodoTask(projectPath, ONBOARDING_TASK_NAME, ONBOARDING_TASK_PROMPT);
+    if (!result.success) {
+      onboardingLog.warn('seed task creation failed', { projectPath, error: result.error });
+      return;
+    }
+
+    await setGlobalSetting(ONBOARDING_SEEDED_PROJECT_KEY, projectPath);
+    onboardingLog.info('seeded onboarding task', { projectPath, taskNumber: result.task?.taskNumber });
+  } catch (error) {
+    onboardingLog.error('seed failed unexpectedly', {
+      projectPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -4,10 +4,28 @@ import { getLogger } from './logger';
 
 const onboardingLog = getLogger().scope('onboarding');
 
+export const ONBOARDING_FIRST_PROJECT_KEY = 'onboarding:firstProjectPath';
 export const ONBOARDING_SEEDED_PROJECT_KEY = 'onboarding:seededProject';
 export const ONBOARDING_SEEDED_TASK_NUMBER_KEY = 'onboarding:seededTaskNumber';
 export const ONBOARDING_DISMISSED_KEY = 'onboarding:dismissed';
 export const ONBOARDING_TASK_NAME = 'Your first task';
+
+/**
+ * Records the path of the first project the user adds (whether via create-new
+ * or open-existing). The OnboardingPanel uses this to decide which project
+ * gets the first-run experience. Idempotent: subsequent project additions are
+ * ignored, so the panel remains anchored to the original first project.
+ *
+ * Returns whether this call was the one that set the value — callers use this
+ * to decide whether to trigger one-time side effects like auto-seeding.
+ */
+export async function recordFirstProjectIfNeeded(projectPath: string): Promise<boolean> {
+  const existing = await getGlobalSetting(ONBOARDING_FIRST_PROJECT_KEY);
+  if (existing) return false;
+  await setGlobalSetting(ONBOARDING_FIRST_PROJECT_KEY, projectPath);
+  onboardingLog.info('recorded first project', { projectPath });
+  return true;
+}
 
 export const ONBOARDING_TASK_PROMPT = `Welcome to Ouijit. This is a practice task to show how the app works end to end.
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -5,26 +5,30 @@ import { getLogger } from './logger';
 const onboardingLog = getLogger().scope('onboarding');
 
 export const ONBOARDING_FIRST_PROJECT_KEY = 'onboarding:firstProjectPath';
+export const ONBOARDING_FIRST_PROJECT_SOURCE_KEY = 'onboarding:firstProjectSource';
 export const ONBOARDING_SEEDED_PROJECT_KEY = 'onboarding:seededProject';
 export const ONBOARDING_SEEDED_TASK_NUMBER_KEY = 'onboarding:seededTaskNumber';
-export const ONBOARDING_SEEDED_ON_DEMAND_KEY = 'onboarding:seededOnDemand';
 export const ONBOARDING_DISMISSED_KEY = 'onboarding:dismissed';
 export const ONBOARDING_TASK_NAME = 'Your first task';
 
+export type FirstProjectSource = 'created' | 'added';
+
 /**
- * Records the path of the first project the user adds (whether via create-new
- * or open-existing). The OnboardingPanel uses this to decide which project
- * gets the first-run experience. Idempotent: subsequent project additions are
- * ignored, so the panel remains anchored to the original first project.
+ * Records the path and source of the first project the user adds (whether via
+ * create-new or open-existing). The OnboardingPanel uses both to decide which
+ * project gets the first-run experience and to vary copy by path. Idempotent:
+ * subsequent project additions are ignored, so the panel remains anchored to
+ * the original first project.
  *
  * Returns whether this call was the one that set the value — callers use this
- * to decide whether to trigger one-time side effects like auto-seeding.
+ * to decide whether to trigger one-time side effects.
  */
-export async function recordFirstProjectIfNeeded(projectPath: string): Promise<boolean> {
+export async function recordFirstProjectIfNeeded(projectPath: string, source: FirstProjectSource): Promise<boolean> {
   const existing = await getGlobalSetting(ONBOARDING_FIRST_PROJECT_KEY);
   if (existing) return false;
   await setGlobalSetting(ONBOARDING_FIRST_PROJECT_KEY, projectPath);
-  onboardingLog.info('recorded first project', { projectPath });
+  await setGlobalSetting(ONBOARDING_FIRST_PROJECT_SOURCE_KEY, source);
+  onboardingLog.info('recorded first project', { projectPath, source });
   return true;
 }
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,5 +1,5 @@
 import { createTodoTask } from './worktree';
-import { getGlobalSetting, setGlobalSetting } from './db';
+import { getGlobalSetting, getTaskByNumber, setGlobalSetting } from './db';
 import { getLogger } from './logger';
 import { type OnboardingStorageIO, patchOnboardingState, readOnboardingState } from './onboardingState';
 import { getProjectList } from './scanner';
@@ -50,13 +50,22 @@ export async function recordFirstProjectIfNeeded(projectPath: string, source: Fi
 
 /**
  * Seeds the onboarding tutorial task in the user's first project. Idempotent
- * via the `seededTaskNumber` field — if a task has already been seeded, this
- * is a no-op. Failure is non-fatal; we log and return.
+ * if a real seeded task already exists. If the persisted `seededTaskNumber`
+ * points at a task that's been deleted, we treat the reference as stale and
+ * re-seed — otherwise the user would be stranded on the intro stage with the
+ * IPC silently no-op'ing forever. Failure is non-fatal; we log and return.
  */
 export async function seedOnboardingTaskIfFirstProject(projectPath: string): Promise<void> {
   try {
     const state = await readOnboardingState(io);
-    if (state?.seededTaskNumber != null) return;
+    if (state?.seededTaskNumber != null) {
+      const existing = await getTaskByNumber(projectPath, state.seededTaskNumber);
+      if (existing) return;
+      onboardingLog.info('seeded task missing; re-seeding', {
+        projectPath,
+        previousTaskNumber: state.seededTaskNumber,
+      });
+    }
 
     const result = await createTodoTask(projectPath, ONBOARDING_TASK_NAME, ONBOARDING_TASK_PROMPT);
     if (!result.success || !result.task) {

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -7,6 +7,7 @@ const onboardingLog = getLogger().scope('onboarding');
 export const ONBOARDING_FIRST_PROJECT_KEY = 'onboarding:firstProjectPath';
 export const ONBOARDING_SEEDED_PROJECT_KEY = 'onboarding:seededProject';
 export const ONBOARDING_SEEDED_TASK_NUMBER_KEY = 'onboarding:seededTaskNumber';
+export const ONBOARDING_SEEDED_ON_DEMAND_KEY = 'onboarding:seededOnDemand';
 export const ONBOARDING_DISMISSED_KEY = 'onboarding:dismissed';
 export const ONBOARDING_TASK_NAME = 'Your first task';
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -5,6 +5,7 @@ import { getLogger } from './logger';
 const onboardingLog = getLogger().scope('onboarding');
 
 export const ONBOARDING_SEEDED_PROJECT_KEY = 'onboarding:seededProject';
+export const ONBOARDING_SEEDED_TASK_NUMBER_KEY = 'onboarding:seededTaskNumber';
 export const ONBOARDING_DISMISSED_KEY = 'onboarding:dismissed';
 export const ONBOARDING_TASK_NAME = 'Your first task';
 
@@ -32,6 +33,9 @@ export async function seedOnboardingTaskIfFirstProject(projectPath: string): Pro
     }
 
     await setGlobalSetting(ONBOARDING_SEEDED_PROJECT_KEY, projectPath);
+    if (result.task) {
+      await setGlobalSetting(ONBOARDING_SEEDED_TASK_NUMBER_KEY, String(result.task.taskNumber));
+    }
     onboardingLog.info('seeded onboarding task', { projectPath, taskNumber: result.task?.taskNumber });
   } catch (error) {
     onboardingLog.error('seed failed unexpectedly', {

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -33,19 +33,31 @@ const io: OnboardingStorageIO = {
  * Ouijit before and should be treated as already onboarded.
  */
 export async function recordFirstProjectIfNeeded(projectPath: string, source: FirstProjectSource): Promise<boolean> {
-  const existing = await readOnboardingState(io);
-  if (existing?.firstProjectPath) return false;
+  // Errors here must not bubble: this runs inside the create-project and
+  // add-project IPC handlers, and we don't want a settings-read or scanner
+  // failure to make a successful project add look like a failure to the
+  // renderer. Worst case the user just doesn't get the onboarding panel.
+  try {
+    const existing = await readOnboardingState(io);
+    if (existing?.firstProjectPath) return false;
 
-  const projects = await getProjectList();
-  if (projects.length > 1) {
-    await patchOnboardingState(io, { dismissed: true });
-    onboardingLog.info('existing user detected; suppressing onboarding', { projectCount: projects.length });
+    const projects = await getProjectList();
+    if (projects.length > 1) {
+      await patchOnboardingState(io, { dismissed: true });
+      onboardingLog.info('existing user detected; suppressing onboarding', { projectCount: projects.length });
+      return false;
+    }
+
+    await patchOnboardingState(io, { firstProjectPath: projectPath, source });
+    onboardingLog.info('recorded first project', { projectPath, source });
+    return true;
+  } catch (error) {
+    onboardingLog.error('recordFirstProjectIfNeeded failed', {
+      projectPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return false;
   }
-
-  await patchOnboardingState(io, { firstProjectPath: projectPath, source });
-  onboardingLog.info('recorded first project', { projectPath, source });
-  return true;
 }
 
 /**

--- a/src/onboardingState.ts
+++ b/src/onboardingState.ts
@@ -1,0 +1,77 @@
+import type { FirstProjectSource, OnboardingState } from './types';
+
+export const ONBOARDING_STATE_KEY = 'onboarding:state';
+export const ONBOARDING_STATE_VERSION = 1;
+
+const DEFAULT_STATE: OnboardingState = {
+  version: ONBOARDING_STATE_VERSION,
+  firstProjectPath: '',
+  source: 'added',
+  seededTaskNumber: null,
+  dismissed: false,
+};
+
+/**
+ * Parses a raw serialized blob and returns a known-shape OnboardingState, or
+ * null if no state exists yet. Missing fields fall back to defaults so older
+ * persisted blobs still produce a valid object. Future schema changes should
+ * bump ONBOARDING_STATE_VERSION and add a `parsed.version === X` branch here
+ * to migrate forward.
+ */
+export function normalizeOnboardingState(raw: string | undefined | null): OnboardingState | null {
+  if (raw == null || raw === '') return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+  const source: FirstProjectSource =
+    obj.source === 'created' || obj.source === 'added' ? obj.source : DEFAULT_STATE.source;
+  return {
+    version: ONBOARDING_STATE_VERSION,
+    firstProjectPath: typeof obj.firstProjectPath === 'string' ? obj.firstProjectPath : DEFAULT_STATE.firstProjectPath,
+    source,
+    seededTaskNumber: typeof obj.seededTaskNumber === 'number' ? obj.seededTaskNumber : null,
+    dismissed: obj.dismissed === true,
+  };
+}
+
+export function serializeOnboardingState(state: OnboardingState): string {
+  return JSON.stringify(state);
+}
+
+export function mergeOnboardingPatch(
+  current: OnboardingState | null,
+  patch: Partial<OnboardingState>,
+): OnboardingState {
+  const base = current ?? DEFAULT_STATE;
+  return { ...base, ...patch, version: ONBOARDING_STATE_VERSION };
+}
+
+/**
+ * Minimal storage interface so the read/patch helpers can be reused from
+ * both the main process (db functions) and the renderer (window.api), each
+ * passing in their own get/set.
+ */
+export interface OnboardingStorageIO {
+  get(key: string): Promise<string | undefined>;
+  set(key: string, value: string): Promise<{ success: boolean }>;
+}
+
+export async function readOnboardingState(io: OnboardingStorageIO): Promise<OnboardingState | null> {
+  const raw = await io.get(ONBOARDING_STATE_KEY);
+  return normalizeOnboardingState(raw ?? null);
+}
+
+export async function patchOnboardingState(
+  io: OnboardingStorageIO,
+  patch: Partial<OnboardingState>,
+): Promise<OnboardingState> {
+  const current = await readOnboardingState(io);
+  const next = mergeOnboardingPatch(current, patch);
+  await io.set(ONBOARDING_STATE_KEY, serializeOnboardingState(next));
+  return next;
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -205,6 +205,10 @@ contextBridge.exposeInMainWorld('api', {
     set: (key: string, value: string) => typedInvoke('settings:set-global', key, value),
   },
 
+  onboarding: {
+    seedTask: (projectPath: string) => typedInvoke('onboarding:seed-task', projectPath),
+  },
+
   health: {
     check: () => typedInvoke('health:check'),
     onUpdate: (callback: (status: import('./healthCheck').HealthStatus) => void) => typedListen('health', callback),

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -21,6 +21,7 @@ interface AppStoreState {
   sandboxVmStatus: string;
   sandboxStarting: boolean;
   whatsNew: { version: string; notes: string } | null;
+  helpDialogOpen: boolean;
   health: HealthStatus | null;
   homeActivePanel: 'home' | 'settings';
   homeRecents: HomeRecentTask[] | null;
@@ -38,6 +39,7 @@ interface AppStoreActions {
   setSandboxStatus: (available: boolean, vmStatus: string) => void;
   setSandboxStarting: (starting: boolean) => void;
   setWhatsNew: (info: { version: string; notes: string } | null) => void;
+  setHelpDialogOpen: (open: boolean) => void;
   setHealth: (status: HealthStatus | null) => void;
   setHomeActivePanel: (panel: 'home' | 'settings') => void;
   navigateToProject: (path: string, project: Project, options?: { direction?: ViewTransitionDirection }) => void;
@@ -76,6 +78,7 @@ export const useAppStore = create<AppStore>()((set, get) => ({
   sandboxVmStatus: '',
   sandboxStarting: false,
   whatsNew: null,
+  helpDialogOpen: false,
   health: null,
   homeActivePanel: 'home',
   homeRecents: null,
@@ -93,6 +96,8 @@ export const useAppStore = create<AppStore>()((set, get) => ({
   setSandboxStarting: (starting) => set({ sandboxStarting: starting }),
 
   setWhatsNew: (info) => set({ whatsNew: info }),
+
+  setHelpDialogOpen: (open) => set({ helpDialogOpen: open }),
 
   setHealth: (status) => set({ health: status }),
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -22,6 +22,14 @@ interface AppStoreState {
   sandboxStarting: boolean;
   whatsNew: { version: string; notes: string } | null;
   helpDialogOpen: boolean;
+  /**
+   * Session-only onboarding panel state. Lives in the app store (not in the
+   * OnboardingPanel component) so it survives kanban-toggle remounts — without
+   * this, hitting "Hide for now" or being in the stuck state would reset every
+   * time the user toggled the kanban view off and back on.
+   */
+  onboardingSoftDismissed: boolean;
+  onboardingStuckLatched: boolean;
   health: HealthStatus | null;
   homeActivePanel: 'home' | 'settings';
   homeRecents: HomeRecentTask[] | null;
@@ -40,6 +48,8 @@ interface AppStoreActions {
   setSandboxStarting: (starting: boolean) => void;
   setWhatsNew: (info: { version: string; notes: string } | null) => void;
   setHelpDialogOpen: (open: boolean) => void;
+  setOnboardingSoftDismissed: (value: boolean) => void;
+  setOnboardingStuckLatched: (value: boolean) => void;
   setHealth: (status: HealthStatus | null) => void;
   setHomeActivePanel: (panel: 'home' | 'settings') => void;
   navigateToProject: (path: string, project: Project, options?: { direction?: ViewTransitionDirection }) => void;
@@ -79,6 +89,8 @@ export const useAppStore = create<AppStore>()((set, get) => ({
   sandboxStarting: false,
   whatsNew: null,
   helpDialogOpen: false,
+  onboardingSoftDismissed: false,
+  onboardingStuckLatched: false,
   health: null,
   homeActivePanel: 'home',
   homeRecents: null,
@@ -98,6 +110,10 @@ export const useAppStore = create<AppStore>()((set, get) => ({
   setWhatsNew: (info) => set({ whatsNew: info }),
 
   setHelpDialogOpen: (open) => set({ helpDialogOpen: open }),
+
+  setOnboardingSoftDismissed: (value) => set({ onboardingSoftDismissed: value }),
+
+  setOnboardingStuckLatched: (value) => set({ onboardingStuckLatched: value }),
 
   setHealth: (status) => set({ health: status }),
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -558,6 +558,30 @@ export interface OnboardingAPI {
 }
 
 /**
+ * Whether the user's first project was created fresh or added from an
+ * existing folder. Used to vary the intro stage lead.
+ */
+export type FirstProjectSource = 'created' | 'added';
+
+/**
+ * All first-run onboarding state, stored as a single JSON blob under the
+ * `onboarding:state` global setting. Single read on mount, single write per
+ * transition. The seeded task itself lives in the task table — only the
+ * task number is kept here so the panel can resolve it.
+ *
+ * `version` exists for schema evolution: bump the constant in
+ * `src/onboardingState.ts` and add migration logic to `normalizeOnboardingState`
+ * when the shape changes.
+ */
+export interface OnboardingState {
+  version: number;
+  firstProjectPath: string;
+  source: FirstProjectSource;
+  seededTaskNumber: number | null;
+  dismissed: boolean;
+}
+
+/**
  * Health probe API exposed to the renderer
  */
 export interface HealthAPI {

--- a/src/types.ts
+++ b/src/types.ts
@@ -542,10 +542,19 @@ export interface ElectronAPI {
   lima: LimaAPI;
   /** Global settings API */
   globalSettings: GlobalSettingsAPI;
+  /** Onboarding API */
+  onboarding: OnboardingAPI;
   /** Health probe API (git/claude/lima detection) */
   health: HealthAPI;
   /** Capture-mode API (only populated when OUIJIT_CAPTURE_MODE=1) */
   capture: CaptureAPI;
+}
+
+/**
+ * Onboarding API exposed to the renderer
+ */
+export interface OnboardingAPI {
+  seedTask(projectPath: string): Promise<{ success: boolean }>;
 }
 
 /**

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -57,6 +57,7 @@ import pencilSimple from '@phosphor-icons/core/assets/regular/pencil-simple.svg?
 import play from '@phosphor-icons/core/assets/regular/play.svg?raw';
 import plus from '@phosphor-icons/core/assets/regular/plus.svg?raw';
 import prohibit from '@phosphor-icons/core/assets/regular/prohibit.svg?raw';
+import question from '@phosphor-icons/core/assets/regular/question.svg?raw';
 import rocket from '@phosphor-icons/core/assets/regular/rocket.svg?raw';
 import sidebarSimple from '@phosphor-icons/core/assets/regular/sidebar-simple.svg?raw';
 import splitHorizontal from '@phosphor-icons/core/assets/regular/split-horizontal.svg?raw';
@@ -127,6 +128,7 @@ export const iconMap: Record<string, string> = {
   play: play,
   plus: plus,
   prohibit: prohibit,
+  question: question,
   rocket: rocket,
   'sidebar-simple': sidebarSimple,
   'split-horizontal': splitHorizontal,


### PR DESCRIPTION
## Summary

- Unify create-new and open-existing paths through a single opt-in intro stage. Both record the first project; neither auto-seeds. The user always sees an intro before the practice task is added.
- Redesign the home empty state: drop the logotype and tagline, replace the single CTA with two verb-led action rows ("Open" / "Create") that bypass the sidebar add-menu and dispatch directly to the existing handlers.
- Add a stuck-state recovery in in-flight when the start hook wasn't configured (or was set after the task moved). Shows the failure factually with a `Move task back to To Do` path forward and an amber `!` badge instead of the normal check.
- One-click `Use this` button next to the example start hook so the practice task actually runs without the user typing the command into a dialog.
- Soft dismiss at the intro stage (returns next session) so users who hit X without engaging aren't permanently stranded; later stages dismiss permanently as before.
- Help & setup and Docs CTAs visible on every stage; navigate into the project after add-existing.
- Consolidate persisted onboarding state into a single versioned JSON blob (`onboarding:state`) with shared normalize/patch helpers in `src/onboardingState.ts`. One key, one read on mount, one write per change, with a `version` field and field-by-field normalization for future schema evolution.