### PR TITLE
Patch transitive deps to clear npm audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -660,25 +660,21 @@
       }
     },
     "node_modules/@electron-forge/cli": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.11.1.tgz",
-      "integrity": "sha512-pk8AoLsr7t7LBAt0cFD06XFA6uxtPdvtLx06xeal7O9o7GHGCbj29WGwFoJ8Br/ENM0Ho868S3PrAn1PtBXt5g==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.11.2.tgz",
+      "integrity": "sha512-c+C4ndLfHbxwZuCn9G8iT9wD/woLdaVkoSVjAIbj+0nJhi8UmiVsz/+Gxlj4cvhMRTzBMBxudstLU7RocMikfg==",
       "dev": true,
       "funding": [
         {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-.electron-forge-cli?utm_medium=referral&utm_source=npm_fund"
+          "type": "opencollective",
+          "url": "https://opencollective.com/electron"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/core": "7.11.1",
-        "@electron-forge/core-utils": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/core": "7.11.2",
+        "@electron-forge/core-utils": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2",
         "@electron/get": "^3.0.0",
         "@inquirer/prompts": "^6.0.1",
         "@listr2/prompt-adapter-inquirer": "^2.0.22",
@@ -699,6 +695,35 @@
         "node": ">= 16.4.0"
       }
     },
+    "node_modules/@electron-forge/cli/node_modules/@electron-forge/shared-types": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.2.tgz",
+      "integrity": "sha512-Tcles7y74xy3jN5dEC+Pt1duJYk4c7W2xu98tjWW8RewmfKD2uHkie6I1I3yifPFZXZ/QfTlaFOOoKIQ9ENZjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/tracer": "7.11.2",
+        "@electron/packager": "^18.3.5",
+        "@electron/rebuild": "^3.7.0",
+        "listr2": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/cli/node_modules/@electron-forge/tracer": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.2.tgz",
+      "integrity": "sha512-U8j5Hyj2Zt7I5PciJvPJfmEv69Gb/Da9v+k655z3Jj1cuY0UnToEJ61IhXrzlTYqo+jUKC+fgAjDJ6vltJTS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chrome-trace-event": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
+      }
+    },
     "node_modules/@electron-forge/cli/node_modules/commander": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
@@ -710,33 +735,29 @@
       }
     },
     "node_modules/@electron-forge/core": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.11.1.tgz",
-      "integrity": "sha512-YtuPLzggPKPabFAD2rOZFE0s7f4KaUTpGRduhSMbZUqpqD1TIPyfoDBpYiZvao3Ht8pyZeOJjbzcC0LpFs9gIQ==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.11.2.tgz",
+      "integrity": "sha512-RbOvlCahSlYBkY1XFgD5QuoifZltEY3ezYGqJYnV1z6RiUK1DfUXwdidmclBLI9d6u8NNr9xWPv79LHVc9ZA3Q==",
       "dev": true,
       "funding": [
         {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-.electron-forge-core?utm_medium=referral&utm_source=npm_fund"
+          "type": "opencollective",
+          "url": "https://opencollective.com/electron"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/core-utils": "7.11.1",
-        "@electron-forge/maker-base": "7.11.1",
-        "@electron-forge/plugin-base": "7.11.1",
-        "@electron-forge/publisher-base": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
-        "@electron-forge/template-vite": "7.11.1",
-        "@electron-forge/template-vite-typescript": "7.11.1",
-        "@electron-forge/template-webpack": "7.11.1",
-        "@electron-forge/template-webpack-typescript": "7.11.1",
-        "@electron-forge/tracer": "7.11.1",
+        "@electron-forge/core-utils": "7.11.2",
+        "@electron-forge/maker-base": "7.11.2",
+        "@electron-forge/plugin-base": "7.11.2",
+        "@electron-forge/publisher-base": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2",
+        "@electron-forge/template-base": "7.11.2",
+        "@electron-forge/template-vite": "7.11.2",
+        "@electron-forge/template-vite-typescript": "7.11.2",
+        "@electron-forge/template-webpack": "7.11.2",
+        "@electron-forge/template-webpack-typescript": "7.11.2",
+        "@electron-forge/tracer": "7.11.2",
         "@electron/get": "^3.0.0",
         "@electron/packager": "^18.3.5",
         "@electron/rebuild": "^3.7.0",
@@ -744,6 +765,7 @@
         "@vscode/sudo-prompt": "^9.3.1",
         "chalk": "^4.0.0",
         "debug": "^4.3.1",
+        "eta": "^3.5.0",
         "fast-glob": "^3.2.7",
         "filenamify": "^4.1.0",
         "find-up": "^5.0.0",
@@ -753,7 +775,6 @@
         "interpret": "^3.1.1",
         "jiti": "^2.4.2",
         "listr2": "^7.0.2",
-        "lodash": "^4.17.20",
         "log-symbols": "^4.0.0",
         "node-fetch": "^2.6.7",
         "rechoir": "^0.8.0",
@@ -766,13 +787,13 @@
       }
     },
     "node_modules/@electron-forge/core-utils": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-7.11.1.tgz",
