### PR TITLE
Build DMG installers with stable per-arch filenames and 'Ouijit' volume name

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -157,15 +157,22 @@ const config: ForgeConfig = {
   },
   hooks: {
     postMake: async (_config, makeResults) => {
-      // Strip version from artifact filenames so GitHub release asset URLs
-      // are stable across versions (enables /releases/latest/download/<name>)
+      // Stabilize artifact filenames so GitHub release asset URLs are stable
+      // across versions (enables /releases/latest/download/<name>)
       for (const result of makeResults) {
         result.artifacts = result.artifacts.map((artifact) => {
           const dir = path.dirname(artifact);
           const ext = path.extname(artifact);
           const base = path.basename(artifact, ext);
-          // Match patterns like "ouijit-1.0.6-darwin-arm64" or "ouijit-darwin-arm64-1.0.6"
-          const stripped = base.replace(/-\d+\.\d+\.\d+/, '');
+          // maker-dmg can't see targetArch in its static config, so each DMG is
+          // emitted with the same version-stamped name and would collide on the
+          // shared release. Rename here (result.arch is available) to a stable,
+          // arch-distinct, version-less name matching the ZIP convention.
+          const stripped =
+            ext === '.dmg'
+              ? `ouijit-darwin-${result.arch}`
+              : // Match patterns like "ouijit-1.0.6-darwin-arm64" or "ouijit-darwin-arm64-1.0.6"
+                base.replace(/-\d+\.\d+\.\d+/, '');
           if (stripped === base) return artifact;
           const newPath = path.join(dir, stripped + ext);
           fs.renameSync(artifact, newPath);
@@ -231,7 +238,10 @@ const config: ForgeConfig = {
     new MakerDeb({}),
     new MakerDMG(
       {
-        name: 'Install Ouijit',
+        // Mounted volume title only. Leave `name` unset so the DMG filename is
+        // renamed to a stable, arch-distinct name in the postMake hook below
+        // (where targetArch is available, unlike here in the static config).
+        title: 'Ouijit',
         icon: './src/assets/icons/icon.icns',
         background: './src/assets/dmg/background.png',
         format: 'ULFO',

--- a/src/__tests__/forgeDmg.test.ts
+++ b/src/__tests__/forgeDmg.test.ts
@@ -8,7 +8,7 @@ describe('notarizeAndStapleArtifact', () => {
     const notarizeFn = vi.fn().mockRejectedValue(new Error('notarize failed'));
     const stapleFn = vi.fn();
     await expect(
-      notarizeAndStapleArtifact('/tmp/Install Ouijit.dmg', {
+      notarizeAndStapleArtifact('/tmp/ouijit-darwin-arm64.dmg', {
         keychainProfile: 'ouijit-notarize',
         notarizeFn,
         stapleFn,
@@ -26,7 +26,7 @@ describe('notarizeAndStapleDMGs', () => {
 
     await notarizeAndStapleDMGs(
       [
-        '/out/make/Install Ouijit.dmg',
+        '/out/make/ouijit-darwin-arm64.dmg',
         '/out/make/zip/darwin/arm64/ouijit-darwin-arm64.zip',
         '/out/make/ouijit-1.0.deb',
       ],
@@ -38,7 +38,7 @@ describe('notarizeAndStapleDMGs', () => {
     );
 
     expect(notarizeFn).toHaveBeenCalledTimes(1);
-    expect(notarizeFn).toHaveBeenCalledWith(expect.objectContaining({ appPath: '/out/make/Install Ouijit.dmg' }));
+    expect(notarizeFn).toHaveBeenCalledWith(expect.objectContaining({ appPath: '/out/make/ouijit-darwin-arm64.dmg' }));
     expect(stapleFn).toHaveBeenCalledTimes(1);
   });
 
@@ -46,7 +46,7 @@ describe('notarizeAndStapleDMGs', () => {
     const notarizeFn = vi.fn();
     const stapleFn = vi.fn();
 
-    await notarizeAndStapleDMGs(['/out/make/Install Ouijit.dmg'], {
+    await notarizeAndStapleDMGs(['/out/make/ouijit-darwin-arm64.dmg'], {
       env: { SKIP_NOTARIZE: '1' },
       notarizeFn,
       stapleFn,


### PR DESCRIPTION
## Summary
- The macOS DMG from #187 mounted a volume titled `Install Ouijit` and, because `MakerDMG`'s `name` field doubles as both the volume title and the output filename, both arch builds emitted a colliding `Install Ouijit.dmg` with no stable, version-less URL to link to.
- Set `MakerDMG` `title` to `Ouijit` (volume name) and leave `name` unset.
- Rename each DMG in the `postMake` hook to `ouijit-darwin-<arch>.dmg`, matching the ZIP convention and giving each arch a stable `releases/latest/download` URL.
- Update `forgeDmg` tests for the new artifact name.
- Safe to merge before a release: only changes build-time artifact naming, and the macOS `.zip` makers still run so existing `.zip` download links keep working. The download-link/copy flip lands separately in #201 once a release shipping these DMGs is cut.