### PR TITLE
Offer git init when adding a non-git folder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { GlobalSettingsPanel } from './components/GlobalSettingsPanel';
 import { ProjectView } from './components/ProjectViewReact';
 import { ToastContainer } from './components/ui/ToastContainer';
 import { NewProjectDialog } from './components/dialogs/NewProjectDialog';
+import { InitGitRepoDialog } from './components/dialogs/InitGitRepoDialog';
 import { WhatsNewDialog } from './components/dialogs/WhatsNewDialog';
 import { HelpDialog } from './components/dialogs/HelpDialog';
 import { installCaptureNavigator } from './capture/navigator';
@@ -66,6 +67,7 @@ export function App() {
   const helpDialogOpen = useAppStore((s) => s.helpDialogOpen);
   const homeActivePanel = useAppStore((s) => s.homeActivePanel);
   const [showNewProject, setShowNewProject] = useState(false);
+  const [gitInitPath, setGitInitPath] = useState<string | null>(null);
   const [initialized, setInitialized] = useState(false);
 
   // Hydrate experimental flags whenever the active project changes
@@ -202,23 +204,46 @@ export function App() {
     window.api.globalSettings.set('lastActiveView', JSON.stringify({ type: 'home' }));
   }, []);
 
+  // Register the added folder, refresh the project list, and navigate to it.
+  const finalizeAddedProject = useCallback(async (addedPath: string) => {
+    const projects = await window.api.refreshProjects();
+    useAppStore.getState().setProjects(projects);
+    const project = projects.find((p) => p.path === addedPath);
+    if (project) {
+      useAppStore.getState().navigateToProject(addedPath, project);
+    }
+  }, []);
+
   const handleAddExisting = useCallback(async () => {
     const result = await window.api.showFolderPicker();
     if (!result.canceled && result.filePaths.length > 0) {
       const addedPath = result.filePaths[0];
       const addResult = await window.api.addProject(addedPath);
       if (addResult.success) {
-        const projects = await window.api.refreshProjects();
-        useAppStore.getState().setProjects(projects);
-        const project = projects.find((p) => p.path === addedPath);
-        if (project) {
-          useAppStore.getState().navigateToProject(addedPath, project);
-        }
+        await finalizeAddedProject(addedPath);
+      } else if (addResult.reason === 'not-a-git-repo') {
+        // Recoverable dead-end: offer to `git init` the folder in place.
+        setGitInitPath(addedPath);
       } else if (addResult.error) {
         useProjectStore.getState().addToast(addResult.error, 'error');
       }
     }
-  }, []);
+  }, [finalizeAddedProject]);
+
+  const handleGitInitClose = useCallback(
+    async (result: { initialized: boolean; initialCommit: boolean } | null) => {
+      const folderPath = gitInitPath;
+      setGitInitPath(null);
+      if (!result?.initialized || !folderPath) return;
+      const addResult = await window.api.addProject(folderPath);
+      if (addResult.success) {
+        await finalizeAddedProject(folderPath);
+      } else if (addResult.error) {
+        useProjectStore.getState().addToast(addResult.error, 'error');
+      }
+    },
+    [gitInitPath, finalizeAddedProject],
+  );
 
   const handleCreateNew = useCallback(() => {
     setShowNewProject(true);
@@ -281,6 +306,7 @@ export function App() {
       </div>
       <ToastContainer />
       {showNewProject && <NewProjectDialog onClose={handleNewProjectClose} />}
+      {gitInitPath && <InitGitRepoDialog folderPath={gitInitPath} onClose={handleGitInitClose} />}
       {whatsNew && (
         <WhatsNewDialog
           version={whatsNew.version}

--- a/src/__tests__/renderer/setup.ts
+++ b/src/__tests__/renderer/setup.ts
@@ -39,6 +39,7 @@ const mockApi = {
   createProject: vi.fn().mockResolvedValue({ success: true }),
   showFolderPicker: vi.fn().mockResolvedValue({ canceled: true, filePaths: [] }),
   addProject: vi.fn().mockResolvedValue({ success: true }),
+  initGitRepo: vi.fn().mockResolvedValue({ success: true }),
   removeProject: vi.fn().mockResolvedValue({ success: true }),
   reorderProjects: vi.fn().mockResolvedValue({ success: true }),
   onFullscreenChange: vi.fn().mockReturnValue(() => {}),

--- a/src/__tests__/validateProjectFolder.test.ts
+++ b/src/__tests__/validateProjectFolder.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect, beforeEach } from 'vitest';
+import { execSync } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { validateProjectFolder } from '../projectCreator';
+import { validateProjectFolder, initGitRepo } from '../projectCreator';
 
 let scratchDir: string;
 
@@ -18,7 +19,10 @@ describe('validateProjectFolder', () => {
     const result = await validateProjectFolder(folder);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error).toMatch(/not a git repository/i);
+    if (!result.ok) {
+      expect(result.error).toMatch(/not a git repository/i);
+      expect(result.reason).toBe('not-a-git-repo');
+    }
   });
 
   test('accepts a folder containing a .git directory', async () => {
@@ -45,6 +49,7 @@ describe('validateProjectFolder', () => {
     const folder = path.join(scratchDir, 'does-not-exist');
     const result = await validateProjectFolder(folder);
     expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('not-found');
   });
 
   test('rejects a path that is a file, not a directory', async () => {
@@ -52,6 +57,48 @@ describe('validateProjectFolder', () => {
     await fs.writeFile(file, 'hi');
     const result = await validateProjectFolder(file);
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error).toMatch(/not a directory/i);
+    if (!result.ok) {
+      expect(result.error).toMatch(/not a directory/i);
+      expect(result.reason).toBe('not-a-directory');
+    }
+  });
+});
+
+describe('initGitRepo', () => {
+  test('initializes a repo in a plain folder, making it pass validation', async () => {
+    const folder = path.join(scratchDir, 'to-init');
+    await fs.mkdir(folder);
+
+    const result = await initGitRepo(folder);
+
+    expect(result.success).toBe(true);
+    await expect(fs.access(path.join(folder, '.git'))).resolves.toBeUndefined();
+    expect((await validateProjectFolder(folder)).ok).toBe(true);
+  });
+
+  test('creates an initial commit when requested', async () => {
+    const folder = path.join(scratchDir, 'with-commit');
+    await fs.mkdir(folder);
+    await fs.writeFile(path.join(folder, 'README.md'), '# hi\n');
+
+    const result = await initGitRepo(folder, { initialCommit: true });
+
+    expect(result.success).toBe(true);
+    const log = execSync('git log --oneline', { cwd: folder }).toString();
+    expect(log).toMatch(/Initial commit/);
+  });
+
+  test('is a no-op success when the folder is already a repo', async () => {
+    const folder = path.join(scratchDir, 'already-repo');
+    await fs.mkdir(folder);
+    execSync('git init', { cwd: folder, stdio: 'ignore' });
+
+    const result = await initGitRepo(folder);
+    expect(result.success).toBe(true);
+  });
+
+  test('fails when the folder does not exist', async () => {
+    const result = await initGitRepo(path.join(scratchDir, 'nope'));
+    expect(result.success).toBe(false);
   });
 });

--- a/src/components/dialogs/InitGitRepoDialog.tsx
+++ b/src/components/dialogs/InitGitRepoDialog.tsx
@@ -1,0 +1,109 @@
+import { useState, useEffect, useCallback } from 'react';
+import { DialogOverlay } from './DialogOverlay';
+import { useAppStore } from '../../stores/appStore';
+
+interface InitGitRepoDialogProps {
+  folderPath: string;
+  onClose: (result: { initialized: boolean; initialCommit: boolean } | null) => void;
+}
+
+/** Basename for display — full path is shown as a subtitle. */
+function folderName(folderPath: string): string {
+  const parts = folderPath.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? folderPath;
+}
+
+/**
+ * Offered when a user picks a plain (non-git) folder to add as a project.
+ * Turns the "not a git repository" dead-end into a guided `git init` in place,
+ * with an optional initial commit of any existing files.
+ */
+export function InitGitRepoDialog({ folderPath, onClose }: InitGitRepoDialogProps) {
+  const [visible, setVisible] = useState(false);
+  const [initialCommit, setInitialCommit] = useState(true);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const health = useAppStore((s) => s.health);
+  const gitMissing = health !== null && !health.git;
+
+  useEffect(() => {
+    requestAnimationFrame(() => setVisible(true));
+  }, []);
+
+  const dismiss = useCallback(
+    (result: { initialized: boolean; initialCommit: boolean } | null) => {
+      setVisible(false);
+      setTimeout(() => onClose(result), 200);
+    },
+    [onClose],
+  );
+
+  const handleInit = useCallback(async () => {
+    if (working || gitMissing) return;
+    setError(null);
+    setWorking(true);
+    const result = await window.api.initGitRepo(folderPath, initialCommit);
+    if (result.success) {
+      dismiss({ initialized: true, initialCommit });
+    } else {
+      setError(result.error ?? 'Could not initialize git repository.');
+      setWorking(false);
+    }
+  }, [working, gitMissing, folderPath, initialCommit, dismiss]);
+
+  return (
+    <DialogOverlay visible={visible} onDismiss={() => dismiss(null)} maxWidth={440}>
+      <h2 data-testid="dialog-title" className="text-lg font-semibold text-text-primary mb-4 text-center">
+        Not a Git Repository
+      </h2>
+      <p className="text-sm text-text-secondary text-center">
+        &ldquo;<strong className="text-text-primary">{folderName(folderPath)}</strong>&rdquo; isn&rsquo;t a Git
+        repository yet. Initialize one here to add it as a project?
+      </p>
+      <p className="text-xs text-text-secondary/70 text-center mt-1 font-mono break-all">{folderPath}</p>
+      {gitMissing ? (
+        <div
+          className="mt-4 px-3 py-2 rounded-md text-xs text-text-primary"
+          style={{ background: 'var(--color-git-light)', border: '1px solid var(--color-git)' }}
+        >
+          <strong className="font-medium">Git not found.</strong> Install via{' '}
+          <code className="px-1 py-0.5 rounded bg-white/10 font-mono">xcode-select --install</code> (macOS) or your
+          package manager.
+        </div>
+      ) : (
+        <label className="flex items-center gap-2 justify-center mt-4 text-sm text-text-secondary [-webkit-app-region:no-drag]">
+          <input
+            type="checkbox"
+            checked={initialCommit}
+            onChange={(e) => setInitialCommit(e.target.checked)}
+            disabled={working}
+          />
+          Create an initial commit of existing files
+        </label>
+      )}
+      {error && (
+        <p data-testid="dialog-error" className="text-xs text-error mt-3 text-center">
+          {error}
+        </p>
+      )}
+      <div className="flex gap-2 justify-end mt-4 items-center">
+        <button
+          data-testid="dialog-cancel"
+          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-accent bg-accent-light hover:bg-[rgba(0,122,255,0.15)]"
+          onClick={() => dismiss(null)}
+          disabled={working}
+        >
+          Cancel
+        </button>
+        <button
+          data-testid="dialog-init"
+          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
+          onClick={handleInit}
+          disabled={working || gitMissing}
+        >
+          {working ? 'Initializing…' : 'Initialize Repository'}
+        </button>
+      </div>
+    </DialogOverlay>
+  );
+}

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -33,6 +33,7 @@ import type {
   BranchInfo,
   TagRow,
   Script,
+  ValidateFolderFailureReason,
 } from '../types';
 import type { SandboxStatus } from '../lima/types';
 import type { HookStatusEntry } from '../hookServer';
@@ -60,7 +61,14 @@ export interface IpcInvokeContract {
   'refresh-projects': { args: []; return: Project[] };
   'create-project': { args: [options: CreateProjectOptions]; return: CreateProjectResult };
   'show-folder-picker': { args: []; return: { canceled: boolean; filePaths: string[] } };
-  'add-project': { args: [folderPath: string]; return: { success: boolean; error?: string } };
+  'add-project': {
+    args: [folderPath: string];
+    return: { success: boolean; error?: string; reason?: ValidateFolderFailureReason };
+  };
+  'init-git-repo': {
+    args: [folderPath: string, initialCommit?: boolean];
+    return: { success: boolean; error?: string };
+  };
   'remove-project': { args: [folderPath: string]; return: { success: boolean } };
   'reorder-projects': { args: [paths: string[]]; return: { success: boolean } };
   'get-project-settings': { args: [projectPath: string]; return: ProjectSettings };

--- a/src/ipc/handlers/project.ts
+++ b/src/ipc/handlers/project.ts
@@ -3,7 +3,7 @@ import { shell, BrowserWindow, dialog } from 'electron';
 import { typedHandle } from '../helpers';
 import { getProjectList } from '../../scanner';
 import { addProject, removeProject, reorderProjects, getProjectSettings, setKillExistingOnRun } from '../../db';
-import { createProject, validateProjectFolder } from '../../projectCreator';
+import { createProject, validateProjectFolder, initGitRepo } from '../../projectCreator';
 import { recordFirstProjectIfNeeded, seedOnboardingTaskIfFirstProject } from '../../onboarding';
 import { openInEditor, openFileInEditor } from '../../editorLauncher';
 import { deleteWithCleanup } from '../../lima/manager';
@@ -77,7 +77,7 @@ export function registerProjectHandlers(mainWindow: BrowserWindow): void {
 
   typedHandle('add-project', async (folderPath) => {
     const validation = await validateProjectFolder(folderPath);
-    if (validation.ok === false) return { success: false, error: validation.error };
+    if (validation.ok === false) return { success: false, error: validation.error, reason: validation.reason };
     try {
       await addProject(folderPath);
       await recordFirstProjectIfNeeded(folderPath, 'added');
@@ -86,6 +86,7 @@ export function registerProjectHandlers(mainWindow: BrowserWindow): void {
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
     }
   });
+  typedHandle('init-git-repo', (folderPath, initialCommit) => initGitRepo(folderPath, { initialCommit }));
   typedHandle('remove-project', async (folderPath) => {
     // Clean up sandbox config and VM before removing from DB
     await deleteWithCleanup(folderPath).catch(() => {});

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -56,6 +56,7 @@ contextBridge.exposeInMainWorld('api', {
   createProject: (options: CreateProjectOptions) => typedInvoke('create-project', options),
   showFolderPicker: () => typedInvoke('show-folder-picker'),
   addProject: (folderPath: string) => typedInvoke('add-project', folderPath),
+  initGitRepo: (folderPath: string, initialCommit?: boolean) => typedInvoke('init-git-repo', folderPath, initialCommit),
   removeProject: (folderPath: string) => typedInvoke('remove-project', folderPath),
   reorderProjects: (paths: string[]) => typedInvoke('reorder-projects', paths),
   getProjectSettings: (projectPath: string) => typedInvoke('get-project-settings', projectPath),

--- a/src/projectCreator.ts
+++ b/src/projectCreator.ts
@@ -6,12 +6,12 @@ import { execSync } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import type { CreateProjectOptions, CreateProjectResult } from './types';
+import type { CreateProjectOptions, CreateProjectResult, ValidateFolderFailureReason } from './types';
 import { getLogger } from './logger';
 
 const creatorLog = getLogger().scope('projectCreator');
 
-export type ValidateFolderResult = { ok: true } | { ok: false; error: string };
+export type ValidateFolderResult = { ok: true } | { ok: false; error: string; reason: ValidateFolderFailureReason };
 
 /**
  * Validates that a user-picked folder is suitable to add as a project:
@@ -23,20 +23,102 @@ export async function validateProjectFolder(folderPath: string): Promise<Validat
   try {
     stat = await fs.stat(folderPath);
   } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : 'Folder not found' };
+    return { ok: false, reason: 'not-found', error: error instanceof Error ? error.message : 'Folder not found' };
   }
   if (!stat.isDirectory()) {
-    return { ok: false, error: 'Path is not a directory' };
+    return { ok: false, reason: 'not-a-directory', error: 'Path is not a directory' };
   }
   try {
     await fs.access(path.join(folderPath, '.git'));
   } catch {
     return {
       ok: false,
+      reason: 'not-a-git-repo',
       error: 'Selected folder is not a git repository. Run `git init` or pick another folder.',
     };
   }
   return { ok: true };
+}
+
+/** True when both git user.name and user.email resolve in this folder's context. */
+function gitIdentityConfigured(cwd: string): boolean {
+  try {
+    const name = execSync('git config user.name', { cwd, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+    const email = execSync('git config user.email', { cwd, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+    return name.length > 0 && email.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Initializes a git repository in an existing folder so it can be added as a
+ * project. Used to recover from the "not a git repository" dead-end: the user
+ * picks a plain folder, we offer to `git init` it in place.
+ *
+ * `git init` is the essential step. An initial commit is best-effort — if the
+ * folder is empty or no git identity is configured, the commit is skipped but
+ * the repo is still initialized (the recoverable state we care about).
+ */
+export async function initGitRepo(
+  folderPath: string,
+  options: { initialCommit?: boolean } = {},
+): Promise<{ success: boolean; error?: string }> {
+  let stat;
+  try {
+    stat = await fs.stat(folderPath);
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Folder not found' };
+  }
+  if (!stat.isDirectory()) {
+    return { success: false, error: 'Path is not a directory' };
+  }
+
+  try {
+    await fs.access(path.join(folderPath, '.git'));
+    // Already a repo — nothing to do, treat as success.
+    return { success: true };
+  } catch {
+    // Not a repo yet, proceed to init.
+  }
+
+  try {
+    execSync('git init', { cwd: folderPath, stdio: 'ignore' });
+  } catch (error) {
+    creatorLog.error('git init failed', {
+      folderPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return {
+      success: false,
+      error: 'Could not initialize git. Install via `xcode-select --install` (macOS) or your package manager (Linux).',
+    };
+  }
+
+  if (options.initialCommit) {
+    try {
+      execSync('git add -A', { cwd: folderPath, stdio: 'ignore' });
+      // Prefer the user's configured identity; fall back to a neutral one only
+      // when git has none, so first-time users still get a commit instead of an
+      // "Author identity unknown" failure.
+      const hasIdentity = gitIdentityConfigured(folderPath);
+      const identityFlags = hasIdentity ? '' : '-c user.name="Ouijit" -c user.email="noreply@ouijit.dev" ';
+      execSync(`git ${identityFlags}commit -m "Initial commit"`, { cwd: folderPath, stdio: 'ignore' });
+    } catch (error) {
+      // Best-effort: nothing to commit (empty folder). The repo is still
+      // initialized, which is all the add-project flow requires.
+      creatorLog.warn('initial commit skipped after git init', {
+        folderPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { success: true };
 }
 
 export async function createProject(options: CreateProjectOptions): Promise<CreateProjectResult> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -482,7 +482,9 @@ export interface ElectronAPI {
   /** Show native folder picker dialog */
   showFolderPicker(): Promise<{ canceled: boolean; filePaths: string[] }>;
   /** Add a project folder to the app */
-  addProject(folderPath: string): Promise<{ success: boolean; error?: string }>;
+  addProject(folderPath: string): Promise<{ success: boolean; error?: string; reason?: ValidateFolderFailureReason }>;
+  /** Initialize a git repository in an existing folder (recovers a non-git folder) */
+  initGitRepo(folderPath: string, initialCommit?: boolean): Promise<{ success: boolean; error?: string }>;
   /** Remove a project folder from the app */
   removeProject(folderPath: string): Promise<{ success: boolean }>;
   /** Reorder projects in the sidebar */
@@ -660,6 +662,9 @@ export interface CreateProjectResult {
   projectPath?: string;
   error?: string;
 }
+
+/** Why a picked folder failed project validation. `not-a-git-repo` is recoverable via `initGitRepo`. */
+export type ValidateFolderFailureReason = 'not-found' | 'not-a-directory' | 'not-a-git-repo';
 
 declare global {
   interface Window {


### PR DESCRIPTION
## Summary

- Adding a plain (non-git) folder used to dead-end at a "not a git repository" error toast; it now opens a dialog offering to `git init` the folder in place, then retries the add automatically.
- `validateProjectFolder` now tags failures with a `reason` (`not-found` / `not-a-directory` / `not-a-git-repo`) so the renderer can distinguish the recoverable case.
- New `initGitRepo` runs `git init` with an optional initial commit; the commit is best-effort and falls back to a neutral identity only when git has none configured (real users keep their own identity).
- New `init-git-repo` IPC channel wired through the contract, preload, and `WindowApi` types; new `InitGitRepoDialog` follows existing dialog conventions and disables the action with install guidance when git is missing.
- Added `initGitRepo` unit tests and updated validation tests for the new `reason` field.