### PR TITLE
Terminal renderer port (swappable backend)

### DIFF
--- a/src/components/terminal/rendererPort.ts
+++ b/src/components/terminal/rendererPort.ts
@@ -1,0 +1,105 @@
+/**
+ * Terminal renderer port.
+ *
+ * Separates the VT core (PTY wiring, status logic, display state — owned by
+ * OuijitTerminal) from the renderer implementation that actually paints the
+ * grid. The port is the swap point: today the only backend is xterm.js
+ * (`XtermRenderer`), but a future renderer built against another VT engine's
+ * render-state API (e.g. a WebGL surface over libghostty) can drop in by
+ * implementing the same interface, without touching OuijitTerminal or the app.
+ *
+ * The port surface is deliberately small — the five operations every backend
+ * must provide. Backend-specific affordances (xterm addons, custom key
+ * handlers, selection, paste) stay on the concrete class as additional public
+ * members; OuijitTerminal reaches them through the typed backend handle.
+ */
+
+import { Terminal as XTerminal, type ITheme } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { WebLinksAddon } from '@xterm/addon-web-links';
+
+/**
+ * Read-only handle on the terminal's active grid buffer. xterm-compatible by
+ * construction (it *is* xterm's `IBuffer`), which keeps it aligned with the
+ * #460 readBuffer contract. Derived from the xterm typings because `IBuffer`
+ * is not exported as a named symbol.
+ */
+export type RendererBuffer = XTerminal['buffer']['active'];
+
+/**
+ * The swappable renderer surface. Everything the VT core needs to drive a
+ * renderer, and nothing it doesn't.
+ */
+export interface TerminalRenderer {
+  /** Feed raw VT bytes/string into the renderer's parser. */
+  write(data: string): void;
+  /** Resize the rendered grid to `cols` × `rows`. */
+  resize(cols: number, rows: number): void;
+  /** Read the active grid buffer (xterm `IBuffer`-compatible). */
+  readBuffer(): RendererBuffer;
+  /** Mount the renderer into a DOM target element. */
+  render(target: HTMLElement): void;
+  /** Tear down the renderer and release its resources. */
+  dispose(): void;
+}
+
+export interface XtermRendererOptions {
+  theme: ITheme;
+  fontFamily: string;
+  fontSize: number;
+  /** Runner terminals don't blink the cursor (they're transient, non-interactive). */
+  isRunner: boolean;
+  /** Invoked when the user clicks a detected link in the terminal. */
+  onLinkClick: (uri: string) => void;
+}
+
+/**
+ * The xterm.js backend — the libghostty-spike conclusion landing point: web
+ * renderer (xterm canvas) behind the port. Owns the `Terminal` instance, the
+ * fit addon, and the web-links addon. Exposes `terminal` and `fitAddon` so the
+ * xterm-coupled bits of OuijitTerminal (custom key handling, scroll
+ * preservation, selection, paste, drag/drop, font/option mutation) keep working
+ * unchanged — those are inherently web-renderer concerns and a different
+ * backend would reimplement them against its own primitives.
+ */
+export class XtermRenderer implements TerminalRenderer {
+  readonly terminal: XTerminal;
+  readonly fitAddon: FitAddon;
+
+  constructor(opts: XtermRendererOptions) {
+    this.terminal = new XTerminal({
+      theme: opts.theme,
+      fontFamily: opts.fontFamily,
+      fontSize: opts.fontSize,
+      lineHeight: 1.2,
+      cursorBlink: !opts.isRunner,
+      cursorStyle: 'bar',
+      allowTransparency: false,
+      scrollback: 2000,
+    });
+
+    this.fitAddon = new FitAddon();
+    this.terminal.loadAddon(this.fitAddon);
+    this.terminal.loadAddon(new WebLinksAddon((_event, uri) => opts.onLinkClick(uri)));
+  }
+
+  write(data: string): void {
+    this.terminal.write(data);
+  }
+
+  resize(cols: number, rows: number): void {
+    this.terminal.resize(cols, rows);
+  }
+
+  readBuffer(): RendererBuffer {
+    return this.terminal.buffer.active;
+  }
+
+  render(target: HTMLElement): void {
+    this.terminal.open(target);
+  }
+
+  dispose(): void {
+    this.terminal.dispose();
+  }
+}

