### PR TITLE
Replace xterm.js with libghostty for terminal emulation

### DIFF
--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -151,7 +151,7 @@ test('project mode: terminals, kanban, context menu, and task lifecycle', async 
   await expect(contextMenu).toBeVisible({ timeout: 5_000 });
   await expect(contextMenu.locator('.context-menu-item', { hasText: 'Open in Terminal' })).toBeVisible();
   await expect(contextMenu.locator('.context-menu-item', { hasText: 'Move to Done' })).toBeVisible();
-  await expect(contextMenu.locator('.context-menu-item--danger', { hasText: 'Delete' })).toBeVisible();
+  await expect(contextMenu.locator('.context-menu-item--danger', { hasText: 'Move to Trash' })).toBeVisible();
 
   await contextMenu.locator('.context-menu-item', { hasText: 'Open in Terminal' }).click();
 
@@ -171,7 +171,7 @@ test('project mode: terminals, kanban, context menu, and task lifecycle', async 
   await ipCard.click({ button: 'right' });
   await expect(appPage.locator('.context-menu--visible')).toBeVisible({ timeout: 5_000 });
 
-  await appPage.locator('.context-menu-item--danger', { hasText: 'Delete' }).click();
+  await appPage.locator('.context-menu-item--danger', { hasText: 'Move to Trash' }).click();
 
   // React version deletes immediately without confirmation
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(0, { timeout: 5_000 });
@@ -179,6 +179,7 @@ test('project mode: terminals, kanban, context menu, and task lifecycle', async 
 });
 
 test('terminal reconnect after reload does not produce % artifacts', async ({ appPage, testRepo }) => {
+  test.setTimeout(20_000);
   await enterProject(appPage, testRepo.repoPath);
   await dismissKanban(appPage);
 
@@ -199,8 +200,15 @@ test('terminal reconnect after reload does not produce % artifacts', async ({ ap
   await appPage.reload();
   await appPage.waitForLoadState('domcontentloaded');
 
-  // Wait for terminal reconnection — project view should restore
-  await expect(appPage.locator('.project-card--active')).toHaveCount(1, { timeout: 15_000 });
+  // After reload the app restores to the home view — a saved session snapshot
+  // forces home so the resume banner is shown first. The live PTY reconnects
+  // automatically and its terminal renders in the home view's preview stack;
+  // wait for the reconnected instance before reading its buffer.
+  await appPage.waitForFunction(
+    () => ((window as { __terminalInstances?: Map<string, unknown> }).__terminalInstances?.size ?? 0) >= 1,
+    null,
+    { timeout: 15_000 },
+  );
   await expect(appPage.locator('.terminal-xterm-container').first()).toBeAttached({ timeout: 5_000 });
 
   // Wait for reconnection and any resize events to settle
@@ -263,7 +271,9 @@ test('lifecycle hooks: start hook via drag shows dialog', async ({ appPage, test
 
   // Click "Run" — terminal created in background, task moves to in_progress
   await hookDialog.locator('[data-testid="dialog-run"]').click();
-  await expect(appPage.locator('[data-testid="dialog-overlay"][data-visible="true"]')).not.toBeVisible({ timeout: 5_000 });
+  await expect(appPage.locator('[data-testid="dialog-overlay"][data-visible="true"]')).not.toBeVisible({
+    timeout: 5_000,
+  });
   // Kanban stays visible for background run — verify task moved
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(1, { timeout: 5_000 });
   await expect(todoColumn.locator('.kanban-card')).toHaveCount(0);
@@ -284,14 +294,17 @@ test('lifecycle hooks: start hook via drag shows dialog', async ({ appPage, test
   await expect(hookDialog).toBeVisible({ timeout: 15_000 });
   await expect(hookDialog.locator('[data-testid="dialog-title"]')).toHaveText('Start Task');
 
-  // Click "Cancel" — no terminal, task still moves to in_progress (worktree already created)
+  // Click "Cancel" — the hook command is skipped, but in_progress drops always
+  // open a terminal, so the task still moves to in_progress with a plain shell.
   await hookDialog.locator('[data-testid="dialog-cancel"]').click();
-  await expect(appPage.locator('[data-testid="dialog-overlay"][data-visible="true"]')).not.toBeVisible({ timeout: 5_000 });
+  await expect(appPage.locator('[data-testid="dialog-overlay"][data-visible="true"]')).not.toBeVisible({
+    timeout: 5_000,
+  });
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(2, { timeout: 5_000 });
   await expect(todoColumn.locator('.kanban-card')).toHaveCount(0);
-  // Verify no new terminal was created (still just 1 from earlier)
+  // Cancel skips the hook but still spawns a plain-shell terminal (2 total now)
   await appPage.keyboard.press(`${modifier}+t`);
-  await expect(appPage.locator('.project-card')).toHaveCount(1);
+  await expect(appPage.locator('.project-card')).toHaveCount(2, { timeout: 15_000 });
   await appPage.keyboard.press(`${modifier}+t`);
 
   // --- No dialog after hook deleted ---
@@ -307,7 +320,9 @@ test('lifecycle hooks: start hook via drag shows dialog', async ({ appPage, test
   await dragCard(appPage, todoColumn.locator('.kanban-card').first(), inProgressBody);
 
   await appPage.waitForTimeout(1_000);
-  await expect(appPage.locator('[data-testid="dialog-overlay"][data-visible="true"] [data-testid="dialog"]')).not.toBeVisible();
+  await expect(
+    appPage.locator('[data-testid="dialog-overlay"][data-visible="true"] [data-testid="dialog"]'),
+  ).not.toBeVisible();
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(3, { timeout: 5_000 });
   await expect(todoColumn.locator('.kanban-card')).toHaveCount(0);
 });
@@ -384,7 +399,8 @@ test('whats new: modal appears and dismisses', async ({ appPage }) => {
   await appPage.evaluate(() => {
     (window as any).__appStore.getState().setWhatsNew({
       version: '1.1.0',
-      notes: '## Improvements\n- **Faster startup** with lazy loading\n- Fixed `bug #42` in terminal\n\n## Bug Fixes\n- Resolved crash on exit',
+      notes:
+        '## Improvements\n- **Faster startup** with lazy loading\n- Fixed `bug #42` in terminal\n\n## Bug Fixes\n- Resolved crash on exit',
     });
   });
 
@@ -401,7 +417,9 @@ test('whats new: modal appears and dismisses', async ({ appPage }) => {
   await expect(dialog).not.toBeVisible({ timeout: 3_000 });
 
   // Store should be cleared (after 200ms dismiss animation)
-  await appPage.waitForFunction(() => (window as any).__appStore.getState().whatsNew === null, null, { timeout: 3_000 });
+  await appPage.waitForFunction(() => (window as any).__appStore.getState().whatsNew === null, null, {
+    timeout: 3_000,
+  });
 });
 
 test('whats new: modal dismisses on Escape', async ({ appPage }) => {

--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -27,10 +27,11 @@ async function enterProject(appPage: Page, repoPath: string): Promise<void> {
 }
 
 /**
- * Helper: dismiss the kanban board by pressing Escape.
+ * Helper: dismiss the kanban board. Board toggling is owned by Cmd/Ctrl+T
+ * (Escape is reserved for form-level resets inside the board).
  */
 async function dismissKanban(appPage: Page): Promise<void> {
-  await appPage.keyboard.press('Escape');
+  await appPage.keyboard.press(`${modifier}+t`);
   await expect(appPage.locator('.kanban-board')).toHaveCount(0, { timeout: 5_000 });
 }
 
@@ -205,11 +206,20 @@ test('terminal reconnect after reload does not produce % artifacts', async ({ ap
   // Wait for reconnection and any resize events to settle
   await appPage.waitForTimeout(3_000);
 
-  // Read the terminal's visible text content
-  // xterm renders rows in .xterm-rows; text is accessible via textContent
+  // Read the terminal's text content. ghostty-web renders to canvas, so the
+  // text is read through the buffer API on the exposed instance registry.
   const terminalText = await appPage.evaluate(() => {
-    const rows = document.querySelector('.terminal-xterm-container .xterm-rows');
-    return rows?.textContent ?? '';
+    type BufferLine = { translateToString(trimRight?: boolean): string };
+    type Instance = { xterm: { buffer: { active: { length: number; getLine(y: number): BufferLine | undefined } } } };
+    const instances = (window as { __terminalInstances?: Map<string, Instance> }).__terminalInstances;
+    const instance = instances?.values().next().value;
+    if (!instance) return '';
+    const buffer = instance.xterm.buffer.active;
+    const lines: string[] = [];
+    for (let y = 0; y < buffer.length; y++) {
+      lines.push(buffer.getLine(y)?.translateToString(false) ?? '');
+    }
+    return lines.join('\n');
   });
 
   // The marker should be present (reconnection replayed the buffer)
@@ -433,7 +443,7 @@ test('update available: persistent toast with download action', async ({ appPage
   await expect(toast).toBeVisible();
 
   // Dismiss via close button
-  const closeBtn = toast.locator('button', { hasText: '✕' });
+  const closeBtn = toast.locator('button[aria-label="Dismiss"]');
   await expect(closeBtn).toBeVisible();
   await closeBtn.click();
   await expect(toast).not.toBeVisible({ timeout: 3_000 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,6 @@
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
         "@phosphor-icons/core": "^2.1.1",
-        "@xterm/addon-fit": "^0.11.0",
-        "@xterm/addon-web-links": "^0.12.0",
-        "@xterm/xterm": "^6.0.0",
         "@xyflow/react": "^12.10.2",
         "better-sqlite3": "^12.6.2",
         "commander": "^14.0.3",
@@ -22,6 +19,7 @@
         "electron-log": "^5.4.3",
         "electron-squirrel-startup": "^1.0.1",
         "fix-path": "^5.0.0",
+        "ghostty-web": "0.4.0",
         "hotkeys-js": "^4.0.0",
         "koffi": "^2.15.1",
         "launch-editor": "^2.13.2",
@@ -5897,26 +5895,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@xterm/addon-fit": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
-      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
-      "license": "MIT"
-    },
-    "node_modules/@xterm/addon-web-links": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
-      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw=="
-    },
-    "node_modules/@xterm/xterm": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
-      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
-      "license": "MIT",
-      "workspaces": [
-        "addons/*"
-      ]
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -9610,6 +9588,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/ghostty-web": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ghostty-web/-/ghostty-web-0.4.0.tgz",
+      "integrity": "sha512-0puDBik2qapbD/QQBW9o5ZHfXnZBqZWx/ctBiVtKZ6ZLds4NYb+wZuw1cRLXZk9zYovIQ908z3rvFhexAvc5Hg==",
+      "license": "MIT"
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -83,9 +83,6 @@
   "dependencies": {
     "@floating-ui/dom": "^1.7.6",
     "@phosphor-icons/core": "^2.1.1",
-    "@xterm/addon-fit": "^0.11.0",
-    "@xterm/addon-web-links": "^0.12.0",
-    "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.10.2",
     "better-sqlite3": "^12.6.2",
     "commander": "^14.0.3",
@@ -93,6 +90,7 @@
     "electron-log": "^5.4.3",
     "electron-squirrel-startup": "^1.0.1",
     "fix-path": "^5.0.0",
+    "ghostty-web": "0.4.0",
     "hotkeys-js": "^4.0.0",
     "koffi": "^2.15.1",
     "launch-editor": "^2.13.2",

--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -11,6 +11,7 @@ import { useTerminalPanels } from './terminal/useTerminalPanels';
 import { useHookStatusListener } from '../hooks/useHookStatusListener';
 import { Icon } from './terminal/Icon';
 import { stringToColor, getInitials } from '../utils/projectIcon';
+import { passThroughSystemShortcut } from '../utils/keyboard';
 import { RecentTasksPanel } from './RecentTasksPanel';
 import { ResumeBanner } from './ResumeBanner';
 import type { Project } from '../types';
@@ -231,6 +232,11 @@ export function HomeView() {
       if (e.repeat) return;
       const mod = isMac ? e.metaKey : e.ctrlKey;
       if (!mod) return;
+
+      // Let Electron's native accelerators (reload, quit) through to the OS
+      // instead of the focused terminal. Shared with the project view.
+      if (passThroughSystemShortcut(e)) return;
+
       const key = e.key.toLowerCase();
 
       // Cmd+I — new terminal, brought to the front of the stack

--- a/src/components/ProjectViewReact.tsx
+++ b/src/components/ProjectViewReact.tsx
@@ -4,6 +4,7 @@ import { useProjectStore } from '../stores/projectStore';
 import { useTerminalStore, getTerminalIndexByStackPosition, STACK_PAGE_SIZE } from '../stores/terminalStore';
 import { useCanvasStore, persistCanvas } from '../stores/canvasStore';
 import { useExperimentalStore } from '../stores/experimentalStore';
+import { passThroughSystemShortcut } from '../utils/keyboard';
 import { TerminalCardStack } from './terminal/TerminalCardStack';
 import { TerminalCanvas, syncCanvasWithTerminals } from './canvas/TerminalCanvas';
 import { KanbanBoard } from './kanban/KanbanBoard';
@@ -67,16 +68,11 @@ export function ProjectView() {
       const mod = isMac ? e.metaKey : e.ctrlKey;
       if (!mod) return;
 
-      const key = e.key.toLowerCase();
+      // Let Electron's native accelerators (reload, quit) through to the OS
+      // instead of the focused terminal. Shared with the home view.
+      if (passThroughSystemShortcut(e)) return;
 
-      // Cmd+R (reload) and Cmd+Q (quit) are Electron's native accelerators.
-      // ghostty-web's input handler calls preventDefault on every key it sees,
-      // which swallows them when a terminal is focused. Stop the event before it
-      // reaches the terminal, but do NOT preventDefault — let Electron handle it.
-      if (key === 'r' || key === 'q') {
-        e.stopPropagation();
-        return;
-      }
+      const key = e.key.toLowerCase();
 
       // Cmd+I — spawn shell terminal
       if (key === 'i') {

--- a/src/components/ProjectViewReact.tsx
+++ b/src/components/ProjectViewReact.tsx
@@ -69,6 +69,15 @@ export function ProjectView() {
 
       const key = e.key.toLowerCase();
 
+      // Cmd+R (reload) and Cmd+Q (quit) are Electron's native accelerators.
+      // ghostty-web's input handler calls preventDefault on every key it sees,
+      // which swallows them when a terminal is focused. Stop the event before it
+      // reaches the terminal, but do NOT preventDefault — let Electron handle it.
+      if (key === 'r' || key === 'q') {
+        e.stopPropagation();
+        return;
+      }
+
       // Cmd+I — spawn shell terminal
       if (key === 'i') {
         e.preventDefault();

--- a/src/components/terminal/boxDrawing.ts
+++ b/src/components/terminal/boxDrawing.ts
@@ -1,0 +1,427 @@
+import type { Terminal, GhosttyCell } from 'ghostty-web';
+import log from 'electron-log/renderer';
+
+const boxDrawingLog = log.scope('boxDrawing');
+
+// ── Why this exists ──────────────────────────────────────────────────
+// ghostty-web's CanvasRenderer draws every cell — including box-drawing
+// (U+2500–257F) and block (U+2580–259F) characters — with ctx.fillText()
+// using the font glyph. Its cell box is `ceil(ascent + descent) + 2` tall
+// (2px of leading the glyph doesn't fill), so vertical rules can't reach the
+// next row and borders render as dashed/broken lines. Native Ghostty and the
+// xterm.js renderer we migrated off both draw these glyphs as geometry tiled
+// exactly to the cell. This module restores that: it intercepts the renderer's
+// per-cell text pass, draws the covered codepoints procedurally so they tile
+// seamlessly, and delegates everything else back to ghostty-web unchanged.
+//
+// Coverage: light/heavy/mixed box lines, corners, T-junctions, crosses,
+// rounded corners, dashes, half-stubs, diagonals, straight double lines
+// (═ ║), and the full block range (halves, eighths, quadrants, shades).
+// Double-line corners/junctions (U+2552–256C) fall back to the font glyph —
+// their junction geometry isn't handled yet, so they render as they did before
+// (no regression).
+
+const CellFlag = {
+  UNDERLINE: 4,
+  INVERSE: 16,
+  INVISIBLE: 32,
+  FAINT: 128,
+} as const;
+
+// Arm weights per codepoint, ordered [up, right, down, left].
+// 0 = none, 1 = light, 2 = heavy. Double-line arms are handled separately.
+const ARMS: Record<number, [number, number, number, number]> = {
+  0x2500: [0, 1, 0, 1],
+  0x2501: [0, 2, 0, 2],
+  0x2502: [1, 0, 1, 0],
+  0x2503: [2, 0, 2, 0],
+  0x250c: [0, 1, 1, 0],
+  0x250d: [0, 2, 1, 0],
+  0x250e: [0, 1, 2, 0],
+  0x250f: [0, 2, 2, 0],
+  0x2510: [0, 0, 1, 1],
+  0x2511: [0, 0, 1, 2],
+  0x2512: [0, 0, 2, 1],
+  0x2513: [0, 0, 2, 2],
+  0x2514: [1, 1, 0, 0],
+  0x2515: [1, 2, 0, 0],
+  0x2516: [2, 1, 0, 0],
+  0x2517: [2, 2, 0, 0],
+  0x2518: [1, 0, 0, 1],
+  0x2519: [1, 0, 0, 2],
+  0x251a: [2, 0, 0, 1],
+  0x251b: [2, 0, 0, 2],
+  0x251c: [1, 1, 1, 0],
+  0x251d: [1, 2, 1, 0],
+  0x251e: [2, 1, 1, 0],
+  0x251f: [1, 1, 2, 0],
+  0x2520: [2, 1, 2, 0],
+  0x2521: [2, 2, 1, 0],
+  0x2522: [1, 2, 2, 0],
+  0x2523: [2, 2, 2, 0],
+  0x2524: [1, 0, 1, 1],
+  0x2525: [1, 0, 1, 2],
+  0x2526: [2, 0, 1, 1],
+  0x2527: [1, 0, 2, 1],
+  0x2528: [2, 0, 2, 1],
+  0x2529: [2, 0, 1, 2],
+  0x252a: [1, 0, 2, 2],
+  0x252b: [2, 0, 2, 2],
+  0x252c: [0, 1, 1, 1],
+  0x252d: [0, 1, 1, 2],
+  0x252e: [0, 2, 1, 1],
+  0x252f: [0, 2, 1, 2],
+  0x2530: [0, 1, 2, 1],
+  0x2531: [0, 1, 2, 2],
+  0x2532: [0, 2, 2, 1],
+  0x2533: [0, 2, 2, 2],
+  0x2534: [1, 1, 0, 1],
+  0x2535: [1, 1, 0, 2],
+  0x2536: [1, 2, 0, 1],
+  0x2537: [1, 2, 0, 2],
+  0x2538: [2, 1, 0, 1],
+  0x2539: [2, 1, 0, 2],
+  0x253a: [2, 2, 0, 1],
+  0x253b: [2, 2, 0, 2],
+  0x253c: [1, 1, 1, 1],
+  0x253d: [1, 1, 1, 2],
+  0x253e: [1, 2, 1, 1],
+  0x253f: [1, 2, 1, 2],
+  0x2540: [2, 1, 1, 1],
+  0x2541: [1, 1, 2, 1],
+  0x2542: [2, 1, 2, 1],
+  0x2543: [2, 1, 1, 2],
+  0x2544: [2, 2, 1, 1],
+  0x2545: [1, 1, 2, 2],
+  0x2546: [1, 2, 2, 1],
+  0x2547: [2, 2, 1, 2],
+  0x2548: [1, 2, 2, 2],
+  0x2549: [2, 1, 2, 2],
+  0x254a: [2, 2, 2, 1],
+  0x254b: [2, 2, 2, 2],
+  // Half-line stubs.
+  0x2574: [0, 0, 0, 1],
+  0x2575: [1, 0, 0, 0],
+  0x2576: [0, 1, 0, 0],
+  0x2577: [0, 0, 1, 0],
+  0x2578: [0, 0, 0, 2],
+  0x2579: [2, 0, 0, 0],
+  0x257a: [0, 2, 0, 0],
+  0x257b: [0, 0, 2, 0],
+  0x257c: [0, 2, 0, 1],
+  0x257d: [1, 0, 2, 0],
+  0x257e: [0, 1, 0, 2],
+  0x257f: [2, 0, 1, 0],
+};
+
+// Dashed lines: codepoint -> [axis, weight, dashCount].
+const DASHES: Record<number, ['h' | 'v', number, number]> = {
+  0x2504: ['h', 1, 3],
+  0x2505: ['h', 2, 3],
+  0x2506: ['v', 1, 3],
+  0x2507: ['v', 2, 3],
+  0x2508: ['h', 1, 4],
+  0x2509: ['h', 2, 4],
+  0x250a: ['v', 1, 4],
+  0x250b: ['v', 2, 4],
+  0x254c: ['h', 1, 2],
+  0x254d: ['h', 2, 2],
+  0x254e: ['v', 1, 2],
+  0x254f: ['v', 2, 2],
+};
+
+const ROUNDED = new Set([0x256d, 0x256e, 0x256f, 0x2570]);
+const DIAGONALS = new Set([0x2571, 0x2572, 0x2573]);
+
+// Quadrant membership for block characters [UL, UR, LL, LR].
+const QUADRANTS: Record<number, [boolean, boolean, boolean, boolean]> = {
+  0x2596: [false, false, true, false],
+  0x2597: [false, false, false, true],
+  0x2598: [true, false, false, false],
+  0x2599: [true, false, true, true],
+  0x259a: [true, false, false, true],
+  0x259b: [true, true, true, false],
+  0x259c: [true, true, false, true],
+  0x259d: [false, true, false, false],
+  0x259e: [false, true, true, false],
+  0x259f: [false, true, true, true],
+};
+
+interface RendererInternals {
+  renderCellText(cell: GhosttyCell, col: number, row: number): void;
+  getCanvas(): HTMLCanvasElement;
+  getMetrics(): { width: number; height: number; baseline: number };
+  fontSize?: number;
+  __seamlessBoxPatched?: boolean;
+}
+
+function isHandledCodepoint(cp: number): boolean {
+  if (cp in ARMS || cp in DASHES || cp in QUADRANTS) return true;
+  if (ROUNDED.has(cp) || DIAGONALS.has(cp)) return true;
+  if (cp === 0x2550 || cp === 0x2551) return true; // straight double lines
+  if (cp >= 0x2580 && cp <= 0x2595) return true; // halves / eighths / shades
+  return false;
+}
+
+/**
+ * Draw a supported box-drawing or block glyph filling the whole cell.
+ * Returns true if the codepoint was handled, false to fall back to the font.
+ */
+function drawGlyph(renderer: RendererInternals, cell: GhosttyCell, col: number, row: number): boolean {
+  const cp = cell.codepoint;
+  if (!isHandledCodepoint(cp)) return false;
+
+  const canvas = renderer.getCanvas();
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return false;
+  const m = renderer.getMetrics();
+  const dpr = window.devicePixelRatio || 1;
+
+  // Tile in device pixels so adjacent cells share exact edges (no seams).
+  const cw = cell.width || 1;
+  const X = Math.round(col * m.width * dpr);
+  const right = Math.round((col + cw) * m.width * dpr);
+  const Y = Math.round(row * m.height * dpr);
+  const bottom = Math.round((row + 1) * m.height * dpr);
+  const W = right - X;
+  const H = bottom - Y;
+  const CX = X + Math.round(W / 2);
+  const CY = Y + Math.round(H / 2);
+
+  const fontSize = renderer.fontSize ?? m.height / 1.2;
+  const lightT = Math.max(1, Math.round((fontSize / 16) * dpr));
+  const heavyT = Math.max(lightT + 1, Math.round((fontSize / 8) * dpr));
+
+  const inverse = (cell.flags & CellFlag.INVERSE) !== 0;
+  const r = inverse ? cell.bg_r : cell.fg_r;
+  const g = inverse ? cell.bg_g : cell.fg_g;
+  const b = inverse ? cell.bg_b : cell.fg_b;
+
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
+  ctx.strokeStyle = ctx.fillStyle;
+  if (cell.flags & CellFlag.FAINT) ctx.globalAlpha = 0.5;
+
+  try {
+    if (cp >= 0x2580 && cp <= 0x259f) {
+      drawBlock(ctx, cp, X, Y, W, H);
+    } else if (cp === 0x2550 || cp === 0x2551) {
+      drawDouble(ctx, cp, X, Y, W, H, CX, CY, lightT, dpr);
+    } else if (cp in DASHES) {
+      const [axis, weight, count] = DASHES[cp];
+      drawDashed(ctx, axis, count, weight === 2 ? heavyT : lightT, X, Y, W, H, CX, CY);
+    } else if (ROUNDED.has(cp)) {
+      drawRounded(ctx, cp, X, Y, W, H, lightT);
+    } else if (DIAGONALS.has(cp)) {
+      drawDiagonal(ctx, cp, X, Y, W, H, lightT);
+    } else {
+      drawArms(ctx, ARMS[cp], X, Y, W, H, CX, CY, lightT, heavyT);
+    }
+  } finally {
+    ctx.restore();
+  }
+  return true;
+}
+
+function drawArms(
+  ctx: CanvasRenderingContext2D,
+  arms: [number, number, number, number],
+  X: number,
+  Y: number,
+  W: number,
+  H: number,
+  CX: number,
+  CY: number,
+  lightT: number,
+  heavyT: number,
+): void {
+  const [u, rt, d, l] = arms;
+  const th = (w: number) => (w === 2 ? heavyT : lightT);
+
+  if (l) ctx.fillRect(X, CY - (th(l) >> 1), CX - X, th(l));
+  if (rt) ctx.fillRect(CX, CY - (th(rt) >> 1), X + W - CX, th(rt));
+  if (u) ctx.fillRect(CX - (th(u) >> 1), Y, th(u), CY - Y);
+  if (d) ctx.fillRect(CX - (th(d) >> 1), CY, th(d), Y + H - CY);
+
+  const count = (u ? 1 : 0) + (rt ? 1 : 0) + (d ? 1 : 0) + (l ? 1 : 0);
+  if (count >= 2) {
+    // Fill the junction so corners and crosses join solidly.
+    const tv = Math.max(u ? th(u) : 0, d ? th(d) : 0, lightT);
+    const tc = Math.max(l ? th(l) : 0, rt ? th(rt) : 0, lightT);
+    ctx.fillRect(CX - (tv >> 1), CY - (tc >> 1), tv, tc);
+  }
+}
+
+function drawDashed(
+  ctx: CanvasRenderingContext2D,
+  axis: 'h' | 'v',
+  count: number,
+  t: number,
+  X: number,
+  Y: number,
+  W: number,
+  H: number,
+  CX: number,
+  CY: number,
+): void {
+  if (axis === 'h') {
+    const slot = W / count;
+    const dash = slot * 0.6;
+    for (let i = 0; i < count; i++) {
+      ctx.fillRect(Math.round(X + i * slot + (slot - dash) / 2), CY - (t >> 1), Math.max(1, Math.round(dash)), t);
+    }
+  } else {
+    const slot = H / count;
+    const dash = slot * 0.6;
+    for (let i = 0; i < count; i++) {
+      ctx.fillRect(CX - (t >> 1), Math.round(Y + i * slot + (slot - dash) / 2), t, Math.max(1, Math.round(dash)));
+    }
+  }
+}
+
+function drawRounded(
+  ctx: CanvasRenderingContext2D,
+  cp: number,
+  X: number,
+  Y: number,
+  W: number,
+  H: number,
+  t: number,
+): void {
+  const rx = W / 2;
+  const ry = H / 2;
+  ctx.lineWidth = t;
+  ctx.beginPath();
+  if (cp === 0x256d) ctx.ellipse(X + W, Y + H, rx, ry, 0, Math.PI, 1.5 * Math.PI);
+  else if (cp === 0x256e) ctx.ellipse(X, Y + H, rx, ry, 0, 1.5 * Math.PI, 2 * Math.PI);
+  else if (cp === 0x256f) ctx.ellipse(X, Y, rx, ry, 0, 0, 0.5 * Math.PI);
+  else ctx.ellipse(X + W, Y, rx, ry, 0, 0.5 * Math.PI, Math.PI); // 0x2570
+  ctx.stroke();
+}
+
+function drawDiagonal(
+  ctx: CanvasRenderingContext2D,
+  cp: number,
+  X: number,
+  Y: number,
+  W: number,
+  H: number,
+  t: number,
+): void {
+  ctx.lineWidth = t;
+  ctx.beginPath();
+  if (cp === 0x2571 || cp === 0x2573) {
+    ctx.moveTo(X, Y + H);
+    ctx.lineTo(X + W, Y);
+  }
+  if (cp === 0x2572 || cp === 0x2573) {
+    ctx.moveTo(X, Y);
+    ctx.lineTo(X + W, Y + H);
+  }
+  ctx.stroke();
+}
+
+function drawDouble(
+  ctx: CanvasRenderingContext2D,
+  cp: number,
+  X: number,
+  Y: number,
+  W: number,
+  H: number,
+  CX: number,
+  CY: number,
+  t: number,
+  dpr: number,
+): void {
+  const gap = Math.max(t, Math.round(1.5 * dpr));
+  if (cp === 0x2550) {
+    ctx.fillRect(X, CY - gap - (t >> 1), W, t);
+    ctx.fillRect(X, CY + gap - (t >> 1), W, t);
+  } else {
+    ctx.fillRect(CX - gap - (t >> 1), Y, t, H);
+    ctx.fillRect(CX + gap - (t >> 1), Y, t, H);
+  }
+}
+
+function drawBlock(ctx: CanvasRenderingContext2D, cp: number, X: number, Y: number, W: number, H: number): void {
+  const eighth = (n: number, total: number) => Math.round((total * n) / 8);
+
+  if (cp === 0x2580) {
+    // Upper half.
+    ctx.fillRect(X, Y, W, Math.round(H / 2));
+  } else if (cp >= 0x2581 && cp <= 0x2588) {
+    // Lower eighths (2581 = 1/8 .. 2588 = full).
+    const n = cp - 0x2580;
+    const h = eighth(n, H);
+    ctx.fillRect(X, Y + H - h, W, h);
+  } else if (cp >= 0x2589 && cp <= 0x258f) {
+    // Left eighths (2589 = 7/8 .. 258F = 1/8).
+    const n = 0x2590 - cp;
+    ctx.fillRect(X, Y, eighth(n, W), H);
+  } else if (cp === 0x2590) {
+    // Right half.
+    const w = Math.round(W / 2);
+    ctx.fillRect(X + W - w, Y, w, H);
+  } else if (cp === 0x2591 || cp === 0x2592 || cp === 0x2593) {
+    // Shades.
+    const alpha = cp === 0x2591 ? 0.25 : cp === 0x2592 ? 0.5 : 0.75;
+    const prev = ctx.globalAlpha;
+    ctx.globalAlpha = prev * alpha;
+    ctx.fillRect(X, Y, W, H);
+    ctx.globalAlpha = prev;
+  } else if (cp === 0x2594) {
+    // Upper one eighth.
+    ctx.fillRect(X, Y, W, eighth(1, H));
+  } else if (cp === 0x2595) {
+    // Right one eighth.
+    const w = eighth(1, W);
+    ctx.fillRect(X + W - w, Y, w, H);
+  } else {
+    // Quadrants (2596-259F).
+    const quads = QUADRANTS[cp];
+    if (!quads) return;
+    const hw = Math.round(W / 2);
+    const hh = Math.round(H / 2);
+    const [ul, ur, ll, lr] = quads;
+    if (ul) ctx.fillRect(X, Y, hw, hh);
+    if (ur) ctx.fillRect(X + hw, Y, W - hw, hh);
+    if (ll) ctx.fillRect(X, Y + hh, hw, H - hh);
+    if (lr) ctx.fillRect(X + hw, Y + hh, W - hw, H - hh);
+  }
+}
+
+/**
+ * Patch ghostty-web's CanvasRenderer so box-drawing and block glyphs render as
+ * geometry that fills the cell. Patches the prototype once, so it applies to
+ * every terminal and survives renderer recreation (e.g. font changes). Safe to
+ * call repeatedly — only the first call mutates the prototype.
+ */
+export function installSeamlessBoxDrawing(term: Terminal): void {
+  const renderer = (term as unknown as { renderer?: RendererInternals }).renderer;
+  if (!renderer) return;
+
+  const proto = Object.getPrototypeOf(renderer) as RendererInternals;
+  if (proto.__seamlessBoxPatched) return;
+  if (typeof proto.renderCellText !== 'function') {
+    boxDrawingLog.warn('renderCellText not found on renderer prototype; box-drawing fix not applied');
+    return;
+  }
+
+  const original = proto.renderCellText;
+  proto.renderCellText = function (this: RendererInternals, cell: GhosttyCell, col: number, row: number): void {
+    if (
+      cell &&
+      cell.codepoint >= 0x2500 &&
+      cell.codepoint <= 0x259f &&
+      cell.grapheme_len === 0 &&
+      !(cell.flags & CellFlag.INVISIBLE) &&
+      !(cell.flags & CellFlag.UNDERLINE)
+    ) {
+      if (drawGlyph(this, cell, col, row)) return;
+    }
+    original.call(this, cell, col, row);
+  };
+  proto.__seamlessBoxPatched = true;
+  boxDrawingLog.info('installed seamless box-drawing renderer');
+}

--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -1,14 +1,16 @@
 /**
- * OuijitTerminal (React) — encapsulates xterm instance, PTY lifecycle,
- * and display state push to Zustand terminalStore.
+ * OuijitTerminal (React) — encapsulates the ghostty-web terminal instance,
+ * PTY lifecycle, and display state push to Zustand terminalStore.
  *
  * React owns the card chrome (header, tags, git stats, runner panel).
- * This class owns only the xterm viewport and imperative PTY wiring.
+ * This class owns only the terminal viewport and imperative PTY wiring.
+ *
+ * ghostty-web exposes an xterm.js-compatible API (Terminal, FitAddon,
+ * buffer/selection/scroll methods), so the `xterm` property name is kept
+ * for the rest of the renderer.
  */
 
-import { Terminal as XTerminal } from '@xterm/xterm';
-import { FitAddon } from '@xterm/addon-fit';
-import { WebLinksAddon } from '@xterm/addon-web-links';
+import { Terminal as XTerminal, FitAddon, UrlRegexProvider, type ILink } from 'ghostty-web';
 import type { PtyId, PtySpawnOptions, GitFileStatus } from '../../types';
 import { notifyReady, readyBody } from '../../utils/notifications';
 import { generateId } from '../../utils/ids';
@@ -69,9 +71,6 @@ function getTerminalTheme(): Record<string, string> {
     cursor: '#e4e4e4',
     cursorAccent: '#171717',
     selectionBackground: 'rgba(255, 255, 255, 0.15)',
-    scrollbarSliderBackground: 'rgba(255, 255, 255, 0.15)',
-    scrollbarSliderHoverBackground: 'rgba(255, 255, 255, 0.3)',
-    scrollbarSliderActiveBackground: 'rgba(255, 255, 255, 0.4)',
     black: '#171717',
     red: '#ff6b6b',
     green: '#69db7c',
@@ -100,9 +99,9 @@ function setupTerminalAppHotkeys(terminal: XTerminal, writeToPty: (data: string)
 
     // Shift+Enter — emit the Kitty keyboard-protocol CSI 13;2u sequence so
     // TUIs (Claude Code, Pi, Codex) insert a line break instead of submitting.
-    // xterm.js otherwise maps Shift+Enter to a plain CR, identical to Enter.
-    // Pi only recognizes shift+enter via CSI-u when the kitty protocol is
-    // inactive — the previous ESC+CR (`\x1b\r`) was parsed by Pi as
+    // The terminal otherwise maps Shift+Enter to a plain CR, identical to
+    // Enter. Pi only recognizes shift+enter via CSI-u when the kitty protocol
+    // is inactive — the previous ESC+CR (`\x1b\r`) was parsed by Pi as
     // alt+enter and queued a follow-up instead of breaking the line. See
     // pi-mono/packages/tui/src/keys.ts.
     if (
@@ -113,10 +112,10 @@ function setupTerminalAppHotkeys(terminal: XTerminal, writeToPty: (data: string)
       !event.metaKey &&
       !event.altKey
     ) {
-      // preventDefault is required: returning false alone skips xterm's
-      // keydown handling but also skips the preventDefault it would have
-      // done, so the textarea still emits a trailing carriage return that
-      // submits the prompt right after our newline.
+      // preventDefault is required: returning false alone skips the
+      // terminal's keydown handling but also skips the preventDefault it
+      // would have done, so the hidden textarea still emits a trailing
+      // carriage return that submits the prompt right after our newline.
       event.preventDefault();
       writeToPty('\x1b[13;2u');
       return false;
@@ -230,6 +229,13 @@ export function resolveTerminalLabel(
 
 /** Global registry of OuijitTerminal instances by ptyId */
 export const terminalInstances = new Map<string, OuijitTerminal>();
+
+// Expose for e2e tests — ghostty-web renders to canvas, so Playwright reads
+// terminal text through the buffer API instead of querying DOM rows.
+// Guarded: some unit tests import this module in a node environment.
+if (typeof window !== 'undefined') {
+  (window as any).__terminalInstances = terminalInstances;
+}
 
 // ── Terminal font (global setting cache) ─────────────────────────────
 
@@ -470,12 +476,11 @@ export class OuijitTerminal {
     this.summaryType = opts.initialSummaryType ?? 'ready';
     this.tags = opts.tags ?? [];
 
-    // Create xterm instance
+    // Create ghostty-web terminal instance
     this.xterm = new XTerminal({
       theme: getTerminalTheme(),
       fontFamily: cachedTerminalFontFamily,
       fontSize: cachedTerminalFontSize,
-      lineHeight: 1.2,
       cursorBlink: !this.isRunner,
       cursorStyle: 'bar',
       allowTransparency: false,
@@ -484,11 +489,6 @@ export class OuijitTerminal {
 
     this.fitAddon = new FitAddon();
     this.xterm.loadAddon(this.fitAddon);
-    this.xterm.loadAddon(
-      new WebLinksAddon((_event, uri) => {
-        window.api.openExternal(uri);
-      }),
-    );
 
     setupTerminalAppHotkeys(this.xterm, (data) => {
       if (this.ptyId) window.api.pty.write(this.ptyId, data);
@@ -526,9 +526,29 @@ export class OuijitTerminal {
 
   // ── Public API ──────────────────────────────────────────────────────
 
-  /** Open the xterm in its viewport element and set up drag/drop. */
+  /** Open the terminal in its viewport element and set up links + drag/drop. */
   openTerminal(): void {
     this.xterm.open(this.viewportElement);
+
+    // URL detection: reuse ghostty-web's regex provider but route activation
+    // through the main process so links open in the system browser instead of
+    // a new Electron window. Must run after open() — ghostty-web rejects link
+    // providers on an unopened terminal.
+    const urlProvider = new UrlRegexProvider(this.xterm);
+    this.xterm.registerLinkProvider({
+      provideLinks: (y: number, callback: (links: ILink[] | undefined) => void) => {
+        urlProvider.provideLinks(y, (links) => {
+          callback(
+            links?.map((link) => ({
+              ...link,
+              activate: () => window.api.openExternal(link.text),
+            })),
+          );
+        });
+      },
+      dispose: () => urlProvider.dispose(),
+    });
+
     this.wireDragDrop(this.viewportElement);
   }
 
@@ -953,7 +973,7 @@ export class OuijitTerminal {
   }
 
   private wireDragDrop(xtermContainer: HTMLElement): void {
-    const screen = xtermContainer.querySelector('.xterm-screen');
+    const screen = xtermContainer.querySelector('canvas');
     const target = screen || xtermContainer;
 
     target.addEventListener('dragover', (e) => {

--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -94,6 +94,9 @@ function getTerminalTheme(): Record<string, string> {
 const isMac = navigator.platform.toLowerCase().includes('mac');
 
 function setupTerminalAppHotkeys(terminal: XTerminal, writeToPty: (data: string) => void): void {
+  // ghostty-web's custom key handler semantics are INVERTED from xterm.js:
+  // returning true consumes the event (the terminal preventDefaults and skips
+  // its own key processing); returning false lets the terminal handle the key.
   terminal.attachCustomKeyEventHandler((event) => {
     const hasModifier = isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;
 
@@ -112,13 +115,8 @@ function setupTerminalAppHotkeys(terminal: XTerminal, writeToPty: (data: string)
       !event.metaKey &&
       !event.altKey
     ) {
-      // preventDefault is required: returning false alone skips the
-      // terminal's keydown handling but also skips the preventDefault it
-      // would have done, so the hidden textarea still emits a trailing
-      // carriage return that submits the prompt right after our newline.
-      event.preventDefault();
       writeToPty('\x1b[13;2u');
-      return false;
+      return true;
     }
 
     if (hasModifier && !event.altKey) {
@@ -129,30 +127,32 @@ function setupTerminalAppHotkeys(terminal: XTerminal, writeToPty: (data: string)
         if (key === 'c') {
           const selection = terminal.getSelection();
           if (selection) navigator.clipboard.writeText(selection);
-          return false;
+          return true;
         }
         if (key === 'v') {
-          event.preventDefault();
           navigator.clipboard.readText().then((text) => {
             if (text) terminal.paste(text);
           });
-          return false;
+          return true;
         }
       }
 
-      // Mod+Shift+Arrow for page navigation
+      // Mod+Shift+Arrow for page navigation — consumed here so the terminal
+      // doesn't see them; the app's capture-phase document listener handles
+      // the actual page switch.
       if (event.shiftKey && (key === 'arrowleft' || key === 'arrowright')) {
-        return false;
+        return true;
       }
 
-      // App hotkeys that should pass through to hotkeys-js
+      // App hotkeys — consume so the terminal ignores them; hotkeys-js and the
+      // app's document-level listeners still receive the event via bubbling.
       const appHotkeys = ['n', 't', 'b', 'i', 'p', 'd', 's', 'w', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
       if (appHotkeys.includes(key)) {
-        return false;
+        return true;
       }
     }
 
-    return true;
+    return false;
   });
 }
 

--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -17,6 +17,7 @@ import { generateId } from '../../utils/ids';
 import { useTerminalStore } from '../../stores/terminalStore';
 import { closeProjectTerminal } from './terminalActions';
 import { parseOsc133ExitCodes } from './osc133';
+import { installSeamlessBoxDrawing } from './boxDrawing';
 
 // ── Idle fallback timer constants ────────────────────────────────────
 const IDLE_FALLBACK_MS = 3000;
@@ -529,6 +530,11 @@ export class OuijitTerminal {
   /** Open the terminal in its viewport element and set up links + drag/drop. */
   openTerminal(): void {
     this.xterm.open(this.viewportElement);
+
+    // ghostty-web stamps box-drawing/block glyphs as font text in a cell box
+    // that's taller than the glyph, so borders render with gaps. Patch the
+    // renderer to draw those codepoints as cell-filling geometry instead.
+    installSeamlessBoxDrawing(this.xterm);
 
     // URL detection: reuse ghostty-web's regex provider but route activation
     // through the main process so links open in the system browser instead of

--- a/src/index.css
+++ b/src/index.css
@@ -562,26 +562,6 @@ textarea,
 }
 
 /* ===================================
-   xterm overrides — third-party DOM we don't control
-   =================================== */
-
-.terminal-xterm-container .xterm {
-  @apply h-full w-full;
-}
-
-.terminal-xterm-container .xterm-viewport {
-  background-color: transparent !important;
-}
-
-.runner-xterm-container .xterm {
-  @apply h-full w-full;
-}
-
-.runner-xterm-container .xterm-viewport {
-  background-color: transparent !important;
-}
-
-/* ===================================
    Plan panel markdown styles
    =================================== */
 

--- a/src/index.css
+++ b/src/index.css
@@ -562,6 +562,19 @@ textarea,
 }
 
 /* ===================================
+   Terminal (ghostty-web)
+   =================================== */
+
+/* ghostty-web draws the real cursor on its canvas and keeps a hidden textarea
+   for input/IME. The textarea is visually suppressed with opacity:0 but still
+   inherits a light caret-color, so when it takes focus Chromium paints a second
+   blinking caret at the viewport's top-left — "outside the shell". Suppress it. */
+.terminal-xterm-container textarea,
+.runner-xterm-container textarea {
+  caret-color: transparent;
+}
+
+/* ===================================
    Plan panel markdown styles
    =================================== */
 

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,10 +1,13 @@
 import './tailwind.css';
-import '@xterm/xterm/css/xterm.css';
+import { init as initGhostty } from 'ghostty-web';
 import { createRoot } from 'react-dom/client';
+import log from 'electron-log/renderer';
 import { App } from './App';
 import { initIcons } from './utils/icons';
 import { useAppStore } from './stores/appStore';
 import { useProjectStore } from './stores/projectStore';
+
+const rendererLog = log.scope('renderer');
 
 initIcons();
 
@@ -12,7 +15,16 @@ initIcons();
 (window as any).__appStore = useAppStore;
 (window as any).__projectStore = useProjectStore;
 
+// ghostty-web's WASM module must finish loading before any Terminal is
+// constructed, so gate the first render on it. Terminals are only created
+// after mount (user action or session restore), never at module scope.
 const root = document.getElementById('root');
 if (root) {
-  createRoot(root).render(<App />);
+  initGhostty()
+    .catch((error) => {
+      rendererLog.error('ghostty wasm init failed', { error: error instanceof Error ? error.message : String(error) });
+    })
+    .then(() => {
+      createRoot(root).render(<App />);
+    });
 }

--- a/src/utils/keyboard.ts
+++ b/src/utils/keyboard.ts
@@ -1,0 +1,22 @@
+/**
+ * Shortcuts that belong to Electron / the OS, not the terminal.
+ *
+ * ghostty-web's input handler calls preventDefault on every key it processes,
+ * so when a terminal is focused these would be swallowed. Both the home and
+ * project capture-phase keydown handlers call this — keeping behavior identical
+ * across views — to stop the event before it reaches the terminal WITHOUT
+ * preventing the default, so Electron's native accelerators (reload, quit)
+ * still fire.
+ *
+ * The caller must have already confirmed the platform modifier (Cmd/Ctrl) is
+ * held. Returns true if the event was a system shortcut and was handled (the
+ * caller should then return).
+ */
+export function passThroughSystemShortcut(e: KeyboardEvent): boolean {
+  const key = e.key.toLowerCase();
+  if (key === 'r' || key === 'q') {
+    e.stopPropagation();
+    return true;
+  }
+  return false;
+}

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
     minify: false,
   },
   optimizeDeps: {
-    exclude: ['xterm'],
+    exclude: ['ghostty-web'],
   },
 });


### PR DESCRIPTION
## Summary

- Replace xterm.js (`@xterm/*`) with libghostty (`ghostty-web`) for terminal emulation, keeping the `xterm`-compatible API surface so the rest of the renderer is unchanged
- Adapt the custom key-event handler to ghostty-web's inverted semantics (return `true` to consume), preserving Shift+Enter CSI-u, copy/paste, page navigation, and app hotkey passthrough
- Render box-drawing and block glyphs procedurally so borders draw without gaps
- Route URL link activation through the main process so links open in the system browser
- Fix terminal input and double-cursor issues surfaced by the migration
- Let Cmd+R and Cmd+Q reach Electron when a terminal is focused (home and project views)
- Update e2e tests to match intended app behavior: context menu uses "Move to Trash"; reload restores to the home view (resumable snapshot) so the reconnect test gates on the reconnected terminal instance; in-progress drops always spawn a terminal, so cancelling the start hook still creates a plain shell