### PR TITLE
Audit hook dialog UX copy

### DIFF
--- a/src/components/dialogs/CombinedHookConfigDialog.tsx
+++ b/src/components/dialogs/CombinedHookConfigDialog.tsx
@@ -3,14 +3,8 @@ import type { ScriptHook } from '../../types';
 import { useProjectStore } from '../../stores/projectStore';
 import { useAutoResize } from '../../hooks/useAutoResize';
 import { DialogOverlay } from './DialogOverlay';
-
-const ENV_VARS = [
-  '$OUIJIT_PROJECT_PATH',
-  '$OUIJIT_WORKTREE_PATH',
-  '$OUIJIT_TASK_BRANCH',
-  '$OUIJIT_TASK_NAME',
-  '$OUIJIT_TASK_DESCRIPTION',
-];
+import { HookCliHint } from './HookCliHint';
+import { HookEnvVars } from './HookEnvVars';
 
 interface CombinedHookConfigDialogProps {
   projectPath: string;
@@ -28,7 +22,6 @@ export function CombinedHookConfigDialog({
   const [startCommand, setStartCommand] = useState(existingStart?.command ?? '');
   const [continueCommand, setContinueCommand] = useState(existingContinue?.command ?? '');
   const [visible, setVisible] = useState(false);
-  const [copiedVar, setCopiedVar] = useState<string | null>(null);
   const startRef = useRef<HTMLTextAreaElement>(null);
   const autoResize = useAutoResize();
 
@@ -81,12 +74,6 @@ export function CombinedHookConfigDialog({
     dismiss({ saved: true });
   }, [startCommand, continueCommand, projectPath, existingStart, existingContinue, dismiss]);
 
-  const copyVar = useCallback((varName: string) => {
-    navigator.clipboard.writeText(varName);
-    setCopiedVar(varName);
-    setTimeout(() => setCopiedVar(null), 1500);
-  }, []);
-
   return (
     <DialogOverlay visible={visible} onDismiss={() => dismiss(null)}>
       <h2 className="text-lg font-semibold text-text-primary mb-4 text-center">Start & Continue Hooks</h2>
@@ -104,7 +91,7 @@ export function CombinedHookConfigDialog({
             id="hook-start-command"
             className="w-full px-3 py-2 font-mono text-sm leading-snug text-text-primary bg-background border border-border rounded-md outline-none resize-none overflow-hidden focus:border-accent focus:ring-3 focus:ring-accent-light placeholder:text-text-tertiary"
             style={{ transition: 'border-color 150ms ease-out, box-shadow 150ms ease-out' }}
-            placeholder='npm install && claude "$OUIJIT_TASK_DESCRIPTION"'
+            placeholder='claude "complete the current task and move it into in review"'
             value={startCommand}
             onChange={(e) => {
               setStartCommand(e.target.value);
@@ -135,31 +122,19 @@ export function CombinedHookConfigDialog({
           />
         </div>
 
-        <details className="mt-3 text-xs text-text-secondary [&>summary]:cursor-default [&>summary]:select-none [&_ul]:mt-2 [&_ul]:mb-0 [&_ul]:pl-5 [&_li]:my-1">
-          <summary>Environment variables</summary>
-          <ul>
-            {ENV_VARS.map((v) => (
-              <li key={v}>
-                <code
-                  className={`font-mono text-[13px] px-1.5 py-0.5 rounded inline-block bg-background-secondary hover:text-text-primary hover:bg-border-hover ${copiedVar === v ? 'text-accent !bg-[color-mix(in_srgb,var(--color-accent)_15%,transparent)]' : ''}`}
-                  style={{ transition: 'background 100ms ease, color 100ms ease' }}
-                  onClick={() => copyVar(v)}
-                >
-                  {copiedVar === v ? 'Copied!' : v}
-                </code>
-              </li>
-            ))}
-          </ul>
-        </details>
+        <HookEnvVars />
       </div>
 
-      <div className="flex gap-2 justify-end mt-4 items-center">
-        <button className="btn-secondary" onClick={() => dismiss(null)}>
-          Cancel
-        </button>
-        <button className="btn-primary" onClick={handleSave}>
-          Save
-        </button>
+      <div className="flex gap-2 justify-between mt-4 items-center">
+        <HookCliHint />
+        <div className="flex gap-2">
+          <button className="btn-secondary" onClick={() => dismiss(null)}>
+            Cancel
+          </button>
+          <button className="btn-primary" onClick={handleSave}>
+            Save
+          </button>
+        </div>
       </div>
     </DialogOverlay>
   );

--- a/src/components/dialogs/HookCliHint.tsx
+++ b/src/components/dialogs/HookCliHint.tsx
@@ -1,0 +1,27 @@
+import { Tooltip } from '../ui/Tooltip';
+import { Icon } from '../terminal/Icon';
+
+/**
+ * Info icon + tooltip shown next to hook command fields. Explains that a hook
+ * runs in the task's worktree and that an agent started there can inspect and
+ * update the task through the ouijit CLI — which is what lets command
+ * placeholders be plain-language prompts instead of env-var plumbing.
+ */
+export function HookCliHint({ placement = 'top' }: { placement?: 'top' | 'bottom' | 'right' }) {
+  return (
+    <Tooltip
+      placement={placement}
+      text={
+        <span className="block max-w-[260px] whitespace-normal leading-snug font-normal">
+          Hooks run in the task&apos;s worktree. An agent started here can inspect and update the task with the ouijit
+          CLI.
+        </span>
+      }
+    >
+      <Icon
+        name="info"
+        className="w-[18px] h-[18px] text-text-tertiary hover:text-text-secondary transition-colors duration-100"
+      />
+    </Tooltip>
+  );
+}

--- a/src/components/dialogs/HookConfigDialog.tsx
+++ b/src/components/dialogs/HookConfigDialog.tsx
@@ -3,12 +3,14 @@ import type { ScriptHook, HookType } from '../../types';
 import { useProjectStore } from '../../stores/projectStore';
 import { useAutoResize } from '../../hooks/useAutoResize';
 import { DialogOverlay } from './DialogOverlay';
+import { HookCliHint } from './HookCliHint';
+import { HookEnvVars } from './HookEnvVars';
 
 const HOOK_LABELS: Record<HookType, { title: string; description: string; placeholder: string; envVars?: boolean }> = {
   start: {
     title: 'Start Hook',
     description: 'Runs when a task moves from To Do to In Progress',
-    placeholder: 'npm install && claude "$OUIJIT_TASK_DESCRIPTION"',
+    placeholder: 'claude "complete the current task and move it into in review"',
     envVars: true,
   },
   continue: {
@@ -26,7 +28,7 @@ const HOOK_LABELS: Record<HookType, { title: string; description: string; placeh
   review: {
     title: 'Review Hook',
     description: 'Runs when a task moves to In Review',
-    placeholder: 'gh pr create --fill',
+    placeholder: 'claude "open a pull request for the current task"',
     envVars: true,
   },
   done: {
@@ -41,14 +43,6 @@ const HOOK_LABELS: Record<HookType, { title: string; description: string; placeh
     placeholder: 'code',
   },
 };
-
-const ENV_VARS = [
-  '$OUIJIT_PROJECT_PATH',
-  '$OUIJIT_WORKTREE_PATH',
-  '$OUIJIT_TASK_BRANCH',
-  '$OUIJIT_TASK_NAME',
-  '$OUIJIT_TASK_DESCRIPTION',
-];
 
 interface HookConfigDialogProps {
   projectPath: string;
@@ -71,7 +65,6 @@ export function HookConfigDialog({
   const [command, setCommand] = useState(existingHook?.command ?? '');
   const [killExisting, setKillExisting] = useState(killExistingOnRun !== false);
   const [visible, setVisible] = useState(false);
-  const [copiedVar, setCopiedVar] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const autoResize = useAutoResize();
 
@@ -119,12 +112,6 @@ export function HookConfigDialog({
     dismiss({ saved: true, hook, killExistingOnRun: killExisting });
   }, [command, projectPath, hookType, existingHook, labels, isRunHook, killExisting, dismiss]);
 
-  const copyVar = useCallback((varName: string) => {
-    navigator.clipboard.writeText(varName);
-    setCopiedVar(varName);
-    setTimeout(() => setCopiedVar(null), 1500);
-  }, []);
-
   return (
     <DialogOverlay visible={visible} onDismiss={() => dismiss(null)}>
       <h2 className="text-lg font-semibold text-text-primary mb-4 text-center">{labels.title}</h2>
@@ -164,33 +151,19 @@ export function HookConfigDialog({
           </div>
         )}
 
-        {labels.envVars && (
-          <details className="mt-3 text-xs text-text-secondary [&>summary]:cursor-default [&>summary]:select-none [&_ul]:mt-2 [&_ul]:mb-0 [&_ul]:pl-5 [&_li]:my-1">
-            <summary>Environment variables</summary>
-            <ul>
-              {ENV_VARS.map((v) => (
-                <li key={v}>
-                  <code
-                    className={`font-mono text-[13px] px-1.5 py-0.5 rounded inline-block bg-background-secondary hover:text-text-primary hover:bg-border-hover ${copiedVar === v ? 'text-accent !bg-[color-mix(in_srgb,var(--color-accent)_15%,transparent)]' : ''}`}
-                    style={{ transition: 'background 100ms ease, color 100ms ease' }}
-                    onClick={() => copyVar(v)}
-                  >
-                    {copiedVar === v ? 'Copied!' : v}
-                  </code>
-                </li>
-              ))}
-            </ul>
-          </details>
-        )}
+        {labels.envVars && <HookEnvVars />}
       </div>
 
-      <div className="flex gap-2 justify-end mt-4 items-center">
-        <button className="btn-secondary" onClick={() => dismiss(null)}>
-          Cancel
-        </button>
-        <button className="btn-primary" onClick={handleSave}>
-          Save
-        </button>
+      <div className="flex gap-2 justify-between mt-4 items-center">
+        {labels.envVars ? <HookCliHint /> : <div />}
+        <div className="flex gap-2">
+          <button className="btn-secondary" onClick={() => dismiss(null)}>
+            Cancel
+          </button>
+          <button className="btn-primary" onClick={handleSave}>
+            Save
+          </button>
+        </div>
       </div>
     </DialogOverlay>
   );

--- a/src/components/dialogs/HookEnvVars.tsx
+++ b/src/components/dialogs/HookEnvVars.tsx
@@ -1,0 +1,46 @@
+import { useState, useCallback } from 'react';
+
+/** Variables Ouijit sets in the hook's shell. */
+const ENV_VARS = [
+  '$OUIJIT_PROJECT_PATH',
+  '$OUIJIT_WORKTREE_PATH',
+  '$OUIJIT_TASK_BRANCH',
+  '$OUIJIT_TASK_NAME',
+  '$OUIJIT_TASK_DESCRIPTION',
+];
+
+/**
+ * The "Environment variables" disclosure shared by the hook dialogs. Explains
+ * what the variables are, lists them, and copies one to the clipboard on click.
+ */
+export function HookEnvVars() {
+  const [copiedVar, setCopiedVar] = useState<string | null>(null);
+
+  const copyVar = useCallback((varName: string) => {
+    navigator.clipboard.writeText(varName);
+    setCopiedVar(varName);
+    setTimeout(() => setCopiedVar(null), 1500);
+  }, []);
+
+  return (
+    <details className="mt-3 text-xs text-text-secondary [&>summary]:cursor-default [&>summary]:select-none [&_ul]:mt-2 [&_ul]:mb-0 [&_ul]:pl-5 [&_li]:my-1">
+      <summary>Environment variables</summary>
+      <p className="mt-2 mb-0 text-text-tertiary leading-snug">
+        Ouijit sets these in the hook&apos;s shell. Reference one in your command, or click to copy.
+      </p>
+      <ul>
+        {ENV_VARS.map((v) => (
+          <li key={v}>
+            <code
+              className={`font-mono text-[13px] px-1.5 py-0.5 rounded inline-block bg-background-secondary hover:text-text-primary hover:bg-border-hover ${copiedVar === v ? 'text-accent !bg-[color-mix(in_srgb,var(--color-accent)_15%,transparent)]' : ''}`}
+              style={{ transition: 'background 100ms ease, color 100ms ease' }}
+              onClick={() => copyVar(v)}
+            >
+              {copiedVar === v ? 'Copied!' : v}
+            </code>
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}

--- a/src/components/dialogs/RunHookDialog.tsx
+++ b/src/components/dialogs/RunHookDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import type { ScriptHook, HookType } from '../../types';
 import { useAutoResize } from '../../hooks/useAutoResize';
 import { DialogOverlay } from './DialogOverlay';
+import { HookEnvVars } from './HookEnvVars';
 
 const HOOK_TITLES: Record<string, string> = {
   start: 'Start Task',
@@ -10,14 +11,6 @@ const HOOK_TITLES: Record<string, string> = {
   done: 'Done',
   run: 'Run',
 };
-
-const ENV_VARS = [
-  '$OUIJIT_PROJECT_PATH',
-  '$OUIJIT_WORKTREE_PATH',
-  '$OUIJIT_TASK_BRANCH',
-  '$OUIJIT_TASK_NAME',
-  '$OUIJIT_TASK_DESCRIPTION',
-];
 
 export interface RunHookResult {
   command: string;
@@ -57,7 +50,6 @@ export function RunHookDialog({
   const [sandboxed, setSandboxed] = useState(false);
   const [limaAvailable, setLimaAvailable] = useState(false);
   const [visible, setVisible] = useState(false);
-  const [copiedVar, setCopiedVar] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const autoResize = useAutoResize();
 
@@ -95,12 +87,6 @@ export function RunHookDialog({
     setTimeout(() => onSkipAll?.(), 200);
   }, [onSkipAll]);
 
-  const copyVar = useCallback((varName: string) => {
-    navigator.clipboard.writeText(varName);
-    setCopiedVar(varName);
-    setTimeout(() => setCopiedVar(null), 1500);
-  }, []);
-
   const title = HOOK_TITLES[hookType] || hookType;
   const queued = queueTotal != null && queueTotal > 1;
 
@@ -137,22 +123,7 @@ export function RunHookDialog({
         rows={1}
       />
 
-      <details className="mt-3 text-xs text-text-secondary [&>summary]:cursor-default [&>summary]:select-none [&_ul]:mt-2 [&_ul]:mb-0 [&_ul]:pl-5 [&_li]:my-1">
-        <summary>Environment variables</summary>
-        <ul>
-          {ENV_VARS.map((v) => (
-            <li key={v}>
-              <code
-                className={`font-mono text-[13px] px-1.5 py-0.5 rounded inline-block bg-background-secondary hover:text-text-primary hover:bg-border-hover ${copiedVar === v ? 'text-accent !bg-[color-mix(in_srgb,var(--color-accent)_15%,transparent)]' : ''}`}
-                style={{ transition: 'background 100ms ease, color 100ms ease' }}
-                onClick={() => copyVar(v)}
-              >
-                {copiedVar === v ? 'Copied!' : v}
-              </code>
-            </li>
-          ))}
-        </ul>
-      </details>
+      <HookEnvVars />
 
       <div className="flex gap-2 justify-between mt-4 items-center">
         {limaAvailable ? (

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -11,7 +11,7 @@ interface OnboardingPanelProps {
   onOpenHelp: () => void;
 }
 
-const EXAMPLE_START_HOOK_COMMAND = `claude "complete the current task and move it to in-review"`;
+const EXAMPLE_START_HOOK_COMMAND = `claude "complete the current task and move it into in review"`;
 
 type Stage = 'intro' | 'setup' | 'in-flight' | 'complete';
 

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -73,7 +73,7 @@ export function Tooltip({
         createPortal(
           <div
             ref={refs.setFloating}
-            className="fixed z-[10000] pointer-events-none"
+            className="fixed z-[10002] pointer-events-none"
             style={floatingStyles}
             {...getFloatingProps()}
           >

--- a/src/components/ui/TooltipButton.tsx
+++ b/src/components/ui/TooltipButton.tsx
@@ -68,7 +68,7 @@ export function TooltipButton({
         createPortal(
           <div
             ref={refs.setFloating}
-            className="fixed z-[10000] pointer-events-none"
+            className="fixed z-[10002] pointer-events-none"
             style={floatingStyles}
             {...getFloatingProps()}
           >


### PR DESCRIPTION
## Summary
- Replaced env-var-heavy placeholders with plain-language agent prompts for the start and review hooks (start now uses `claude "complete the current task and move it into in review"`)
- Added a dialog-level CLI hint (info icon + tooltip in the action row) explaining that hooks run in the task worktree and an agent started there can inspect and update the task via the ouijit CLI
- Added an explainer blurb to the "Environment variables" disclosure
- Extracted shared `HookCliHint` and `HookEnvVars` components, removing the triplicated env-var list and copy logic across the three hook dialogs
- Raised the tooltip portal z-index above modal dialogs so hints render in front of the overlay
- Aligned the onboarding example hook to the canonical start prompt