-      "integrity": "sha512-9UxRWVsfcziBsbAA2MS0Oz4yYovQCO2BhnGIfsbKNTBtMc/RcVSxAS0NMyymce44i43p1ZC/FqWhnt1XqYw3bQ==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-7.11.2.tgz",
+      "integrity": "sha512-/Fpwo44an6ulUdq94co5OOcbRCohgYNci/E6eoZZuTO9f72X+PqJkMkghqkMX3iQ8Aq2QRLkGKFwrKWJNTjL7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/shared-types": "7.11.2",
         "@electron/rebuild": "^3.7.0",
         "@malept/cross-spawn-promise": "^2.0.0",
         "chalk": "^4.0.0",
@@ -785,6 +806,105 @@
       },
       "engines": {
         "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/core-utils/node_modules/@electron-forge/shared-types": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.2.tgz",
+      "integrity": "sha512-Tcles7y74xy3jN5dEC+Pt1duJYk4c7W2xu98tjWW8RewmfKD2uHkie6I1I3yifPFZXZ/QfTlaFOOoKIQ9ENZjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/tracer": "7.11.2",
+        "@electron/packager": "^18.3.5",
+        "@electron/rebuild": "^3.7.0",
+        "listr2": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/core-utils/node_modules/@electron-forge/tracer": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.2.tgz",
+      "integrity": "sha512-U8j5Hyj2Zt7I5PciJvPJfmEv69Gb/Da9v+k655z3Jj1cuY0UnToEJ61IhXrzlTYqo+jUKC+fgAjDJ6vltJTS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chrome-trace-event": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
+      }
+    },
+    "node_modules/@electron-forge/core/node_modules/@electron-forge/maker-base": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.11.2.tgz",
+      "integrity": "sha512-9934zYu9WVdgCYQXvtS+eL1oyLagsY8JlWhZmoK8yWTYftSAydH7jb3seVpfy6n85SYmY/yjcAy2lvOTy5dUwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/shared-types": "7.11.2",
+        "fs-extra": "^10.0.0",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/core/node_modules/@electron-forge/plugin-base": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-7.11.2.tgz",
+      "integrity": "sha512-tIFzEE2+D9NnCAn/rLwSkh8H59IqN+G973JNl7xmCzquO6qa7/veitZOQFGO79Zmmgkc8R/fmiCbh7LIdLS9Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/shared-types": "7.11.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/core/node_modules/@electron-forge/publisher-base": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-7.11.2.tgz",
+      "integrity": "sha512-YwK4ZF3+uW7PBEV/ho59NVTriP3fCahskORrztUaFIdG0QP3hqMsfmo01euv98FDsBEW9UXo7/EW8t5jpmYZ0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/shared-types": "7.11.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/core/node_modules/@electron-forge/shared-types": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.2.tgz",
+      "integrity": "sha512-Tcles7y74xy3jN5dEC+Pt1duJYk4c7W2xu98tjWW8RewmfKD2uHkie6I1I3yifPFZXZ/QfTlaFOOoKIQ9ENZjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/tracer": "7.11.2",
+        "@electron/packager": "^18.3.5",
+        "@electron/rebuild": "^3.7.0",
+        "listr2": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/core/node_modules/@electron-forge/tracer": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.2.tgz",
+      "integrity": "sha512-U8j5Hyj2Zt7I5PciJvPJfmEv69Gb/Da9v+k655z3Jj1cuY0UnToEJ61IhXrzlTYqo+jUKC+fgAjDJ6vltJTS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chrome-trace-event": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
       }
     },
     "node_modules/@electron-forge/maker-base": {
@@ -1018,14 +1138,14 @@
       }
     },
     "node_modules/@electron-forge/template-base": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-7.11.1.tgz",
