### PR TITLE
Drop captureFixture subtask assertion

### DIFF
--- a/src/__tests__/captureFixture.test.ts
+++ b/src/__tests__/captureFixture.test.ts
@@ -38,7 +38,6 @@ describe('seedCaptureFixture', () => {
     const tasks = new TaskRepo(db).getAllForProject(result.projectPath);
     const statuses = new Set(tasks.map((t) => t.status));
     expect(statuses).toEqual(new Set(['todo', 'in_progress', 'in_review', 'done']));
-    expect(tasks.some((t) => t.parent_task_number !== null)).toBe(true);
   });
 
   test('seeds hooks and scripts', () => {


### PR DESCRIPTION
## Summary
- Remove the `parent_task_number !== null` assertion in `captureFixture.test.ts` since the seeder no longer creates a subtask.