### PR TITLE
Fix home view terminal focus for Cmd+I and Cmd+W

### DIFF
--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -52,6 +52,18 @@ export function HomeView() {
   const [activePtyId, setActivePtyId] = useState<string | null>(null);
   const reconnectedRef = useRef(false);
 
+  // Stack order: bigger tick = closer to the front. A terminal gets a tick
+  // when it first appears and a fresh one each time it becomes the active
+  // card, so the back stack stays in most-recently-front order — adding or
+  // closing the front card only shifts its neighbors by one depth.
+  const stackTickRef = useRef(0);
+  const stackRecencyRef = useRef(new Map<string, number>());
+
+  useEffect(() => {
+    if (!activePtyId) return;
+    stackRecencyRef.current.set(activePtyId, ++stackTickRef.current);
+  }, [activePtyId]);
+
   useHookStatusListener(null);
 
   useEffect(() => {
@@ -107,6 +119,14 @@ export function HomeView() {
     const groups: Group[] = [];
     const seen = new Map<string, number>();
 
+    // Assign appearance ticks so a freshly spawned terminal sorts to the
+    // front of the back stack even before its activation tick lands
+    const recency = stackRecencyRef.current;
+    for (const ptyId of allPtyIds) {
+      if (!recency.has(ptyId)) recency.set(ptyId, ++stackTickRef.current);
+    }
+    const rank = (ptyId: string) => recency.get(ptyId) ?? 0;
+
     for (const ptyId of allPtyIds) {
       const display = displayStates[ptyId];
       if (!display) continue;
@@ -147,9 +167,13 @@ export function HomeView() {
       }
     }
 
-    const ordered = activeGroupKey
-      ? [...groups.filter((g) => g.key === activeGroupKey), ...groups.filter((g) => g.key !== activeGroupKey)]
-      : groups;
+    for (const group of groups) {
+      group.ptyIds.sort((a, b) => rank(b) - rank(a));
+    }
+
+    const groupRank = (group: Group) => Math.max(...group.ptyIds.map(rank));
+    const rest = groups.filter((g) => g.key !== activeGroupKey).sort((a, b) => groupRank(b) - groupRank(a));
+    const ordered = activeGroupKey ? [...groups.filter((g) => g.key === activeGroupKey), ...rest] : rest;
 
     const items: StackItem[] = [];
     let depth = 0;

--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -3,7 +3,7 @@ import { useAppStore } from '../stores/appStore';
 import { useTerminalStore } from '../stores/terminalStore';
 import { useUIStore } from '../stores/uiStore';
 import { terminalInstances } from './terminal/terminalReact';
-import { reconnectTerminal, addProjectTerminal } from './terminal/terminalActions';
+import { reconnectTerminal, addProjectTerminal, closeProjectTerminal } from './terminal/terminalActions';
 import { TerminalHeader } from './terminal/TerminalHeader';
 import { TerminalBody } from './terminal/TerminalBody';
 import { XTermContainer } from './terminal/XTermContainer';
@@ -53,17 +53,6 @@ export function HomeView() {
   const reconnectedRef = useRef(false);
 
   useHookStatusListener(null);
-
-  // Keep activePtyId valid: if the active terminal was removed, fall back
-  useEffect(() => {
-    if (allPtyIds.length === 0) {
-      if (activePtyId !== null) setActivePtyId(null);
-      return;
-    }
-    if (activePtyId === null || !allPtyIds.includes(activePtyId)) {
-      setActivePtyId(allPtyIds[allPtyIds.length - 1]);
-    }
-  }, [allPtyIds, activePtyId]);
 
   useEffect(() => {
     window.api.getProjects().then((projs) => {
@@ -184,6 +173,19 @@ export function HomeView() {
     return { stackItems: items, orderedGroups: ordered };
   }, [allPtyIds, displayStates, homeGroupMode, activeDisplay, activePtyId]);
 
+  // Keep activePtyId valid: if the active terminal was removed, fall back to
+  // the front-most card of the back stack (visual order, not insertion order)
+  useEffect(() => {
+    if (allPtyIds.length === 0) {
+      if (activePtyId !== null) setActivePtyId(null);
+      return;
+    }
+    if (activePtyId === null || !allPtyIds.includes(activePtyId)) {
+      const next = stackItems.find((i): i is Extract<StackItem, { type: 'terminal' }> => i.type === 'terminal');
+      setActivePtyId(next ? next.ptyId : allPtyIds[allPtyIds.length - 1]);
+    }
+  }, [allPtyIds, activePtyId, stackItems]);
+
   const maxDepth = stackItems.length > 0 ? stackItems[stackItems.length - 1].depth : 0;
 
   const stackTop = 82 + maxDepth * 24;
@@ -207,11 +209,16 @@ export function HomeView() {
       if (!mod) return;
       const key = e.key.toLowerCase();
 
-      // Cmd+I — new terminal
+      // Cmd+I — new terminal, brought to the front of the stack
       if (key === 'i') {
         e.preventDefault();
         e.stopPropagation();
-        window.api.homePath().then((homePath) => addProjectTerminal(homePath));
+        window.api.homePath().then(async (homePath) => {
+          const added = await addProjectTerminal(homePath);
+          if (!added) return;
+          const ptyIds = useTerminalStore.getState().terminalsByProject[homePath];
+          if (ptyIds && ptyIds.length > 0) setActivePtyId(ptyIds[ptyIds.length - 1]);
+        });
         return;
       }
 
@@ -227,9 +234,11 @@ export function HomeView() {
       if (key === 'w' && activePtyId) {
         e.preventDefault();
         e.stopPropagation();
-        const instance = terminalInstances.get(activePtyId);
-        if (instance) instance.dispose();
-        useTerminalStore.getState().removeTerminal(activePtyId);
+        // Promote the next card in visual stack order before closing so
+        // repeated Cmd+W peels cards front-to-back
+        const next = stackItems.find((i): i is Extract<StackItem, { type: 'terminal' }> => i.type === 'terminal');
+        if (next) setActivePtyId(next.ptyId);
+        closeProjectTerminal(activePtyId);
         return;
       }
 
@@ -274,9 +283,11 @@ export function HomeView() {
   );
 
   const handleClose = (ptyId: string) => {
-    const instance = terminalInstances.get(ptyId);
-    if (instance) instance.dispose();
-    useTerminalStore.getState().removeTerminal(ptyId);
+    if (ptyId === activePtyId) {
+      const next = stackItems.find((i): i is Extract<StackItem, { type: 'terminal' }> => i.type === 'terminal');
+      if (next) setActivePtyId(next.ptyId);
+    }
+    closeProjectTerminal(ptyId);
   };
 
   const {


### PR DESCRIPTION
## Summary
- Cmd+I in the home view now makes the newly spawned terminal the front, focused card instead of leaving it hidden in the back stack while it silently holds keyboard focus
- Cmd+W now closes the front/focused terminal and promotes the next card in visual stack order, so repeated Cmd+W peels cards front-to-back
- All home view close paths (Cmd+W, header close button, removed-terminal fallback) now go through `closeProjectTerminal` so canvas node cleanup runs instead of leaving stale canvas state