-      "integrity": "sha512-XpTaEf+EfQw+0BlSAtSpZKYIKYvKu4raNzSGHZZoSYHp+HDC7R+MlpFQmSJiGdYQzQ14C+uxO42tVjgM0DMbpw==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-7.11.2.tgz",
+      "integrity": "sha512-l10I+XZRbbxFGiDLMnuXmlOppmLYmimKj6FWjEGUvft4VJFXW2BIDrLIugIGdM1nbrl/0aYjen2xRg0nZlcWzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/core-utils": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/core-utils": "7.11.2",
+        "@electron-forge/shared-types": "7.11.2",
         "@malept/cross-spawn-promise": "^2.0.0",
         "debug": "^4.3.1",
         "fs-extra": "^10.0.0",
@@ -1036,15 +1156,44 @@
         "node": ">= 16.4.0"
       }
     },
-    "node_modules/@electron-forge/template-vite": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-7.11.1.tgz",
-      "integrity": "sha512-Or8Lxf4awoeUZoMTKJEw5KQDIhqOFs24WhVka3yZXxc6VgVWN79KmYKYM6uM/YMQttmafhsBhY2t1Lxo1WR/ug==",
+    "node_modules/@electron-forge/template-base/node_modules/@electron-forge/shared-types": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.2.tgz",
+      "integrity": "sha512-Tcles7y74xy3jN5dEC+Pt1duJYk4c7W2xu98tjWW8RewmfKD2uHkie6I1I3yifPFZXZ/QfTlaFOOoKIQ9ENZjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
+        "@electron-forge/tracer": "7.11.2",
+        "@electron/packager": "^18.3.5",
+        "@electron/rebuild": "^3.7.0",
+        "listr2": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/template-base/node_modules/@electron-forge/tracer": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.2.tgz",
+      "integrity": "sha512-U8j5Hyj2Zt7I5PciJvPJfmEv69Gb/Da9v+k655z3Jj1cuY0UnToEJ61IhXrzlTYqo+jUKC+fgAjDJ6vltJTS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chrome-trace-event": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
+      }
+    },
+    "node_modules/@electron-forge/template-vite": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-7.11.2.tgz",
+      "integrity": "sha512-yFSDSu3IdyNpgLXzrwODSUyaWniHRSZI82gwcXdnJLx7D7DIDLtbx6KzEoy7QBmWZRULO3F7rLsYG+Ur7orvyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/shared-types": "7.11.2",
+        "@electron-forge/template-base": "7.11.2",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -1052,29 +1201,87 @@
       }
     },
     "node_modules/@electron-forge/template-vite-typescript": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-7.11.1.tgz",
