### PR TITLE
Fix run hook losing parent terminal on app refresh

### DIFF
--- a/src/__tests__/renderer/reconnectRunner.test.tsx
+++ b/src/__tests__/renderer/reconnectRunner.test.tsx
@@ -1,0 +1,106 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('electron-log/renderer', () => ({
+  default: { scope: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
+}));
+
+// Stand-in for the xterm-backed terminal module. terminalActions reaches the
+// same `terminalInstances` map the test does (imported back below). The fake
+// OuijitTerminal records the lifecycle calls reconnectRunnerToParent makes so
+// we can assert the runner reattaches to its parent rather than becoming a card.
+vi.mock('../../components/terminal/terminalReact', () => {
+  class FakeTerminal {
+    ptyId?: string;
+    label?: string;
+    isRunner: boolean;
+    runnerStatus: string | null = null;
+    runnerCommand: string | null = null;
+    setRunner = vi.fn();
+    pushDisplayState = vi.fn();
+    openTerminal = vi.fn();
+    replayBuffer = vi.fn();
+    bind = vi.fn();
+    dispose = vi.fn();
+    constructor(opts: { ptyId?: string; label?: string; isRunner?: boolean }) {
+      this.ptyId = opts.ptyId;
+      this.label = opts.label;
+      this.isRunner = opts.isRunner ?? false;
+    }
+  }
+  return {
+    terminalInstances: new Map(),
+    OuijitTerminal: FakeTerminal,
+    resolveTerminalLabel: (taskName?: string | null, branch?: string, fallback?: string) =>
+      taskName || branch || fallback || 'Shell',
+  };
+});
+
+import { reconnectRunnerToParent } from '../../components/terminal/terminalActions';
+import { terminalInstances, OuijitTerminal } from '../../components/terminal/terminalReact';
+import { useTerminalStore } from '../../stores/terminalStore';
+import type { ActiveSession } from '../../types';
+
+const PROJECT = '/project';
+
+interface FakeTerminal {
+  ptyId?: string;
+  runnerStatus: string | null;
+  setRunner: ReturnType<typeof vi.fn>;
+}
+
+function makeParent(ptyId: string): FakeTerminal {
+  const parent = new (OuijitTerminal as unknown as new (o: { ptyId: string }) => FakeTerminal)({ ptyId });
+  terminalInstances.set(ptyId, parent as never);
+  return parent;
+}
+
+function runnerSession(over: Partial<ActiveSession> = {}): ActiveSession {
+  return {
+    ptyId: 'runner-1',
+    projectPath: PROJECT,
+    command: 'npm run dev',
+    label: 'run hook',
+    isRunner: true,
+    parentPtyId: 'parent-1',
+    ...over,
+  } as ActiveSession;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  terminalInstances.clear();
+  useTerminalStore.setState({ terminalsByProject: {}, displayStates: {} } as never);
+  (window.api.pty.reconnect as ReturnType<typeof vi.fn>).mockResolvedValue({
+    success: true,
+    bufferedOutput: '',
+    lastCols: 80,
+    isAltScreen: false,
+  });
+});
+
+describe('reconnectRunnerToParent', () => {
+  test('reattaches the runner to its parent as panel state, not a standalone card', async () => {
+    const parent = makeParent('parent-1');
+
+    const ok = await reconnectRunnerToParent(runnerSession());
+
+    expect(ok).toBe(true);
+    // Runner state lands on the parent...
+    expect(parent.setRunner).toHaveBeenCalledTimes(1);
+    expect(parent.runnerStatus).toBe('running');
+    // ...and the runner is NOT promoted to its own card in the stack.
+    const stack = useTerminalStore.getState().terminalsByProject[PROJECT] ?? [];
+    expect(stack).not.toContain('runner-1');
+  });
+
+  test('does not promote the runner to a standalone card when the parent is missing', async () => {
+    // Parent never reconnected (e.g. wrong ordering) — leave the runner orphaned
+    // rather than spawning a bogus "run hook" card.
+    const ok = await reconnectRunnerToParent(runnerSession({ parentPtyId: 'absent' }));
+
+    expect(ok).toBe(false);
+    expect(window.api.pty.reconnect).not.toHaveBeenCalled();
+    const stack = useTerminalStore.getState().terminalsByProject[PROJECT] ?? [];
+    expect(stack).not.toContain('runner-1');
+  });
+});

--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -3,7 +3,12 @@ import { useAppStore } from '../stores/appStore';
 import { useTerminalStore } from '../stores/terminalStore';
 import { useUIStore } from '../stores/uiStore';
 import { terminalInstances } from './terminal/terminalReact';
-import { reconnectTerminal, addProjectTerminal, closeProjectTerminal } from './terminal/terminalActions';
+import {
+  reconnectTerminal,
+  reconnectRunnerToParent,
+  addProjectTerminal,
+  closeProjectTerminal,
+} from './terminal/terminalActions';
 import { TerminalHeader } from './terminal/TerminalHeader';
 import { TerminalBody } from './terminal/TerminalBody';
 import { XTermContainer } from './terminal/XTermContainer';
@@ -87,7 +92,14 @@ export function HomeView() {
       }
       if (sessions.length === 0) return;
 
-      for (const session of sessions) {
+      // Runners (run hooks / scripts) aren't standalone cards — they live as
+      // state on their parent terminal. Reconnect main terminals first so the
+      // parents are back in terminalInstances before runners reattach,
+      // otherwise a runner would be promoted to its own "run hook" card.
+      const mainSessions = sessions.filter((s) => !s.isRunner);
+      const runnerSessions = sessions.filter((s) => s.isRunner);
+
+      for (const session of mainSessions) {
         if (terminalInstances.has(session.ptyId)) continue;
         let worktreeBranch: string | undefined;
         if (session.taskId != null) {
@@ -104,6 +116,11 @@ export function HomeView() {
           term.planPath = planPath;
           term.pushDisplayState({ planPath });
         }
+      }
+
+      for (const session of runnerSessions) {
+        if (terminalInstances.has(session.ptyId)) continue;
+        await reconnectRunnerToParent(session);
       }
     })();
   }, [allPtyIds.length]);

