### PR TITLE
Fix white bars at window edges for light mode systems

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -114,6 +114,10 @@ html {
   text-rendering: optimizeLegibility;
   color-scheme: dark;
   overflow: hidden;
+  /* Paint the themed background on the root element too, not just <body>.
+     During async window resize macOS exposes newly grown pixels before the
+     WebContents repaints; without a background here those pixels flash white. */
+  background-color: var(--color-background);
 }
 
 body {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, nativeTheme, shell } from 'electron';
+import { app, BrowserWindow, dialog, shell } from 'electron';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import started from 'electron-squirrel-startup';
@@ -94,9 +94,12 @@ if (started) {
 }
 
 const createWindow = (): BrowserWindow => {
-  // Determine background color based on system theme
-  const isDark = nativeTheme.shouldUseDarkColors;
-  const backgroundColor = isDark ? '#1C1C1E' : '#F5F5F7';
+  // The renderer UI is always dark (see --color-background / color-scheme:dark
+  // in index.css), so the native window background must be dark too regardless
+  // of the system theme. Otherwise, in light mode the WebContents surface lags
+  // behind the native frame during live resize and the near-white window
+  // background flashes through as bars on the bottom and right edges.
+  const backgroundColor = '#1C1C1E';
 
   // Create the browser window.
   const isMac = process.platform === 'darwin';


### PR DESCRIPTION
## Summary

- The renderer UI is always dark, but the BrowserWindow `backgroundColor` was chosen from the system theme (`#F5F5F7` in light mode). During live resize the WebContents surface lags the native frame, so in light mode the near-white window background flashed through as bars on the bottom and right edges. Pinned the window background to the dark renderer color (`#1C1C1E`) so the resize gap matches.
- Removed the now-unused `nativeTheme` import in `src/main.ts`.
- Painted the themed background on the `<html>` root element in `index.css` (not just `<body>`) as a complementary defense so the in-page canvas covers newly exposed pixels during resize.