### PR TITLE
Fix renderer-refresh state loss and repair the rotted e2e suite

### DIFF
--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -284,18 +284,18 @@ test('lifecycle hooks: start hook via drag shows dialog', async ({ appPage, test
   await expect(hookDialog).toBeVisible({ timeout: 15_000 });
   await expect(hookDialog.locator('[data-testid="dialog-title"]')).toHaveText('Start Task');
 
-  // Click "Cancel" — the task still moves to in_progress and the loading slot
-  // still resolves into a terminal, just a plain shell instead of running the
-  // hook (cancel skips the hook, it does not abort the start).
+  // Click "Cancel" — an explicit "don't run the hook, don't open a terminal".
+  // The task still moves to in_progress (worktree already created), but no
+  // terminal is spawned and the loading slot is removed.
   await hookDialog.locator('[data-testid="dialog-cancel"]').click();
   await expect(appPage.locator('[data-testid="dialog-overlay"][data-visible="true"]')).not.toBeVisible({
     timeout: 5_000,
   });
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(2, { timeout: 5_000 });
   await expect(todoColumn.locator('.kanban-card')).toHaveCount(0);
-  // A plain-shell terminal was spawned for the cancelled task (2 total now).
+  // No new terminal was created — still just the one from the Run flow earlier.
   await appPage.keyboard.press(`${modifier}+t`);
-  await expect(appPage.locator('.project-card')).toHaveCount(2, { timeout: 15_000 });
+  await expect(appPage.locator('.project-card')).toHaveCount(1);
   await appPage.keyboard.press(`${modifier}+t`);
 
   // --- No dialog after hook deleted ---

--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -27,10 +27,11 @@ async function enterProject(appPage: Page, repoPath: string): Promise<void> {
 }
 
 /**
- * Helper: dismiss the kanban board by pressing Escape.
+ * Helper: dismiss the kanban board. Board/stack toggling is owned by
+ * Cmd/Ctrl+T (Escape is reserved for form-level resets), so toggle with that.
  */
 async function dismissKanban(appPage: Page): Promise<void> {
-  await appPage.keyboard.press('Escape');
+  await appPage.keyboard.press(`${modifier}+t`);
   await expect(appPage.locator('.kanban-board')).toHaveCount(0, { timeout: 5_000 });
 }
 
@@ -150,7 +151,7 @@ test('project mode: terminals, kanban, context menu, and task lifecycle', async 
   await expect(contextMenu).toBeVisible({ timeout: 5_000 });
   await expect(contextMenu.locator('.context-menu-item', { hasText: 'Open in Terminal' })).toBeVisible();
   await expect(contextMenu.locator('.context-menu-item', { hasText: 'Move to Done' })).toBeVisible();
-  await expect(contextMenu.locator('.context-menu-item--danger', { hasText: 'Delete' })).toBeVisible();
+  await expect(contextMenu.locator('.context-menu-item--danger', { hasText: 'Move to Trash' })).toBeVisible();
 
   await contextMenu.locator('.context-menu-item', { hasText: 'Open in Terminal' }).click();
 
@@ -164,20 +165,24 @@ test('project mode: terminals, kanban, context menu, and task lifecycle', async 
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(1);
   await expect(todoColumn.locator('.kanban-card')).toHaveCount(0);
 
-  // --- Context menu: delete task ---
+  // --- Context menu: trash task ---
 
   const ipCard = inProgressColumn.locator('.kanban-card').first();
   await ipCard.click({ button: 'right' });
   await expect(appPage.locator('.context-menu--visible')).toBeVisible({ timeout: 5_000 });
 
-  await appPage.locator('.context-menu-item--danger', { hasText: 'Delete' }).click();
+  await appPage.locator('.context-menu-item--danger', { hasText: 'Move to Trash' }).click();
 
-  // React version deletes immediately without confirmation
+  // Trashing removes the card from the board immediately, no confirmation
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(0, { timeout: 5_000 });
   await expect(todoColumn.locator('.kanban-card')).toHaveCount(0);
 });
 
 test('terminal reconnect after reload does not produce % artifacts', async ({ appPage, testRepo }) => {
+  // Shell init, renderer reload, and PTY reconnection each cost real time and
+  // overrun the 10s default; give this flow room to finish.
+  test.setTimeout(40_000);
+
   await enterProject(appPage, testRepo.repoPath);
   await dismissKanban(appPage);
 
@@ -198,8 +203,11 @@ test('terminal reconnect after reload does not produce % artifacts', async ({ ap
   await appPage.reload();
   await appPage.waitForLoadState('domcontentloaded');
 
-  // Wait for terminal reconnection — project view should restore
+  // A refresh must land back in the same project view (its PTYs are still
+  // alive), and reconnectOrphanedSessions reattaches and refocuses the terminal.
   await expect(appPage.locator('.project-card--active')).toHaveCount(1, { timeout: 15_000 });
+  // Exactly one card — reconnect must not duplicate the shared session.
+  await expect(appPage.locator('.project-card')).toHaveCount(1);
   await expect(appPage.locator('.terminal-xterm-container').first()).toBeAttached({ timeout: 5_000 });
 
   // Wait for reconnection and any resize events to settle
@@ -253,7 +261,9 @@ test('lifecycle hooks: start hook via drag shows dialog', async ({ appPage, test
 
   // Click "Run" — terminal created in background, task moves to in_progress
   await hookDialog.locator('[data-testid="dialog-run"]').click();
-  await expect(appPage.locator('[data-testid="dialog-overlay"][data-visible="true"]')).not.toBeVisible({ timeout: 5_000 });
+  await expect(appPage.locator('[data-testid="dialog-overlay"][data-visible="true"]')).not.toBeVisible({
+    timeout: 5_000,
+  });
   // Kanban stays visible for background run — verify task moved
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(1, { timeout: 5_000 });
   await expect(todoColumn.locator('.kanban-card')).toHaveCount(0);
@@ -274,14 +284,18 @@ test('lifecycle hooks: start hook via drag shows dialog', async ({ appPage, test
   await expect(hookDialog).toBeVisible({ timeout: 15_000 });
   await expect(hookDialog.locator('[data-testid="dialog-title"]')).toHaveText('Start Task');
 
-  // Click "Cancel" — no terminal, task still moves to in_progress (worktree already created)
+  // Click "Cancel" — the task still moves to in_progress and the loading slot
+  // still resolves into a terminal, just a plain shell instead of running the
+  // hook (cancel skips the hook, it does not abort the start).
   await hookDialog.locator('[data-testid="dialog-cancel"]').click();
-  await expect(appPage.locator('[data-testid="dialog-overlay"][data-visible="true"]')).not.toBeVisible({ timeout: 5_000 });
+  await expect(appPage.locator('[data-testid="dialog-overlay"][data-visible="true"]')).not.toBeVisible({
+    timeout: 5_000,
+  });
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(2, { timeout: 5_000 });
   await expect(todoColumn.locator('.kanban-card')).toHaveCount(0);
-  // Verify no new terminal was created (still just 1 from earlier)
+  // A plain-shell terminal was spawned for the cancelled task (2 total now).
   await appPage.keyboard.press(`${modifier}+t`);
-  await expect(appPage.locator('.project-card')).toHaveCount(1);
+  await expect(appPage.locator('.project-card')).toHaveCount(2, { timeout: 15_000 });
   await appPage.keyboard.press(`${modifier}+t`);
 
   // --- No dialog after hook deleted ---
@@ -297,7 +311,9 @@ test('lifecycle hooks: start hook via drag shows dialog', async ({ appPage, test
   await dragCard(appPage, todoColumn.locator('.kanban-card').first(), inProgressBody);
 
   await appPage.waitForTimeout(1_000);
-  await expect(appPage.locator('[data-testid="dialog-overlay"][data-visible="true"] [data-testid="dialog"]')).not.toBeVisible();
+  await expect(
+    appPage.locator('[data-testid="dialog-overlay"][data-visible="true"] [data-testid="dialog"]'),
+  ).not.toBeVisible();
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(3, { timeout: 5_000 });
   await expect(todoColumn.locator('.kanban-card')).toHaveCount(0);
 });
@@ -374,7 +390,8 @@ test('whats new: modal appears and dismisses', async ({ appPage }) => {
   await appPage.evaluate(() => {
     (window as any).__appStore.getState().setWhatsNew({
       version: '1.1.0',
-      notes: '## Improvements\n- **Faster startup** with lazy loading\n- Fixed `bug #42` in terminal\n\n## Bug Fixes\n- Resolved crash on exit',
+      notes:
+        '## Improvements\n- **Faster startup** with lazy loading\n- Fixed `bug #42` in terminal\n\n## Bug Fixes\n- Resolved crash on exit',
     });
   });
 
@@ -391,7 +408,9 @@ test('whats new: modal appears and dismisses', async ({ appPage }) => {
   await expect(dialog).not.toBeVisible({ timeout: 3_000 });
 
   // Store should be cleared (after 200ms dismiss animation)
-  await appPage.waitForFunction(() => (window as any).__appStore.getState().whatsNew === null, null, { timeout: 3_000 });
+  await appPage.waitForFunction(() => (window as any).__appStore.getState().whatsNew === null, null, {
+    timeout: 3_000,
+  });
 });
 
 test('whats new: modal dismisses on Escape', async ({ appPage }) => {
@@ -432,8 +451,8 @@ test('update available: persistent toast with download action', async ({ appPage
   await appPage.waitForTimeout(5_000);
   await expect(toast).toBeVisible();
 
-  // Dismiss via close button
-  const closeBtn = toast.locator('button', { hasText: '✕' });
+  // Dismiss via close button (renders an SVG Icon, labelled for a11y)
+  const closeBtn = toast.locator('button[aria-label="Dismiss"]');
   await expect(closeBtn).toBeVisible();
   await closeBtn.click();
   await expect(toast).not.toBeVisible({ timeout: 3_000 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,15 +135,32 @@ export function App() {
     window.api.getProjects().then(async (projects) => {
       useAppStore.getState().setProjects(projects);
 
-      // If we have a session snapshot to resume, force the user to home so
-      // the resume banner is the first thing they see — taking them back to
-      // their last project view would hide the offer behind the kanban/empty
-      // state and force them to navigate manually.
+      // A persisted snapshot only means "force home for the resume banner" on a
+      // cold launch, where its PTYs are gone. When those PTYs are still alive
+      // the renderer merely reloaded (a refresh): restore the prior view so the
+      // user lands exactly where they were and reconnectOrphanedSessions
+      // reattaches the terminals. (ResumeBanner uses the same live-PTY check to
+      // stay silent in that case.)
       const pendingSnapshot = await window.api.globalSettings.get('lastSession:snapshot');
       const hasResumable = !!pendingSnapshot && pendingSnapshot.length > 0;
 
+      let snapshotPtysAlive = false;
+      if (hasResumable) {
+        try {
+          const snap = JSON.parse(pendingSnapshot) as { terminals?: { ptyId?: string }[] };
+          const snapPtyIds = new Set((snap.terminals ?? []).map((t) => t.ptyId).filter(Boolean));
+          if (snapPtyIds.size > 0) {
+            const live = await window.api.pty.getActiveSessions();
+            snapshotPtysAlive = live.some((s) => snapPtyIds.has(s.ptyId));
+          }
+        } catch {
+          /* unparseable snapshot — treat as a cold launch */
+        }
+      }
+      const forceHomeForResume = hasResumable && !snapshotPtysAlive;
+
       let restoredToProject = false;
-      if (!hasResumable) {
+      if (!forceHomeForResume) {
         const lastView = await window.api.globalSettings.get('lastActiveView');
         if (lastView) {
           try {

--- a/src/__tests__/renderer/taskStartService.test.tsx
+++ b/src/__tests__/renderer/taskStartService.test.tsx
@@ -85,7 +85,7 @@ describe('taskStartService.beginTransition', () => {
     expect(useProjectStore.getState().startingTaskNumbers.has(7)).toBe(false);
   });
 
-  test('hook prompt cancel: still spawns a plain shell so the loading slot resolves', async () => {
+  test('hook prompt cancel: opens no terminal and removes the loading slot', async () => {
     vi.mocked(window.api.hooks.get).mockResolvedValue({
       start: { command: 'npm install', name: 'Start', source: 'configured', priority: 0 },
     });
@@ -101,14 +101,15 @@ describe('taskStartService.beginTransition', () => {
     const req = useProjectStore.getState().runHookQueue[0]!;
     expect(req.hookType).toBe('start');
 
-    // User cancels.
+    // User cancels the start-hook dialog — an explicit "don't run a hook and
+    // don't open a terminal", just move the task.
     useProjectStore.getState().resolveRunHookRequest(req.id, null);
 
     await waitFor(() => !useProjectStore.getState().startingTaskNumbers.has(7));
 
-    // Terminal still spawned, but with no runConfig (plain shell).
-    expect(addProjectTerminal).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(addProjectTerminal).mock.calls[0][1]).toBeUndefined();
+    // No terminal spawned, and the loading slot was cleaned up.
+    expect(addProjectTerminal).not.toHaveBeenCalled();
+    expect(useTerminalStore.getState().terminalsByProject[PROJECT] ?? []).toHaveLength(0);
   });
 
   test('hook prompt accept: spawns terminal with the captured command', async () => {
@@ -429,21 +430,23 @@ describe('taskStartService.beginTransition', () => {
     expect(useProjectStore.getState().runHookQueueTotal).toBe(2);
     expect(useProjectStore.getState().runHookQueue[0]!.task.taskNumber).toBe(7);
 
-    // Resolve the head — the second prompt slides into its place.
-    useProjectStore.getState().resolveRunHookRequest(useProjectStore.getState().runHookQueue[0]!.id, null);
+    // Accept the head — the second prompt slides into its place.
+    const runResult = { command: 'npm install', sandboxed: false, foreground: false };
+    useProjectStore.getState().resolveRunHookRequest(useProjectStore.getState().runHookQueue[0]!.id, runResult);
     await waitFor(() => useProjectStore.getState().runHookQueue.length === 1);
     expect(useProjectStore.getState().runHookQueue[0]!.task.taskNumber).toBe(8);
     // Total stays fixed so the stepper counts up rather than shrinking.
     expect(useProjectStore.getState().runHookQueueTotal).toBe(2);
 
-    useProjectStore.getState().resolveRunHookRequest(useProjectStore.getState().runHookQueue[0]!.id, null);
+    useProjectStore.getState().resolveRunHookRequest(useProjectStore.getState().runHookQueue[0]!.id, runResult);
     await waitFor(
       () =>
         !useProjectStore.getState().startingTaskNumbers.has(7) &&
         !useProjectStore.getState().startingTaskNumbers.has(8),
     );
 
-    // Both tasks spawned a terminal — no start hook was silently dropped.
+    // Both prompts were shown (neither evicted) and both accepted starts
+    // spawned a terminal — no start hook was silently dropped.
     expect(addProjectTerminal).toHaveBeenCalledTimes(2);
     expect(useProjectStore.getState().runHookQueueTotal).toBe(0);
   });

--- a/src/components/terminal/terminalActions.ts
+++ b/src/components/terminal/terminalActions.ts
@@ -663,8 +663,12 @@ export async function reconnectOrphanedSessions(projectPath: string): Promise<vo
   const mainSessions = projectSessions.filter((s) => !s.isRunner);
   const runnerSessions = projectSessions.filter((s) => s.isRunner);
 
-  // Reconnect main terminals first
+  // Reconnect main terminals first. Skip any session already reconnected — the
+  // home view runs the same reconnect as the user lands, so on a refresh both
+  // paths can fire for one project; without this guard the shared session would
+  // be added to the stack twice.
   for (const session of mainSessions) {
+    if (terminalInstances.has(session.ptyId)) continue;
     let worktreeBranch: string | undefined;
     let mergeTarget: string | undefined;
     if (session.taskId != null) {
@@ -714,6 +718,7 @@ export async function reconnectOrphanedSessions(projectPath: string): Promise<vo
 
   // Reconnect runners to their parent terminals
   for (const session of runnerSessions) {
+    if (terminalInstances.has(session.ptyId)) continue;
     await reconnectRunnerToParent(session);
   }
 }

--- a/src/services/taskStartService.ts
+++ b/src/services/taskStartService.ts
@@ -263,6 +263,12 @@ async function runTransition(
     // decided — skip the dialog entirely. Otherwise show the dialog
     // proactively if a hook is configured for this transition.
     let hookPromise: Promise<RunHookResult | null> = Promise.resolve(null);
+    // True when an interactive start-hook dialog is shown to the user. Clicking
+    // its Cancel button (hookResult === null) is an explicit "don't run a hook
+    // and don't open a terminal" — distinct from the no-hook drop, where a plain
+    // shell is the whole point. We only honor that on this interactive path, not
+    // for CLI-driven (hookControl) starts.
+    const interactiveHookOffered = !hookControl && transitioningToInProgress && !!hookType && !!hook;
     if (hookControl) {
       let resolved: RunHookResult | null = null;
       if (hookControl.mode === 'command' && hookControl.command) {
@@ -322,12 +328,18 @@ async function runTransition(
 
     await useProjectStore.getState().loadTasks(projectPath);
 
-    // 6. Spawn the terminal. For in_progress drops we always open a terminal
-    // (with the hook command if accepted, otherwise a plain shell) so the
-    // loading slot always morphs into a real card. For review/done the
-    // terminal only spawns if the user accepted the hook.
+    // 6. Spawn the terminal. For in_progress drops we open a terminal (with the
+    // hook command if accepted, otherwise a plain shell) so the loading slot
+    // morphs into a real card. The exception: explicitly cancelling an offered
+    // start-hook dialog means "move the task but open no terminal" — skip the
+    // spawn and let the finally block remove the loading slot. For review/done
+    // the terminal only spawns if the user accepted the hook.
     if (transitioningToInProgress) {
-      await spawnTerminalForInProgress(projectPath, resolvedTask, hookResult, slotId);
+      if (interactiveHookOffered && !hookResult) {
+        taskStartLog.info('start hook cancelled — moving to in_progress without a terminal', { taskNumber });
+      } else {
+        await spawnTerminalForInProgress(projectPath, resolvedTask, hookResult, slotId);
+      }
     } else if (hookResult) {
       await runNonStartHookInTerminal(projectPath, resolvedTask, newStatus, hookResult, onForegroundOpen);
     }


### PR DESCRIPTION
## Summary

- Restore the active view on a renderer refresh: a reload kept PTYs alive but dropped the user to the home view, because the at-launch restore was skipped whenever a session snapshot existed and the resume banner stays silent while those PTYs are alive. Now only a cold launch (snapshot PTYs gone) forces home for the banner; a refresh restores the prior view and reconnects.
- Make `reconnectOrphanedSessions` idempotent — the home view and project view both run reconnect as the user lands, so on a refresh the shared session could be added to the stack twice.
- Cancelling the start/continue hook dialog now opens no terminal: it moves the task to in_progress and removes the loading slot, rather than spawning a plain shell. An explicit Cancel means "don't run a hook and don't open a terminal" (CLI-driven and no-hook drops, where a plain shell is intended, are unchanged).
- Repair the stale e2e tests in `app.test.ts` (the suite doesn't run in CI and had drifted): board dismissal toggles with Cmd/Ctrl+T instead of Escape, the context-menu danger item is "Move to Trash", the toast close button is queried by its "Dismiss" aria-label, and the refresh/reconnect flow asserts a single restored card with room past the 10s default.