-      "integrity": "sha512-Us4AHXFb+4z+gXgZImSqMBS63oKnsQWLOhqRg321xiDzu2UcQPlwgWNb4rAEKNVC1e7LXrUNDHuBiTrQkvWXbg==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-7.11.2.tgz",
+      "integrity": "sha512-QvvdmO9Gdv+3aISI9+bBLKPBTyKaucs6HhXxz+IDALcdykIL9wVN0/BrWuwwgbwuw4BiJTyXGSPNXuJ+EWnP6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
+        "@electron-forge/shared-types": "7.11.2",
+        "@electron-forge/template-base": "7.11.2",
         "fs-extra": "^10.0.0"
       },
       "engines": {
         "node": ">= 16.4.0"
       }
     },
-    "node_modules/@electron-forge/template-webpack": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.11.1.tgz",
-      "integrity": "sha512-15lbXxi+er461MPk6sbwAOyjofAHwmQjTvxNCiNpaU2naEwbj3t0SlLq/BMr5HxnVOaMmA7+lKV9afkIom+d4Q==",
+    "node_modules/@electron-forge/template-vite-typescript/node_modules/@electron-forge/shared-types": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.2.tgz",
+      "integrity": "sha512-Tcles7y74xy3jN5dEC+Pt1duJYk4c7W2xu98tjWW8RewmfKD2uHkie6I1I3yifPFZXZ/QfTlaFOOoKIQ9ENZjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
+        "@electron-forge/tracer": "7.11.2",
+        "@electron/packager": "^18.3.5",
+        "@electron/rebuild": "^3.7.0",
+        "listr2": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/template-vite-typescript/node_modules/@electron-forge/tracer": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.2.tgz",
+      "integrity": "sha512-U8j5Hyj2Zt7I5PciJvPJfmEv69Gb/Da9v+k655z3Jj1cuY0UnToEJ61IhXrzlTYqo+jUKC+fgAjDJ6vltJTS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chrome-trace-event": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
+      }
+    },
+    "node_modules/@electron-forge/template-vite/node_modules/@electron-forge/shared-types": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.2.tgz",
+      "integrity": "sha512-Tcles7y74xy3jN5dEC+Pt1duJYk4c7W2xu98tjWW8RewmfKD2uHkie6I1I3yifPFZXZ/QfTlaFOOoKIQ9ENZjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/tracer": "7.11.2",
+        "@electron/packager": "^18.3.5",
+        "@electron/rebuild": "^3.7.0",
+        "listr2": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/template-vite/node_modules/@electron-forge/tracer": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.2.tgz",
+      "integrity": "sha512-U8j5Hyj2Zt7I5PciJvPJfmEv69Gb/Da9v+k655z3Jj1cuY0UnToEJ61IhXrzlTYqo+jUKC+fgAjDJ6vltJTS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chrome-trace-event": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
+      }
+    },
+    "node_modules/@electron-forge/template-webpack": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.11.2.tgz",
+      "integrity": "sha512-JjG8XIZctrSZvTlii7Hqvt/pHDKigRk4PoLTQCs1TiT05ZWsn40itBm8cbja3L7bfm0ccDd3JTWWOl2G7PhlmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/shared-types": "7.11.2",
+        "@electron-forge/template-base": "7.11.2",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -1082,20 +1289,49 @@
       }
     },
     "node_modules/@electron-forge/template-webpack-typescript": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-7.11.1.tgz",
