### PR TITLE
Exclude expanded card area from kanban drag handle

### DIFF
--- a/src/components/kanban/KanbanCardView.tsx
+++ b/src/components/kanban/KanbanCardView.tsx
@@ -342,7 +342,13 @@ export const KanbanCardView = memo(function KanbanCardView({
       )}
 
       {expanded && (
-        <div className="grid mt-2 pt-2 border-t border-white/[0.04] gap-2">
+        <div
+          className="grid mt-2 pt-2 border-t border-white/[0.04] gap-2"
+          // Keep the card's drag activator (dnd-kit listeners on the wrapper)
+          // out of the expanded area so selecting description text doesn't
+          // start a card drag.
+          onPointerDown={(e) => e.stopPropagation()}
+        >
           <div className="flex flex-col gap-1 text-sm">
             <DescriptionChipEditor
               ref={descEditorRef}


### PR DESCRIPTION
## Summary
- Selecting description text in an expanded kanban card no longer starts a card drag.
- dnd-kit's drag listeners are spread over the entire card wrapper, so a pointer-down anywhere (including the expanded description) activated a drag. The expanded section now stops pointer-down propagation so the drag activator doesn't fire there.
- The rest of the card (name, badges, terminal rows) stays draggable.