### PR TITLE
Centralize button styling and give the marketing site a CRT background

### DIFF
--- a/src/components/canvas/SmartGuideOverlay.tsx
+++ b/src/components/canvas/SmartGuideOverlay.tsx
@@ -28,7 +28,7 @@ export const SmartGuideOverlay = memo(function SmartGuideOverlay({ guides }: Sma
               y1={0}
               x2={guide.screenPos}
               y2="100%"
-              stroke="rgba(10, 132, 255, 0.5)"
+              stroke="color-mix(in srgb, var(--color-accent) 50%, transparent)"
               strokeWidth={1}
               strokeDasharray="4 4"
             />
@@ -39,7 +39,7 @@ export const SmartGuideOverlay = memo(function SmartGuideOverlay({ guides }: Sma
               y1={guide.screenPos}
               x2="100%"
               y2={guide.screenPos}
-              stroke="rgba(10, 132, 255, 0.5)"
+              stroke="color-mix(in srgb, var(--color-accent) 50%, transparent)"
               strokeWidth={1}
               strokeDasharray="4 4"
             />

--- a/src/components/dialogs/BranchFromTaskDialog.tsx
+++ b/src/components/dialogs/BranchFromTaskDialog.tsx
@@ -67,17 +67,10 @@ export function BranchFromTaskDialog({ projectPath, parentTask, onClose }: Branc
         }}
       />
       <div className="flex gap-2 justify-end mt-4">
-        <button
-          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-accent bg-accent-light hover:bg-[rgba(0,122,255,0.15)]"
-          onClick={() => dismiss(false)}
-        >
+        <button className="btn-secondary" onClick={() => dismiss(false)}>
           Cancel
         </button>
-        <button
-          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
-          onClick={handleSubmit}
-          disabled={submitting}
-        >
+        <button className="btn-primary" onClick={handleSubmit} disabled={submitting}>
           Create
         </button>
       </div>

--- a/src/components/dialogs/CombinedHookConfigDialog.tsx
+++ b/src/components/dialogs/CombinedHookConfigDialog.tsx
@@ -154,16 +154,10 @@ export function CombinedHookConfigDialog({
       </div>
 
       <div className="flex gap-2 justify-end mt-4 items-center">
-        <button
-          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-accent bg-accent-light hover:bg-[rgba(0,122,255,0.15)]"
-          onClick={() => dismiss(null)}
-        >
+        <button className="btn-secondary" onClick={() => dismiss(null)}>
           Cancel
         </button>
-        <button
-          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
-          onClick={handleSave}
-        >
+        <button className="btn-primary" onClick={handleSave}>
           Save
         </button>
       </div>

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -105,10 +105,7 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
       </div>
 
       <div className="flex justify-end mt-5">
-        <button
-          className="inline-flex items-center justify-center gap-2 px-5 py-1.5 font-sans text-sm font-medium border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
-          onClick={dismiss}
-        >
+        <button className="btn-primary px-5" onClick={dismiss}>
           Got it
         </button>
       </div>

--- a/src/components/dialogs/HookConfigDialog.tsx
+++ b/src/components/dialogs/HookConfigDialog.tsx
@@ -185,16 +185,10 @@ export function HookConfigDialog({
       </div>
 
       <div className="flex gap-2 justify-end mt-4 items-center">
-        <button
-          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-accent bg-accent-light hover:bg-[rgba(0,122,255,0.15)]"
-          onClick={() => dismiss(null)}
-        >
+        <button className="btn-secondary" onClick={() => dismiss(null)}>
           Cancel
         </button>
-        <button
-          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
-          onClick={handleSave}
-        >
+        <button className="btn-primary" onClick={handleSave}>
           Save
         </button>
       </div>

--- a/src/components/dialogs/InitGitRepoDialog.tsx
+++ b/src/components/dialogs/InitGitRepoDialog.tsx
@@ -87,20 +87,10 @@ export function InitGitRepoDialog({ folderPath, onClose }: InitGitRepoDialogProp
         </p>
       )}
       <div className="flex gap-2 justify-end mt-4 items-center">
-        <button
-          data-testid="dialog-cancel"
-          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-accent bg-accent-light hover:bg-[rgba(0,122,255,0.15)]"
-          onClick={() => dismiss(null)}
-          disabled={working}
-        >
+        <button data-testid="dialog-cancel" className="btn-secondary" onClick={() => dismiss(null)} disabled={working}>
           Cancel
         </button>
-        <button
-          data-testid="dialog-init"
-          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
-          onClick={handleInit}
-          disabled={working || gitMissing}
-        >
+        <button data-testid="dialog-init" className="btn-primary" onClick={handleInit} disabled={working || gitMissing}>
           {working ? 'Initializing…' : 'Initialize Repository'}
         </button>
       </div>

--- a/src/components/dialogs/MissingWorktreeDialog.tsx
+++ b/src/components/dialogs/MissingWorktreeDialog.tsx
@@ -46,18 +46,10 @@ export function MissingWorktreeDialog({ task, branchExists, onClose }: MissingWo
         </p>
       )}
       <div className="flex gap-2 justify-end mt-4 items-center">
-        <button
-          data-testid="dialog-cancel"
-          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-accent bg-accent-light hover:bg-[rgba(0,122,255,0.15)]"
-          onClick={() => dismiss(null)}
-        >
+        <button data-testid="dialog-cancel" className="btn-secondary" onClick={() => dismiss(null)}>
           Cancel
         </button>
-        <button
-          data-testid="dialog-recover"
-          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
-          onClick={() => dismiss('recover')}
-        >
+        <button data-testid="dialog-recover" className="btn-primary" onClick={() => dismiss('recover')}>
           {branchExists ? 'Recreate Worktree' : 'Create Worktree'}
         </button>
       </div>

--- a/src/components/dialogs/NewProjectDialog.tsx
+++ b/src/components/dialogs/NewProjectDialog.tsx
@@ -89,18 +89,10 @@ export function NewProjectDialog({ onClose }: NewProjectDialogProps) {
         </div>
       </div>
       <div className="flex gap-2 justify-end mt-4 items-center">
-        <button
-          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-accent bg-accent-light hover:bg-[rgba(0,122,255,0.15)]"
-          onClick={() => dismiss(null)}
-          disabled={creating}
-        >
+        <button className="btn-secondary" onClick={() => dismiss(null)} disabled={creating}>
           Cancel
         </button>
-        <button
-          className="inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
-          onClick={handleCreate}
-          disabled={!isValid || creating}
-        >
+        <button className="btn-primary" onClick={handleCreate} disabled={!isValid || creating}>
           {creating ? 'Creating\u2026' : 'Create'}
         </button>
       </div>

--- a/src/components/dialogs/RunHookDialog.tsx
+++ b/src/components/dialogs/RunHookDialog.tsx
@@ -158,7 +158,7 @@ export function RunHookDialog({
         {limaAvailable ? (
           <div className="flex items-center gap-2" onClick={() => setSandboxed((s) => !s)}>
             <div
-              className={`relative w-[34px] h-5 rounded-[10px] shrink-0 transition-[background] duration-200 ease-out ${sandboxed ? 'bg-[#0a84ff]' : 'bg-white/15'}`}
+              className={`relative w-[34px] h-5 rounded-[10px] shrink-0 transition-[background] duration-200 ease-out ${sandboxed ? 'bg-accent' : 'bg-white/15'}`}
             >
               <div
                 className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.3)] transition-transform duration-200 ease-out ${sandboxed ? 'translate-x-3.5' : ''}`}
@@ -170,16 +170,12 @@ export function RunHookDialog({
           <div />
         )}
         <div className="flex gap-2">
-          <button
-            data-testid="dialog-cancel"
-            className="btn-secondary inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-accent bg-accent-light hover:bg-[rgba(0,122,255,0.15)]"
-            onClick={() => dismiss(null)}
-          >
+          <button data-testid="dialog-cancel" className="btn-secondary" onClick={() => dismiss(null)}>
             {queued ? 'Skip' : 'Cancel'}
           </button>
           <button
             data-testid="dialog-run-open"
-            className="btn-primary inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98] whitespace-nowrap"
+            className="btn-primary whitespace-nowrap"
             onClick={() => dismiss({ command: command.trim(), sandboxed, foreground: true })}
             disabled={!command.trim()}
           >
@@ -187,7 +183,7 @@ export function RunHookDialog({
           </button>
           <button
             data-testid="dialog-run"
-            className="btn-primary inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
+            className="btn-primary"
             onClick={() => dismiss({ command: command.trim(), sandboxed, foreground: false })}
             disabled={!command.trim()}
           >

--- a/src/components/dialogs/WhatsNewDialog.tsx
+++ b/src/components/dialogs/WhatsNewDialog.tsx
@@ -83,10 +83,7 @@ export function WhatsNewDialog({ version, notes, onClose }: WhatsNewDialogProps)
         dangerouslySetInnerHTML={{ __html: renderMarkdown(notes) }}
       />
       <div className="flex justify-end mt-5">
-        <button
-          className="inline-flex items-center justify-center gap-2 px-5 py-1.5 font-sans text-sm font-medium no-underline border-none rounded-full outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light text-white bg-accent hover:bg-accent-hover active:scale-[0.98]"
-          onClick={dismiss}
-        >
+        <button className="btn-primary px-5" onClick={dismiss}>
           Got it
         </button>
       </div>

--- a/src/components/kanban/KanbanCardView.tsx
+++ b/src/components/kanban/KanbanCardView.tsx
@@ -210,9 +210,9 @@ export const KanbanCardView = memo(function KanbanCardView({
       className="kanban-card group px-3 py-3.5 ease-out [-webkit-app-region:no-drag] hover:bg-black/10 active:bg-black/[0.12]"
       style={{
         background: isSelected
-          ? 'rgba(10, 132, 255, 0.06)'
+          ? 'color-mix(in srgb, var(--color-accent) 6%, transparent)'
           : isHoveredBadgeTarget
-            ? 'rgba(10, 132, 255, 0.08)'
+            ? 'color-mix(in srgb, var(--color-accent) 8%, transparent)'
             : expanded
               ? 'rgba(0, 0, 0, 0.15)'
               : 'var(--color-terminal-bg)',
@@ -220,9 +220,9 @@ export const KanbanCardView = memo(function KanbanCardView({
           'background 150ms ease-out, opacity 150ms ease-out, outline-color 150ms ease-out, box-shadow 150ms ease-out',
         borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
         outline: isHoveredBadgeTarget
-          ? '1px solid rgba(10, 132, 255, 0.6)'
+          ? '1px solid color-mix(in srgb, var(--color-accent) 60%, transparent)'
           : isValidBadgeTarget
-            ? '1px dashed rgba(10, 132, 255, 0.3)'
+            ? '1px dashed color-mix(in srgb, var(--color-accent) 30%, transparent)'
             : 'none',
         outlineOffset: -1,
         ...(isInvalidBadgeTarget && { opacity: 0.4 }),

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -156,7 +156,11 @@ function SortableCard({
     return (
       <div
         ref={setNodeRef}
-        style={{ ...style, background: 'rgba(10, 132, 255, 0.15)', border: '1px solid rgba(10, 132, 255, 0.4)' }}
+        style={{
+          ...style,
+          background: 'color-mix(in srgb, var(--color-accent) 15%, transparent)',
+          border: '1px solid color-mix(in srgb, var(--color-accent) 40%, transparent)',
+        }}
         {...attributes}
         {...listeners}
         className="[&>*]:opacity-0"

--- a/src/components/kanban/KanbanColumnView.tsx
+++ b/src/components/kanban/KanbanColumnView.tsx
@@ -70,7 +70,7 @@ export function KanbanColumnView({
           scrollbarColor: 'transparent transparent',
           transition: 'background 150ms ease',
           minHeight: 80,
-          background: isOver ? 'rgba(10, 132, 255, 0.08)' : undefined,
+          background: isOver ? 'color-mix(in srgb, var(--color-accent) 8%, transparent)' : undefined,
         }}
         onClick={onBodyClick}
       >

--- a/src/components/scripts/SandboxSection.tsx
+++ b/src/components/scripts/SandboxSection.tsx
@@ -249,7 +249,7 @@ export function SandboxSection({ projectPath }: SandboxSectionProps) {
 
   const [showMerged, setShowMerged] = useState(false);
   const statusLabel = sandboxStarting ? 'Starting\u2026' : VM_STATUS_LABELS[vmStatus] || vmStatus;
-  const statusColor = vmStatus === 'Running' && !sandboxStarting ? 'text-[#0a84ff]' : 'text-text-primary';
+  const statusColor = vmStatus === 'Running' && !sandboxStarting ? 'text-success' : 'text-text-primary';
 
   return (
     <div className="space-y-4">
@@ -285,7 +285,7 @@ export function SandboxSection({ projectPath }: SandboxSectionProps) {
             </button>
             {isDirty && (
               <button
-                className="text-[10px] px-2 py-0.5 rounded bg-[#0a84ff]/20 text-[#0a84ff] hover:bg-[#0a84ff]/30 transition-colors"
+                className="text-[10px] px-2 py-0.5 rounded bg-accent/20 text-accent hover:bg-accent/30 transition-colors"
                 onClick={handleSave}
               >
                 Save
@@ -324,7 +324,7 @@ export function SandboxSection({ projectPath }: SandboxSectionProps) {
         <div className="flex items-center gap-2 px-1">
           <span className="text-xs text-text-secondary">Config changed. Recreate VM now?</span>
           <button
-            className="text-[10px] px-2 py-0.5 rounded bg-[#0a84ff]/20 text-[#0a84ff] hover:bg-[#0a84ff]/30"
+            className="text-[10px] px-2 py-0.5 rounded bg-accent/20 text-accent hover:bg-accent/30"
             onClick={handleRecreate}
           >
             Yes

--- a/src/index.css
+++ b/src/index.css
@@ -31,10 +31,13 @@
   --color-border: rgba(255, 255, 255, 0.1);
   --color-border-hover: rgba(255, 255, 255, 0.15);
 
-  /* Accent Colors */
-  --color-accent: #0a84ff;
-  --color-accent-hover: #409cff;
-  --color-accent-light: rgba(10, 132, 255, 0.2);
+  /* Accent / brand — Ouijit blue. App-wide accent: links, selection, focus
+     rings, primary buttons, the homepage Run button. --color-accent-ink is
+     the text color on filled accent buttons (white, since blue is dark). */
+  --color-accent: #2f6fe6;
+  --color-accent-hover: #4d88f0;
+  --color-accent-light: rgba(47, 111, 230, 0.2);
+  --color-accent-ink: #ffffff;
 
   /* Status Colors */
   --color-git: #ff6b4a;
@@ -169,8 +172,147 @@ textarea,
 }
 
 /* ===================================
+   Buttons (shared dialog/CTA pattern)
+   "CRT screen" primary: an animated lava-lamp fill (::before) under a CRT
+   shadow-mask overlay of vertical R/G/B phosphor dots + tube vignette +
+   static (::after), with a white, softly-glowing label on top. Full pill.
+   Keep in sync with the website's .btn in website/src/styles/marketing.css.
+   =================================== */
+
+/* Sparse phosphor noise: feTurbulence mapped to ALPHA (transparent except
+   sparse opaque black specks) so it composites cleanly above the opaque RGB
+   grille layer and reads as CRT static under the multiply overlay. */
+:root {
+  --btn-grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.5' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0 0 0 0 1'/%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  /* CRT shadow-mask overlay: vertical R/G/B phosphor stripes, segmented into
+     dots by thin horizontal gaps, plus tube vignette + static, multiplied
+     over the lava. --crt-strength fades the whole effect; --crt-dot is the
+     subpixel width (triad = 3x); --crt-line is the dot row height. */
+  --crt-strength: 0.42;
+  --crt-dot: 1.5px;
+  --crt-line: 2px;
+
+  /* Lava-lamp fill: drifting hue blobs behind the label. Hues are spread
+     wide (indigo / magenta / cyan) and distinct from the blue base for
+     visible contrast, but kept dark enough that white text stays legible. */
+  --lava-1: rgba(79, 70, 229, 0.95); /* indigo */
+  --lava-2: rgba(147, 51, 234, 0.95); /* magenta */
+  --lava-3: rgba(8, 145, 178, 0.92); /* cyan */
+  --lava-speed: 9s;
+  --lava-blur: 7px;
+}
+
+@layer components {
+  .btn-primary {
+    @apply relative isolate overflow-hidden inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light active:scale-[0.98] disabled:opacity-50;
+    border-radius: 9999px;
+    background-color: var(--color-accent);
+    color: var(--color-accent-ink);
+    text-shadow: 0 0 5px rgba(170, 205, 255, 0.45); /* phosphor glow */
+  }
+
+  /* Animated lava-lamp fill (z-index -2): three blurred hue blobs drifting
+     via background-position. Clipped to the pill, sits below both the grain
+     and the label. */
+  .btn-primary::before {
+    content: '';
+    position: absolute;
+    inset: -25%;
+    z-index: -2;
+    background-image:
+      radial-gradient(circle, var(--lava-1) 0%, transparent 46%),
+      radial-gradient(circle, var(--lava-2) 0%, transparent 46%),
+      radial-gradient(circle, var(--lava-3) 0%, transparent 46%);
+    background-repeat: no-repeat;
+    background-size:
+      120% 120%,
+      130% 130%,
+      115% 115%;
+    background-position:
+      0% 0%,
+      100% 0%,
+      50% 100%;
+    filter: blur(var(--lava-blur));
+    animation: lava-drift var(--lava-speed) ease-in-out infinite alternate;
+    pointer-events: none;
+  }
+
+  /* CRT shadow-mask overlay (z-index -1), multiplied onto the lava. Top to
+     bottom: horizontal dot-row gaps, tube vignette, phosphor static, then the
+     opaque vertical R/G/B grille. Sits BEHIND the label (scoped by `isolate`)
+     so it masks the screen without touching the text. */
+  .btn-primary::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background-image:
+      repeating-linear-gradient(to bottom, rgba(0, 0, 0, 0.7) 0 1px, transparent 1px var(--crt-line)),
+      radial-gradient(125% 135% at 50% 50%, transparent 52%, rgba(0, 0, 0, 0.55) 100%), var(--btn-grain),
+      repeating-linear-gradient(
+        to right,
+        rgb(255, 45, 45) 0 var(--crt-dot),
+        rgb(45, 255, 45) var(--crt-dot) calc(var(--crt-dot) * 2),
+        rgb(60, 60, 255) calc(var(--crt-dot) * 2) calc(var(--crt-dot) * 3)
+      );
+    background-size:
+      auto,
+      auto,
+      120px 120px,
+      auto;
+    image-rendering: pixelated;
+    mix-blend-mode: multiply;
+    opacity: var(--crt-strength);
+    pointer-events: none;
+  }
+
+  .btn-primary:hover:not(:disabled) {
+    background-color: var(--color-accent-hover);
+  }
+
+  .btn-secondary {
+    @apply inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none outline-none text-text-primary transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-white/15 active:scale-[0.98] disabled:opacity-50;
+    border-radius: 9999px;
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .btn-secondary:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.1);
+  }
+}
+
+/* ===================================
    Animations
    =================================== */
+
+/* Lava-lamp blob drift for primary buttons (see .btn-primary::before). */
+@keyframes lava-drift {
+  0% {
+    background-position:
+      0% 0%,
+      100% 0%,
+      50% 100%;
+  }
+  50% {
+    background-position:
+      70% 80%,
+      10% 60%,
+      90% 10%;
+  }
+  100% {
+    background-position:
+      100% 40%,
+      40% 100%,
+      0% 30%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn-primary::before,
+  .cli-prompt-bubble__run::before {
+    animation: none;
+  }
+}
 
 @keyframes spin {
   from {
@@ -215,11 +357,11 @@ textarea,
 @keyframes sandbox-icon-pulse {
   0%,
   100% {
-    color: #409cff;
+    color: var(--color-accent-hover);
     opacity: 0.4;
   }
   50% {
-    color: #409cff;
+    color: var(--color-accent-hover);
     opacity: 1;
   }
 }
@@ -507,13 +649,13 @@ textarea,
 
 .react-flow__node.react-flow__node-terminal .react-flow__resize-control.handle:hover {
   transform: scale(1.25);
-  box-shadow: 0 0 0 4px rgba(10, 132, 255, 0.2);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 20%, transparent);
 }
 
 .react-flow__node.react-flow__node-terminal .react-flow__resize-control.handle:active,
 .react-flow__node.react-flow__node-terminal .react-flow__resize-control.handle:focus-visible {
   transform: scale(1.2);
-  box-shadow: 0 0 0 5px rgba(10, 132, 255, 0.3);
+  box-shadow: 0 0 0 5px color-mix(in srgb, var(--color-accent) 30%, transparent);
   outline: none;
 }
 
@@ -787,8 +929,8 @@ textarea,
 
 /* Selection box styling */
 .terminal-canvas .react-flow__selection {
-  border: 1px solid rgba(10, 132, 255, 0.3);
-  background: rgba(10, 132, 255, 0.05);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 5%, transparent);
 }
 
 /* Minimap — styled to match controls bar */

--- a/src/index.css
+++ b/src/index.css
@@ -174,9 +174,9 @@ textarea,
 /* ===================================
    Buttons (shared dialog/CTA pattern)
    .btn-primary / .btn-secondary are plain flat pills used everywhere (app
-   dialogs + website). .btn-crt is an opt-in "CRT screen" modifier (animated
-   lava + R/G/B shadow mask + glowing label) reserved for the most important
-   marketing CTAs. Keep in sync with website/src/styles/marketing.css.
+   dialogs + website). .btn-crt is an opt-in "CRT screen" treatment (animated
+   blue plasma + R/G/B shadow mask + glowing label) reserved for the marketing
+   hero CTA; the cursor glow lives in website/src/styles/marketing.css.
    =================================== */
 
 /* Sparse phosphor static: feTurbulence mapped to ALPHA (transparent except
@@ -184,19 +184,19 @@ textarea,
    as CRT static under the multiply overlay. */
 :root {
   --btn-grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.5' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0 0 0 0 1'/%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-  /* CRT shadow-mask overlay: vertical R/G/B phosphor stripes segmented into
-     dots by thin horizontal gaps, plus vignette + static, multiplied over the
-     lava. --crt-strength fades it; --crt-dot = subpixel width (triad = 3x);
-     --crt-line = dot row height. */
+  /* CRT shadow-mask overlay (used by .btn-crt): vertical R/G/B phosphor
+     stripes segmented into dots by thin horizontal gaps, plus vignette +
+     static, multiplied over the lava. --crt-strength fades it; --crt-dot =
+     subpixel width (triad = 3x); --crt-line = dot row height. */
   --crt-strength: 0.42;
   --crt-dot: 1.5px;
   --crt-line: 2px;
 
-  /* Lava-lamp fill: drifting shades of blue around the primary accent, over a
-     dark navy screen — a cohesive, on-brand glowing blue. */
-  --lava-base: var(--color-accent); /* screen base = primary accent */
-  --lava-1: rgba(96, 165, 250, 0.9); /* light sky */
-  --lava-2: rgba(47, 111, 230, 0.95); /* primary blue */
+  /* Lava fill: drifting shades of blue around the primary accent, over a
+     screen base of the accent itself — a cohesive, on-brand glowing blue. */
+  --lava-base: var(--color-accent);
+  --lava-1: rgba(59, 130, 246, 0.9); /* sky (deeper, more saturated) */
+  --lava-2: rgba(37, 99, 235, 0.95); /* primary blue */
   --lava-3: rgba(29, 78, 216, 0.95); /* deep blue */
   --lava-speed: 9s;
   --lava-blur: 7px;
@@ -210,16 +210,23 @@ textarea,
     color: var(--color-accent-ink);
   }
 
-  /* "CRT screen" treatment — an OPT-IN modifier for the most important
-     marketing CTAs only (not app dialog buttons). Pair with .btn-primary:
-     it layers an animated lava fill (::before) + a CRT shadow mask (::after)
-     behind a glowing label. */
+  /* "CRT screen" treatment — opt-in modifier for the marketing hero CTA only
+     (pair with .btn-primary): animated blue plasma (::before) under a CRT
+     shadow mask (::after), behind a glowing label. */
   .btn-crt {
     @apply relative isolate overflow-hidden;
     text-shadow: 0 0 5px rgba(170, 205, 255, 0.45); /* phosphor glow */
+    filter: saturate(1.12); /* rich saturated screen at rest */
+    transition:
+      filter 90ms ease-out,
+      transform 90ms ease-out;
   }
 
-  /* Animated lava fill (z-index -2): drifting hue blobs on a dark screen base. */
+  /* Snappy traditional hover: the saturated screen brightens (gets lighter). */
+  .btn-crt:hover {
+    filter: saturate(1.12) brightness(1.14);
+  }
+
   .btn-crt::before {
     content: '';
     position: absolute;
@@ -244,9 +251,6 @@ textarea,
     pointer-events: none;
   }
 
-  /* CRT shadow-mask overlay (z-index -1) multiplied onto the lava: dot-row
-     gaps, tube vignette, phosphor static, then the vertical R/G/B grille.
-     Sits BEHIND the label (scoped by `isolate`). */
   .btn-crt::after {
     content: '';
     position: absolute;
@@ -291,7 +295,7 @@ textarea,
    Animations
    =================================== */
 
-/* Lava-lamp blob drift for primary buttons (see .btn-primary::before). */
+/* Lava drift for the CRT CTA (.btn-crt::before). */
 @keyframes lava-drift {
   0% {
     background-position:
@@ -314,8 +318,7 @@ textarea,
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .btn-primary::before,
-  .cli-prompt-bubble__run::before {
+  .btn-crt::before {
     animation: none;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -34,9 +34,9 @@
   /* Accent / brand — Ouijit blue. App-wide accent: links, selection, focus
      rings, primary buttons, the homepage Run button. --color-accent-ink is the
      text color on filled accent buttons. */
-  --color-accent: #2f6fe6;
-  --color-accent-hover: #4d88f0;
-  --color-accent-light: rgba(47, 111, 230, 0.2);
+  --color-accent: #0a84ff;
+  --color-accent-hover: #409cff;
+  --color-accent-light: rgba(10, 132, 255, 0.2);
   --color-accent-ink: #ffffff;
 
   /* Status Colors */

--- a/src/index.css
+++ b/src/index.css
@@ -192,11 +192,12 @@ textarea,
   --crt-dot: 1.5px;
   --crt-line: 2px;
 
-  /* Lava-lamp fill: drifting hue blobs (indigo / magenta / cyan), dark enough
-     that white text stays legible. */
-  --lava-1: rgba(79, 70, 229, 0.95); /* indigo */
-  --lava-2: rgba(147, 51, 234, 0.95); /* magenta */
-  --lava-3: rgba(8, 145, 178, 0.92); /* cyan */
+  /* Lava-lamp fill: drifting shades of blue around the primary accent, over a
+     dark navy screen — a cohesive, on-brand glowing blue. */
+  --lava-base: var(--color-accent); /* screen base = primary accent */
+  --lava-1: rgba(96, 165, 250, 0.9); /* light sky */
+  --lava-2: rgba(47, 111, 230, 0.95); /* primary blue */
+  --lava-3: rgba(29, 78, 216, 0.95); /* deep blue */
   --lava-speed: 9s;
   --lava-blur: 7px;
 }
@@ -218,12 +219,13 @@ textarea,
     text-shadow: 0 0 5px rgba(170, 205, 255, 0.45); /* phosphor glow */
   }
 
-  /* Animated lava fill (z-index -2): drifting hue blobs behind the label. */
+  /* Animated lava fill (z-index -2): drifting hue blobs on a dark screen base. */
   .btn-crt::before {
     content: '';
     position: absolute;
     inset: -25%;
     z-index: -2;
+    background-color: var(--lava-base);
     background-image:
       radial-gradient(circle, var(--lava-1) 0%, transparent 46%),
       radial-gradient(circle, var(--lava-2) 0%, transparent 46%),

--- a/src/index.css
+++ b/src/index.css
@@ -32,8 +32,8 @@
   --color-border-hover: rgba(255, 255, 255, 0.15);
 
   /* Accent / brand — Ouijit blue. App-wide accent: links, selection, focus
-     rings, primary buttons, the homepage Run button. --color-accent-ink is
-     the text color on filled accent buttons (white, since blue is dark). */
+     rings, primary buttons, the homepage Run button. --color-accent-ink is the
+     text color on filled accent buttons. */
   --color-accent: #2f6fe6;
   --color-accent-hover: #4d88f0;
   --color-accent-light: rgba(47, 111, 230, 0.2);
@@ -173,28 +173,27 @@ textarea,
 
 /* ===================================
    Buttons (shared dialog/CTA pattern)
-   "CRT screen" primary: an animated lava-lamp fill (::before) under a CRT
-   shadow-mask overlay of vertical R/G/B phosphor dots + tube vignette +
-   static (::after), with a white, softly-glowing label on top. Full pill.
-   Keep in sync with the website's .btn in website/src/styles/marketing.css.
+   .btn-primary / .btn-secondary are plain flat pills used everywhere (app
+   dialogs + website). .btn-crt is an opt-in "CRT screen" modifier (animated
+   lava + R/G/B shadow mask + glowing label) reserved for the most important
+   marketing CTAs. Keep in sync with website/src/styles/marketing.css.
    =================================== */
 
-/* Sparse phosphor noise: feTurbulence mapped to ALPHA (transparent except
-   sparse opaque black specks) so it composites cleanly above the opaque RGB
-   grille layer and reads as CRT static under the multiply overlay. */
+/* Sparse phosphor static: feTurbulence mapped to ALPHA (transparent except
+   sparse opaque black specks) so it composites above the RGB grille and reads
+   as CRT static under the multiply overlay. */
 :root {
   --btn-grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.5' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0 0 0 0 1'/%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-  /* CRT shadow-mask overlay: vertical R/G/B phosphor stripes, segmented into
-     dots by thin horizontal gaps, plus tube vignette + static, multiplied
-     over the lava. --crt-strength fades the whole effect; --crt-dot is the
-     subpixel width (triad = 3x); --crt-line is the dot row height. */
+  /* CRT shadow-mask overlay: vertical R/G/B phosphor stripes segmented into
+     dots by thin horizontal gaps, plus vignette + static, multiplied over the
+     lava. --crt-strength fades it; --crt-dot = subpixel width (triad = 3x);
+     --crt-line = dot row height. */
   --crt-strength: 0.42;
   --crt-dot: 1.5px;
   --crt-line: 2px;
 
-  /* Lava-lamp fill: drifting hue blobs behind the label. Hues are spread
-     wide (indigo / magenta / cyan) and distinct from the blue base for
-     visible contrast, but kept dark enough that white text stays legible. */
+  /* Lava-lamp fill: drifting hue blobs (indigo / magenta / cyan), dark enough
+     that white text stays legible. */
   --lava-1: rgba(79, 70, 229, 0.95); /* indigo */
   --lava-2: rgba(147, 51, 234, 0.95); /* magenta */
   --lava-3: rgba(8, 145, 178, 0.92); /* cyan */
@@ -204,17 +203,23 @@ textarea,
 
 @layer components {
   .btn-primary {
-    @apply relative isolate overflow-hidden inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light active:scale-[0.98] disabled:opacity-50;
+    @apply inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline outline-none transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-accent-light active:scale-[0.98] disabled:opacity-50;
     border-radius: 9999px;
     background-color: var(--color-accent);
     color: var(--color-accent-ink);
+  }
+
+  /* "CRT screen" treatment — an OPT-IN modifier for the most important
+     marketing CTAs only (not app dialog buttons). Pair with .btn-primary:
+     it layers an animated lava fill (::before) + a CRT shadow mask (::after)
+     behind a glowing label. */
+  .btn-crt {
+    @apply relative isolate overflow-hidden;
     text-shadow: 0 0 5px rgba(170, 205, 255, 0.45); /* phosphor glow */
   }
 
-  /* Animated lava-lamp fill (z-index -2): three blurred hue blobs drifting
-     via background-position. Clipped to the pill, sits below both the grain
-     and the label. */
-  .btn-primary::before {
+  /* Animated lava fill (z-index -2): drifting hue blobs behind the label. */
+  .btn-crt::before {
     content: '';
     position: absolute;
     inset: -25%;
@@ -237,11 +242,10 @@ textarea,
     pointer-events: none;
   }
 
-  /* CRT shadow-mask overlay (z-index -1), multiplied onto the lava. Top to
-     bottom: horizontal dot-row gaps, tube vignette, phosphor static, then the
-     opaque vertical R/G/B grille. Sits BEHIND the label (scoped by `isolate`)
-     so it masks the screen without touching the text. */
-  .btn-primary::after {
+  /* CRT shadow-mask overlay (z-index -1) multiplied onto the lava: dot-row
+     gaps, tube vignette, phosphor static, then the vertical R/G/B grille.
+     Sits BEHIND the label (scoped by `isolate`). */
+  .btn-crt::after {
     content: '';
     position: absolute;
     inset: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -174,33 +174,8 @@ textarea,
 /* ===================================
    Buttons (shared dialog/CTA pattern)
    .btn-primary / .btn-secondary are plain flat pills used everywhere (app
-   dialogs + website). .btn-crt is an opt-in "CRT screen" treatment (animated
-   blue plasma + R/G/B shadow mask + glowing label) reserved for the marketing
-   hero CTA; the cursor glow lives in website/src/styles/marketing.css.
+   dialogs + website).
    =================================== */
-
-/* Sparse phosphor static: feTurbulence mapped to ALPHA (transparent except
-   sparse opaque black specks) so it composites above the RGB grille and reads
-   as CRT static under the multiply overlay. */
-:root {
-  --btn-grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.5' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='0 0 0 0 1'/%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-  /* CRT shadow-mask overlay (used by .btn-crt): vertical R/G/B phosphor
-     stripes segmented into dots by thin horizontal gaps, plus vignette +
-     static, multiplied over the lava. --crt-strength fades it; --crt-dot =
-     subpixel width (triad = 3x); --crt-line = dot row height. */
-  --crt-strength: 0.42;
-  --crt-dot: 1.5px;
-  --crt-line: 2px;
-
-  /* Lava fill: drifting shades of blue around the primary accent, over a
-     screen base of the accent itself — a cohesive, on-brand glowing blue. */
-  --lava-base: var(--color-accent);
-  --lava-1: rgba(59, 130, 246, 0.9); /* sky (deeper, more saturated) */
-  --lava-2: rgba(37, 99, 235, 0.95); /* primary blue */
-  --lava-3: rgba(29, 78, 216, 0.95); /* deep blue */
-  --lava-speed: 9s;
-  --lava-blur: 7px;
-}
 
 @layer components {
   .btn-primary {
@@ -208,72 +183,6 @@ textarea,
     border-radius: 9999px;
     background-color: var(--color-accent);
     color: var(--color-accent-ink);
-  }
-
-  /* "CRT screen" treatment — opt-in modifier for the marketing hero CTA only
-     (pair with .btn-primary): animated blue plasma (::before) under a CRT
-     shadow mask (::after), behind a glowing label. */
-  .btn-crt {
-    @apply relative isolate overflow-hidden;
-    text-shadow: 0 0 5px rgba(170, 205, 255, 0.45); /* phosphor glow */
-    filter: saturate(1.12); /* rich saturated screen at rest */
-    transition:
-      filter 90ms ease-out,
-      transform 90ms ease-out;
-  }
-
-  /* Snappy traditional hover: the saturated screen brightens (gets lighter). */
-  .btn-crt:hover {
-    filter: saturate(1.12) brightness(1.14);
-  }
-
-  .btn-crt::before {
-    content: '';
-    position: absolute;
-    inset: -25%;
-    z-index: -2;
-    background-color: var(--lava-base);
-    background-image:
-      radial-gradient(circle, var(--lava-1) 0%, transparent 46%),
-      radial-gradient(circle, var(--lava-2) 0%, transparent 46%),
-      radial-gradient(circle, var(--lava-3) 0%, transparent 46%);
-    background-repeat: no-repeat;
-    background-size:
-      120% 120%,
-      130% 130%,
-      115% 115%;
-    background-position:
-      0% 0%,
-      100% 0%,
-      50% 100%;
-    filter: blur(var(--lava-blur));
-    animation: lava-drift var(--lava-speed) ease-in-out infinite alternate;
-    pointer-events: none;
-  }
-
-  .btn-crt::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    z-index: -1;
-    background-image:
-      repeating-linear-gradient(to bottom, rgba(0, 0, 0, 0.7) 0 1px, transparent 1px var(--crt-line)),
-      radial-gradient(125% 135% at 50% 50%, transparent 52%, rgba(0, 0, 0, 0.55) 100%), var(--btn-grain),
-      repeating-linear-gradient(
-        to right,
-        rgb(255, 45, 45) 0 var(--crt-dot),
-        rgb(45, 255, 45) var(--crt-dot) calc(var(--crt-dot) * 2),
-        rgb(60, 60, 255) calc(var(--crt-dot) * 2) calc(var(--crt-dot) * 3)
-      );
-    background-size:
-      auto,
-      auto,
-      120px 120px,
-      auto;
-    image-rendering: pixelated;
-    mix-blend-mode: multiply;
-    opacity: var(--crt-strength);
-    pointer-events: none;
   }
 
   .btn-primary:hover:not(:disabled) {
@@ -294,34 +203,6 @@ textarea,
 /* ===================================
    Animations
    =================================== */
-
-/* Lava drift for the CRT CTA (.btn-crt::before). */
-@keyframes lava-drift {
-  0% {
-    background-position:
-      0% 0%,
-      100% 0%,
-      50% 100%;
-  }
-  50% {
-    background-position:
-      70% 80%,
-      10% 60%,
-      90% 10%;
-  }
-  100% {
-    background-position:
-      100% 40%,
-      40% 100%,
-      0% 30%;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .btn-crt::before {
-    animation: none;
-  }
-}
 
 @keyframes spin {
   from {

--- a/website/src/components/demo/MockPanels.tsx
+++ b/website/src/components/demo/MockPanels.tsx
@@ -470,7 +470,7 @@ function OnboardingPreviewPage() {
   return (
     <div className="w-full h-full flex flex-col bg-[#fafafa] text-[#0a0a0c] font-sans overflow-hidden">
       <div className="px-6 py-3 border-b border-black/10 flex items-center gap-3">
-        <div className="w-6 h-6 rounded-md bg-gradient-to-br from-[#0a84ff] to-[#5ac8fa]" />
+        <div className="w-6 h-6 rounded-md bg-gradient-to-br from-accent to-[#9af0c0]" />
         <span className="text-[12px] font-medium">Constellation</span>
         <div className="ml-auto text-[11px] text-black/40">Step 2 of 3</div>
       </div>
@@ -480,7 +480,7 @@ function OnboardingPreviewPage() {
         <div className="w-full max-w-[320px] flex flex-col gap-3">
           <div>
             <div className="text-[10px] uppercase tracking-wide text-black/45 mb-1">Workspace name</div>
-            <div className="px-2.5 py-1.5 rounded border border-[#0a84ff]/60 bg-white text-[12px] shadow-[0_0_0_3px_rgba(10,132,255,0.15)]">
+            <div className="px-2.5 py-1.5 rounded border border-accent/60 bg-white text-[12px] ring-[3px] ring-accent/15">
               Northwind
             </div>
           </div>
@@ -495,7 +495,7 @@ function OnboardingPreviewPage() {
             <button className="px-3 py-1.5 rounded text-[11px] text-black/60 bg-transparent border border-black/15">
               Back
             </button>
-            <button className="px-3 py-1.5 rounded text-[11px] text-white bg-[#0a84ff] border-none">Continue</button>
+            <button className="px-3 py-1.5 rounded text-[11px] text-accent-ink bg-accent border-none">Continue</button>
           </div>
         </div>
       </div>

--- a/website/src/ouijit-ui/components/kanban/KanbanCardView.tsx
+++ b/website/src/ouijit-ui/components/kanban/KanbanCardView.tsx
@@ -151,9 +151,9 @@ export const KanbanCardView = memo(function KanbanCardView({
       className="kanban-card group px-3 py-3.5 ease-out [-webkit-app-region:no-drag] hover:bg-black/10 active:bg-black/[0.12]"
       style={{
         background: isSelected
-          ? 'rgba(10, 132, 255, 0.06)'
+          ? 'color-mix(in srgb, var(--color-accent) 6%, transparent)'
           : isHoveredBadgeTarget
-            ? 'rgba(10, 132, 255, 0.08)'
+            ? 'color-mix(in srgb, var(--color-accent) 8%, transparent)'
             : expanded
               ? 'rgba(0, 0, 0, 0.15)'
               : 'var(--color-terminal-bg)',
@@ -161,9 +161,9 @@ export const KanbanCardView = memo(function KanbanCardView({
           'background 150ms ease-out, opacity 150ms ease-out, outline-color 150ms ease-out, box-shadow 150ms ease-out',
         borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
         outline: isHoveredBadgeTarget
-          ? '1px solid rgba(10, 132, 255, 0.6)'
+          ? '1px solid color-mix(in srgb, var(--color-accent) 60%, transparent)'
           : isValidBadgeTarget
-            ? '1px dashed rgba(10, 132, 255, 0.3)'
+            ? '1px dashed color-mix(in srgb, var(--color-accent) 30%, transparent)'
             : 'none',
         outlineOffset: -1,
         ...(isInvalidBadgeTarget && { opacity: 0.4 }),

--- a/website/src/ouijit-ui/components/kanban/KanbanColumnView.tsx
+++ b/website/src/ouijit-ui/components/kanban/KanbanColumnView.tsx
@@ -62,7 +62,7 @@ export function KanbanColumnView({
           scrollbarColor: 'transparent transparent',
           transition: 'background 150ms ease',
           minHeight: 80,
-          background: isOver ? 'rgba(10, 132, 255, 0.08)' : undefined,
+          background: isOver ? 'color-mix(in srgb, var(--color-accent) 8%, transparent)' : undefined,
         }}
         onClick={onBodyClick}
       >

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -59,8 +59,7 @@ const softwareSchema = {
     </div>
     <p class="hero-fine-print">Free and open source. No account, no sign-in, no telemetry.</p>
     <div class="mobile-cta">
-      <p>You're on a phone. This is a desktop app.</p>
-      <a href="https://github.com/ouijit/ouijit" class="btn btn-primary">Here's the source code though</a>
+      <div class="mobile-cta-note" role="note">View on desktop to download</div>
     </div>
   </section>
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -50,7 +50,7 @@ const softwareSchema = {
     <div class="download-buttons">
       <a
         href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-arm64.zip"
-        class="btn btn-primary">Download for macOS (Apple Silicon)</a>
+        class="btn btn-primary btn-crt">Download for macOS (Apple Silicon)</a>
       <a
         href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-x64.zip"
         class="btn btn-secondary">macOS (Intel)</a>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -50,7 +50,7 @@ const softwareSchema = {
     <div class="download-buttons">
       <a
         href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-arm64.zip"
-        class="btn btn-primary btn-crt">Download for macOS (Apple Silicon)</a>
+        class="btn btn-primary">Download for macOS (Apple Silicon)</a>
       <a
         href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-x64.zip"
         class="btn btn-secondary">macOS (Intel)</a>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -62,7 +62,7 @@ body.marketing ::-webkit-scrollbar-thumb:hover {
 :root {
   --marketing-bg: #0a0a0c;
   --marketing-surface: #16161a;
-  --marketing-blue: #0a84ff;
+  --marketing-accent: var(--color-accent);
   --marketing-blue-deep: #001b65;
   --marketing-fade: rgba(255, 255, 255, 0.75);
   --marketing-fade-2: rgba(255, 255, 255, 0.5);

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -65,14 +65,22 @@ img {
 }
 
 @media (max-width: 768px) {
+  /* CRT-styled sticky bar: opaque page color + the same scanlines/grille as
+     the site background, viewport-aligned so they line up. No glass blur. */
   .site-nav {
     position: sticky;
     top: 0;
-    background: rgba(10, 10, 12, 0.85);
-    backdrop-filter: blur(20px) saturate(180%);
-    -webkit-backdrop-filter: blur(20px) saturate(180%);
-    border-bottom: 1px solid var(--color-border);
     z-index: 100;
+    background-color: var(--marketing-bg);
+    background-image:
+      repeating-linear-gradient(to bottom, rgba(0, 0, 0, 0.4) 0 1px, transparent 1px 3px),
+      repeating-linear-gradient(
+        to right,
+        rgba(255, 0, 0, 0.08) 0 1px,
+        rgba(0, 255, 0, 0.08) 1px 2px,
+        rgba(0, 0, 255, 0.08) 2px 3px
+      );
+    background-attachment: fixed;
   }
 }
 
@@ -129,8 +137,17 @@ img {
 .nav-mobile {
   display: none;
   padding: 8px var(--content-padding) 16px;
-  background: var(--marketing-bg);
-  border-bottom: 1px solid var(--color-border);
+  /* CRT-styled panel, continuous with the sticky nav (same fixed scanlines). */
+  background-color: var(--marketing-bg);
+  background-image:
+    repeating-linear-gradient(to bottom, rgba(0, 0, 0, 0.4) 0 1px, transparent 1px 3px),
+    repeating-linear-gradient(
+      to right,
+      rgba(255, 0, 0, 0.08) 0 1px,
+      rgba(0, 255, 0, 0.08) 1px 2px,
+      rgba(0, 0, 255, 0.08) 2px 3px
+    );
+  background-attachment: fixed;
   position: relative;
   z-index: 100;
 }
@@ -225,9 +242,8 @@ img {
   }
 }
 
-/* Ouijit button system — flat phosphor-green fill with film-grain texture
-   and dark ink text. Driven by the shared --color-accent token + --btn-grain
-   (imported from src/index.css). */
+/* Ouijit button system — flat accent-blue pills, white label. Driven by the
+   shared --color-accent token (imported from src/index.css). */
 body.marketing .btn {
   display: inline-flex;
   align-items: center;
@@ -261,15 +277,18 @@ body.marketing .btn-primary {
 body.marketing .btn-primary:hover {
   background-color: var(--color-accent-hover);
   color: var(--color-accent-ink);
+  transform: translateY(-1px);
 }
 
+/* Opaque fills (matching the old translucent shades over --marketing-bg) so
+   the site-wide CRT background doesn't show through the ghost buttons. */
 body.marketing .btn-secondary {
-  background: rgba(255, 255, 255, 0.06);
+  background: #19191b;
   color: var(--color-text-primary);
 }
 
 body.marketing .btn-secondary:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: #232326;
   color: var(--color-text-primary);
 }
 
@@ -447,7 +466,10 @@ body.marketing .home-agents-footnote a:hover {
 .workspace-scene-clip {
   position: relative;
   width: 100%;
-  overflow: hidden;
+  /* clip (not hidden) + a margin so card drop shadows can spill past the
+     scaled-height bottom edge instead of being cut off. */
+  overflow: clip;
+  overflow-clip-margin: 160px;
   display: flex;
   justify-content: center;
   padding-top: 12px;
@@ -609,7 +631,6 @@ body.marketing .home-agents-footnote a:hover {
     transform 150ms ease-out;
 }
 
-
 .cli-prompt-bubble:hover:not(:disabled) .cli-prompt-bubble__run {
   background-color: var(--color-accent-hover);
   transform: translateY(-1px);
@@ -623,7 +644,6 @@ body.marketing .home-agents-footnote a:hover {
   display: block;
   margin-left: -2px;
 }
-
 
 .cli-prompt-bubble__prompt {
   color: color-mix(in srgb, var(--color-accent) 90%, transparent);
@@ -1075,13 +1095,7 @@ body.marketing .home-agents-footnote a:hover {
 }
 
 .docs-content code {
-  font-family:
-    'SF Mono',
-    Monaco,
-    Menlo,
-    'Cascadia Code',
-    'Fira Code',
-    monospace;
+  font-family: 'SF Mono', Monaco, Menlo, 'Cascadia Code', 'Fira Code', monospace;
   font-size: 0.875em;
   background: rgba(255, 255, 255, 0.15);
   padding: 2px 6px;
@@ -1189,4 +1203,29 @@ body.marketing {
 }
 .workspace-scene .kanban-column-body::-webkit-scrollbar {
   display: none;
+}
+
+/* ===================================
+   Site-wide CRT overlay — scanlines + tube vignette fixed over the viewport.
+   The animated hero scene and the supported-harness cards opt out by sitting
+   above it (raised z-index below). pointer-events: none so it never blocks.
+   =================================== */
+body.marketing::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1; /* behind all content — CRT shows only through the background */
+  pointer-events: none;
+  background-image:
+    /* scanlines (darken content rows) */
+    repeating-linear-gradient(to bottom, rgba(0, 0, 0, 0.4) 0 1px, transparent 1px 3px),
+    /* vertical R/G/B phosphor grille — adds color shimmer even on dark areas */
+    repeating-linear-gradient(
+      to right,
+      rgba(255, 0, 0, 0.08) 0 1px,
+      rgba(0, 255, 0, 0.08) 1px 2px,
+      rgba(0, 0, 255, 0.08) 2px 3px
+    ),
+    /* tube vignette */
+    radial-gradient(120% 120% at 50% 50%, transparent 45%, rgba(0, 0, 0, 0.55) 100%);
 }

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -590,13 +590,9 @@ body.marketing .home-agents-footnote a:hover {
   align-self: flex-end;
   gap: 8px;
   padding: 11px 22px 11px 20px;
-  position: relative;
-  isolation: isolate;
-  overflow: hidden;
   border-radius: 9999px;
   background-color: var(--color-accent);
   color: var(--color-accent-ink);
-  text-shadow: 0 0 5px rgba(170, 205, 255, 0.45);
   font-family:
     system-ui,
     -apple-system,
@@ -613,56 +609,6 @@ body.marketing .home-agents-footnote a:hover {
     transform 150ms ease-out;
 }
 
-/* Animated lava-lamp fill (z-index -2), matching .btn-primary. */
-.cli-prompt-bubble__run::before {
-  content: '';
-  position: absolute;
-  inset: -25%;
-  z-index: -2;
-  background-image:
-    radial-gradient(circle, var(--lava-1) 0%, transparent 46%),
-    radial-gradient(circle, var(--lava-2) 0%, transparent 46%),
-    radial-gradient(circle, var(--lava-3) 0%, transparent 46%);
-  background-repeat: no-repeat;
-  background-size:
-    120% 120%,
-    130% 130%,
-    115% 115%;
-  background-position:
-    0% 0%,
-    100% 0%,
-    50% 100%;
-  filter: blur(var(--lava-blur));
-  animation: lava-drift var(--lava-speed) ease-in-out infinite alternate;
-  pointer-events: none;
-}
-
-/* CRT shadow-mask overlay, behind the label (z-index -1), matching .btn-primary. */
-.cli-prompt-bubble__run::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  background-image:
-    repeating-linear-gradient(to bottom, rgba(0, 0, 0, 0.7) 0 1px, transparent 1px var(--crt-line)),
-    radial-gradient(125% 135% at 50% 50%, transparent 52%, rgba(0, 0, 0, 0.55) 100%),
-    var(--btn-grain),
-    repeating-linear-gradient(
-      to right,
-      rgb(255, 45, 45) 0 var(--crt-dot),
-      rgb(45, 255, 45) var(--crt-dot) calc(var(--crt-dot) * 2),
-      rgb(60, 60, 255) calc(var(--crt-dot) * 2) calc(var(--crt-dot) * 3)
-    );
-  background-size:
-    auto,
-    auto,
-    120px 120px,
-    auto;
-  image-rendering: pixelated;
-  mix-blend-mode: multiply;
-  opacity: var(--crt-strength);
-  pointer-events: none;
-}
 
 .cli-prompt-bubble:hover:not(:disabled) .cli-prompt-bubble__run {
   background-color: var(--color-accent-hover);

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -476,10 +476,11 @@ body.marketing .home-agents-footnote a:hover {
 .workspace-scene-clip {
   position: relative;
   width: 100%;
-  /* clip (not hidden) + a margin so card drop shadows can spill past the
-     scaled-height bottom edge instead of being cut off. */
-  overflow: clip;
-  overflow-clip-margin: 160px;
+  /* Clip the 1160px canvas horizontally, but let it overflow vertically so
+     the cards' drop shadows aren't cut at the scaled-height bottom edge.
+     (clip + visible is the one mixed combo that doesn't force a scrollbar.) */
+  overflow-x: clip;
+  overflow-y: visible;
   display: flex;
   justify-content: center;
   padding-top: 12px;

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -228,9 +228,19 @@ img {
   display: none;
 }
 
-.mobile-cta p {
+/* Full-width grey pill, non-interactive — just tells touch users to use a
+   desktop to download. */
+.mobile-cta-note {
+  display: block;
+  width: 100%;
+  text-align: center;
+  padding: 14px 30px;
+  border-radius: 9999px;
+  background: #19191b;
   color: var(--color-text-secondary);
   font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
 }
 
 @media (hover: none) and (pointer: coarse) {

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -225,12 +225,15 @@ img {
   }
 }
 
+/* Ouijit button system — flat phosphor-green fill with film-grain texture
+   and dark ink text. Driven by the shared --color-accent token + --btn-grain
+   (imported from src/index.css). */
 body.marketing .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 13px 28px;
+  padding: 14px 30px;
   border-radius: 9999px;
   font-size: 1rem;
   font-weight: 500;
@@ -249,24 +252,25 @@ body.marketing .btn:focus-visible {
   box-shadow: 0 0 0 3px var(--color-accent-light);
 }
 
+/* Grain overlay (.btn-primary::after) is inherited from src/index.css. */
 body.marketing .btn-primary {
-  background: var(--color-accent);
-  color: #fff;
+  background-color: var(--color-accent);
+  color: var(--color-accent-ink);
 }
 
 body.marketing .btn-primary:hover {
-  background: var(--color-accent-hover);
-  color: #fff;
+  background-color: var(--color-accent-hover);
+  color: var(--color-accent-ink);
 }
 
 body.marketing .btn-secondary {
-  background: var(--color-accent-light);
-  color: var(--color-accent);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--color-text-primary);
 }
 
 body.marketing .btn-secondary:hover {
-  background: rgba(10, 132, 255, 0.28);
-  color: var(--color-accent);
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--color-text-primary);
 }
 
 /* --- Hero workspace scene --- */
@@ -586,9 +590,13 @@ body.marketing .home-agents-footnote a:hover {
   align-self: flex-end;
   gap: 8px;
   padding: 11px 22px 11px 20px;
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
   border-radius: 9999px;
-  background: var(--color-accent);
-  color: #fff;
+  background-color: var(--color-accent);
+  color: var(--color-accent-ink);
+  text-shadow: 0 0 5px rgba(170, 205, 255, 0.45);
   font-family:
     system-ui,
     -apple-system,
@@ -605,8 +613,59 @@ body.marketing .home-agents-footnote a:hover {
     transform 150ms ease-out;
 }
 
+/* Animated lava-lamp fill (z-index -2), matching .btn-primary. */
+.cli-prompt-bubble__run::before {
+  content: '';
+  position: absolute;
+  inset: -25%;
+  z-index: -2;
+  background-image:
+    radial-gradient(circle, var(--lava-1) 0%, transparent 46%),
+    radial-gradient(circle, var(--lava-2) 0%, transparent 46%),
+    radial-gradient(circle, var(--lava-3) 0%, transparent 46%);
+  background-repeat: no-repeat;
+  background-size:
+    120% 120%,
+    130% 130%,
+    115% 115%;
+  background-position:
+    0% 0%,
+    100% 0%,
+    50% 100%;
+  filter: blur(var(--lava-blur));
+  animation: lava-drift var(--lava-speed) ease-in-out infinite alternate;
+  pointer-events: none;
+}
+
+/* CRT shadow-mask overlay, behind the label (z-index -1), matching .btn-primary. */
+.cli-prompt-bubble__run::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background-image:
+    repeating-linear-gradient(to bottom, rgba(0, 0, 0, 0.7) 0 1px, transparent 1px var(--crt-line)),
+    radial-gradient(125% 135% at 50% 50%, transparent 52%, rgba(0, 0, 0, 0.55) 100%),
+    var(--btn-grain),
+    repeating-linear-gradient(
+      to right,
+      rgb(255, 45, 45) 0 var(--crt-dot),
+      rgb(45, 255, 45) var(--crt-dot) calc(var(--crt-dot) * 2),
+      rgb(60, 60, 255) calc(var(--crt-dot) * 2) calc(var(--crt-dot) * 3)
+    );
+  background-size:
+    auto,
+    auto,
+    120px 120px,
+    auto;
+  image-rendering: pixelated;
+  mix-blend-mode: multiply;
+  opacity: var(--crt-strength);
+  pointer-events: none;
+}
+
 .cli-prompt-bubble:hover:not(:disabled) .cli-prompt-bubble__run {
-  background: var(--color-accent-hover);
+  background-color: var(--color-accent-hover);
   transform: translateY(-1px);
 }
 
@@ -621,7 +680,7 @@ body.marketing .home-agents-footnote a:hover {
 
 
 .cli-prompt-bubble__prompt {
-  color: rgba(10, 132, 255, 0.9);
+  color: color-mix(in srgb, var(--color-accent) 90%, transparent);
   flex-shrink: 0;
 }
 
@@ -684,13 +743,13 @@ body.marketing .home-agents-footnote a:hover {
 
 @keyframes workspace-scene-task-pulse {
   0% {
-    box-shadow: 0 0 0 0 rgba(10, 132, 255, 0.55);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-accent) 55%, transparent);
   }
   60% {
-    box-shadow: 0 0 0 10px rgba(10, 132, 255, 0);
+    box-shadow: 0 0 0 10px color-mix(in srgb, var(--color-accent) 0%, transparent);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(10, 132, 255, 0);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-accent) 0%, transparent);
   }
 }
 
@@ -739,7 +798,7 @@ body.marketing .home-agents-footnote a:hover {
   font-weight: 600;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--marketing-blue);
+  color: var(--marketing-accent);
   margin-bottom: 16px;
 }
 
@@ -983,7 +1042,7 @@ body.marketing .home-agents-footnote a:hover {
 }
 
 .docs-sidebar a.active {
-  color: var(--marketing-blue);
+  color: var(--marketing-accent);
   background: none;
   font-weight: 600;
 }


### PR DESCRIPTION
## Summary

- Centralize primary/secondary button styling into shared `.btn-primary` / `.btn-secondary` classes and apply them across all dialogs, removing the duplicated inline Tailwind strings.
- Tokenize hardcoded accent-blue literals (kanban drag highlights, smart guides, sandbox, dialogs, website demos) to the `--color-accent` token so the accent is a single source of truth.
- Add a site-wide "CRT screen" background to the marketing site: a fixed overlay of scanlines + R/G/B phosphor grille + tube vignette behind all content.
- Restyle the mobile sticky nav and hamburger menu to match the CRT look: opaque, viewport-aligned scanlines, no glass blur or borders.
- Make the secondary download buttons opaque so the CRT background doesn't show through them.
- Replace the mobile phone/desktop quip with an inert, full-width "View on desktop to download" pill.
- Fix the hero workspace-scene drop shadows being clipped, using `overflow-x: clip` + `overflow-y: visible` so horizontal clipping is preserved (no x-overflow) while shadows spill below.