-      "integrity": "sha512-6ExfFnFkHBz8rvRFTFg5HVGTC12uJpbVk4q8DVg0R8rhhxhqiVNh8lF2UPtZ2yT2UtGWjXNVlyP3Y3T6q6E3GQ==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-7.11.2.tgz",
+      "integrity": "sha512-2lwK+OrCeZgYM8WqsUXJzk94rdF0z/kA7WnAf79U3COEmAAMcFIwJtwF8c/n+52UecP3yrEE70LIGmM1sjGZJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
+        "@electron-forge/shared-types": "7.11.2",
+        "@electron-forge/template-base": "7.11.2",
         "fs-extra": "^10.0.0",
         "typescript": "~5.4.5",
         "webpack": "^5.69.1"
       },
       "engines": {
         "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/template-webpack-typescript/node_modules/@electron-forge/shared-types": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.2.tgz",
+      "integrity": "sha512-Tcles7y74xy3jN5dEC+Pt1duJYk4c7W2xu98tjWW8RewmfKD2uHkie6I1I3yifPFZXZ/QfTlaFOOoKIQ9ENZjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/tracer": "7.11.2",
+        "@electron/packager": "^18.3.5",
+        "@electron/rebuild": "^3.7.0",
+        "listr2": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/template-webpack-typescript/node_modules/@electron-forge/tracer": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.2.tgz",
+      "integrity": "sha512-U8j5Hyj2Zt7I5PciJvPJfmEv69Gb/Da9v+k655z3Jj1cuY0UnToEJ61IhXrzlTYqo+jUKC+fgAjDJ6vltJTS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chrome-trace-event": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
       }
     },
     "node_modules/@electron-forge/template-webpack-typescript/node_modules/typescript": {
@@ -1110,6 +1346,35 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/@electron-forge/template-webpack/node_modules/@electron-forge/shared-types": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.2.tgz",
+      "integrity": "sha512-Tcles7y74xy3jN5dEC+Pt1duJYk4c7W2xu98tjWW8RewmfKD2uHkie6I1I3yifPFZXZ/QfTlaFOOoKIQ9ENZjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/tracer": "7.11.2",
+        "@electron/packager": "^18.3.5",
+        "@electron/rebuild": "^3.7.0",
+        "listr2": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "node_modules/@electron-forge/template-webpack/node_modules/@electron-forge/tracer": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.2.tgz",
+      "integrity": "sha512-U8j5Hyj2Zt7I5PciJvPJfmEv69Gb/Da9v+k655z3Jj1cuY0UnToEJ61IhXrzlTYqo+jUKC+fgAjDJ6vltJTS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chrome-trace-event": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
       }
     },
     "node_modules/@electron-forge/tracer": {
@@ -1501,9 +1766,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4532,28 +4797,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4903,9 +5146,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5761,9 +6004,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8123,14 +8366,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
+      "integrity": "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -8199,9 +8442,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8474,9 +8717,9 @@
       }
     },
     "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8668,6 +8911,19 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eta": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-3.5.0.tgz",
+      "integrity": "sha512-e3x3FBvGzeCIHhF+zhK8FZA2vC5uFn6b4HJjegUbIWrDb4mJ7JjTGMJY9VGIbRVpmSwHopNiaJibhjIr+HfLug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/eta-dev/eta?sponsor=1"
       }
     },
     "node_modules/eventemitter3": {
@@ -10131,13 +10387,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -10643,9 +10892,9 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10677,7 +10926,8 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -12929,9 +13179,9 @@
       }
     },
     "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -13612,9 +13862,9 @@
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13760,9 +14010,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
-      "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13782,10 +14032,37 @@
         "webpack": "^5.1.0"
       },
       "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
         "@swc/core": {
           "optional": true
         },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
         "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
           "optional": true
         },
         "uglify-js": {
@@ -13904,9 +14181,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14790,14 +15067,12 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.105.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.3.tgz",
-      "integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
+      "version": "5.107.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
+      "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
@@ -14807,21 +15082,20 @@
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.19.0",
-        "es-module-lexer": "^2.0.0",
+        "enhanced-resolve": "^5.22.0",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "loader-runner": "^4.3.2",
+        "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.16",
+        "terser-webpack-plugin": "^5.5.0",
         "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.4"
+        "webpack-sources": "^3.5.0"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -14840,13 +15114,23 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
-      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/whatwg-mimetype": {


### PR DESCRIPTION
## Summary
- Ran `npm audit fix` to bump transitive deps (`tmp` 0.2.5 → 0.2.7, `brace-expansion` 5.0.5 → 5.0.6, webpack/forge template updates)
- Clears 6 vulnerabilities (1 moderate, 5 high) reported by `npm audit`; lockfile-only change