### PR TITLE
Don't scaffold CLAUDE.md on project creation

### DIFF
--- a/src/projectCreator.ts
+++ b/src/projectCreator.ts
@@ -1,5 +1,5 @@
 /**
- * Creates a new project directory with git init and CLAUDE.md scaffold.
+ * Creates a new project directory with git init.
  */
 
 import { execSync } from 'node:child_process';
@@ -164,19 +164,6 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
         error: 'Git is required. Install via `xcode-select --install` (macOS) or your package manager (Linux).',
       };
     }
-
-    // Create CLAUDE.md
-    const claudeMdContent = `# ${options.name}
-
-## Project Overview
-
-<!-- Describe your project here -->
-
-## Development Guidelines
-
-<!-- Add guidelines for Claude to follow -->
-`;
-    await fs.writeFile(path.join(projectPath, 'CLAUDE.md'), claudeMdContent, 'utf-8');
 
     return { success: true, projectPath };
   } catch (error) {


### PR DESCRIPTION
## Summary

- Removed the CLAUDE.md scaffold from `createProject` in `src/projectCreator.ts`; new projects no longer get an auto-generated `CLAUDE.md` written on creation. Project creation still runs `git init`.
- Updated the file's doc comment to drop the "and CLAUDE.md scaffold" wording.