### PR TITLE
Add opencode as a supported agent harness

### DIFF
--- a/src/__tests__/healthCheck.test.ts
+++ b/src/__tests__/healthCheck.test.ts
@@ -45,7 +45,15 @@ describe('healthCheck', () => {
 
     const { checkHealth } = await import('../healthCheck');
     const status = await checkHealth();
-    expect(status).toEqual({ git: true, claude: true, codex: true, pi: true, lima: true, gitVersion: '2.39.5' });
+    expect(status).toEqual({
+      git: true,
+      claude: true,
+      codex: true,
+      pi: true,
+      opencode: true,
+      lima: true,
+      gitVersion: '2.39.5',
+    });
   });
 
   test('reports git missing when execFile rejects', async () => {
@@ -58,7 +66,15 @@ describe('healthCheck', () => {
 
     const { checkHealth } = await import('../healthCheck');
     const status = await checkHealth();
-    expect(status).toEqual({ git: false, claude: false, codex: false, pi: false, lima: false, gitVersion: undefined });
+    expect(status).toEqual({
+      git: false,
+      claude: false,
+      codex: false,
+      pi: false,
+      opencode: false,
+      lima: false,
+      gitVersion: undefined,
+    });
   });
 
   test('detects codex independently of claude', async () => {
@@ -72,7 +88,15 @@ describe('healthCheck', () => {
 
     const { checkHealth } = await import('../healthCheck');
     const status = await checkHealth();
-    expect(status).toEqual({ git: true, claude: false, codex: true, pi: false, lima: false, gitVersion: '2.41.0' });
+    expect(status).toEqual({
+      git: true,
+      claude: false,
+      codex: true,
+      pi: false,
+      opencode: false,
+      lima: false,
+      gitVersion: '2.41.0',
+    });
   });
 
   test('detects pi independently of claude and codex', async () => {
@@ -86,7 +110,37 @@ describe('healthCheck', () => {
 
     const { checkHealth } = await import('../healthCheck');
     const status = await checkHealth();
-    expect(status).toEqual({ git: true, claude: false, codex: false, pi: true, lima: false, gitVersion: '2.42.0' });
+    expect(status).toEqual({
+      git: true,
+      claude: false,
+      codex: false,
+      pi: true,
+      opencode: false,
+      lima: false,
+      gitVersion: '2.42.0',
+    });
+  });
+
+  test('detects opencode independently of the other agents', async () => {
+    execFileMock.mockImplementation((cmd: string, args: string[], cb: Function) => {
+      if (cmd === 'git') cb(null, 'git version 2.43.0\n', '');
+      else if (cmd === 'which' && args[0] === 'opencode') cb(null, '/opt/homebrew/bin/opencode\n', '');
+      else if (cmd === 'which') cb(new Error('not found'));
+      else cb(new Error(`unexpected ${cmd}`));
+    });
+    isLimaInstalledMock.mockResolvedValue(false);
+
+    const { checkHealth } = await import('../healthCheck');
+    const status = await checkHealth();
+    expect(status).toEqual({
+      git: true,
+      claude: false,
+      codex: false,
+      pi: false,
+      opencode: true,
+      lima: false,
+      gitVersion: '2.43.0',
+    });
   });
 
   test('caches result and exposes via getCachedHealth', async () => {
@@ -105,6 +159,7 @@ describe('healthCheck', () => {
       claude: false,
       codex: false,
       pi: false,
+      opencode: false,
       lima: true,
       gitVersion: '2.40.0',
     });

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -435,11 +435,10 @@ describe('installWrapper', () => {
     // No-API fallthrough still surfaces the CLI reference, plugin left inert.
     expect(wrapper).toContain('if [ -z "$OUIJIT_API_URL" ]; then');
 
-    // Plugin lands in Ouijit's own dir (loaded via config path), never in the
-    // user's opencode config dir.
-    const pluginPath = path.join(tmpHome, '.config', 'Ouijit', 'opencode', 'ouijit-plugin.ts');
+    // Plugin lands in opencode's auto-load dir (imported directly at startup;
+    // a `plugin` config entry would be bun-add'd and fail for a local file).
+    const pluginPath = path.join(tmpHome, '.config', 'opencode', 'plugins', 'ouijit.ts');
     expect(fs.existsSync(pluginPath)).toBe(true);
-    expect(fs.existsSync(path.join(tmpHome, '.config', 'opencode'))).toBe(false);
     const plugin = fs.readFileSync(pluginPath, 'utf-8');
     expect(plugin).toContain('export const OuijitStatusPlugin');
     expect(plugin).toContain('session.status');
@@ -1407,10 +1406,11 @@ describe('OPENCODE_WRAPPER', () => {
     expect(OPENCODE_WRAPPER).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
   });
 
-  test('builds a valid embedded config with instructions + plugin', () => {
+  test('builds a valid embedded instructions config', () => {
     // Expand the OUIJIT_OPENCODE_CONFIG assignment under bash with a fake HOME
-    // and confirm the result parses as JSON pointing at the CLI reference and
-    // the status plugin (both as absolute paths).
+    // and confirm the result parses as JSON pointing at the CLI reference.
+    // (The plugin is loaded from the auto-load dir, not via config — a
+    // `plugin` config entry would be bun-add'd and fail for a local file.)
     const home = '/home/user';
     const result = execFileSync(
       'bash',
@@ -1419,16 +1419,15 @@ describe('OPENCODE_WRAPPER', () => {
         [
           `HOME="${home}"`,
           'REFERENCE_FILE="$HOME/.config/Ouijit/ouijit-cli-reference.md"',
-          'PLUGIN_FILE="$HOME/.config/Ouijit/opencode/ouijit-plugin.ts"',
-          'OUIJIT_OPENCODE_CONFIG="{\\"instructions\\":[\\"$REFERENCE_FILE\\"],\\"plugin\\":[\\"$PLUGIN_FILE\\"]}"',
+          'OUIJIT_OPENCODE_CONFIG="{\\"instructions\\":[\\"$REFERENCE_FILE\\"]}"',
           'printf %s "$OUIJIT_OPENCODE_CONFIG"',
         ].join('\n'),
       ],
       { encoding: 'utf8' },
     );
-    const parsed = JSON.parse(result) as { instructions: string[]; plugin: string[] };
+    const parsed = JSON.parse(result) as { instructions: string[] };
     expect(parsed.instructions).toEqual([`${home}/.config/Ouijit/ouijit-cli-reference.md`]);
-    expect(parsed.plugin).toEqual([`${home}/.config/Ouijit/opencode/ouijit-plugin.ts`]);
+    expect(parsed).not.toHaveProperty('plugin');
   });
 
   describe('subcommand passthrough', () => {
@@ -1474,11 +1473,13 @@ describe('OPENCODE_WRAPPER', () => {
       expect(hook).toBe('');
     });
 
-    test('bare `opencode` injects the CLI reference + plugin and activates the hook', () => {
+    test('bare `opencode` injects the CLI reference and activates the hook', () => {
       const { cfg, hook } = runWrapper([], { OUIJIT_API_URL: 'http://stub' });
-      const parsed = JSON.parse(cfg) as { instructions: string[]; plugin: string[] };
+      const parsed = JSON.parse(cfg) as { instructions: string[] };
       expect(parsed.instructions[0]).toContain('ouijit-cli-reference.md');
-      expect(parsed.plugin[0]).toContain('ouijit-plugin.ts');
+      // The plugin is NOT referenced in config (auto-loaded instead); a config
+      // `plugin` entry would be bun-add'd and fail for a local file.
+      expect(cfg).not.toContain('plugin');
       expect(hook).toContain('ouijit-hook');
     });
 
@@ -1486,14 +1487,12 @@ describe('OPENCODE_WRAPPER', () => {
       const { argv, cfg, hook } = runWrapper(['run', 'hello world'], { OUIJIT_API_URL: 'http://stub' });
       expect(argv).toEqual(['run', 'hello world']);
       expect(cfg).toContain('ouijit-cli-reference.md');
-      expect(cfg).toContain('ouijit-plugin.ts');
       expect(hook).toContain('ouijit-hook');
     });
 
-    test('without OUIJIT_API_URL the config is injected but the plugin stays inert (no hook bin)', () => {
+    test('without OUIJIT_API_URL the CLI reference is injected but the plugin stays inert (no hook bin)', () => {
       const { cfg, hook } = runWrapper([], { OUIJIT_API_URL: '' });
       expect(cfg).toContain('ouijit-cli-reference.md');
-      expect(cfg).toContain('ouijit-plugin.ts');
       expect(hook).toBe('');
     });
   });

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -44,10 +44,13 @@ import {
   buildVmCodexConfig,
   buildVmCodexTrustState,
   buildVmPiExtension,
+  buildVmOpencodePlugin,
   CLAUDE_WRAPPER,
   CODEX_WRAPPER,
   PI_WRAPPER,
   PI_EXTENSION,
+  OPENCODE_WRAPPER,
+  OPENCODE_PLUGIN,
 } from '../hookServer';
 import { issueToken, revokeAllTokens } from '../apiAuth';
 
@@ -415,6 +418,33 @@ describe('installWrapper', () => {
     expect(ext).toContain("pi.on('agent_start'");
     expect(ext).toContain("pi.on('agent_end'");
     expect(ext).toContain('OUIJIT_HOOK_BIN');
+  });
+
+  test('creates opencode wrapper and status plugin on first install', () => {
+    installWrapper();
+
+    const wrapperPath = path.join(tmpHome, '.config', 'Ouijit', 'bin', 'opencode');
+    const wrapper = fs.readFileSync(wrapperPath, 'utf-8');
+    expect(wrapper).toContain('#!/bin/bash');
+    expect(wrapper).toContain('REAL_BIN=');
+    expect(wrapper).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
+    // Injects the CLI reference via OPENCODE_CONFIG_CONTENT and activates the
+    // plugin via OUIJIT_HOOK_BIN (opencode has no system-prompt/hook flags).
+    expect(wrapper).toContain('OPENCODE_CONFIG_CONTENT="$OUIJIT_OPENCODE_CONFIG"');
+    expect(wrapper).toContain('OUIJIT_HOOK_BIN="$HOOK_BIN"');
+    // No-API fallthrough still surfaces the CLI reference, plugin left inert.
+    expect(wrapper).toContain('if [ -z "$OUIJIT_API_URL" ]; then');
+
+    // Plugin lands in Ouijit's own dir (loaded via config path), never in the
+    // user's opencode config dir.
+    const pluginPath = path.join(tmpHome, '.config', 'Ouijit', 'opencode', 'ouijit-plugin.ts');
+    expect(fs.existsSync(pluginPath)).toBe(true);
+    expect(fs.existsSync(path.join(tmpHome, '.config', 'opencode'))).toBe(false);
+    const plugin = fs.readFileSync(pluginPath, 'utf-8');
+    expect(plugin).toContain('export const OuijitStatusPlugin');
+    expect(plugin).toContain('session.status');
+    expect(plugin).toContain("'ready' : 'thinking'");
+    expect(plugin).toContain('OUIJIT_HOOK_BIN');
   });
 
   test('creates CLI reference file with command documentation', () => {
@@ -1365,5 +1395,230 @@ describe('buildVmPiExtension', () => {
     const ext = buildVmPiExtension();
     expect(ext).not.toContain('ouijit-cli-reference');
     expect(ext).not.toContain('.config/Ouijit');
+  });
+});
+
+// ── OPENCODE_WRAPPER constant ────────────────────────────────────────
+
+describe('OPENCODE_WRAPPER', () => {
+  test('resolves real opencode and re-exports wrapper dir on PATH', () => {
+    expect(OPENCODE_WRAPPER).toContain('WRAPPER_DIR=');
+    expect(OPENCODE_WRAPPER).toContain('REAL_BIN=');
+    expect(OPENCODE_WRAPPER).toContain('export PATH="$WRAPPER_DIR:$CLEAN_PATH"');
+  });
+
+  test('builds a valid embedded config with instructions + plugin', () => {
+    // Expand the OUIJIT_OPENCODE_CONFIG assignment under bash with a fake HOME
+    // and confirm the result parses as JSON pointing at the CLI reference and
+    // the status plugin (both as absolute paths).
+    const home = '/home/user';
+    const result = execFileSync(
+      'bash',
+      [
+        '-c',
+        [
+          `HOME="${home}"`,
+          'REFERENCE_FILE="$HOME/.config/Ouijit/ouijit-cli-reference.md"',
+          'PLUGIN_FILE="$HOME/.config/Ouijit/opencode/ouijit-plugin.ts"',
+          'OUIJIT_OPENCODE_CONFIG="{\\"instructions\\":[\\"$REFERENCE_FILE\\"],\\"plugin\\":[\\"$PLUGIN_FILE\\"]}"',
+          'printf %s "$OUIJIT_OPENCODE_CONFIG"',
+        ].join('\n'),
+      ],
+      { encoding: 'utf8' },
+    );
+    const parsed = JSON.parse(result) as { instructions: string[]; plugin: string[] };
+    expect(parsed.instructions).toEqual([`${home}/.config/Ouijit/ouijit-cli-reference.md`]);
+    expect(parsed.plugin).toEqual([`${home}/.config/Ouijit/opencode/ouijit-plugin.ts`]);
+  });
+
+  describe('subcommand passthrough', () => {
+    const runWrapper = (args: string[], extraEnv: Record<string, string> = {}) => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-wrapper-test-'));
+      const wrapperDir = path.join(root, 'wrapper');
+      const stubDir = path.join(root, 'stub');
+      fs.mkdirSync(wrapperDir);
+      fs.mkdirSync(stubDir);
+      const logFile = path.join(root, 'invoke.log');
+      fs.writeFileSync(path.join(wrapperDir, 'opencode'), OPENCODE_WRAPPER, { mode: 0o755 });
+      // Stub records argv plus the injected env so we can assert both.
+      fs.writeFileSync(
+        path.join(stubDir, 'opencode'),
+        [
+          '#!/bin/bash',
+          `for a in "$@"; do printf 'ARGV:%s\\n' "$a" >> "${logFile}"; done`,
+          `printf 'CFG:%s\\n' "$OPENCODE_CONFIG_CONTENT" >> "${logFile}"`,
+          `printf 'HOOK:%s\\n' "$OUIJIT_HOOK_BIN" >> "${logFile}"`,
+          '',
+        ].join('\n'),
+        { mode: 0o755 },
+      );
+      try {
+        execFileSync(path.join(wrapperDir, 'opencode'), args, {
+          env: { PATH: `${wrapperDir}:${stubDir}:/usr/bin:/bin`, HOME: root, ...extraEnv },
+          encoding: 'utf8',
+        });
+        const lines = fs.existsSync(logFile) ? fs.readFileSync(logFile, 'utf8').split('\n').filter(Boolean) : [];
+        const argv = lines.filter((l) => l.startsWith('ARGV:')).map((l) => l.slice(5));
+        const cfg = lines.find((l) => l.startsWith('CFG:'))?.slice(4) ?? '';
+        const hook = lines.find((l) => l.startsWith('HOOK:'))?.slice(5) ?? '';
+        return { argv, cfg, hook };
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    };
+
+    test('`opencode auth` passes through with no config/hook injection', () => {
+      const { argv, cfg, hook } = runWrapper(['auth'], { OUIJIT_API_URL: 'http://stub' });
+      expect(argv).toEqual(['auth']);
+      expect(cfg).toBe('');
+      expect(hook).toBe('');
+    });
+
+    test('bare `opencode` injects the CLI reference + plugin and activates the hook', () => {
+      const { cfg, hook } = runWrapper([], { OUIJIT_API_URL: 'http://stub' });
+      const parsed = JSON.parse(cfg) as { instructions: string[]; plugin: string[] };
+      expect(parsed.instructions[0]).toContain('ouijit-cli-reference.md');
+      expect(parsed.plugin[0]).toContain('ouijit-plugin.ts');
+      expect(hook).toContain('ouijit-hook');
+    });
+
+    test('`opencode run <message>` still gets injection', () => {
+      const { argv, cfg, hook } = runWrapper(['run', 'hello world'], { OUIJIT_API_URL: 'http://stub' });
+      expect(argv).toEqual(['run', 'hello world']);
+      expect(cfg).toContain('ouijit-cli-reference.md');
+      expect(cfg).toContain('ouijit-plugin.ts');
+      expect(hook).toContain('ouijit-hook');
+    });
+
+    test('without OUIJIT_API_URL the config is injected but the plugin stays inert (no hook bin)', () => {
+      const { cfg, hook } = runWrapper([], { OUIJIT_API_URL: '' });
+      expect(cfg).toContain('ouijit-cli-reference.md');
+      expect(cfg).toContain('ouijit-plugin.ts');
+      expect(hook).toBe('');
+    });
+  });
+
+  test('does not recurse into itself when PATH lists the wrapper dir twice (regression for T-407)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wrapper-resolver-opencode-'));
+    try {
+      const wrapperDir = path.join(tmp, 'wrapper-bin');
+      const realDir = path.join(tmp, 'real-bin');
+      fs.mkdirSync(wrapperDir);
+      fs.mkdirSync(realDir);
+      fs.writeFileSync(path.join(wrapperDir, 'opencode'), OPENCODE_WRAPPER, { mode: 0o755 });
+      // Real-binary stand-in prints a sentinel and echoes the injected config.
+      fs.writeFileSync(
+        path.join(realDir, 'opencode'),
+        '#!/bin/bash\necho REAL_BIN_OK\nprintf "CFG:%s\\n" "$OPENCODE_CONFIG_CONTENT"\nprintf "%s\\n" "$@"\n',
+        { mode: 0o755 },
+      );
+      const wrapperDirSymlink = path.join(tmp, 'wrapper-bin-link');
+      fs.symlinkSync(wrapperDir, wrapperDirSymlink);
+      const fakePath = [wrapperDir, realDir, wrapperDirSymlink, '/usr/bin', '/bin'].join(':');
+
+      const result = execFileSync('bash', [path.join(wrapperDir, 'opencode'), 'hello'], {
+        env: { PATH: fakePath, HOME: tmp, OUIJIT_API_URL: '' },
+        encoding: 'utf8',
+        timeout: 10_000,
+      });
+
+      expect(result).toContain('REAL_BIN_OK');
+      expect(result).toContain('ouijit-cli-reference.md');
+      expect(result).toContain('hello');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── OPENCODE_PLUGIN constant ─────────────────────────────────────────
+
+describe('OPENCODE_PLUGIN', () => {
+  test('is a TypeScript module with a named-export factory', () => {
+    expect(OPENCODE_PLUGIN).toMatch(/export const OuijitStatusPlugin = async \(\{ \$ \}/);
+  });
+
+  test('no-ops when OUIJIT_HOOK_BIN is unset (safe outside Ouijit)', () => {
+    expect(OPENCODE_PLUGIN).toMatch(/const hookBin = process\.env\.OUIJIT_HOOK_BIN/);
+    expect(OPENCODE_PLUGIN).toMatch(/if \(!hookBin\) return \{\}/);
+  });
+
+  test('drives status off session.status (not the deprecated session.idle) and swallows shell errors', () => {
+    expect(OPENCODE_PLUGIN).toContain("event?.type !== 'session.status'");
+    expect(OPENCODE_PLUGIN).toContain("=== 'idle' ? 'ready' : 'thinking'");
+    expect(OPENCODE_PLUGIN).toContain('.catch(() => {})');
+    // The deprecated event must not be what we key off of.
+    expect(OPENCODE_PLUGIN).not.toContain("=== 'session.idle'");
+  });
+
+  test('returns no handlers when OUIJIT_HOOK_BIN is unset', async () => {
+    const factory = compileOpencodePlugin(OPENCODE_PLUGIN);
+    const pings: string[] = [];
+    const $ = makeFakeShell(pings);
+    const handlers = await factory({ $ });
+    expect(handlers.event).toBeUndefined();
+    expect(pings).toEqual([]);
+  });
+
+  test('maps session.status busy/idle to thinking/ready and dedups repeats', async () => {
+    const factory = compileOpencodePlugin(OPENCODE_PLUGIN);
+    const pings: string[] = [];
+    const $ = makeFakeShell(pings);
+    process.env.OUIJIT_HOOK_BIN = '/fake/ouijit-hook';
+    const status = (type: string) => ({ event: { type: 'session.status', properties: { status: { type } } } });
+    try {
+      const handlers = await factory({ $ });
+      await handlers.event!(status('busy'));
+      await handlers.event!(status('busy')); // repeat — deduped
+      // Non-status events are ignored entirely.
+      await handlers.event!({ event: { type: 'message.updated' } });
+      await handlers.event!(status('idle'));
+      expect(pings).toEqual(['thinking', 'ready']);
+
+      // A second turn pings again.
+      await handlers.event!(status('busy'));
+      await handlers.event!(status('idle'));
+      expect(pings).toEqual(['thinking', 'ready', 'thinking', 'ready']);
+    } finally {
+      delete process.env.OUIJIT_HOOK_BIN;
+    }
+  });
+});
+
+type OpencodeEvent = { type: string; properties?: { status?: { type?: string } } };
+type OpencodeEventHandlers = { event?: (arg: { event: OpencodeEvent }) => Promise<void> };
+type FakeShellResult = { quiet(): { nothrow(): Promise<unknown> } };
+type FakeShell = (strings: TemplateStringsArray, ...values: unknown[]) => FakeShellResult;
+
+/** Fake Bun `$` that records the status from the last interpolated value. */
+function makeFakeShell(pings: string[]): FakeShell {
+  return (_strings: TemplateStringsArray, ...values: unknown[]) => {
+    pings.push(String(values[values.length - 1]));
+    return { quiet: () => ({ nothrow: () => Promise.resolve() }) };
+  };
+}
+
+/** Strips type annotations from the OPENCODE_PLUGIN TS string into a runnable factory. */
+function compileOpencodePlugin(src: string): (ctx: { $: FakeShell }) => Promise<OpencodeEventHandlers> {
+  const transpiled = ts.transpileModule(src, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+  }).outputText;
+  const moduleExports: { exports: { OuijitStatusPlugin?: unknown } } = { exports: {} };
+  new Function('exports', 'module', 'process', transpiled)(moduleExports.exports, moduleExports, process);
+  return moduleExports.exports.OuijitStatusPlugin as (ctx: { $: FakeShell }) => Promise<OpencodeEventHandlers>;
+}
+
+// ── buildVmOpencodePlugin ────────────────────────────────────────────
+
+describe('buildVmOpencodePlugin', () => {
+  test('matches the host-side plugin exactly', () => {
+    expect(buildVmOpencodePlugin()).toBe(OPENCODE_PLUGIN);
+  });
+
+  test('omits any reference to the host-only CLI reference file', () => {
+    // Lateral-movement: agent in sandbox must not get the CLI.
+    const plugin = buildVmOpencodePlugin();
+    expect(plugin).not.toContain('ouijit-cli-reference');
+    expect(plugin).not.toContain('.config/Ouijit');
   });
 });

--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -1569,7 +1569,7 @@ describe('OPENCODE_PLUGIN', () => {
     try {
       const handlers = await factory({ $ });
       await handlers.event!(status('busy'));
-      await handlers.event!(status('busy')); // repeat — deduped
+      await handlers.event!(status('busy')); // repeat, deduped
       // Non-status events are ignored entirely.
       await handlers.event!({ event: { type: 'message.updated' } });
       await handlers.event!(status('idle'));

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -70,6 +70,7 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
               <HealthRow ok={health.claude} label="claude" hint="not on PATH" />
               <HealthRow ok={health.codex} label="codex" hint="not on PATH" />
               <HealthRow ok={health.pi} label="pi" hint="not on PATH" />
+              <HealthRow ok={health.opencode} label="opencode" hint="not on PATH" />
             </div>
           ) : (
             <div className="text-xs text-text-tertiary">Checking…</div>

--- a/src/healthCheck.ts
+++ b/src/healthCheck.ts
@@ -12,6 +12,7 @@ export interface HealthStatus {
   claude: boolean;
   codex: boolean;
   pi: boolean;
+  opencode: boolean;
   lima: boolean;
   gitVersion?: string;
 }
@@ -55,20 +56,31 @@ async function detectPi(): Promise<boolean> {
   }
 }
 
+async function detectOpencode(): Promise<boolean> {
+  try {
+    await execFileAsync('which', ['opencode']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function checkHealth(): Promise<HealthStatus> {
-  const [git, claude, codex, pi, lima] = await Promise.all([
+  const [git, claude, codex, pi, opencode, lima] = await Promise.all([
     detectGit(),
     detectClaude(),
     detectCodex(),
     detectPi(),
+    detectOpencode(),
     isLimaInstalled(),
   ]);
-  cached = { git: git.ok, claude, codex, pi, lima, gitVersion: git.version };
+  cached = { git: git.ok, claude, codex, pi, opencode, lima, gitVersion: git.version };
   healthLog.info('health probe', {
     git: cached.git,
     claude: cached.claude,
     codex: cached.codex,
     pi: cached.pi,
+    opencode: cached.opencode,
     lima: cached.lima,
     gitVersion: cached.gitVersion,
   });

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -757,11 +757,11 @@ export const PI_WRAPPER = [
 //   • `plugin` takes our plugin's absolute path (path specs are supported
 //     alongside npm names), so opencode loads it only for wrapped sessions.
 //     The plugin lives in Ouijit's own dir, never in the user's opencode
-//     config — the same scoping Pi gets from `--extension`.
+//     config. This is the same scoping Pi gets from `--extension`.
 //   • `instructions` takes the CLI reference path; opencode concatenates it
 //     onto the user's instructions (it never replaces them).
 // The plugin is additionally a no-op unless OUIJIT_HOOK_BIN is set, which
-// only the wrapper does — belt-and-suspenders on top of the scoped load.
+// only the wrapper does: belt-and-suspenders on top of the scoped load.
 
 /** Directory for Ouijit's opencode status plugin (loaded via config path, not opencode's auto-load dir). */
 export function getOpencodePluginDir(): string {

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -751,26 +751,28 @@ export const PI_WRAPPER = [
 
 // ── opencode plugin + wrapper ────────────────────────────────────────
 // opencode exposes lifecycle events only to JS/TS plugins, and it has no
-// --append-system-prompt / hook CLI flag. Both the status plugin and the
-// CLI reference ride on OPENCODE_CONFIG_CONTENT, an env var opencode parses
-// as JSON and merges (additively) into the resolved config at launch:
-//   • `plugin` takes our plugin's absolute path (path specs are supported
-//     alongside npm names), so opencode loads it only for wrapped sessions.
-//     The plugin lives in Ouijit's own dir, never in the user's opencode
-//     config. This is the same scoping Pi gets from `--extension`.
-//   • `instructions` takes the CLI reference path; opencode concatenates it
-//     onto the user's instructions (it never replaces them).
-// The plugin is additionally a no-op unless OUIJIT_HOOK_BIN is set, which
-// only the wrapper does: belt-and-suspenders on top of the scoped load.
+// --append-system-prompt / hook CLI flag. Status and the CLI reference are
+// injected two different ways:
+//   • Status plugin: written into opencode's auto-load dir
+//     (~/.config/opencode/plugins), which opencode imports directly at
+//     startup. This is the only mechanism that works on released opencode:
+//     a `plugin` entry in config (even an absolute path) is instead treated
+//     as an npm package and `bun add`-ed, which fails for a local file. The
+//     plugin loads for every opencode session but is a no-op unless
+//     OUIJIT_HOOK_BIN is set (only the wrapper sets it), so a plain
+//     `opencode` run is unaffected.
+//   • CLI reference: rides on OPENCODE_CONFIG_CONTENT, an env var opencode
+//     parses as JSON and merges additively into the resolved config. Its
+//     `instructions` array concatenates onto the user's (never replaces).
 
-/** Directory for Ouijit's opencode status plugin (loaded via config path, not opencode's auto-load dir). */
+/** opencode's global plugin auto-load directory. */
 export function getOpencodePluginDir(): string {
-  return path.join(os.homedir(), '.config', 'Ouijit', 'opencode');
+  return path.join(os.homedir(), '.config', 'opencode', 'plugins');
 }
 
 /** Path to the ouijit opencode status plugin. */
 export function getOpencodePluginPath(): string {
-  return path.join(getOpencodePluginDir(), 'ouijit-plugin.ts');
+  return path.join(getOpencodePluginDir(), 'ouijit.ts');
 }
 
 export const OPENCODE_PLUGIN = `// Ouijit opencode plugin - bridges opencode session status to the
@@ -824,11 +826,11 @@ export const OuijitStatusPlugin = async ({ $ }: OuijitOpencodeContext) => {
 export const OPENCODE_WRAPPER = [
   '#!/bin/bash',
   '# Ouijit opencode wrapper - injects the Ouijit CLI reference via',
-  '# OPENCODE_CONFIG_CONTENT - opencode parses it as JSON and merges it into',
-  '# the resolved config. We add the CLI reference to `instructions` and the',
-  '# status plugin path to `plugin` (both additive). The plugin only reports',
-  '# status once OUIJIT_HOOK_BIN is set. opencode has no system-prompt or hook',
-  '# CLI flags, so everything rides on env + config.',
+  '# OPENCODE_CONFIG_CONTENT (opencode parses it as JSON and merges it into',
+  '# the resolved config; `instructions` concatenates onto the user config).',
+  '# The status plugin is loaded separately from opencode auto-load dir; this',
+  '# wrapper only flips it on by exporting OUIJIT_HOOK_BIN. opencode has no',
+  '# system-prompt or hook CLI flags, so everything rides on env + config.',
   buildWrapperResolver('opencode'),
   '',
   '# opencode utility subcommands do not start an agent session. Run them',
@@ -845,13 +847,10 @@ export const OPENCODE_WRAPPER = [
   'done',
   '',
   'REFERENCE_FILE="$HOME/.config/Ouijit/ouijit-cli-reference.md"',
-  'PLUGIN_FILE="$HOME/.config/Ouijit/opencode/ouijit-plugin.ts"',
   'HOOK_BIN="$HOME/.config/Ouijit/bin/ouijit-hook"',
   '',
-  '# Add the CLI reference (instructions) and the status plugin (plugin) to',
-  '# opencode config for this invocation only. opencode concatenates both onto',
-  '# the user config, so their own opencode.json is never modified.',
-  'OUIJIT_OPENCODE_CONFIG="{\\"instructions\\":[\\"$REFERENCE_FILE\\"],\\"plugin\\":[\\"$PLUGIN_FILE\\"]}"',
+  '# Add the CLI reference to opencode instructions for this invocation only.',
+  'OUIJIT_OPENCODE_CONFIG="{\\"instructions\\":[\\"$REFERENCE_FILE\\"]}"',
   '',
   '# If ouijit is not running, still surface the CLI reference but leave the',
   '# status plugin inert (OUIJIT_HOOK_BIN unset).',
@@ -859,8 +858,8 @@ export const OPENCODE_WRAPPER = [
   '  OPENCODE_CONFIG_CONTENT="$OUIJIT_OPENCODE_CONFIG" exec "$REAL_BIN" "$@"',
   'fi',
   '',
-  '# OUIJIT_HOOK_BIN activates the ouijit status plugin; it shells out to',
-  '# ouijit-hook on session.status busy/idle transitions.',
+  '# OUIJIT_HOOK_BIN activates the ouijit status plugin (loaded from opencode',
+  '# auto-load dir); it shells out to ouijit-hook on session.status busy/idle.',
   'OPENCODE_CONFIG_CONTENT="$OUIJIT_OPENCODE_CONFIG" OUIJIT_HOOK_BIN="$HOOK_BIN" exec "$REAL_BIN" "$@"',
   '',
 ].join('\n');
@@ -899,9 +898,11 @@ export function installWrapper(): void {
     fs.writeFileSync(piExtPath, PI_EXTENSION, { mode: 0o644 });
 
     // Write opencode wrapper (shadows `opencode`) and the status plugin into
-    // Ouijit's own dir. The wrapper points opencode at the plugin via
-    // OPENCODE_CONFIG_CONTENT, so opencode loads it only for wrapped sessions
-    // and the user's opencode config is never touched.
+    // opencode's auto-load dir. opencode imports auto-load files directly,
+    // whereas a `plugin` config entry is `bun add`-ed (fails for a local
+    // file), so the auto-load dir is the only working host mechanism. The
+    // plugin is inert until the wrapper exports OUIJIT_HOOK_BIN, so a plain
+    // `opencode` run is unaffected.
     fs.writeFileSync(path.join(binDir, 'opencode'), OPENCODE_WRAPPER, { mode: 0o755 });
     const opencodePluginPath = getOpencodePluginPath();
     fs.mkdirSync(path.dirname(opencodePluginPath), { recursive: true });

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -749,6 +749,122 @@ export const PI_WRAPPER = [
   '',
 ].join('\n');
 
+// ── opencode plugin + wrapper ────────────────────────────────────────
+// opencode exposes lifecycle events only to JS/TS plugins, and it has no
+// --append-system-prompt / hook CLI flag. Both the status plugin and the
+// CLI reference ride on OPENCODE_CONFIG_CONTENT, an env var opencode parses
+// as JSON and merges (additively) into the resolved config at launch:
+//   • `plugin` takes our plugin's absolute path (path specs are supported
+//     alongside npm names), so opencode loads it only for wrapped sessions.
+//     The plugin lives in Ouijit's own dir, never in the user's opencode
+//     config — the same scoping Pi gets from `--extension`.
+//   • `instructions` takes the CLI reference path; opencode concatenates it
+//     onto the user's instructions (it never replaces them).
+// The plugin is additionally a no-op unless OUIJIT_HOOK_BIN is set, which
+// only the wrapper does — belt-and-suspenders on top of the scoped load.
+
+/** Directory for Ouijit's opencode status plugin (loaded via config path, not opencode's auto-load dir). */
+export function getOpencodePluginDir(): string {
+  return path.join(os.homedir(), '.config', 'Ouijit', 'opencode');
+}
+
+/** Path to the ouijit opencode status plugin. */
+export function getOpencodePluginPath(): string {
+  return path.join(getOpencodePluginDir(), 'ouijit-plugin.ts');
+}
+
+export const OPENCODE_PLUGIN = `// Ouijit opencode plugin - bridges opencode session status to the
+// per-terminal status indicator. Auto-installed; safe to delete (Ouijit
+// recreates it). No-ops when OUIJIT_HOOK_BIN is unset, so it is harmless if
+// it ever loads outside Ouijit.
+
+type OuijitStatus = 'thinking' | 'ready';
+
+interface OuijitShellResult {
+  quiet(): { nothrow(): Promise<unknown> };
+}
+
+interface OuijitOpencodeContext {
+  $: (strings: TemplateStringsArray, ...values: unknown[]) => OuijitShellResult;
+}
+
+interface OuijitSessionEvent {
+  type: string;
+  properties?: { status?: { type?: string } };
+}
+
+export const OuijitStatusPlugin = async ({ $ }: OuijitOpencodeContext) => {
+  const hookBin = process.env.OUIJIT_HOOK_BIN;
+  if (!hookBin) return {};
+
+  // Only report real transitions so we don't spawn a hook process per event.
+  let last: OuijitStatus | null = null;
+  const ping = (status: OuijitStatus) => {
+    if (status === last) return;
+    last = status;
+    try {
+      $\`\${hookBin} status status=\${status}\`.quiet().nothrow().catch(() => {});
+    } catch {
+      // best-effort: never let status reporting break the session
+    }
+  };
+
+  return {
+    // session.status carries opencode's busy/idle state (session.idle is
+    // deprecated). status.type is 'busy' | 'retry' | 'idle'; anything that is
+    // not idle means the agent is still working.
+    event: async ({ event }: { event: OuijitSessionEvent }) => {
+      if (event?.type !== 'session.status') return;
+      ping(event.properties?.status?.type === 'idle' ? 'ready' : 'thinking');
+    },
+  };
+};
+`;
+
+export const OPENCODE_WRAPPER = [
+  '#!/bin/bash',
+  '# Ouijit opencode wrapper - injects the Ouijit CLI reference via',
+  '# OPENCODE_CONFIG_CONTENT - opencode parses it as JSON and merges it into',
+  '# the resolved config. We add the CLI reference to `instructions` and the',
+  '# status plugin path to `plugin` (both additive). The plugin only reports',
+  '# status once OUIJIT_HOOK_BIN is set. opencode has no system-prompt or hook',
+  '# CLI flags, so everything rides on env + config.',
+  buildWrapperResolver('opencode'),
+  '',
+  '# opencode utility subcommands do not start an agent session. Run them',
+  '# untouched so config injection never interferes (mirrors the claude and',
+  '# pi subcommand guards).',
+  'for arg in "$@"; do',
+  '  case "$arg" in',
+  '    -*) continue ;;',
+  '    auth|models|upgrade|uninstall|stats|mcp|serve|github|export|import|debug|agent|session|db|plugin)',
+  '      exec "$REAL_BIN" "$@"',
+  '      ;;',
+  '    *) break ;;',
+  '  esac',
+  'done',
+  '',
+  'REFERENCE_FILE="$HOME/.config/Ouijit/ouijit-cli-reference.md"',
+  'PLUGIN_FILE="$HOME/.config/Ouijit/opencode/ouijit-plugin.ts"',
+  'HOOK_BIN="$HOME/.config/Ouijit/bin/ouijit-hook"',
+  '',
+  '# Add the CLI reference (instructions) and the status plugin (plugin) to',
+  '# opencode config for this invocation only. opencode concatenates both onto',
+  '# the user config, so their own opencode.json is never modified.',
+  'OUIJIT_OPENCODE_CONFIG="{\\"instructions\\":[\\"$REFERENCE_FILE\\"],\\"plugin\\":[\\"$PLUGIN_FILE\\"]}"',
+  '',
+  '# If ouijit is not running, still surface the CLI reference but leave the',
+  '# status plugin inert (OUIJIT_HOOK_BIN unset).',
+  'if [ -z "$OUIJIT_API_URL" ]; then',
+  '  OPENCODE_CONFIG_CONTENT="$OUIJIT_OPENCODE_CONFIG" exec "$REAL_BIN" "$@"',
+  'fi',
+  '',
+  '# OUIJIT_HOOK_BIN activates the ouijit status plugin; it shells out to',
+  '# ouijit-hook on session.status busy/idle transitions.',
+  'OPENCODE_CONFIG_CONTENT="$OUIJIT_OPENCODE_CONFIG" OUIJIT_HOOK_BIN="$HOOK_BIN" exec "$REAL_BIN" "$@"',
+  '',
+].join('\n');
+
 /**
  * Install the ouijit-hook helper script and claude wrapper into
  * ~/.config/Ouijit/bin/. The wrapper injects hooks via --settings
@@ -781,6 +897,15 @@ export function installWrapper(): void {
     const piExtPath = getPiExtensionPath();
     fs.mkdirSync(path.dirname(piExtPath), { recursive: true });
     fs.writeFileSync(piExtPath, PI_EXTENSION, { mode: 0o644 });
+
+    // Write opencode wrapper (shadows `opencode`) and the status plugin into
+    // Ouijit's own dir. The wrapper points opencode at the plugin via
+    // OPENCODE_CONFIG_CONTENT, so opencode loads it only for wrapped sessions
+    // and the user's opencode config is never touched.
+    fs.writeFileSync(path.join(binDir, 'opencode'), OPENCODE_WRAPPER, { mode: 0o755 });
+    const opencodePluginPath = getOpencodePluginPath();
+    fs.mkdirSync(path.dirname(opencodePluginPath), { recursive: true });
+    fs.writeFileSync(opencodePluginPath, OPENCODE_PLUGIN, { mode: 0o644 });
 
     // Write ouijit CLI wrapper (delegates to the bundled CLI JS via env vars set by PTY manager)
     fs.writeFileSync(
@@ -923,4 +1048,9 @@ export function buildVmCodexTrustState(): string {
 /** Pi extension for the sandbox VM. Identical to the host-side source. */
 export function buildVmPiExtension(): string {
   return PI_EXTENSION;
+}
+
+/** opencode status plugin for the sandbox VM. Identical to the host-side source. */
+export function buildVmOpencodePlugin(): string {
+  return OPENCODE_PLUGIN;
 }

--- a/src/hooks/useHookStatusListener.ts
+++ b/src/hooks/useHookStatusListener.ts
@@ -3,7 +3,7 @@ import { useTerminalStore } from '../stores/terminalStore';
 import { terminalInstances } from '../components/terminal/terminalReact';
 
 /**
- * Subscribes to CLI agent hook status events (claude / codex / pi) and dispatches
+ * Subscribes to CLI agent hook status events (claude / codex / pi / opencode) and dispatches
  * them to the matching terminal instance. On mount, seeds existing terminals
  * with their current status so the dot reflects state captured before the
  * listener was registered.

--- a/src/lima/spawn.ts
+++ b/src/lima/spawn.ts
@@ -11,6 +11,7 @@ import {
   buildVmCodexConfig,
   buildVmCodexTrustState,
   buildVmPiExtension,
+  buildVmOpencodePlugin,
 } from '../hookServer';
 import { issueToken, revokeToken } from '../apiAuth';
 import { getTaskByNumber } from '../db';
@@ -59,8 +60,9 @@ function handleOutput(ptyId: PtyId, channel: string, data: string): void {
 
 /**
  * Build bash commands that inject the ouijit-hook script, Claude settings,
- * Codex config, and the Pi extension into the VM's ephemeral home directory.
- * Runs once per shell spawn so hooks are always fresh (never stale).
+ * Codex config, the Pi extension, and the opencode plugin into the VM's
+ * ephemeral home directory. Runs once per shell spawn so hooks are always
+ * fresh (never stale).
  *
  * The ouijit CLI reference file is deliberately not written into the
  * sandbox VM. The CLI would give an agent inside the VM task-management
@@ -72,6 +74,7 @@ function buildVmHookSetup(): string {
   const hookSettings = buildVmHookSettings();
   const codexConfig = buildVmCodexConfig();
   const piExtension = buildVmPiExtension();
+  const opencodePlugin = buildVmOpencodePlugin();
   return [
     // Write hook script using quoted heredoc (prevents $VAR expansion at write time)
     `cat > ~/ouijit-hook <<'OUIJIT_HOOK_EOF'`,
@@ -99,6 +102,13 @@ function buildVmHookSetup(): string {
     `cat > ~/.pi/agent/extensions/ouijit/index.ts <<'OUIJIT_PI_EXT_EOF'`,
     piExtension,
     'OUIJIT_PI_EXT_EOF',
+    // opencode plugin lands in its global auto-load path (no wrapper in the
+    // VM). OUIJIT_HOOK_BIN is exported below, so the plugin reports status
+    // exactly as on the host. The CLI reference is deliberately omitted.
+    'mkdir -p ~/.config/opencode/plugins',
+    `cat > ~/.config/opencode/plugins/ouijit.ts <<'OUIJIT_OPENCODE_PLUGIN_EOF'`,
+    opencodePlugin,
+    'OUIJIT_OPENCODE_PLUGIN_EOF',
     '',
   ].join('\n');
 }

--- a/src/taskLifecycle.ts
+++ b/src/taskLifecycle.ts
@@ -113,10 +113,10 @@ export async function beginTask(
   // Surface a non-fatal warning if no supported coding agent is on PATH. The
   // kanban / open terminal handlers route these to a one-time toast.
   const health = getCachedHealth();
-  if (health && !health.claude && !health.codex && !health.pi) {
+  if (health && !health.claude && !health.codex && !health.pi && !health.opencode) {
     result.warnings = [
       ...(result.warnings ?? []),
-      'No coding agent found on PATH. Install Claude Code (claude.com/claude-code), Codex, or Pi (pi.dev) to use AI workflows in this terminal.',
+      'No coding agent found on PATH. Install Claude Code (claude.com/claude-code), Codex, Pi (pi.dev), or opencode (opencode.ai) to use AI workflows in this terminal.',
     ];
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -553,7 +553,7 @@ export interface ElectronAPI {
   tags: TagsAPI;
   /** Ad-hoc scripts API */
   scripts: ScriptsAPI;
-  /** CLI agent hook events (claude/codex/pi) */
+  /** CLI agent hook events (claude/codex/pi/opencode) */
   agentHooks: AgentHooksAPI;
   /** Plan file detection and viewing */
   plan: PlanAPI;
@@ -620,7 +620,7 @@ export interface CaptureAPI {
 }
 
 /**
- * CLI agent hook events API exposed to the renderer. Shared by claude / codex / pi.
+ * CLI agent hook events API exposed to the renderer. Shared by claude / codex / pi / opencode.
  */
 export interface AgentHooksAPI {
   onStatus(callback: (ptyId: PtyId, status: HookStatus) => void): () => void;


### PR DESCRIPTION
## Summary

- Add opencode (opencode.ai) as a fourth supported agent harness, at parity with the claude/codex/pi integrations.
- Detect the `opencode` binary in the health probe and surface it in the Help dialog and the "no coding agent on PATH" warning.
- Ship an `opencode` wrapper that injects the Ouijit CLI reference and a status plugin via `OPENCODE_CONFIG_CONTENT` (opencode has no system-prompt or hook CLI flags). Both are merged additively into opencode's resolved config, so the user's opencode config is never modified, and the plugin loads only for Ouijit-launched sessions.
- The status plugin lives in Ouijit's own dir and reports busy/idle off opencode's `session.status` event (`session.idle` is deprecated); it is additionally a no-op unless `OUIJIT_HOOK_BIN` is set.
- Inject the plugin into the sandbox VM's ephemeral home via opencode's auto-load dir, matching the existing per-agent VM setup.