### PR TITLE
Switch macOS download links to DMG installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Ouijit is a customizable task and terminal session manager that integrates with 
 
 Download the latest release:
 
-- [macOS (Apple Silicon)](https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-arm64.zip)
-- [macOS (Intel)](https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-x64.zip)
+- [macOS (Apple Silicon)](https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-arm64.dmg)
+- [macOS (Intel)](https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-x64.dmg)
 - [Linux (x64)](https://github.com/ouijit/ouijit/releases/latest/download/ouijit-linux-x64.zip)
 
 Free and open source. No account, no sign-in, no telemetry.

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -20,7 +20,7 @@ Free and open source under the AGPL-3.0 license. No account, no sign-in. Distrib
 - [Home](https://ouijit.com): Download links, demo, value prop.
 - [FAQ](https://ouijit.com/faq/): Frequently asked questions about platform support, agent integrations, sandbox behavior.
 - [GitHub repo](https://github.com/ouijit/ouijit): Source code, releases, issues.
-- [Latest release](https://github.com/ouijit/ouijit/releases/latest): macOS (arm64/x64) and Linux (x64) zipped binaries.
+- [Latest release](https://github.com/ouijit/ouijit/releases/latest): macOS (arm64/x64) DMG installers and Linux (x64) zipped binaries.
 
 ## Notable behavior for agents
 

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -38,13 +38,13 @@ const sections = [
         <h2>Download &amp; Install</h2>
         <p>Download the latest release for your platform:</p>
         <ul>
-          <li><a href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-arm64.zip">macOS (Apple Silicon)</a></li>
-          <li><a href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-x64.zip">macOS (Intel)</a></li>
+          <li><a href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-arm64.dmg">macOS (Apple Silicon)</a></li>
+          <li><a href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-x64.dmg">macOS (Intel)</a></li>
           <li><a href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-linux-x64.zip">Linux (x64)</a></li>
         </ul>
         <p>
-          Unzip the archive and move <strong>Ouijit.app</strong> to your Applications folder (macOS) or extract the binary to
-          a location on your PATH (Linux).
+          Open the DMG and drag <strong>Ouijit.app</strong> to your Applications folder (macOS) or unzip the archive and
+          extract the binary to a location on your PATH (Linux).
         </p>
 
         <h3>Building from source</h3>

--- a/website/src/pages/faq/index.astro
+++ b/website/src/pages/faq/index.astro
@@ -41,7 +41,7 @@ const faqs: Faq[] = [
   },
   {
     q: 'Where do I download Ouijit?',
-    a: 'From ouijit.com or the GitHub releases page: github.com/ouijit/ouijit/releases/latest. Unzip the archive and move Ouijit.app to your Applications folder on macOS, or extract the binary to a directory on your PATH on Linux.',
+    a: 'From ouijit.com or the GitHub releases page: github.com/ouijit/ouijit/releases/latest. Open the DMG and drag Ouijit.app to your Applications folder on macOS, or unzip the archive and extract the binary to a directory on your PATH on Linux.',
   },
   {
     q: 'How do I build Ouijit from source?',

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -49,10 +49,10 @@ const softwareSchema = {
     <h1>Integrated Divination Environment</h1>
     <div class="download-buttons">
       <a
-        href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-arm64.zip"
+        href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-arm64.dmg"
         class="btn btn-primary">Download for macOS (Apple Silicon)</a>
       <a
-        href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-x64.zip"
+        href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-x64.dmg"
         class="btn btn-secondary">macOS (Intel)</a>
       <a href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-linux-x64.zip" class="btn btn-secondary"
         >Linux</a>


### PR DESCRIPTION
## Summary
- Point macOS download links at `.dmg` (README, homepage, docs); Linux stays `.zip`.
- Reword macOS install copy from unzip to mount-and-drag (faq, docs, llms.txt).
- Follows #200, which ships the `ouijit-darwin-<arch>.dmg` artifacts.

**Draft / do not merge** until a release carrying those DMGs lands, otherwise the `releases/latest/download/*.dmg` links 404.