--- a/src/components/terminal/terminalActions.ts
+++ b/src/components/terminal/terminalActions.ts
@@ -714,50 +714,64 @@ export async function reconnectOrphanedSessions(projectPath: string): Promise<vo
 
   // Reconnect runners to their parent terminals
   for (const session of runnerSessions) {
-    const parentTerminal = terminalInstances.get(session.parentPtyId!);
-    if (!parentTerminal) {
-      actionsLog.warn('could not find parent for runner', { ptyId: session.ptyId, parentPtyId: session.parentPtyId });
-      continue;
-    }
-
-    const runner = new OuijitTerminal({
-      projectPath: session.projectPath,
-      label: session.label,
-      isRunner: true,
-      ptyId: session.ptyId,
-    });
-    runner.openTerminal();
-
-    const result = await window.api.pty.reconnect(session.ptyId);
-    if (!result.success) {
-      runner.dispose();
-      continue;
-    }
-
-    runner.replayBuffer(result.bufferedOutput, result.lastCols, result.isAltScreen);
-    terminalInstances.set(session.ptyId, runner);
-    runner.bind(session.ptyId, {
-      skipSideEffects: true,
-      onData: (data) => {
-        const oscMatches = data.matchAll(/\x1b\]0;([^\x07]*)\x07/g);
-        for (const match of oscMatches) {
-          if (match[1]) {
-            parentTerminal.runnerCommand = match[1];
-            parentTerminal.pushDisplayState({ runnerStatus: parentTerminal.runnerStatus });
-          }
-        }
-        updateRunnerStatusFromOsc133(data, parentTerminal);
-        const detected = detectDevServerUrl(data);
-        if (detected) applyDetectedWebPreviewUrl(parentTerminal, detected);
-      },
-      onExit: (exitCode) => {
-        parentTerminal.runnerStatus = exitCode === 0 ? 'success' : 'error';
-        parentTerminal.pushDisplayState({ runnerStatus: parentTerminal.runnerStatus });
-      },
-    });
-
-    parentTerminal.runnerStatus = 'running';
-    parentTerminal.setRunner(runner);
-    parentTerminal.pushDisplayState({ runnerStatus: 'running' });
+    await reconnectRunnerToParent(session);
   }
+}
+
+/**
+ * Reattach a runner (run hook / script) session to its parent terminal after a
+ * renderer reload. The runner is NOT a standalone card — it lives as state on
+ * the parent (runnerStatus, the runner panel). The parent must already be back
+ * in `terminalInstances`, so callers reconnect main terminals first.
+ *
+ * Returns false if the parent could not be found (caller should leave the
+ * session orphaned rather than promote it to a standalone card).
+ */
+export async function reconnectRunnerToParent(session: ActiveSession): Promise<boolean> {
+  const parentTerminal = session.parentPtyId ? terminalInstances.get(session.parentPtyId) : undefined;
+  if (!parentTerminal) {
+    actionsLog.warn('could not find parent for runner', { ptyId: session.ptyId, parentPtyId: session.parentPtyId });
+    return false;
+  }
+
+  const runner = new OuijitTerminal({
+    projectPath: session.projectPath,
+    label: session.label,
+    isRunner: true,
+    ptyId: session.ptyId,
+  });
+  runner.openTerminal();
+
+  const result = await window.api.pty.reconnect(session.ptyId);
+  if (!result.success) {
+    runner.dispose();
+    return false;
+  }
+
+  runner.replayBuffer(result.bufferedOutput, result.lastCols, result.isAltScreen);
+  terminalInstances.set(session.ptyId, runner);
+  runner.bind(session.ptyId, {
+    skipSideEffects: true,
+    onData: (data) => {
+      const oscMatches = data.matchAll(/\x1b\]0;([^\x07]*)\x07/g);
+      for (const match of oscMatches) {
+        if (match[1]) {
+          parentTerminal.runnerCommand = match[1];
+          parentTerminal.pushDisplayState({ runnerStatus: parentTerminal.runnerStatus });
+        }
+      }
+      updateRunnerStatusFromOsc133(data, parentTerminal);
+      const detected = detectDevServerUrl(data);
+      if (detected) applyDetectedWebPreviewUrl(parentTerminal, detected);
+    },
+    onExit: (exitCode) => {
+      parentTerminal.runnerStatus = exitCode === 0 ? 'success' : 'error';
+      parentTerminal.pushDisplayState({ runnerStatus: parentTerminal.runnerStatus });
+    },
+  });
+
+  parentTerminal.runnerStatus = 'running';
+  parentTerminal.setRunner(runner);
+  parentTerminal.pushDisplayState({ runnerStatus: 'running' });
+  return true;
 }


### PR DESCRIPTION
## Summary
- The home view's session-reconnect path looped over every active PTY session and called `reconnectTerminal` on each, promoting runner (run hook / script) sessions to standalone "run hook" cards instead of reattaching them to their parent terminal.
- Extracted the runner-reattach logic from `reconnectOrphanedSessions` into a shared `reconnectRunnerToParent` helper, and used it in `HomeViewReact`: reconnect main terminals first so parents are back in `terminalInstances`, then reattach runners as parent panel state.
- Added a regression test covering the helper: a runner reattaches to its parent (`setRunner` / `runnerStatus`) and never enters the card stack, and stays orphaned rather than becoming a card when the parent is missing.