### PR TITLE
Stop rendering command-exit summaries in terminal headers

### DIFF
--- a/src/__tests__/findOtherTaskTerminals.test.ts
+++ b/src/__tests__/findOtherTaskTerminals.test.ts
@@ -9,7 +9,6 @@ function makeDisplay(ptyId: string, patch: Partial<TerminalDisplayState>): Termi
   return {
     ptyId,
     label: '',
-    summary: '',
     summaryType: 'ready',
     gitFileStatus: null,
     lastOscTitle: '',

--- a/src/__tests__/renderer/views.test.tsx
+++ b/src/__tests__/renderer/views.test.tsx
@@ -160,13 +160,12 @@ describe('TerminalHeaderView', () => {
     render(
       <TerminalHeaderView
         summaryType="ready"
-        nameContent={<TerminalHeaderName label="claude" summary="thinking" />}
+        nameContent={<TerminalHeaderName label="claude" lastOscTitle="~/project" />}
         tagsContent={<TerminalHeaderTags tags={['auth']} />}
       />,
     );
     expect(screen.getByText('claude')).toBeTruthy();
-    // Em-dash separator should render literally, not as a backslash escape.
-    expect(screen.getByText('— thinking')).toBeTruthy();
+    expect(screen.getByText('~/project')).toBeTruthy();
     expect(screen.getByText('auth')).toBeTruthy();
   });
 

--- a/src/capture/navigator.ts
+++ b/src/capture/navigator.ts
@@ -25,7 +25,6 @@ function seedTerminal(projectPath: string, seed: CaptureTerminalSeed): void {
     projectPath,
     taskId: seed.taskId,
     label: seed.label,
-    summary: seed.summary ?? '',
     summaryType: seed.summaryType ?? 'ready',
     worktreeBranch: seed.worktreeBranch ?? null,
     sandboxed: seed.sandboxed ?? false,

--- a/src/capture/types.ts
+++ b/src/capture/types.ts
@@ -6,7 +6,6 @@ export interface CaptureTerminalSeed {
   ptyId: string;
   taskId: number;
   label: string;
-  summary?: string;
   summaryType?: TerminalDisplayState['summaryType'];
   worktreeBranch?: string;
   sandboxed?: boolean;

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -47,7 +47,6 @@ export const TerminalHeader = memo(function TerminalHeader({
   // and the header only re-renders when one of these fields actually changes.
   const {
     label,
-    summary,
     summaryType,
     gitFileStatus,
     lastOscTitle,
@@ -68,7 +67,6 @@ export const TerminalHeader = memo(function TerminalHeader({
       const d = s.displayStates[ptyId];
       return {
         label: d?.label ?? '',
-        summary: d?.summary ?? '',
         summaryType: d?.summaryType ?? 'ready',
         gitFileStatus: d?.gitFileStatus ?? null,
         lastOscTitle: d?.lastOscTitle ?? '',
@@ -355,7 +353,7 @@ export const TerminalHeader = memo(function TerminalHeader({
       }}
     />
   ) : (
-    <TerminalHeaderName label={label} summary={summary} lastOscTitle={lastOscTitle} />
+    <TerminalHeaderName label={label} lastOscTitle={lastOscTitle} />
   );
 
   const tagsContent =

--- a/src/components/terminal/TerminalHeaderView.tsx
+++ b/src/components/terminal/TerminalHeaderView.tsx
@@ -15,7 +15,7 @@ export interface TerminalHeaderViewProps {
   isBackCard?: boolean;
   compact?: boolean;
 
-  /** Identity slot (label, summary, optional rename input). Required. */
+  /** Identity slot (label, OSC title, optional rename input). Required. */
   nameContent: ReactNode;
 
   /** Tag chips. Optional. */
@@ -97,23 +97,14 @@ export function TerminalHeaderView({
 }
 
 /**
- * Standard identity content for a terminal header: label, optional summary
- * (em-dash separated), optional OSC title. Used by the in-app TerminalHeader
- * (when not renaming) and by marketing demos.
+ * Standard identity content for a terminal header: label and optional OSC
+ * title. Used by the in-app TerminalHeader (when not renaming) and by
+ * marketing demos.
  */
-export function TerminalHeaderName({
-  label,
-  summary,
-  lastOscTitle,
-}: {
-  label?: string;
-  summary?: string;
-  lastOscTitle?: string;
-}) {
+export function TerminalHeaderName({ label, lastOscTitle }: { label?: string; lastOscTitle?: string }) {
   return (
     <Fragment>
       {label && <span className="font-mono text-xs font-medium text-white/85 shrink-0">{label}</span>}
-      {summary && <span className="font-mono text-xs text-white/45 min-w-0 truncate">— {summary}</span>}
       {lastOscTitle && (
         <span className="font-mono text-xs font-medium text-white/40 min-w-0 truncate">{lastOscTitle}</span>
       )}

--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -381,7 +381,6 @@ export class OuijitTerminal {
 
   // ── Display state (plain values, pushed to Zustand) ────────────────
   label: string;
-  summary = '';
   summaryType: SummaryType;
   gitFileStatus: GitFileStatus | null = null;
   lastOscTitle = '';
@@ -922,22 +921,16 @@ export class OuijitTerminal {
   /**
    * Apply an exit-code-driven status flip. Used by both the PTY-exit path
    * (`wireExitHandler`) and the OSC 133;D in-shell path (`handleCommandExit`).
-   * The PTY-exit path additionally writes the `exited: true` flag and uses a
-   * different summary string ("Exited" vs "Done") so the two callers stay
-   * distinguishable in the UI.
+   * Only the status dot (`summaryType`) reflects the exit code; the PTY-exit
+   * path additionally sets the `exited: true` flag. We don't surface a textual
+   * "Done" / "Exit N" suffix in the header — the dot carries that signal, and
+   * the suffix only collided with the OSC title the shell/agent renders.
    */
   private applyExitState(exitCode: number, opts: { isPtyExit: boolean }): void {
     const nextType: SummaryType = exitCode === 0 ? 'success' : 'error';
-    const successSummary = opts.isPtyExit ? 'Exited' : 'Done';
-    const nextSummary = exitCode === 0 ? successSummary : `Exit ${exitCode}`;
-    if (this.summaryType !== nextType || this.summary !== nextSummary) {
+    if (this.summaryType !== nextType) {
       this.summaryType = nextType;
-      this.summary = nextSummary;
-      this.pushDisplayState(
-        opts.isPtyExit
-          ? { summaryType: nextType, summary: nextSummary, exited: true }
-          : { summaryType: nextType, summary: nextSummary },
-      );
+      this.pushDisplayState(opts.isPtyExit ? { summaryType: nextType, exited: true } : { summaryType: nextType });
     } else if (opts.isPtyExit) {
       this.pushDisplayState({ exited: true });
     }

--- a/src/stores/terminalDisplay.ts
+++ b/src/stores/terminalDisplay.ts
@@ -4,7 +4,6 @@ import type { GitFileStatus } from '../types';
 export interface TerminalDisplayState {
   ptyId: string;
   label: string;
-  summary: string;
   summaryType: 'thinking' | 'ready' | 'success' | 'error';
   gitFileStatus: GitFileStatus | null;
   lastOscTitle: string;
@@ -35,7 +34,6 @@ export interface TerminalDisplayState {
 
 export const DEFAULT_DISPLAY_STATE: Omit<TerminalDisplayState, 'ptyId' | 'projectPath'> = {
   label: '',
-  summary: '',
   summaryType: 'ready',
   gitFileStatus: null,
   lastOscTitle: '',


### PR DESCRIPTION
## Summary

- The OSC 133 exit-code work (#188) began setting a textual `Done` / `Exit N` summary on every interactive command completion, which rendered as a `— Done` / `— Exit 127` suffix in the terminal header, right next to the OSC title.
- The status dot already conveys command success/failure (green/red), so the textual suffix was redundant noise that collided with the OSC title.
- Removes the `summary` text feature entirely: the header now shows just the label, status dot, and OSC title. `applyExitState` only flips the dot (and the `exited` flag on real PTY exit).