### PR TITLE
Fire column hooks on CLI status transitions

### DIFF
--- a/src/__tests__/cli/commands/task.test.ts
+++ b/src/__tests__/cli/commands/task.test.ts
@@ -194,7 +194,7 @@ describe('task commands', () => {
   });
 
   describe('set-status done hook flags', () => {
-    test('done with no flags sends just the status', async () => {
+    test('done with no flags sends just the status (renderer shows the dialog)', async () => {
       vi.mocked(patch).mockResolvedValue({ success: true });
       const output = captureOutput();
       await createProgram().parseAsync(['task', 'set-status', '1', 'done'], { from: 'user' });
@@ -202,22 +202,34 @@ describe('task commands', () => {
       expect(patch).toHaveBeenCalledWith(expect.any(String), { status: 'done' });
     });
 
-    test('done --skip-hook forwards skipHook in the body', async () => {
+    test('done --run-hook forwards hookMode run', async () => {
+      vi.mocked(patch).mockResolvedValue({ success: true });
+      const output = captureOutput();
+      await createProgram().parseAsync(['task', 'set-status', '1', 'done', '--run-hook'], { from: 'user' });
+      output.getJson();
+      expect(patch).toHaveBeenCalledWith(expect.any(String), { status: 'done', hookMode: 'run' });
+    });
+
+    test('done --skip-hook forwards hookMode skip', async () => {
       vi.mocked(patch).mockResolvedValue({ success: true });
       const output = captureOutput();
       await createProgram().parseAsync(['task', 'set-status', '1', 'done', '--skip-hook'], { from: 'user' });
       output.getJson();
-      expect(patch).toHaveBeenCalledWith(expect.any(String), { status: 'done', skipHook: true });
+      expect(patch).toHaveBeenCalledWith(expect.any(String), { status: 'done', hookMode: 'skip' });
     });
 
-    test('done --hook-command forwards hookCommand', async () => {
+    test('done --hook-command forwards hookMode command + hookCommand', async () => {
       vi.mocked(patch).mockResolvedValue({ success: true });
       const output = captureOutput();
       await createProgram().parseAsync(['task', 'set-status', '1', 'done', '--hook-command', 'npm run deploy'], {
         from: 'user',
       });
       output.getJson();
-      expect(patch).toHaveBeenCalledWith(expect.any(String), { status: 'done', hookCommand: 'npm run deploy' });
+      expect(patch).toHaveBeenCalledWith(expect.any(String), {
+        status: 'done',
+        hookMode: 'command',
+        hookCommand: 'npm run deploy',
+      });
     });
 
     test('done with both --skip-hook and --hook-command exits non-zero', async () => {
@@ -246,11 +258,87 @@ describe('task commands', () => {
       }
     });
 
-    test('hook flags on non-done status exit non-zero (no silent ignore)', async () => {
+    test('done with both --skip-hook and --run-hook exits non-zero', async () => {
       const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
       const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
       try {
-        await createProgram().parseAsync(['task', 'set-status', '1', 'in_review', '--skip-hook'], { from: 'user' });
+        await createProgram().parseAsync(['task', 'set-status', '1', 'done', '--skip-hook', '--run-hook'], {
+          from: 'user',
+        });
+        expect(exitSpy).toHaveBeenCalledWith(1);
+      } finally {
+        exitSpy.mockRestore();
+        errSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('set-status in_progress/in_review hook flags', () => {
+    test('in_review with no flags sends just the status (renderer shows the dialog)', async () => {
+      vi.mocked(patch).mockResolvedValue({ success: true });
+      const output = captureOutput();
+      await createProgram().parseAsync(['task', 'set-status', '1', 'in_review'], { from: 'user' });
+      output.getJson();
+      expect(patch).toHaveBeenCalledWith(expect.any(String), { status: 'in_review' });
+    });
+
+    test('in_review --run-hook forwards hookMode run', async () => {
+      vi.mocked(patch).mockResolvedValue({ success: true });
+      const output = captureOutput();
+      await createProgram().parseAsync(['task', 'set-status', '1', 'in_review', '--run-hook'], { from: 'user' });
+      output.getJson();
+      expect(patch).toHaveBeenCalledWith(expect.any(String), { status: 'in_review', hookMode: 'run' });
+    });
+
+    test('in_review --skip-hook forwards hookMode skip', async () => {
+      vi.mocked(patch).mockResolvedValue({ success: true });
+      const output = captureOutput();
+      await createProgram().parseAsync(['task', 'set-status', '1', 'in_review', '--skip-hook'], { from: 'user' });
+      output.getJson();
+      expect(patch).toHaveBeenCalledWith(expect.any(String), { status: 'in_review', hookMode: 'skip' });
+    });
+
+    test('in_review --hook-command forwards hookMode command + hookCommand', async () => {
+      vi.mocked(patch).mockResolvedValue({ success: true });
+      const output = captureOutput();
+      await createProgram().parseAsync(['task', 'set-status', '1', 'in_review', '--hook-command', 'claude review'], {
+        from: 'user',
+      });
+      output.getJson();
+      expect(patch).toHaveBeenCalledWith(expect.any(String), {
+        status: 'in_review',
+        hookMode: 'command',
+        hookCommand: 'claude review',
+      });
+    });
+
+    test('in_progress --run-hook forwards hookMode run', async () => {
+      vi.mocked(patch).mockResolvedValue({ success: true });
+      const output = captureOutput();
+      await createProgram().parseAsync(['task', 'set-status', '1', 'in_progress', '--run-hook'], { from: 'user' });
+      output.getJson();
+      expect(patch).toHaveBeenCalledWith(expect.any(String), { status: 'in_progress', hookMode: 'run' });
+    });
+
+    test('in_review with both --run-hook and --skip-hook exits non-zero', async () => {
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+      const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      try {
+        await createProgram().parseAsync(['task', 'set-status', '1', 'in_review', '--run-hook', '--skip-hook'], {
+          from: 'user',
+        });
+        expect(exitSpy).toHaveBeenCalledWith(1);
+      } finally {
+        exitSpy.mockRestore();
+        errSpy.mockRestore();
+      }
+    });
+
+    test('hook flags on todo exit non-zero (no hook on that transition)', async () => {
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+      const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      try {
+        await createProgram().parseAsync(['task', 'set-status', '1', 'todo', '--skip-hook'], { from: 'user' });
         expect(exitSpy).toHaveBeenCalledWith(1);
       } finally {
         exitSpy.mockRestore();
@@ -273,18 +361,18 @@ describe('task commands', () => {
       expect(result).toEqual({ success: true, status: 'In Review', succeeded: [1, 2, 3], failed: [] });
     });
 
-    test('done forwards --skip-hook to every task', async () => {
+    test('done forwards --skip-hook (hookMode skip) to every task', async () => {
       vi.mocked(patch).mockResolvedValue({ success: true });
       const output = captureOutput();
       await createProgram().parseAsync(['task', 'bulk-set-status', 'done', '5', '6', '--skip-hook'], { from: 'user' });
       output.getJson();
       expect(patch).toHaveBeenCalledWith(expect.stringContaining('/api/tasks/5/status'), {
         status: 'done',
-        skipHook: true,
+        hookMode: 'skip',
       });
       expect(patch).toHaveBeenCalledWith(expect.stringContaining('/api/tasks/6/status'), {
         status: 'done',
-        skipHook: true,
+        hookMode: 'skip',
       });
     });
 

--- a/src/__tests__/cliTaskStartedPush.test.ts
+++ b/src/__tests__/cliTaskStartedPush.test.ts
@@ -23,6 +23,7 @@ vi.mock('../worktree', () => ({
   createTaskWorktree: (...args: unknown[]) => createTaskWorktreeMock(...args),
 }));
 
+const getTaskByNumberMock = vi.fn(async () => null);
 vi.mock('../db', () => ({
   setTaskMergeTarget: vi.fn(),
   setTaskName: vi.fn(),
@@ -38,15 +39,18 @@ vi.mock('../db', () => ({
   getScripts: vi.fn(() => []),
   saveScript: vi.fn(),
   deleteScript: vi.fn(),
+  getTaskByNumber: (...args: unknown[]) => getTaskByNumberMock(...args),
 }));
 
 const beginTaskMock = vi.fn();
+const setTaskStatusWithHooksMock = vi.fn(async () => ({ success: true }));
+const getTaskWithWorkspaceMock = vi.fn(async () => null);
 vi.mock('../taskLifecycle', () => ({
   beginTask: (...args: unknown[]) => beginTaskMock(...args),
-  setTaskStatusWithHooks: vi.fn(async () => ({})),
+  setTaskStatusWithHooks: (...args: unknown[]) => setTaskStatusWithHooksMock(...args),
   deleteTaskWithWorktree: vi.fn(async () => ({})),
   getTasksWithWorkspaces: vi.fn(async () => []),
-  getTaskWithWorkspace: vi.fn(async () => null),
+  getTaskWithWorkspace: (...args: unknown[]) => getTaskWithWorkspaceMock(...args),
 }));
 
 vi.mock('../scanner', () => ({
@@ -100,6 +104,12 @@ beforeEach(async () => {
   typedPushMock.mockClear();
   createTaskWorktreeMock.mockReset();
   beginTaskMock.mockReset();
+  getTaskByNumberMock.mockReset();
+  getTaskByNumberMock.mockResolvedValue(null);
+  setTaskStatusWithHooksMock.mockReset();
+  setTaskStatusWithHooksMock.mockResolvedValue({ success: true });
+  getTaskWithWorkspaceMock.mockReset();
+  getTaskWithWorkspaceMock.mockResolvedValue(null);
   revokeAllTokens();
   await startHookServer(mockWindow());
 });
@@ -282,5 +292,119 @@ describe('cli:task-started push', () => {
     const token = issueToken('pty-host', 'host');
     await request('PATCH', `/api/tasks/3/name?project=${PROJECT}`, token, { name: 'rename' });
     expect(getTaskStartedPushes()).toHaveLength(0);
+  });
+});
+
+function getTaskTransitionedPushes() {
+  return typedPushMock.mock.calls.filter((call) => call[1] === 'cli:task-transitioned');
+}
+
+describe('cli:task-transitioned push', () => {
+  test('fires after PATCH status to in_review when the status actually changed', async () => {
+    getTaskByNumberMock.mockResolvedValueOnce({ taskNumber: 4, status: 'in_progress' });
+    getTaskWithWorkspaceMock.mockResolvedValueOnce({ taskNumber: 4, status: 'in_review' });
+    const token = issueToken('pty-host', 'host');
+    const res = await request('PATCH', `/api/tasks/4/status?project=${PROJECT}`, token, { status: 'in_review' });
+
+    expect(res.status).toBe(200);
+    const pushes = getTaskTransitionedPushes();
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0][2]).toMatchObject({
+      project: '/tmp/test-project',
+      taskNumber: 4,
+      origStatus: 'in_progress',
+      newStatus: 'in_review',
+    });
+  });
+
+  test('forwards hookMode + hookCommand from the request body into the push', async () => {
+    getTaskByNumberMock.mockResolvedValueOnce({ taskNumber: 4, status: 'in_progress' });
+    getTaskWithWorkspaceMock.mockResolvedValueOnce({ taskNumber: 4, status: 'in_review' });
+    const token = issueToken('pty-host', 'host');
+    const res = await request('PATCH', `/api/tasks/4/status?project=${PROJECT}`, token, {
+      status: 'in_review',
+      hookMode: 'command',
+      hookCommand: 'claude review',
+    });
+
+    expect(res.status).toBe(200);
+    const pushes = getTaskTransitionedPushes();
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0][2]).toMatchObject({ hookMode: 'command', hookCommand: 'claude review' });
+  });
+
+  test('does not fire when the status is unchanged (no transition)', async () => {
+    getTaskByNumberMock.mockResolvedValueOnce({ taskNumber: 4, status: 'in_review' });
+    const token = issueToken('pty-host', 'host');
+    const res = await request('PATCH', `/api/tasks/4/status?project=${PROJECT}`, token, { status: 'in_review' });
+
+    expect(res.status).toBe(200);
+    expect(getTaskTransitionedPushes()).toHaveLength(0);
+  });
+
+  test('does not fire for a done transition (that uses cli:task-completed)', async () => {
+    getTaskWithWorkspaceMock.mockResolvedValueOnce({ taskNumber: 4, status: 'done' });
+    const token = issueToken('pty-host', 'host');
+    const res = await request('PATCH', `/api/tasks/4/status?project=${PROJECT}`, token, { status: 'done' });
+
+    expect(res.status).toBe(200);
+    expect(getTaskTransitionedPushes()).toHaveLength(0);
+  });
+
+  test('rejects an invalid hookMode with 400 before writing the status', async () => {
+    const token = issueToken('pty-host', 'host');
+    const res = await request('PATCH', `/api/tasks/4/status?project=${PROJECT}`, token, {
+      status: 'in_review',
+      hookMode: 'bogus',
+    });
+
+    expect(res.status).toBe(400);
+    expect(setTaskStatusWithHooksMock).not.toHaveBeenCalled();
+    expect(getTaskTransitionedPushes()).toHaveLength(0);
+  });
+});
+
+function getTaskCompletedPushes() {
+  return typedPushMock.mock.calls.filter((call) => call[1] === 'cli:task-completed');
+}
+
+describe('cli:task-completed push', () => {
+  test('fires after PATCH status to done, with no hookMode for a bare done', async () => {
+    getTaskWithWorkspaceMock.mockResolvedValueOnce({ taskNumber: 8, status: 'done' });
+    const token = issueToken('pty-host', 'host');
+    const res = await request('PATCH', `/api/tasks/8/status?project=${PROJECT}`, token, { status: 'done' });
+
+    expect(res.status).toBe(200);
+    const pushes = getTaskCompletedPushes();
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0][2]).toMatchObject({ project: '/tmp/test-project', taskNumber: 8 });
+    expect(pushes[0][2].hookMode).toBeUndefined();
+  });
+
+  test('forwards hookMode + hookCommand from the request body into the push', async () => {
+    getTaskWithWorkspaceMock.mockResolvedValueOnce({ taskNumber: 8, status: 'done' });
+    const token = issueToken('pty-host', 'host');
+    const res = await request('PATCH', `/api/tasks/8/status?project=${PROJECT}`, token, {
+      status: 'done',
+      hookMode: 'command',
+      hookCommand: 'npm run deploy',
+    });
+
+    expect(res.status).toBe(200);
+    const pushes = getTaskCompletedPushes();
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0][2]).toMatchObject({ hookMode: 'command', hookCommand: 'npm run deploy' });
+  });
+
+  test('rejects an invalid hookMode on a done PATCH with 400 before writing', async () => {
+    const token = issueToken('pty-host', 'host');
+    const res = await request('PATCH', `/api/tasks/8/status?project=${PROJECT}`, token, {
+      status: 'done',
+      hookMode: 'bogus',
+    });
+
+    expect(res.status).toBe(400);
+    expect(setTaskStatusWithHooksMock).not.toHaveBeenCalled();
+    expect(getTaskCompletedPushes()).toHaveLength(0);
   });
 });

--- a/src/__tests__/cliTaskStartedPush.test.ts
+++ b/src/__tests__/cliTaskStartedPush.test.ts
@@ -407,4 +407,13 @@ describe('cli:task-completed push', () => {
     expect(setTaskStatusWithHooksMock).not.toHaveBeenCalled();
     expect(getTaskCompletedPushes()).toHaveLength(0);
   });
+
+  test('does not fire when the task is already done (no transition, no re-run)', async () => {
+    getTaskByNumberMock.mockResolvedValueOnce({ taskNumber: 8, status: 'done' });
+    const token = issueToken('pty-host', 'host');
+    const res = await request('PATCH', `/api/tasks/8/status?project=${PROJECT}`, token, { status: 'done' });
+
+    expect(res.status).toBe(200);
+    expect(getTaskCompletedPushes()).toHaveLength(0);
+  });
 });

--- a/src/__tests__/renderer/kanbanShiftDrag.test.tsx
+++ b/src/__tests__/renderer/kanbanShiftDrag.test.tsx
@@ -41,18 +41,27 @@ describe('shift-drag (skip done hook)', () => {
     vi.mocked(window.api.task.getAll).mockResolvedValue([]);
   });
 
-  test('skipHook bypasses the configured done hook', async () => {
-    // This is what the KanbanBoard drag-end calls when shiftKeyHeld is true.
-    await completeTask({ projectPath: PROJECT, task: makeTask(), skipHook: true });
+  test('shift-drag (hookControl skip) bypasses the configured done hook with no dialog', async () => {
+    // This is what the KanbanBoard drag-end passes when shiftKeyHeld is true.
+    const promptSpy = vi.spyOn(useProjectStore.getState(), 'requestRunHook');
 
+    await completeTask({ projectPath: PROJECT, task: makeTask(), hookControl: { mode: 'skip' } });
+
+    expect(promptSpy).not.toHaveBeenCalled();
     expect(addProjectTerminal).not.toHaveBeenCalled();
     expect(window.api.task.setStatus).toHaveBeenCalledWith(PROJECT, 9, 'done');
   });
 
-  test('without skipHook the configured hook runs', async () => {
-    // Sanity counterpart: same scenario but no shift held -> hook fires.
+  test('plain drop (no hookControl) shows the Done dialog instead of auto-running', async () => {
+    // Sanity counterpart: no shift held -> the Done dialog is shown, exactly
+    // like every other column transition.
+    const promptSpy = vi
+      .spyOn(useProjectStore.getState(), 'requestRunHook')
+      .mockResolvedValue({ command: 'echo cleanup', sandboxed: false, foreground: false });
+
     await completeTask({ projectPath: PROJECT, task: makeTask() });
 
+    expect(promptSpy).toHaveBeenCalledWith(expect.objectContaining({ hookType: 'done' }));
     expect(vi.mocked(addProjectTerminal).mock.calls[0][1]).toMatchObject({ command: 'echo cleanup' });
   });
 

--- a/src/__tests__/renderer/taskCompletion.test.tsx
+++ b/src/__tests__/renderer/taskCompletion.test.tsx
@@ -54,7 +54,7 @@ describe('completeTask', () => {
       return true;
     });
 
-    await completeTask({ projectPath: PROJECT, task: makeTask() });
+    await completeTask({ projectPath: PROJECT, task: makeTask(), hookControl: { mode: 'run' } });
 
     expect(vi.mocked(addProjectTerminal).mock.calls[0][1]).toMatchObject({ name: 'Done', command: 'echo hey' });
     // The hook terminal opts into autoCloseOnSuccess. The OSC 133 emitted by
@@ -84,31 +84,36 @@ describe('completeTask', () => {
     expect(window.api.task.setStatus).toHaveBeenCalledWith(PROJECT, 7, 'done');
   });
 
-  test('skipHook: configured hook is bypassed', async () => {
+  test('hookControl skip: configured hook is bypassed, no dialog', async () => {
     vi.mocked(window.api.hooks.get).mockResolvedValue({
       done: { command: 'echo hey', name: 'Done', source: 'configured', priority: 0 },
     });
+    const promptSpy = vi.spyOn(useProjectStore.getState(), 'requestRunHook');
 
-    await completeTask({ projectPath: PROJECT, task: makeTask(), skipHook: true });
+    await completeTask({ projectPath: PROJECT, task: makeTask(), hookControl: { mode: 'skip' } });
 
+    expect(promptSpy).not.toHaveBeenCalled();
     expect(addProjectTerminal).not.toHaveBeenCalled();
     expect(window.api.task.setStatus).toHaveBeenCalledWith(PROJECT, 7, 'done');
   });
 
-  test('hookCommand: overrides the configured command for this transition', async () => {
+  test('hookControl run: runs the configured hook headless, no dialog', async () => {
     vi.mocked(window.api.hooks.get).mockResolvedValue({
       done: { command: 'echo configured', name: 'Done', source: 'configured', priority: 0 },
     });
+    const promptSpy = vi.spyOn(useProjectStore.getState(), 'requestRunHook');
 
-    await completeTask({ projectPath: PROJECT, task: makeTask(), hookCommand: 'echo override' });
+    await completeTask({ projectPath: PROJECT, task: makeTask(), hookControl: { mode: 'run' } });
 
-    expect(vi.mocked(addProjectTerminal).mock.calls[0][1]).toMatchObject({
-      name: 'Done',
-      command: 'echo override',
+    expect(promptSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(addProjectTerminal).mock.calls[0][1]).toMatchObject({ command: 'echo configured' });
+    expect(vi.mocked(addProjectTerminal).mock.calls[0][2]).toMatchObject({
+      background: true,
+      autoCloseOnSuccess: true,
     });
   });
 
-  test('hookCommand wins even when skipHook is also true', async () => {
+  test('hookControl command: overrides the configured command for this transition', async () => {
     vi.mocked(window.api.hooks.get).mockResolvedValue({
       done: { command: 'echo configured', name: 'Done', source: 'configured', priority: 0 },
     });
@@ -116,11 +121,58 @@ describe('completeTask', () => {
     await completeTask({
       projectPath: PROJECT,
       task: makeTask(),
-      skipHook: true,
-      hookCommand: 'echo explicit',
+      hookControl: { mode: 'command', command: 'echo override' },
     });
 
-    expect(vi.mocked(addProjectTerminal).mock.calls[0][1]).toMatchObject({ command: 'echo explicit' });
+    expect(vi.mocked(addProjectTerminal).mock.calls[0][1]).toMatchObject({
+      name: 'Done',
+      command: 'echo override',
+    });
+  });
+
+  test('no hookControl with a configured hook: shows the Done dialog and runs the chosen command', async () => {
+    vi.mocked(window.api.hooks.get).mockResolvedValue({
+      done: { command: 'echo configured', name: 'Done', source: 'configured', priority: 0 },
+    });
+    const promptSpy = vi
+      .spyOn(useProjectStore.getState(), 'requestRunHook')
+      .mockResolvedValue({ command: 'echo configured', sandboxed: false, foreground: false });
+
+    await completeTask({ projectPath: PROJECT, task: makeTask() });
+
+    expect(promptSpy).toHaveBeenCalledWith(expect.objectContaining({ projectPath: PROJECT, hookType: 'done' }));
+    expect(vi.mocked(addProjectTerminal).mock.calls[0][1]).toMatchObject({ command: 'echo configured' });
+    expect(window.api.task.setStatus).toHaveBeenCalledWith(PROJECT, 7, 'done');
+  });
+
+  test('dialog skipped (returns null): no hook spawns but the task still completes', async () => {
+    vi.mocked(window.api.hooks.get).mockResolvedValue({
+      done: { command: 'echo configured', name: 'Done', source: 'configured', priority: 0 },
+    });
+    vi.spyOn(useProjectStore.getState(), 'requestRunHook').mockResolvedValue(null);
+
+    await completeTask({ projectPath: PROJECT, task: makeTask() });
+
+    expect(addProjectTerminal).not.toHaveBeenCalled();
+    expect(window.api.task.setStatus).toHaveBeenCalledWith(PROJECT, 7, 'done');
+  });
+
+  test('dialog "Run & Open" (foreground): spawns foreground without autoClose', async () => {
+    vi.mocked(window.api.hooks.get).mockResolvedValue({
+      done: { command: 'echo configured', name: 'Done', source: 'configured', priority: 0 },
+    });
+    vi.spyOn(useProjectStore.getState(), 'requestRunHook').mockResolvedValue({
+      command: 'echo configured',
+      sandboxed: false,
+      foreground: true,
+    });
+
+    await completeTask({ projectPath: PROJECT, task: makeTask() });
+
+    expect(vi.mocked(addProjectTerminal).mock.calls[0][2]).toMatchObject({
+      background: false,
+      autoCloseOnSuccess: false,
+    });
   });
 
   test('targetIndex: routes through moveTask (status + order) instead of bare setStatus', async () => {
@@ -150,7 +202,11 @@ describe('completeTask', () => {
       done: { command: 'echo hey', name: 'Done', source: 'configured', priority: 0 },
     });
 
-    await completeTask({ projectPath: PROJECT, task: makeTask({ worktreePath: undefined }) });
+    await completeTask({
+      projectPath: PROJECT,
+      task: makeTask({ worktreePath: undefined }),
+      hookControl: { mode: 'run' },
+    });
 
     expect(addProjectTerminal).not.toHaveBeenCalled();
     expect(window.api.task.setStatus).toHaveBeenCalledWith(PROJECT, 7, 'done');
@@ -183,9 +239,9 @@ describe('completeTask', () => {
 
     const task = makeTask();
     await Promise.all([
-      completeTask({ projectPath: PROJECT, task }),
-      completeTask({ projectPath: PROJECT, task }),
-      completeTask({ projectPath: PROJECT, task }),
+      completeTask({ projectPath: PROJECT, task, hookControl: { mode: 'run' } }),
+      completeTask({ projectPath: PROJECT, task, hookControl: { mode: 'run' } }),
+      completeTask({ projectPath: PROJECT, task, hookControl: { mode: 'run' } }),
     ]);
 
     expect(spawnCount).toBe(1);

--- a/src/__tests__/renderer/taskStartService.test.tsx
+++ b/src/__tests__/renderer/taskStartService.test.tsx
@@ -315,6 +315,83 @@ describe('taskStartService.beginTransition', () => {
     });
   });
 
+  describe('in_review transition fires the review hook', () => {
+    const reviewTask = (): TaskWithWorkspace => ({
+      ...makeTask(),
+      status: 'in_review',
+      worktreePath: '/wt/T-7',
+      branch: 'wire-up-auth-7',
+    });
+
+    test('hookControl "run": spawns the Review terminal headless, no dialog', async () => {
+      vi.mocked(window.api.hooks.get).mockResolvedValue({
+        review: { command: 'claude review', name: 'Review', source: 'configured', priority: 0 },
+      });
+
+      beginTransition(PROJECT, {
+        origStatus: 'in_progress',
+        newStatus: 'in_review',
+        task: reviewTask(),
+        hookControl: { mode: 'run' },
+      });
+
+      await waitFor(() => vi.mocked(addProjectTerminal).mock.calls.length > 0);
+
+      expect(useProjectStore.getState().runHookQueue[0]).toBeUndefined();
+      expect(vi.mocked(addProjectTerminal).mock.calls[0][1]).toMatchObject({
+        name: 'Review',
+        command: 'claude review',
+      });
+      expect(vi.mocked(addProjectTerminal).mock.calls[0][2]).toMatchObject({ background: true });
+    });
+
+    test('hookControl "skip": no dialog and no terminal spawn', async () => {
+      vi.mocked(window.api.hooks.get).mockResolvedValue({
+        review: { command: 'claude review', name: 'Review', source: 'configured', priority: 0 },
+      });
+
+      beginTransition(PROJECT, {
+        origStatus: 'in_progress',
+        newStatus: 'in_review',
+        task: reviewTask(),
+        hookControl: { mode: 'skip' },
+      });
+
+      // loadTasks (window.api.task.getAll) runs once the transition settles.
+      await waitFor(() => vi.mocked(window.api.task.getAll).mock.calls.length > 0);
+
+      expect(useProjectStore.getState().runHookQueue[0]).toBeUndefined();
+      expect(addProjectTerminal).not.toHaveBeenCalled();
+    });
+
+    test('no hookControl: shows the review dialog, then spawns the Review terminal on accept', async () => {
+      vi.mocked(window.api.hooks.get).mockResolvedValue({
+        review: { command: 'claude review', name: 'Review', source: 'configured', priority: 0 },
+      });
+
+      beginTransition(PROJECT, {
+        origStatus: 'in_progress',
+        newStatus: 'in_review',
+        task: reviewTask(),
+      });
+
+      await waitFor(() => useProjectStore.getState().runHookQueue[0] != null);
+      const req = useProjectStore.getState().runHookQueue[0]!;
+      expect(req.hookType).toBe('review');
+      expect(addProjectTerminal).not.toHaveBeenCalled();
+
+      useProjectStore
+        .getState()
+        .resolveRunHookRequest(req.id, { command: 'claude review', sandboxed: false, foreground: false });
+
+      await waitFor(() => vi.mocked(addProjectTerminal).mock.calls.length > 0);
+      expect(vi.mocked(addProjectTerminal).mock.calls[0][1]).toMatchObject({
+        name: 'Review',
+        command: 'claude review',
+      });
+    });
+  });
+
   test('duplicate concurrent drop for the same task is deduped', async () => {
     beginTransition(PROJECT, { origStatus: 'todo', newStatus: 'in_progress', task: makeTask() });
     beginTransition(PROJECT, { origStatus: 'todo', newStatus: 'in_progress', task: makeTask() });

--- a/src/__tests__/renderer/useIPCListeners.test.tsx
+++ b/src/__tests__/renderer/useIPCListeners.test.tsx
@@ -12,10 +12,13 @@ vi.mock('electron-log/renderer', () => ({
   default: { scope: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
 }));
 
-// The service is exercised in taskStartService.test.tsx; here we only care
-// that the hook hands it the right options.
+// The services are exercised in their own suites; here we only care that the
+// hook hands them the right options.
 vi.mock('../../services/taskStartService', () => ({
   beginTransition: vi.fn(),
+}));
+vi.mock('../../services/taskCompletion', () => ({
+  completeTask: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { useIPCListeners } from '../../hooks/useIPCListeners';
@@ -23,10 +26,15 @@ import { useAppStore } from '../../stores/appStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { useTerminalStore } from '../../stores/terminalStore';
 import { beginTransition } from '../../services/taskStartService';
+import { completeTask } from '../../services/taskCompletion';
 import type { TaskWithWorkspace } from '../../types';
 
 type CliTaskStartedPayload = Parameters<Parameters<typeof window.api.onCliTaskStarted>[0]>[0];
 type CliTaskStartedCb = (payload: CliTaskStartedPayload) => void;
+type CliTaskTransitionedPayload = Parameters<Parameters<typeof window.api.onCliTaskTransitioned>[0]>[0];
+type CliTaskTransitionedCb = (payload: CliTaskTransitionedPayload) => void;
+type CliTaskCompletedPayload = Parameters<Parameters<typeof window.api.onCliTaskCompleted>[0]>[0];
+type CliTaskCompletedCb = (payload: CliTaskCompletedPayload) => void;
 
 const PROJECT = '/proj/a';
 
@@ -59,8 +67,30 @@ function flush(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+function transitionPayload(overrides: Partial<CliTaskTransitionedPayload> = {}): CliTaskTransitionedPayload {
+  return {
+    project: PROJECT,
+    taskNumber: 9,
+    origStatus: 'in_progress',
+    newStatus: 'in_review',
+    task: makeTask(),
+    ...overrides,
+  };
+}
+
+function completedPayload(overrides: Partial<CliTaskCompletedPayload> = {}): CliTaskCompletedPayload {
+  return {
+    project: PROJECT,
+    taskNumber: 9,
+    task: makeTask(),
+    ...overrides,
+  };
+}
+
 interface ListenerStubs {
   cliTaskStartedCb: CliTaskStartedCb | null;
+  cliTaskTransitionedCb: CliTaskTransitionedCb | null;
+  cliTaskCompletedCb: CliTaskCompletedCb | null;
 }
 
 /**
@@ -70,7 +100,7 @@ interface ListenerStubs {
  * fill the gaps here per-test rather than polluting the global mock.
  */
 function installListenerStubs(): ListenerStubs {
-  const stubs: ListenerStubs = { cliTaskStartedCb: null };
+  const stubs: ListenerStubs = { cliTaskStartedCb: null, cliTaskTransitionedCb: null, cliTaskCompletedCb: null };
   const api = window.api as unknown as Record<string, unknown>;
   api['onUpdateAvailable'] = vi.fn(() => () => {});
   api['onWhatsNew'] = vi.fn(() => () => {});
@@ -80,7 +110,14 @@ function installListenerStubs(): ListenerStubs {
     stubs.cliTaskStartedCb = cb;
     return () => {};
   });
-  api['onCliTaskCompleted'] = vi.fn(() => () => {});
+  api['onCliTaskCompleted'] = vi.fn((cb: CliTaskCompletedCb) => {
+    stubs.cliTaskCompletedCb = cb;
+    return () => {};
+  });
+  api['onCliTaskTransitioned'] = vi.fn((cb: CliTaskTransitionedCb) => {
+    stubs.cliTaskTransitionedCb = cb;
+    return () => {};
+  });
   return stubs;
 }
 
@@ -161,5 +198,131 @@ describe('useIPCListeners — cli:task-started → beginTransition', () => {
       mode: 'command',
       command: 'echo queued',
     });
+  });
+});
+
+describe('useIPCListeners — cli:task-transitioned → beginTransition', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useProjectStore.getState().resetForProject();
+    useTerminalStore.setState({ terminalsByProject: {}, displayStates: {}, activeIndices: {} });
+    useAppStore.setState({ activeProjectPath: PROJECT });
+  });
+
+  test('in_review with no hookMode → beginTransition with origStatus/newStatus and hookControl undefined', async () => {
+    const stubs = installListenerStubs();
+    renderHook(() => useIPCListeners());
+    expect(stubs.cliTaskTransitionedCb).not.toBeNull();
+
+    stubs.cliTaskTransitionedCb!(transitionPayload());
+    await flush();
+
+    expect(beginTransition).toHaveBeenCalledTimes(1);
+    const opts = vi.mocked(beginTransition).mock.calls[0][1];
+    expect(opts.origStatus).toBe('in_progress');
+    expect(opts.newStatus).toBe('in_review');
+    expect(opts.hookControl).toBeUndefined();
+  });
+
+  test('hookMode "command" threads command through into hookControl', async () => {
+    const stubs = installListenerStubs();
+    renderHook(() => useIPCListeners());
+
+    stubs.cliTaskTransitionedCb!(transitionPayload({ hookMode: 'command', hookCommand: 'claude review' }));
+    await flush();
+
+    expect(vi.mocked(beginTransition).mock.calls[0][1].hookControl).toEqual({
+      mode: 'command',
+      command: 'claude review',
+    });
+  });
+
+  test('queued-then-drained transition preserves origStatus + hookMode', async () => {
+    useAppStore.setState({ activeProjectPath: '/proj/other' });
+    const stubs = installListenerStubs();
+    renderHook(() => useIPCListeners());
+
+    stubs.cliTaskTransitionedCb!(transitionPayload({ hookMode: 'skip' }));
+    await flush();
+
+    expect(beginTransition).not.toHaveBeenCalled();
+    expect(useProjectStore.getState().pendingCliTransitions[PROJECT]?.[0]?.hookMode).toBe('skip');
+
+    useAppStore.setState({ activeProjectPath: PROJECT });
+    await flush();
+
+    expect(beginTransition).toHaveBeenCalledTimes(1);
+    const opts = vi.mocked(beginTransition).mock.calls[0][1];
+    expect(opts.origStatus).toBe('in_progress');
+    expect(opts.hookControl).toEqual({ mode: 'skip', command: undefined });
+  });
+});
+
+describe('useIPCListeners — cli:task-completed → completeTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useProjectStore.getState().resetForProject();
+    useTerminalStore.setState({ terminalsByProject: {}, displayStates: {}, activeIndices: {} });
+    useAppStore.setState({ activeProjectPath: PROJECT });
+  });
+
+  test('bare done while viewing the project → completeTask with hookControl undefined + skipStatusWrite', async () => {
+    const stubs = installListenerStubs();
+    renderHook(() => useIPCListeners());
+    expect(stubs.cliTaskCompletedCb).not.toBeNull();
+
+    stubs.cliTaskCompletedCb!(completedPayload());
+    await flush();
+
+    expect(completeTask).toHaveBeenCalledTimes(1);
+    const opts = vi.mocked(completeTask).mock.calls[0][0];
+    expect(opts.hookControl).toBeUndefined();
+    expect(opts.skipStatusWrite).toBe(true);
+  });
+
+  test('done --hook-command threads command through into hookControl', async () => {
+    const stubs = installListenerStubs();
+    renderHook(() => useIPCListeners());
+
+    stubs.cliTaskCompletedCb!(completedPayload({ hookMode: 'command', hookCommand: 'npm run deploy' }));
+    await flush();
+
+    expect(vi.mocked(completeTask).mock.calls[0][0].hookControl).toEqual({
+      mode: 'command',
+      command: 'npm run deploy',
+    });
+  });
+
+  test('bare done for a project not in view is queued, then drained on navigation', async () => {
+    useAppStore.setState({ activeProjectPath: '/proj/other' });
+    const stubs = installListenerStubs();
+    renderHook(() => useIPCListeners());
+
+    stubs.cliTaskCompletedCb!(completedPayload());
+    await flush();
+
+    // No dialog can render for an unviewed project, so it must wait.
+    expect(completeTask).not.toHaveBeenCalled();
+    expect(useProjectStore.getState().pendingCliCompletions[PROJECT]?.[0]?.taskNumber).toBe(9);
+
+    useAppStore.setState({ activeProjectPath: PROJECT });
+    await flush();
+
+    expect(completeTask).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(completeTask).mock.calls[0][0].hookControl).toBeUndefined();
+  });
+
+  test('headless done (explicit flag) runs immediately even when off-project', async () => {
+    useAppStore.setState({ activeProjectPath: '/proj/other' });
+    const stubs = installListenerStubs();
+    renderHook(() => useIPCListeners());
+
+    stubs.cliTaskCompletedCb!(completedPayload({ hookMode: 'skip' }));
+    await flush();
+
+    // No dialog for a skip, so it's safe to run regardless of the active project.
+    expect(completeTask).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(completeTask).mock.calls[0][0].hookControl).toEqual({ mode: 'skip', command: undefined });
+    expect(useProjectStore.getState().pendingCliCompletions[PROJECT]).toBeUndefined();
   });
 });

--- a/src/__tests__/renderer/useIPCListeners.test.tsx
+++ b/src/__tests__/renderer/useIPCListeners.test.tsx
@@ -237,16 +237,17 @@ describe('useIPCListeners — cli:task-transitioned → beginTransition', () => 
     });
   });
 
-  test('queued-then-drained transition preserves origStatus + hookMode', async () => {
+  test('bare transition for a project not in view is queued, then drained on navigation', async () => {
     useAppStore.setState({ activeProjectPath: '/proj/other' });
     const stubs = installListenerStubs();
     renderHook(() => useIPCListeners());
 
-    stubs.cliTaskTransitionedCb!(transitionPayload({ hookMode: 'skip' }));
+    // No hookMode → shows a dialog, which can't render off-project, so it waits.
+    stubs.cliTaskTransitionedCb!(transitionPayload());
     await flush();
 
     expect(beginTransition).not.toHaveBeenCalled();
-    expect(useProjectStore.getState().pendingCliTransitions[PROJECT]?.[0]?.hookMode).toBe('skip');
+    expect(useProjectStore.getState().pendingCliTransitions[PROJECT]?.[0]?.origStatus).toBe('in_progress');
 
     useAppStore.setState({ activeProjectPath: PROJECT });
     await flush();
@@ -254,7 +255,23 @@ describe('useIPCListeners — cli:task-transitioned → beginTransition', () => 
     expect(beginTransition).toHaveBeenCalledTimes(1);
     const opts = vi.mocked(beginTransition).mock.calls[0][1];
     expect(opts.origStatus).toBe('in_progress');
+    expect(opts.hookControl).toBeUndefined();
+  });
+
+  test('headless transition (explicit flag) runs immediately even when off-project', async () => {
+    useAppStore.setState({ activeProjectPath: '/proj/other' });
+    const stubs = installListenerStubs();
+    renderHook(() => useIPCListeners());
+
+    // No dialog for a skip, so it's safe to run regardless of the active project.
+    stubs.cliTaskTransitionedCb!(transitionPayload({ hookMode: 'skip' }));
+    await flush();
+
+    expect(beginTransition).toHaveBeenCalledTimes(1);
+    const opts = vi.mocked(beginTransition).mock.calls[0][1];
+    expect(opts.origStatus).toBe('in_progress');
     expect(opts.hookControl).toEqual({ mode: 'skip', command: undefined });
+    expect(useProjectStore.getState().pendingCliTransitions[PROJECT]).toBeUndefined();
   });
 });
 

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -24,6 +24,7 @@ import {
   getScripts,
   saveScript,
   deleteScript,
+  getTaskByNumber,
 } from '../db';
 import {
   beginTask,
@@ -290,6 +291,10 @@ const routes: Route[] = [
       const num = requireInt(r.segments[1], 'Task number');
       const status = r.body.status;
       if (typeof status !== 'string') throw new HttpError(400, 'Missing status in body');
+      // in_progress / in_review / done all fire a renderer-side hook and carry
+      // the same hook-control flags as task-start. Validate them up front so a
+      // bad hookMode fails before any status is written.
+      if (status === 'in_progress' || status === 'in_review' || status === 'done') parseHookControl(r.body);
       return setTaskStatusWithHooks(project, num, status as 'todo' | 'in_progress' | 'in_review' | 'done');
     },
     true,
@@ -568,6 +573,18 @@ async function handleAsync(req: IncomingMessage, res: ServerResponse, window: Br
     }
   }
 
+  // A status PATCH to in_progress/in_review fires a renderer-side hook, which
+  // needs the *old* status to disambiguate start vs continue and to skip a
+  // no-op (status unchanged). Capture it before the handler overwrites it.
+  let prevStatus: string | undefined;
+  if (isStatusPatchRoute(method, segments) && (body.status === 'in_progress' || body.status === 'in_review')) {
+    const num = parseInt(segments[1] ?? '', 10);
+    if (!Number.isNaN(num)) {
+      const existing = await getTaskByNumber(url.searchParams.get('project') ?? '', num);
+      prevStatus = existing?.status;
+    }
+  }
+
   try {
     const result = await matched.route.handler({ method, segments, query: url.searchParams, body, auth });
     json(res, 200, { data: result });
@@ -612,14 +629,44 @@ async function handleAsync(req: IncomingMessage, res: ServerResponse, window: Br
         if (!Number.isNaN(taskNumber)) {
           const task = await getTaskWithWorkspace(project, taskNumber);
           if (task) {
-            const skipHook = body.skipHook === true;
-            const hookCommand = typeof body.hookCommand === 'string' ? body.hookCommand : undefined;
+            const hookControl = parseHookControl(body);
             typedPush(window, 'cli:task-completed', {
               project,
               taskNumber,
               task,
-              skipHook: skipHook || undefined,
-              hookCommand,
+              hookMode: hookControl.hookMode,
+              hookCommand: hookControl.hookCommand,
+            });
+          }
+        }
+      }
+
+      // CLI set-status N in_progress|in_review: the server wrote the status, but
+      // the in_progress/in_review hook lives in the renderer (beginTransition).
+      // Push the transition with the *old* status so the renderer runs the same
+      // path a kanban drop would — dialog by default, headless when the CLI
+      // passed --run-hook/--skip-hook/--hook-command. Skipped when the status
+      // didn't actually change (no transition, no hook).
+      if (
+        isStatusPatchRoute(method, segments) &&
+        (body.status === 'in_progress' || body.status === 'in_review') &&
+        isSuccessfulMutation(result) &&
+        prevStatus &&
+        prevStatus !== body.status
+      ) {
+        const taskNumber = parseInt(segments[1] ?? '', 10);
+        if (!Number.isNaN(taskNumber)) {
+          const task = await getTaskWithWorkspace(project, taskNumber);
+          if (task) {
+            const hookControl = parseHookControl(body);
+            typedPush(window, 'cli:task-transitioned', {
+              project,
+              taskNumber,
+              origStatus: prevStatus as 'todo' | 'in_progress' | 'in_review' | 'done',
+              newStatus: body.status,
+              task,
+              hookMode: hookControl.hookMode,
+              hookCommand: hookControl.hookCommand,
             });
           }
         }

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -573,11 +573,16 @@ async function handleAsync(req: IncomingMessage, res: ServerResponse, window: Br
     }
   }
 
-  // A status PATCH to in_progress/in_review fires a renderer-side hook, which
-  // needs the *old* status to disambiguate start vs continue and to skip a
-  // no-op (status unchanged). Capture it before the handler overwrites it.
+  // A status PATCH to in_progress/in_review/done fires a renderer-side hook,
+  // which needs the *old* status to disambiguate start vs continue and to skip
+  // a no-op (status unchanged — e.g. re-running set-status on a task already in
+  // that column would otherwise re-spawn the hook / re-show the dialog).
+  // Capture it before the handler overwrites it.
   let prevStatus: string | undefined;
-  if (isStatusPatchRoute(method, segments) && (body.status === 'in_progress' || body.status === 'in_review')) {
+  if (
+    isStatusPatchRoute(method, segments) &&
+    (body.status === 'in_progress' || body.status === 'in_review' || body.status === 'done')
+  ) {
     const num = parseInt(segments[1] ?? '', 10);
     if (!Number.isNaN(num)) {
       const existing = await getTaskByNumber(url.searchParams.get('project') ?? '', num);
@@ -624,7 +629,12 @@ async function handleAsync(req: IncomingMessage, res: ServerResponse, window: Br
       // spawn). The task is fetched here and included in the payload so the
       // renderer doesn't need projectStore.tasks (which only holds the active
       // project's task list — would miss when the user is viewing elsewhere).
-      if (isStatusPatchRoute(method, segments) && body.status === 'done' && isSuccessfulMutation(result)) {
+      if (
+        isStatusPatchRoute(method, segments) &&
+        body.status === 'done' &&
+        isSuccessfulMutation(result) &&
+        prevStatus !== 'done'
+      ) {
         const taskNumber = parseInt(segments[1] ?? '', 10);
         if (!Number.isNaN(taskNumber)) {
           const task = await getTaskWithWorkspace(project, taskNumber);

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -41,29 +41,32 @@ function resolveHookFlags(opts: HookFlags): { hookMode?: string; hookCommand?: s
 }
 
 /**
- * Resolve --skip-hook / --hook-command for the `done` transition. Mutually
- * exclusive. Rejected on non-done statuses (would otherwise silently mask
- * typos like `Done`) and on empty --hook-command strings.
+ * Resolve the hook flags for a `set-status` transition into the request body
+ * the status API understands. Every status that fires a hook — in_progress
+ * (continue), in_review (review), and done — supports the same
+ * --run-hook / --skip-hook / --hook-command trio as `task start`, riding on the
+ * `hookMode` / `hookCommand` body fields. With no flag the renderer shows that
+ * column's hook dialog, exactly like a kanban drop. `todo` fires no hook, so
+ * any hook flag is rejected.
+ *
+ * Rejecting flags on `todo` (rather than ignoring them) surfaces typos like
+ * `Todo` instead of silently dropping the request's intent.
  */
-function resolveDoneHookFlags(
+function resolveStatusHookFlags(
   status: string,
-  opts: Pick<HookFlags, 'skipHook' | 'hookCommand'>,
-): { skipHook?: boolean; hookCommand?: string } | { error: string } {
-  if (status !== 'done') {
-    if (opts.skipHook || opts.hookCommand !== undefined) {
-      return { error: '--skip-hook and --hook-command only apply when setting status to "done"' };
+  opts: HookFlags,
+): { body: { hookMode?: string; hookCommand?: string } } | { error: string } {
+  if (status === 'todo') {
+    if (opts.runHook || opts.skipHook || opts.hookCommand !== undefined) {
+      return { error: 'Hook flags do not apply when setting status to "todo" — no hook runs on that transition' };
     }
-    return {};
+    return { body: {} };
   }
-  if (opts.skipHook && opts.hookCommand !== undefined) {
-    return { error: 'Only one of --skip-hook, --hook-command may be used' };
-  }
-  if (opts.skipHook) return { skipHook: true };
-  if (opts.hookCommand !== undefined) {
-    if (!opts.hookCommand.trim()) return { error: '--hook-command requires a non-empty command' };
-    return { hookCommand: opts.hookCommand };
-  }
-  return {};
+
+  // in_progress / in_review / done — same semantics as `task start`.
+  const resolved = resolveHookFlags(opts);
+  if ('error' in resolved) return resolved;
+  return { body: resolved };
 }
 
 const STATUS_LABELS: Record<string, string> = {
@@ -90,7 +93,11 @@ Examples:
   ouijit task start 5 --skip-hook
   ouijit task start 5 --hook-command "claude"
   ouijit task set-status 5 in_review
+  ouijit task set-status 5 in_review --run-hook
+  ouijit task set-status 5 in_review --skip-hook
+  ouijit task set-status 5 in_review --hook-command "claude review"
   ouijit task set-status 5 done
+  ouijit task set-status 5 done --run-hook
   ouijit task set-status 5 done --skip-hook
   ouijit task set-status 5 done --hook-command "npm run deploy"
   ouijit task bulk-set-status done 5 6 7
@@ -200,20 +207,21 @@ Examples:
     .description('Set task status')
     .argument('<number>', 'task number')
     .argument('<status>', 'new status (todo|in_progress|in_review|done)')
-    .option('--skip-hook', 'when setting done, skip the configured done hook')
-    .option('--hook-command <cmd>', 'when setting done, run a one-off command instead of the configured done hook')
-    .action(async (number: string, status: string, opts: Pick<HookFlags, 'skipHook' | 'hookCommand'>) => {
+    .option('--run-hook', "run this transition's configured hook immediately, no dialog")
+    .option('--skip-hook', 'skip the hook for this transition (continue/review/done)')
+    .option('--hook-command <cmd>', 'run a one-off command instead of the configured hook for this transition')
+    .action(async (number: string, status: string, opts: HookFlags) => {
       const num = parseInt(number, 10);
       if (isNaN(num)) return printError('Task number must be an integer');
       if (!VALID_STATUSES.includes(status)) {
         return printError(`Invalid status: ${status}. Must be one of: ${VALID_STATUSES.join(', ')}`);
       }
-      const hookBody = resolveDoneHookFlags(status, opts);
-      if ('error' in hookBody) return printError(hookBody.error);
+      const hook = resolveStatusHookFlags(status, opts);
+      if ('error' in hook) return printError(hook.error);
       const project = requireProject();
       const result = await patch<{ success: boolean; error?: string; hookWarning?: string }>(
         `/api/tasks/${num}/status${projectQuery(project)}`,
-        { status, ...hookBody },
+        { status, ...hook.body },
       );
       if (!result.success) return printError(result.error || 'Failed to set status');
       printJson({ success: true, status: STATUS_LABELS[status] || status, hookWarning: result.hookWarning });
@@ -224,9 +232,10 @@ Examples:
     .description('Set status on multiple tasks in parallel')
     .argument('<status>', 'new status (todo|in_progress|in_review|done)')
     .argument('<numbers...>', 'task numbers (space-separated)')
-    .option('--skip-hook', 'when setting done, skip the configured done hook for every task')
-    .option('--hook-command <cmd>', 'when setting done, run this command instead of the configured done hook')
-    .action(async (status: string, numberArgs: string[], opts: Pick<HookFlags, 'skipHook' | 'hookCommand'>) => {
+    .option('--run-hook', "run this transition's configured hook for every task, no dialog")
+    .option('--skip-hook', 'skip the hook for this transition (continue/review/done) on every task')
+    .option('--hook-command <cmd>', 'run this command instead of the configured hook for every task')
+    .action(async (status: string, numberArgs: string[], opts: HookFlags) => {
       if (!VALID_STATUSES.includes(status)) {
         return printError(`Invalid status: ${status}. Must be one of: ${VALID_STATUSES.join(', ')}`);
       }
@@ -236,14 +245,14 @@ Examples:
         if (isNaN(n)) return printError(`Task number must be an integer: ${arg}`);
         numbers.push(n);
       }
-      const hookBody = resolveDoneHookFlags(status, opts);
-      if ('error' in hookBody) return printError(hookBody.error);
+      const hook = resolveStatusHookFlags(status, opts);
+      if ('error' in hook) return printError(hook.error);
       const project = requireProject();
       const results = await Promise.allSettled(
         numbers.map((n) =>
           patch<{ success: boolean; error?: string; hookWarning?: string }>(
             `/api/tasks/${n}/status${projectQuery(project)}`,
-            { status, ...hookBody },
+            { status, ...hook.body },
           ).then((r) => ({ taskNumber: n, ...r })),
         ),
       );

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -495,9 +495,16 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
           }
           draggedTask = { ...draggedTask, worktreePath: wtPath };
         }
+        // Plain drop prompts with the Done dialog (like every other column);
+        // shift-drag skips the hook outright.
         const skipHook = useProjectStore.getState().shiftKeyHeld;
         setActiveTask(null);
-        await completeTask({ projectPath, task: draggedTask, targetIndex, skipHook });
+        await completeTask({
+          projectPath,
+          task: draggedTask,
+          targetIndex,
+          hookControl: skipHook ? { mode: 'skip' } : undefined,
+        });
         return;
       }
 

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -386,9 +386,15 @@ ouijit task start <number> --skip-hook        # spawn the terminal but run no ho
 ouijit task start <number> --hook-command "<cmd>"  # spawn the terminal running a one-off command instead of the configured hook
 ouijit task create-and-start "<name>"         # create + start in one step (accepts --prompt, --branch, and the same --run-hook / --skip-hook / --hook-command flags); aliased as "task spawn"
 ouijit task set-status <number> <status>      # status: todo | in_progress | in_review | done
-ouijit task set-status <number> done --skip-hook            # skip the configured done hook
+ouijit task set-status <number> in_review                    # default: opens the review-hook dialog (like a kanban drop)
+ouijit task set-status <number> in_review --run-hook         # run the configured review hook immediately, no dialog
+ouijit task set-status <number> in_review --skip-hook        # change status, run no hook
+ouijit task set-status <number> in_review --hook-command "<cmd>" # run a one-off command instead of the review hook
+ouijit task set-status <number> done                         # default: opens the done-hook dialog (like a kanban drop)
+ouijit task set-status <number> done --run-hook              # run the configured done hook immediately, no dialog
+ouijit task set-status <number> done --skip-hook            # change status, run no hook
 ouijit task set-status <number> done --hook-command "<cmd>" # run a one-off command instead of the done hook
-ouijit task bulk-set-status <status> <n1> <n2>...           # set status on many tasks in parallel (same hook flags when status=done)
+ouijit task bulk-set-status <status> <n1> <n2>...           # set status on many tasks in parallel (in_progress/in_review/done all take --run-hook/--skip-hook/--hook-command)
 ouijit task set-name <number> <new name>
 ouijit task set-description <number> <text>
 ouijit task set-merge-target <number> <branch>

--- a/src/hooks/useIPCListeners.ts
+++ b/src/hooks/useIPCListeners.ts
@@ -217,9 +217,11 @@ export function useIPCListeners() {
     );
 
     // CLI-initiated in_progress/in_review transition — fire the column hook via
-    // beginTransition (dialog by default, headless when flags were passed). If
-    // the user isn't viewing the project, queue it and drain on navigation, the
-    // same as a CLI start.
+    // beginTransition. A bare transition (no hookMode) shows that column's hook
+    // dialog, which can only render for the project the user is viewing — queue
+    // it otherwise and drain on navigation. A transition with explicit hook
+    // flags is headless (no dialog), so it runs immediately regardless of which
+    // project is in view, the same as a headless done.
     cleanups.push(
       window.api.onCliTaskTransitioned((payload) => {
         const activeProject = useAppStore.getState().activeProjectPath;
@@ -232,7 +234,7 @@ export function useIPCListeners() {
           hookCommand: payload.hookCommand,
         };
 
-        if (activeProject === payload.project) {
+        if (payload.hookMode || activeProject === payload.project) {
           ipcLog.info('CLI task-transitioned: running transition', {
             taskNumber: payload.taskNumber,
             newStatus: payload.newStatus,

--- a/src/hooks/useIPCListeners.ts
+++ b/src/hooks/useIPCListeners.ts
@@ -1,6 +1,11 @@
 import { useEffect } from 'react';
 import { useAppStore } from '../stores/appStore';
-import { useProjectStore, type PendingCliStart } from '../stores/projectStore';
+import {
+  useProjectStore,
+  type PendingCliStart,
+  type PendingCliTransition,
+  type PendingCliCompletion,
+} from '../stores/projectStore';
 import { useTerminalStore } from '../stores/terminalStore';
 import { beginTransition } from '../services/taskStartService';
 import { completeTask } from '../services/taskCompletion';
@@ -42,6 +47,41 @@ async function spawnTerminalForCliStart(projectPath: string, start: PendingCliSt
       branch: task.branch ?? start.branch,
     },
     hookControl: start.hookMode ? { mode: start.hookMode, command: start.hookCommand } : undefined,
+  });
+}
+
+/**
+ * Run a CLI-initiated in_progress/in_review transition through the same
+ * beginTransition path a kanban drop uses. The server already wrote the status
+ * and fetched the full task, so this just fires the hook: a dialog by default,
+ * or headless when the CLI passed --run-hook/--skip-hook/--hook-command.
+ */
+function runCliTransition(projectPath: string, transition: PendingCliTransition): void {
+  beginTransition(projectPath, {
+    origStatus: transition.origStatus,
+    newStatus: transition.newStatus,
+    task: transition.task,
+    hookControl: transition.hookMode ? { mode: transition.hookMode, command: transition.hookCommand } : undefined,
+  });
+}
+
+/**
+ * Run a CLI-initiated done transition through completeTask. The server already
+ * wrote the status (skipStatusWrite), so this drives the done lifecycle:
+ * terminal cleanup always runs; the hook is a dialog by default, or headless
+ * when the CLI passed --run-hook/--skip-hook/--hook-command.
+ */
+function runCliCompletion(projectPath: string, completion: PendingCliCompletion): void {
+  void completeTask({
+    projectPath,
+    task: completion.task,
+    hookControl: completion.hookMode ? { mode: completion.hookMode, command: completion.hookCommand } : undefined,
+    skipStatusWrite: true,
+  }).catch((err) => {
+    ipcLog.error('CLI task-completed lifecycle failed', {
+      taskNumber: completion.taskNumber,
+      error: err instanceof Error ? err.message : String(err),
+    });
   });
 }
 
@@ -115,24 +155,31 @@ export function useIPCListeners() {
     // visible kanban catches up on next navigation.
     cleanups.push(
       window.api.onCliTaskCompleted((payload) => {
-        ipcLog.info('CLI task-completed: running completeTask', {
-          project: payload.project,
+        const activeProject = useAppStore.getState().activeProjectPath;
+        const completion: PendingCliCompletion = {
           taskNumber: payload.taskNumber,
-        });
-        void completeTask({
-          projectPath: payload.project,
           task: payload.task,
-          skipHook: payload.skipHook,
+          hookMode: payload.hookMode,
           hookCommand: payload.hookCommand,
-          // Server already PATCHed the status before pushing; only the
-          // renderer reload remains.
-          skipStatusWrite: true,
-        }).catch((err) => {
-          ipcLog.error('CLI task-completed lifecycle failed', {
+        };
+
+        // A bare done (no hookMode) shows the Done dialog, which can only render
+        // for the project the user is viewing — queue it otherwise and drain on
+        // navigation. A done with explicit hook flags is headless (no dialog),
+        // so it runs immediately regardless of which project is in view.
+        if (payload.hookMode || activeProject === payload.project) {
+          ipcLog.info('CLI task-completed: running completeTask', {
+            project: payload.project,
             taskNumber: payload.taskNumber,
-            error: err instanceof Error ? err.message : String(err),
           });
-        });
+          runCliCompletion(payload.project, completion);
+        } else {
+          ipcLog.info('CLI task-completed: queuing for later navigation', {
+            project: payload.project,
+            taskNumber: payload.taskNumber,
+          });
+          useProjectStore.getState().enqueueCliCompletion(payload.project, completion);
+        }
       }),
     );
 
@@ -169,6 +216,38 @@ export function useIPCListeners() {
       }),
     );
 
+    // CLI-initiated in_progress/in_review transition — fire the column hook via
+    // beginTransition (dialog by default, headless when flags were passed). If
+    // the user isn't viewing the project, queue it and drain on navigation, the
+    // same as a CLI start.
+    cleanups.push(
+      window.api.onCliTaskTransitioned((payload) => {
+        const activeProject = useAppStore.getState().activeProjectPath;
+        const transition: PendingCliTransition = {
+          taskNumber: payload.taskNumber,
+          origStatus: payload.origStatus,
+          newStatus: payload.newStatus,
+          task: payload.task,
+          hookMode: payload.hookMode,
+          hookCommand: payload.hookCommand,
+        };
+
+        if (activeProject === payload.project) {
+          ipcLog.info('CLI task-transitioned: running transition', {
+            taskNumber: payload.taskNumber,
+            newStatus: payload.newStatus,
+          });
+          runCliTransition(payload.project, transition);
+        } else {
+          ipcLog.info('CLI task-transitioned: queuing for later navigation', {
+            project: payload.project,
+            taskNumber: payload.taskNumber,
+          });
+          useProjectStore.getState().enqueueCliTransition(payload.project, transition);
+        }
+      }),
+    );
+
     // Drain queued CLI starts whenever the active project changes.
     const drain = (projectPath: string | null) => {
       if (!projectPath) return;
@@ -184,6 +263,22 @@ export function useIPCListeners() {
             error: err instanceof Error ? err.message : String(err),
           });
         });
+      }
+      const queuedTransitions = useProjectStore.getState().drainCliTransitions(projectPath);
+      for (const transition of queuedTransitions) {
+        ipcLog.info('draining queued CLI task-transitioned', {
+          project: projectPath,
+          taskNumber: transition.taskNumber,
+        });
+        runCliTransition(projectPath, transition);
+      }
+      const queuedCompletions = useProjectStore.getState().drainCliCompletions(projectPath);
+      for (const completion of queuedCompletions) {
+        ipcLog.info('draining queued CLI task-completed', {
+          project: projectPath,
+          taskNumber: completion.taskNumber,
+        });
+        runCliCompletion(projectPath, completion);
       }
     };
     // Initial drain in case events arrived before this effect mounted.

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -272,9 +272,27 @@ export interface IpcPushContract {
          *  look it up in projectStore.tasks (which only holds the *active*
          *  project's tasks — would miss when the user is viewing a different project). */
         task: TaskWithWorkspace;
-        /** When true, the CLI passed --skip-hook; the renderer should bypass the done hook. */
-        skipHook?: boolean;
-        /** When set, the CLI passed --hook-command; run this instead of the configured hook. */
+        /** Hook-control mode from the CLI flags; absent = default Done dialog. */
+        hookMode?: CliHookMode;
+        /** Custom command when hookMode is 'command'. */
+        hookCommand?: string;
+      },
+    ];
+  };
+  'cli:task-transitioned': {
+    args: [
+      payload: {
+        project: string;
+        taskNumber: number;
+        /** Status before the CLI write — disambiguates start vs continue. */
+        origStatus: TaskStatus;
+        /** Status the CLI just wrote (in_progress or in_review). */
+        newStatus: TaskStatus;
+        /** Full task record fetched server-side (same rationale as cli:task-completed). */
+        task: TaskWithWorkspace;
+        /** Hook-control mode from the CLI flags; absent = default dialog. */
+        hookMode?: CliHookMode;
+        /** Custom command when hookMode is 'command'. */
         hookCommand?: string;
       },
     ];

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -241,10 +241,22 @@ contextBridge.exposeInMainWorld('api', {
       project: string;
       taskNumber: number;
       task: TaskWithWorkspace;
-      skipHook?: boolean;
+      hookMode?: CliHookMode;
       hookCommand?: string;
     }) => void,
   ) => typedListen('cli:task-completed', callback),
+
+  onCliTaskTransitioned: (
+    callback: (payload: {
+      project: string;
+      taskNumber: number;
+      origStatus: TaskStatus;
+      newStatus: TaskStatus;
+      task: TaskWithWorkspace;
+      hookMode?: CliHookMode;
+      hookCommand?: string;
+    }) => void,
+  ) => typedListen('cli:task-transitioned', callback),
 
   capture: {
     onNavigate: (callback: (payload: CaptureNavigatePayload) => void) => typedListen('capture:navigate', callback),

--- a/src/services/taskCompletion.ts
+++ b/src/services/taskCompletion.ts
@@ -4,9 +4,12 @@
  * so the observable behavior of marking a task done is identical regardless
  * of where it's triggered.
  *
- * Order is snapshot → spawn → close → persist. The snapshot is taken before
- * the new done-hook terminal is spawned, so the new terminal is excluded from
- * closure by construction.
+ * Order is (prompt) → snapshot → spawn → close → persist. With no hookControl
+ * the Done dialog is shown first — the same prompt every other column shows —
+ * and its result drives the spawn; shift-drag and the CLI pass an explicit
+ * hookControl to run/skip headlessly. The snapshot is taken after the prompt
+ * resolves but before the new done-hook terminal is spawned, so the new
+ * terminal is excluded from closure by construction.
  */
 
 import log from 'electron-log/renderer';
@@ -14,17 +17,34 @@ import { addProjectTerminal, closeProjectTerminal } from '../components/terminal
 import { useAppStore } from '../stores/appStore';
 import { useProjectStore } from '../stores/projectStore';
 import { useTerminalStore } from '../stores/terminalStore';
-import type { TaskWithWorkspace } from '../types';
+import type { CliHookMode, TaskWithWorkspace } from '../types';
 
 const completionLog = log.scope('taskCompletion');
+
+/**
+ * Governs the done hook for a completion. Mirrors the start/continue/review
+ * transitions so Done behaves uniformly across the four columns:
+ *   - omitted             → show the Done dialog (if a done hook is configured)
+ *   - { mode: 'skip' }        → run no hook
+ *   - { mode: 'run' }         → run the configured done hook headless (no dialog)
+ *   - { mode: 'command', ... }→ run a one-off command headless
+ * The terminal-cleanup + status-write lifecycle runs regardless of this choice.
+ */
+export interface CompleteHookControl {
+  mode: CliHookMode;
+  /** The one-off command, required when `mode` is `command`. */
+  command?: string;
+}
 
 export interface CompleteTaskOptions {
   projectPath: string;
   task: TaskWithWorkspace;
-  /** Skip the configured done hook for this transition. */
-  skipHook?: boolean;
-  /** Override the configured done hook's command for this transition. */
-  hookCommand?: string;
+  /**
+   * How to handle the done hook. Omit to prompt with the Done dialog (the
+   * default for a kanban drop / terminal "Close Task"); set it to run the hook
+   * headlessly, run a custom command, or skip — used by shift-drag and the CLI.
+   */
+  hookControl?: CompleteHookControl;
   /**
    * Kanban-only: when set, also reorder the task within the done column.
    * When omitted, only the status is written.
@@ -64,24 +84,43 @@ export async function completeTask(opts: CompleteTaskOptions): Promise<void> {
 }
 
 async function completeTaskInner(opts: CompleteTaskOptions): Promise<void> {
-  const { projectPath, task, skipHook, hookCommand, targetIndex, skipStatusWrite } = opts;
+  const { projectPath, task, hookControl, targetIndex, skipStatusWrite } = opts;
   const taskNumber = task.taskNumber;
   completionLog.info('completing task', {
     taskNumber,
     projectPath,
-    skipHook,
-    hasHookCommand: !!hookCommand,
+    hookMode: hookControl?.mode ?? 'prompt',
     hasTargetIndex: targetIndex != null,
     skipStatusWrite,
   });
 
-  // 1. Resolve the effective hook command.
+  // 1. Resolve the effective hook command + how to run it. With no hookControl
+  //    the Done dialog is shown (if a hook is configured), matching the dialog
+  //    every other column transition shows; the dialog's foreground/sandbox
+  //    choices are honored. Headless modes (run/command/skip) come from
+  //    shift-drag or the CLI flags and never prompt.
   let effectiveCommand: string | null = null;
-  if (hookCommand) {
-    effectiveCommand = hookCommand;
-  } else if (!skipHook) {
+  let foreground = false;
+  let sandboxed = false;
+  if (hookControl?.mode === 'skip') {
+    // Run no hook.
+  } else if (hookControl?.mode === 'command' && hookControl.command) {
+    effectiveCommand = hookControl.command;
+  } else if (hookControl?.mode === 'run') {
     const hooks = await window.api.hooks.get(projectPath);
     if (hooks.done) effectiveCommand = hooks.done.command;
+  } else if (!hookControl) {
+    const hooks = await window.api.hooks.get(projectPath);
+    if (hooks.done) {
+      const result = await useProjectStore
+        .getState()
+        .requestRunHook({ projectPath, hookType: 'done', hook: hooks.done, task });
+      if (result) {
+        effectiveCommand = result.command;
+        foreground = result.foreground;
+        sandboxed = result.sandboxed;
+      }
+    }
   }
 
   // 2. Snapshot existing task terminals BEFORE spawning the hook terminal,
@@ -107,8 +146,13 @@ async function completeTaskInner(opts: CompleteTaskOptions): Promise<void> {
           existingWorktree: { path: task.worktreePath, branch: task.branch || '', createdAt: task.createdAt },
           taskId: taskNumber,
           skipAutoHook: true,
-          background: true,
-          autoCloseOnSuccess: true,
+          sandboxed,
+          // "Run & Open" (foreground) brings the hook terminal up so the user
+          // can watch it; the background run stays out of the way and tidies up
+          // on success. Either way the hook terminal is excluded from the close
+          // sweep by the snapshot taken above.
+          background: !foreground,
+          autoCloseOnSuccess: !foreground,
         },
       );
     } catch (err) {

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { TaskWithWorkspace, Script, ScriptHook, HookType, CliHookMode } from '../types';
+import type { TaskWithWorkspace, Script, ScriptHook, HookType, CliHookMode, TaskStatus } from '../types';
 import type { RunHookResult } from '../components/dialogs/RunHookDialog';
 import { useAppStore } from './appStore';
 
@@ -21,6 +21,38 @@ export interface PendingCliStart {
   createdAt: string;
   sandboxed: boolean;
   /** Hook-control mode from the CLI flags; absent = default start-hook dialog. */
+  hookMode?: CliHookMode;
+  /** Custom command when hookMode is 'command'. */
+  hookCommand?: string;
+}
+
+/**
+ * A CLI-initiated in_progress/in_review transition awaiting a hook spawn. Queued
+ * like {@link PendingCliStart} when the user isn't viewing the project, and
+ * drained on navigation. Carries the full task and origStatus so the renderer
+ * can run the same beginTransition path a kanban drop would.
+ */
+export interface PendingCliTransition {
+  taskNumber: number;
+  origStatus: TaskStatus;
+  newStatus: TaskStatus;
+  task: TaskWithWorkspace;
+  /** Hook-control mode from the CLI flags; absent = default hook dialog. */
+  hookMode?: CliHookMode;
+  /** Custom command when hookMode is 'command'. */
+  hookCommand?: string;
+}
+
+/**
+ * A CLI-initiated done transition awaiting its lifecycle. Queued like
+ * {@link PendingCliStart} when a *bare* done (which shows the Done dialog) lands
+ * for a project the user isn't viewing, and drained on navigation. A done with
+ * explicit hook flags runs headlessly and is never queued.
+ */
+export interface PendingCliCompletion {
+  taskNumber: number;
+  task: TaskWithWorkspace;
+  /** Hook-control mode from the CLI flags; absent = default Done dialog. */
   hookMode?: CliHookMode;
   /** Custom command when hookMode is 'command'. */
   hookCommand?: string;
@@ -68,6 +100,8 @@ interface ProjectStoreState {
   runHookQueueTotal: number;
   /** Queued CLI-initiated task starts awaiting the user to enter the project. */
   pendingCliStarts: Record<string, PendingCliStart[]>;
+  pendingCliTransitions: Record<string, PendingCliTransition[]>;
+  pendingCliCompletions: Record<string, PendingCliCompletion[]>;
   /**
    * Project-scoped config used by terminal/kanban cards. Loaded once per project
    * so we don't fan out N `lima.status` (subprocess spawn) + `hooks.get` calls
@@ -149,6 +183,16 @@ interface ProjectStoreActions {
   enqueueCliStart: (projectPath: string, start: PendingCliStart) => void;
   /** Atomically drain all queued starts for a project. */
   drainCliStarts: (projectPath: string) => PendingCliStart[];
+
+  /** Queue a CLI-initiated in_progress/in_review transition for a project the user isn't viewing. */
+  enqueueCliTransition: (projectPath: string, transition: PendingCliTransition) => void;
+  /** Atomically drain all queued transitions for a project. */
+  drainCliTransitions: (projectPath: string) => PendingCliTransition[];
+
+  /** Queue a CLI-initiated done transition for a project the user isn't viewing. */
+  enqueueCliCompletion: (projectPath: string, completion: PendingCliCompletion) => void;
+  /** Atomically drain all queued completions for a project. */
+  drainCliCompletions: (projectPath: string) => PendingCliCompletion[];
 }
 
 type ProjectStore = ProjectStoreState & ProjectStoreActions;
@@ -179,6 +223,8 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
   runHookQueue: [],
   runHookQueueTotal: 0,
   pendingCliStarts: {},
+  pendingCliTransitions: {},
+  pendingCliCompletions: {},
   sandboxAvailable: false,
   configuredHooks: {},
   configProjectPath: null,
@@ -482,6 +528,38 @@ export const useProjectStore = create<ProjectStore>()((set, get) => ({
     if (!queued || queued.length === 0) return [];
     const { [projectPath]: _drained, ...rest } = get().pendingCliStarts;
     set({ pendingCliStarts: rest });
+    return queued;
+  },
+
+  enqueueCliTransition: (projectPath, transition) => {
+    const current = get().pendingCliTransitions[projectPath] ?? [];
+    if (current.some((t) => t.taskNumber === transition.taskNumber)) return;
+    set({
+      pendingCliTransitions: { ...get().pendingCliTransitions, [projectPath]: [...current, transition] },
+    });
+  },
+
+  drainCliTransitions: (projectPath) => {
+    const queued = get().pendingCliTransitions[projectPath];
+    if (!queued || queued.length === 0) return [];
+    const { [projectPath]: _drained, ...rest } = get().pendingCliTransitions;
+    set({ pendingCliTransitions: rest });
+    return queued;
+  },
+
+  enqueueCliCompletion: (projectPath, completion) => {
+    const current = get().pendingCliCompletions[projectPath] ?? [];
+    if (current.some((c) => c.taskNumber === completion.taskNumber)) return;
+    set({
+      pendingCliCompletions: { ...get().pendingCliCompletions, [projectPath]: [...current, completion] },
+    });
+  },
+
+  drainCliCompletions: (projectPath) => {
+    const queued = get().pendingCliCompletions[projectPath];
+    if (!queued || queued.length === 0) return [];
+    const { [projectPath]: _drained, ...rest } = get().pendingCliCompletions;
+    set({ pendingCliCompletions: rest });
     return queued;
   },
 }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -518,7 +518,19 @@ export interface ElectronAPI {
       project: string;
       taskNumber: number;
       task: TaskWithWorkspace;
-      skipHook?: boolean;
+      hookMode?: CliHookMode;
+      hookCommand?: string;
+    }) => void,
+  ): () => void;
+  /** Listen for a CLI-initiated in_progress/in_review transition that needs a hook spawn */
+  onCliTaskTransitioned(
+    callback: (payload: {
+      project: string;
+      taskNumber: number;
+      origStatus: TaskStatus;
+      newStatus: TaskStatus;
+      task: TaskWithWorkspace;
+      hookMode?: CliHookMode;
       hookCommand?: string;
     }) => void,
   ): () => void;


### PR DESCRIPTION
## Summary

- CLI `task set-status` to in_progress / in_review / done now fires that column's hook the same way a kanban drop does: a hook dialog by default, with `--run-hook` / `--skip-hook` / `--hook-command` to run it headlessly. Previously only `task start` (in_progress) and `set-status done` had any hook plumbing, and passing flags to in_review errored.
- Done gains the dialog it never had — the most consequential hook (merge/deploy) previously ran silently with skip hidden behind shift-drag — while keeping its terminal-cleanup lifecycle unconditional.
- One uniform CLI flag resolver for all non-todo statuses (`hookMode`/`hookCommand`); `todo` rejects hook flags rather than silently ignoring them.
- Server validates hook flags before writing status, then pushes `cli:task-transitioned` (carrying the prior status, to disambiguate start vs continue) for in_progress/in_review and carries `hookMode` on `cli:task-completed` for done. A status write that doesn't actually change the column is a no-op for all three: re-running `set-status done` on an already-done task no longer re-runs the completion lifecycle or re-shows the Done dialog.
- Renderer routes both events through the existing `beginTransition` / `completeTask` paths; `completeTask` takes a single `hookControl` and prompts by default. Bare transitions that would show a dialog queue when the project isn't in view and drain on navigation; headless ones (explicit hook flags, no dialog) run immediately regardless of which project is in view — for both transitions and completions.
- Updated the embedded CLI reference and command help to document the flags across columns.
