### PR TITLE
Restyle onboarding tips

### DIFF
--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -175,8 +175,8 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
 
   return (
     <div
-      className="mx-3 mt-3 mb-2 px-4 py-3 rounded-[12px] border border-white/10 flex items-start gap-3 onboarding-stage-enter"
-      style={{ background: 'rgba(255, 255, 255, 0.03)' }}
+      className="mx-3 mt-3 mb-2 px-4 py-3 rounded-[12px] flex items-start gap-3 onboarding-stage-enter"
+      style={{ background: 'rgba(0, 0, 0, 0.2)' }}
     >
       <div className="flex-1 min-w-0">
         <StageCrossfade stage={stage} renderStage={renderStageBody} />

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -175,8 +175,8 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
 
   return (
     <div
-      className="mx-3 mt-3 mb-2 px-4 py-3 rounded-[12px] flex items-start gap-3 onboarding-stage-enter"
-      style={{ background: 'rgba(0, 0, 0, 0.2)' }}
+      className="mb-2 px-4 py-3 flex items-start gap-3 onboarding-stage-enter"
+      style={{ background: 'rgba(255, 255, 255, 0.03)' }}
     >
       <div className="flex-1 min-w-0">
         <StageCrossfade stage={stage} renderStage={renderStageBody} />


### PR DESCRIPTION
## Summary
- Onboarding panel in the kanban now spans flush to the board's top and side edges instead of being an inset card (removed side/top margins and rounded corners).
- Kept the existing light translucent background and removed the border.