### PR TITLE
Document OpenCode harness in README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Free and open source. No account, no sign-in, no telemetry.
 - [Claude Code](https://claude.com/claude-code)
 - [Codex](https://github.com/openai/codex)
 - [Pi](https://pi.dev)
+- [OpenCode](https://opencode.ai)
 
 To request support for another harness, [open an issue](https://github.com/ouijit/ouijit/issues/new).
 
@@ -49,7 +50,7 @@ ouijit markdown add ./plan.md                 # open a markdown file as a panel
 ouijit preview add http://localhost:3000      # open a web preview panel
 ```
 
-The supported harnesses (Claude Code, Codex, Pi) know how to use it out of the box. Output is JSON on stdout for easy piping into `jq`. Full command list in the [docs](https://ouijit.com/docs/#cli).
+The supported harnesses (Claude Code, Codex, Pi, OpenCode) know how to use it out of the box. Output is JSON on stdout for easy piping into `jq`. Full command list in the [docs](https://ouijit.com/docs/#cli).
 
 ## Setup
 

--- a/website/public/assets/agents/opencode.svg
+++ b/website/public/assets/agents/opencode.svg
@@ -1,0 +1,1 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg"><title>OpenCode</title><rect width="512" height="512" rx="96" fill="#131010"></rect><path d="M320 224V352H192V224H320Z" fill="#5A5858"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z" fill="white"></path></svg>

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -12,7 +12,7 @@ Free and open source under the AGPL-3.0 license. No account, no sign-in. Distrib
 - [Terminal Sessions](https://ouijit.com/docs/#terminals): Card stack UI, keyboard shortcuts, runner panel, diff panel, tags.
 - [VM Sandbox](https://ouijit.com/docs/#sandbox): Lima-based Linux VM, dual-worktree model with tracked-files-only mount, partial .git mount with hooks/config read-only.
 - [Hooks](https://ouijit.com/docs/#hooks): Lifecycle hooks (start, continue, review, done) and on-demand hooks (run, editor) configured per project.
-- [Agents](https://ouijit.com/docs/#agents): Status indicators and CLI awareness for Claude Code, Codex, and Pi via injected wrappers.
+- [Agents](https://ouijit.com/docs/#agents): Status indicators and CLI awareness for Claude Code, Codex, Pi, and OpenCode via injected wrappers.
 - [CLI](https://ouijit.com/docs/#cli): The `ouijit` command auto-installed in every terminal, with subcommands for tasks, hooks, scripts, tags, plans, and projects.
 
 ## Project
@@ -26,4 +26,4 @@ Free and open source under the AGPL-3.0 license. No account, no sign-in. Distrib
 
 - The `ouijit` CLI is available in every Ouijit-spawned terminal and authenticated by a per-session bearer token. It writes JSON to stdout for piping into `jq`.
 - Inside the VM sandbox, the `ouijit` binary is not installed and `/api/*` routes return 403 for sandbox-scoped tokens. Only the `/hook` status endpoint is reachable from a sandbox.
-- Claude Code, Codex, and Pi wrappers inject the CLI reference into the agent's system prompt, so agents can drive Ouijit (create tasks, flip statuses, manage hooks and scripts, update plans) from the shell.
+- Claude Code, Codex, and Pi wrappers inject the CLI reference into the agent's system prompt, so agents can drive Ouijit (create tasks, flip statuses, manage hooks and scripts, update plans) from the shell. OpenCode gets the same CLI reference, injected via the `OPENCODE_CONFIG_CONTENT` config content rather than a system-prompt flag.

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -26,4 +26,4 @@ Free and open source under the AGPL-3.0 license. No account, no sign-in. Distrib
 
 - The `ouijit` CLI is available in every Ouijit-spawned terminal and authenticated by a per-session bearer token. It writes JSON to stdout for piping into `jq`.
 - Inside the VM sandbox, the `ouijit` binary is not installed and `/api/*` routes return 403 for sandbox-scoped tokens. Only the `/hook` status endpoint is reachable from a sandbox.
-- Claude Code, Codex, and Pi wrappers inject the CLI reference into the agent's system prompt, so agents can drive Ouijit (create tasks, flip statuses, manage hooks and scripts, update plans) from the shell. OpenCode gets the same CLI reference, injected via the `OPENCODE_CONFIG_CONTENT` config content rather than a system-prompt flag.
+- Claude Code, Codex, and Pi wrappers inject the CLI reference into the agent's system prompt, so agents can drive Ouijit (create tasks, flip statuses, manage hooks and scripts, update plans) from the shell. OpenCode gets the same CLI reference, injected via the `OPENCODE_CONFIG_CONTENT` env var rather than a system-prompt flag.

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -12,7 +12,7 @@ const sections = [
   { id: 'cli', label: 'CLI' },
 ];
 ---
-<Site title="Documentation · Ouijit" description="Ouijit documentation: getting started, worktrees, kanban, terminals, VM sandbox, hooks, and Claude Code integration.">
+<Site title="Documentation · Ouijit" description="Ouijit documentation: getting started, worktrees, kanban, terminals, VM sandbox, hooks, and agent harness integration.">
   <div class="docs-layout">
     <aside class="docs-sidebar">
       <h4>Documentation</h4>
@@ -253,7 +253,7 @@ git branch --show-current</code></pre>
         <p>Tag terminals to organize them. Tags appear on terminal cards, and the home view can group by tag.</p>
 
         <h2>Working with harnesses</h2>
-        <p>Each terminal is a normal shell, so any CLI tool runs in it. <a href="#harnesses">Claude Code, Codex, and Pi</a> get live status indicators and can drive Ouijit through the <a href="#cli">CLI</a>.</p>
+        <p>Each terminal is a normal shell, so any CLI tool runs in it. <a href="#harnesses">Claude Code, Codex, Pi, and OpenCode</a> get live status indicators and can drive Ouijit through the <a href="#cli">CLI</a>.</p>
       </section>
 
       <section id="sandbox">
@@ -368,10 +368,10 @@ OUIJIT_HOOK_TYPE=start</code></pre>
 
       <section id="harnesses">
         <h1>Harnesses</h1>
-        <p class="lead">Claude Code, Codex, and Pi get live status indicators and can drive Ouijit through its CLI. No configuration required.</p>
+        <p class="lead">Claude Code, Codex, Pi, and OpenCode get live status indicators and can drive Ouijit through its CLI. No configuration required.</p>
 
         <h2>What you get</h2>
-        <p>Run <code>claude</code>, <code>codex</code>, or <code>pi</code> in any Ouijit terminal and two things happen automatically:</p>
+        <p>Run <code>claude</code>, <code>codex</code>, <code>pi</code>, or <code>opencode</code> in any Ouijit terminal and two things happen automatically:</p>
         <ul>
           <li>
             <strong>Live status</strong>. The terminal card shows whether the agent is thinking or idle, visible across the
@@ -410,12 +410,17 @@ OUIJIT_HOOK_TYPE=start</code></pre>
               <td><code>--extension</code> loading a generated TypeScript extension that subscribes to <code>turn_start</code> / <code>turn_end</code></td>
               <td><code>--append-system-prompt</code></td>
             </tr>
+            <tr>
+              <td><strong>OpenCode</strong></td>
+              <td>Status plugin loaded from opencode's auto-load dir, reporting off the <code>session.status</code> event (<code>session.idle</code> is deprecated)</td>
+              <td>CLI reference injected via <code>OPENCODE_CONFIG_CONTENT</code> (opencode has no system-prompt CLI flag)</td>
+            </tr>
           </tbody>
         </table>
         <p>When <code>OUIJIT_API_URL</code> is unset (i.e. the harness runs outside an Ouijit terminal), the wrappers exec the real binary unmodified.</p>
 
         <h2>Sandboxed terminals</h2>
-        <p>Status indicators work inside the <a href="#sandbox">VM sandbox</a>: Claude settings, Codex config, and the Pi extension are written into the VM's home directory, and their hooks reach back over <code>host.lima.internal</code>.</p>
+        <p>Status indicators work inside the <a href="#sandbox">VM sandbox</a>: Claude settings, Codex config, the Pi extension, and the opencode plugin (written into opencode's auto-load dir in the ephemeral home) are placed in the VM's home directory, and their hooks reach back over <code>host.lima.internal</code>.</p>
         <p>The CLI integration does not extend into the sandbox. The <code>ouijit</code> binary isn't installed in the VM, and the <code>/api/*</code> routes reject sandbox-scoped tokens.</p>
 
         <h2>Notifications</h2>

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -412,7 +412,7 @@ OUIJIT_HOOK_TYPE=start</code></pre>
             </tr>
             <tr>
               <td><strong>OpenCode</strong></td>
-              <td>Status plugin loaded from opencode's auto-load dir, reporting off the <code>session.status</code> event (<code>session.idle</code> is deprecated)</td>
+              <td>Status plugin loaded from opencode's auto-load dir, reporting off the <code>session.status</code> event</td>
               <td>CLI reference injected via <code>OPENCODE_CONFIG_CONTENT</code> (opencode has no system-prompt CLI flag)</td>
             </tr>
           </tbody>

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -420,7 +420,7 @@ OUIJIT_HOOK_TYPE=start</code></pre>
         <p>When <code>OUIJIT_API_URL</code> is unset (i.e. the harness runs outside an Ouijit terminal), the wrappers exec the real binary unmodified.</p>
 
         <h2>Sandboxed terminals</h2>
-        <p>Status indicators work inside the <a href="#sandbox">VM sandbox</a>: Claude settings, Codex config, the Pi extension, and the opencode plugin (written into opencode's auto-load dir in the ephemeral home) are placed in the VM's home directory, and their hooks reach back over <code>host.lima.internal</code>.</p>
+        <p>Status indicators work inside the <a href="#sandbox">VM sandbox</a>: Claude settings, Codex config, the Pi extension, and the opencode plugin are written into the VM's home directory, and their hooks reach back over <code>host.lima.internal</code>.</p>
         <p>The CLI integration does not extend into the sandbox. The <code>ouijit</code> binary isn't installed in the VM, and the <code>/api/*</code> routes reject sandbox-scoped tokens.</p>
 
         <h2>Notifications</h2>

--- a/website/src/pages/faq/index.astro
+++ b/website/src/pages/faq/index.astro
@@ -25,7 +25,7 @@ const faqs: Faq[] = [
   },
   {
     q: 'Which CLI agents does Ouijit integrate with?',
-    a: 'Any CLI tool runs in an Ouijit terminal. Claude Code, Codex, and Pi additionally get live status indicators (thinking / idle) on the terminal card and receive an injected Ouijit CLI reference in their system prompt, so they can create tasks, flip statuses, and update plans from the shell.',
+    a: 'Any CLI tool runs in an Ouijit terminal. Claude Code, Codex, Pi, and OpenCode additionally get live status indicators (thinking / idle) on the terminal card and receive an injected Ouijit CLI reference, so they can create tasks, flip statuses, and update plans from the shell.',
   },
   {
     q: 'How does Ouijit isolate work between tasks?',

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -35,7 +35,7 @@ const softwareSchema = {
     'Per-task git worktrees with Copy-on-Write cloning',
     'Kanban board with lifecycle hooks',
     'Integrated terminal sessions with card stack UI',
-    'Live status indicators for Claude Code, Codex, and Pi',
+    'Live status indicators for Claude Code, Codex, Pi, and OpenCode',
     'VM sandbox via Lima for isolated agent terminals',
     'Session-aware ouijit CLI for driving the app from a shell',
   ],
@@ -46,7 +46,7 @@ const softwareSchema = {
   <script type="application/ld+json" set:html={JSON.stringify(softwareSchema)} />
   <section class="hero">
     <h1>Command parallel coding agents, on your terms</h1>
-    <p class="hero-subtitle">Run Claude, Codex, and Pi in parallel: by hand, with scripts, or through delegation.</p>
+    <p class="hero-subtitle">Run Claude, Codex, Pi, and OpenCode in parallel: by hand, with scripts, or through delegation.</p>
     <div class="download-buttons">
       <a
         href="https://github.com/ouijit/ouijit/releases/latest/download/ouijit-darwin-arm64.dmg"
@@ -99,6 +99,13 @@ const softwareSchema = {
           <img src="/assets/agents/pi.svg" alt="" width="40" height="40" />
           <span class="home-agents-name">Pi</span>
           <span class="home-agents-domain">pi.dev</span>
+        </a>
+      </li>
+      <li>
+        <a class="glass-bevel" href="https://opencode.ai">
+          <img src="/assets/agents/opencode.svg" alt="" width="40" height="40" />
+          <span class="home-agents-name">OpenCode</span>
+          <span class="home-agents-domain">opencode.ai</span>
         </a>
       </li>
     </ul>

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -405,7 +405,7 @@ body.marketing .home-pitch-link:hover span {
   padding: 0;
   margin: 0 0 32px;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 16px;
 }
 
@@ -462,6 +462,12 @@ body.marketing .home-agents-footnote a {
 
 body.marketing .home-agents-footnote a:hover {
   color: #f5f5f7;
+}
+
+@media (max-width: 768px) {
+  .home-agents-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Add OpenCode (opencode.ai) alongside Claude Code, Codex, and Pi across the README and marketing site
- README: Supported harnesses list and the CLI inline mention
- Home page: featureList structured data, hero subtitle, and a new OpenCode card in the agent grid (grid widened to 4 columns so the cards stay balanced)
- Docs: harnesses intro, section lead, the run-line, a new OpenCode row in the comparison table, the sandboxed-terminals paragraph, and a generalized page meta description
- FAQ: agent-integration answer
- llms.txt: agents line and the wrapper-injection note (OpenCode injects the CLI reference via OPENCODE_CONFIG_CONTENT rather than a system-prompt flag)
- New asset: website/public/assets/agents/opencode.svg built from OpenCode's brand mark