--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -8,8 +8,8 @@
 
 import { Terminal as XTerminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
-import { WebLinksAddon } from '@xterm/addon-web-links';
 import type { PtyId, PtySpawnOptions, GitFileStatus } from '../../types';
+import { XtermRenderer, type TerminalRenderer } from './rendererPort';
 import { notifyReady, readyBody } from '../../utils/notifications';
 import { generateId } from '../../utils/ids';
 import { useTerminalStore } from '../../stores/terminalStore';
@@ -369,9 +369,22 @@ export class OuijitTerminal {
   command: string | undefined;
   readonly isRunner: boolean;
 
-  // ── xterm + viewport ───────────────────────────────────────────────
-  readonly xterm: XTerminal;
-  readonly fitAddon: FitAddon;
+  // ── Renderer (swappable backend) + viewport ─────────────────────────
+  // The VT core talks to the renderer through the TerminalRenderer port;
+  // `backend` is the concrete xterm.js implementation, kept typed so the
+  // xterm-coupled bits below (key handling, scroll preservation, selection)
+  // can reach the underlying Terminal. Swapping renderers is a one-line
+  // change at construction.
+  readonly renderer: TerminalRenderer;
+  private readonly backend: XtermRenderer;
+  /** The underlying xterm Terminal. Exposed for xterm-specific operations. */
+  get xterm(): XTerminal {
+    return this.backend.terminal;
+  }
+  /** The xterm fit addon. Exposed for layout fitting. */
+  get fitAddon(): FitAddon {
+    return this.backend.fitAddon;
+  }
   private viewportElement: HTMLDivElement;
 
   // ── PTY cleanup ─────────────────────────────────────────────────────
@@ -470,25 +483,15 @@ export class OuijitTerminal {
     this.summaryType = opts.initialSummaryType ?? 'ready';
     this.tags = opts.tags ?? [];
 
-    // Create xterm instance
-    this.xterm = new XTerminal({
+    // Create the renderer backend behind the swappable port.
+    this.backend = new XtermRenderer({
       theme: getTerminalTheme(),
       fontFamily: cachedTerminalFontFamily,
       fontSize: cachedTerminalFontSize,
-      lineHeight: 1.2,
-      cursorBlink: !this.isRunner,
-      cursorStyle: 'bar',
-      allowTransparency: false,
-      scrollback: 2000,
+      isRunner: this.isRunner,
+      onLinkClick: (uri) => window.api.openExternal(uri),
     });
-
-    this.fitAddon = new FitAddon();
-    this.xterm.loadAddon(this.fitAddon);
-    this.xterm.loadAddon(
-      new WebLinksAddon((_event, uri) => {
-        window.api.openExternal(uri);
-      }),
-    );
+    this.renderer = this.backend;
 
     setupTerminalAppHotkeys(this.xterm, (data) => {
       if (this.ptyId) window.api.pty.write(this.ptyId, data);
@@ -526,9 +529,9 @@ export class OuijitTerminal {
 
   // ── Public API ──────────────────────────────────────────────────────
 
-  /** Open the xterm in its viewport element and set up drag/drop. */
+  /** Mount the renderer in its viewport element and set up drag/drop. */
   openTerminal(): void {
-    this.xterm.open(this.viewportElement);
+    this.renderer.render(this.viewportElement);
     this.wireDragDrop(this.viewportElement);
   }
 
@@ -671,17 +674,17 @@ export class OuijitTerminal {
     const currentRows = this.xterm.rows;
 
     if (lastCols && lastCols !== currentCols) {
-      this.xterm.resize(lastCols, currentRows);
+      this.renderer.resize(lastCols, currentRows);
     }
 
     if (isAltScreen) {
-      this.xterm.write('\x1b[?1049h');
+      this.renderer.write('\x1b[?1049h');
     }
 
-    this.xterm.write(buffer);
+    this.renderer.write(buffer);
 
     if (lastCols && lastCols !== currentCols) {
-      this.xterm.resize(currentCols, currentRows);
+      this.renderer.resize(currentCols, currentRows);
     }
 
     const oscMatches = buffer.matchAll(/\x1b\]0;([^\x07]*)\x07/g);
@@ -754,8 +757,8 @@ export class OuijitTerminal {
     // Disconnect observers
     this.resizeObserver?.disconnect();
 
-    // Dispose xterm
-    this.xterm.dispose();
+    // Dispose the renderer
+    this.renderer.dispose();
 
     // Remove from instance registry
     if (this.ptyId) {
@@ -878,7 +881,7 @@ export class OuijitTerminal {
 
   private wireDataHandler(skipSideEffects?: boolean, onData?: (data: string) => void): void {
     this.cleanupData = window.api.pty.onData(this.ptyId, (data) => {
-      const buf = this.xterm.buffer.active;
+      const buf = this.renderer.readBuffer();
       const atBottom = buf.viewportY >= buf.baseY;
 
       // Capture scroll position on the first write of a batch (while value is still trustworthy)
@@ -888,15 +891,15 @@ export class OuijitTerminal {
         this._scrollRestoreY = null;
       }
 
-      this.xterm.write(data);
+      this.renderer.write(data);
 
-      // Coalesce into a single rAF so the restore runs after xterm's render pass
+      // Coalesce into a single rAF so the restore runs after the render pass
       if (this._scrollRestoreY !== null && this._scrollRestoreRaf === null) {
         const targetY = this._scrollRestoreY;
         this._scrollRestoreRaf = requestAnimationFrame(() => {
           this._scrollRestoreRaf = null;
           this._scrollRestoreY = null;
-          const maxY = this.xterm.buffer.active.baseY;
+          const maxY = this.renderer.readBuffer().baseY;
           this.xterm.scrollToLine(Math.min(targetY, maxY));
         });
       }


### PR DESCRIPTION
## Summary
- Introduce `TerminalRenderer`, a small 5-method renderer port (`write`, `resize`, `readBuffer`, `render`, `dispose`) separating the VT core/PTY wiring from the implementation that paints the grid
- Move today's xterm.js renderer behind it as `XtermRenderer`, the first backend; `OuijitTerminal` reaches xterm-specific affordances through a typed backend handle
- `readBuffer` returns an xterm `IBuffer`-compatible handle, aligned with the #460 Session buffer contract
- No behavior change; a future WebGL-over-libghostty renderer can drop in by implementing the same interface (per the libghostty spike conclusion)