### PR TITLE
Install nono agent packs as directory + lockfile entry pairs

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -137,9 +137,10 @@ const config: ForgeConfig = {
             console.log(`Copied Lima guest agents from ${guestAgentSrc}`);
           }
 
-          // 5b. Copy vendored nono agent packs (platform-independent JSON the
-          // union profile inherits) so the first sandboxed launch needs no
-          // network. Same staged-else-resources resolution as the binaries.
+          // 5b. Copy vendored nono agent packs and their lockfile
+          // (platform-independent JSON the union profile inherits) so the
+          // first sandboxed launch needs no network. Same staged-else-resources
+          // resolution as the binaries.
           // Uses fs.cpSync, not copyRecursive, to preserve the pack hook
           // scripts' exec bits.
           const stagedNonoShare = staging ? path.join(staging, 'share', 'nono') : null;

--- a/scripts/download-nono.sh
+++ b/scripts/download-nono.sh
@@ -49,19 +49,26 @@ else
 fi
 
 # Vendor the agent packs the union profile inherits (claude, codex, opencode,
-# pi) so the first sandboxed launch needs no network. Only the `packages/` tree
-# is bundled — nono resolves the union profile from it directly (no lockfile or
-# wiring needed). Packs are platform-independent JSON, so one vendored copy is
-# valid on every OS. See src/sandbox/nono/profile.ts.
+# pi) so the first sandboxed launch needs no network. The `packages/` tree is
+# bundled together with its `lockfile.json`: nono verifies every pack against
+# the lockfile on each real `nono run` (artifact digests + the Sigstore trust
+# bundle, all offline), and a pack directory with no lockfile entry is a hard
+# error. The app installs each pack as a matched pair — directory plus its
+# vendored lockfile entry. Packs are platform-independent JSON, so one
+# vendored copy is valid on every OS. See src/sandbox/nono/profile.ts.
 #
 # `nono pull` also "wires" agent hooks into the invoking user's real config
 # (~/.config/nono, ~/.claude, …). To keep postinstall from mutating a
 # developer's machine, pull into a throwaway HOME and copy only the packages
-# out; every side effect stays inside the temp dir and is discarded.
+# out; every side effect stays inside the temp dir and is discarded. The
+# wiring_record in the vendored lockfile is emptied to match: the app's
+# copy-install performs no wiring, and the record would otherwise bake this
+# machine's paths into every install.
 SHARE="$RESOURCES/share"
 PACKS_DIR="$SHARE/nono/packages/always-further"
+LOCKFILE="$SHARE/nono/packages/lockfile.json"
 PACKS="claude codex opencode pi"
-if [ -d "$PACKS_DIR/claude" ] && [ -d "$PACKS_DIR/codex" ] && [ -d "$PACKS_DIR/opencode" ] && [ -d "$PACKS_DIR/pi" ]; then
+if [ -f "$LOCKFILE" ] && [ -d "$PACKS_DIR/claude" ] && [ -d "$PACKS_DIR/codex" ] && [ -d "$PACKS_DIR/opencode" ] && [ -d "$PACKS_DIR/pi" ]; then
   echo "nono agent packs already vendored"
 else
   echo "Vendoring nono agent packs into $SHARE/nono/packages..."
@@ -75,6 +82,24 @@ else
       echo "Warning: failed to vendor always-further/$pack; first launch will pull it at runtime"
     fi
   done
+  TMP_LOCKFILE="$PACKS_TMP/.config/nono/packages/lockfile.json"
+  if [ -f "$TMP_LOCKFILE" ]; then
+    python3 - "$TMP_LOCKFILE" "$LOCKFILE" <<'PY'
+import json, sys
+
+src, dest = sys.argv[1], sys.argv[2]
+with open(src) as f:
+    lock = json.load(f)
+# The vendored copy is installed without wiring; drop the temp-HOME paths.
+for entry in lock.get("packages", {}).values():
+    entry["wiring_record"] = []
+with open(dest, "w") as f:
+    json.dump(lock, f, indent=2)
+    f.write("\n")
+PY
+  else
+    echo "Warning: no lockfile produced; first launch will pull packs at runtime"
+  fi
   rm -rf "$PACKS_TMP"
   trap - EXIT
 fi

--- a/scripts/download-nono.sh
+++ b/scripts/download-nono.sh
@@ -77,6 +77,9 @@ else
   trap 'rm -rf "$PACKS_TMP"' EXIT
   for pack in $PACKS; do
     if env -u XDG_CONFIG_HOME HOME="$PACKS_TMP" "$DEST/nono" pull "always-further/$pack" --silent; then
+      # Replace, don't merge: cp -R into an existing dir keeps files deleted
+      # upstream, leaving the vendored tree out of sync with the lockfile.
+      rm -rf "$PACKS_DIR/$pack"
       cp -R "$PACKS_TMP/.config/nono/packages/always-further/$pack" "$PACKS_DIR/"
     else
       echo "Warning: failed to vendor always-further/$pack; first launch will pull it at runtime"

--- a/src/__tests__/nonoProfile.test.ts
+++ b/src/__tests__/nonoProfile.test.ts
@@ -121,61 +121,27 @@ describe('installUnionProfile', () => {
     await expect(fs.readFile(runtimeLockfilePath(), 'utf8')).resolves.toBe(before);
   });
 
-  test('treats a pack directory without a lockfile entry as missing and reinstalls the pair (T-490)', async () => {
-    await writeBundledFixture();
-    // The broken state the old dir-only check produced: pack dirs on disk,
-    // no lockfile — nono fails every run with "has no lockfile entry".
-    const staleDir = path.join(configBase, 'nono', 'packages', 'always-further', 'claude');
-    await fs.mkdir(staleDir, { recursive: true });
-    await fs.writeFile(path.join(staleDir, 'stale.txt'), 'old contents', 'utf8');
-
-    await installUnionProfile(NONO);
-
-    const lockfile = await readRuntimeLockfile();
-    for (const pack of PACKS) expect(lockfile.packages[pack]).toBeDefined();
-    // The stale dir was replaced wholesale so files always match the entry's
-    // digests (a mismatched pair trips nono's tamper check).
-    await expect(fs.access(path.join(staleDir, 'stale.txt'))).rejects.toThrow();
-    await expect(fs.readFile(path.join(staleDir, 'package.json'), 'utf8')).resolves.toContain('claude');
-    expect(execFileMock).not.toHaveBeenCalled();
-  });
-
-  test('reinstalls the pair when the lockfile entry exists but the directory is missing', async () => {
+  test("repairs broken pairs from the bundled tree without clobbering the user's own lockfile state", async () => {
     await writeBundledFixture();
     const packagesDir = path.join(configBase, 'nono', 'packages');
-    await fs.mkdir(packagesDir, { recursive: true });
-    await fs.writeFile(
-      runtimeLockfilePath(),
-      JSON.stringify({
-        lockfile_version: 4,
-        packages: { 'always-further/claude': { version: '9.9.9', artifacts: {} } },
-      }),
-      'utf8',
-    );
-
-    await installUnionProfile(NONO);
-
-    const lockfile = await readRuntimeLockfile();
-    // Entry replaced together with the directory so the pair stays matched.
-    expect(lockfile.packages['always-further/claude'].version).toBe('0.0.1');
-    await expect(
-      fs.access(path.join(packagesDir, 'always-further', 'claude', 'package.json')),
-    ).resolves.toBeUndefined();
-  });
-
-  test("merging never clobbers a user's own lockfile entries or packs", async () => {
-    await writeBundledFixture();
-    const packagesDir = path.join(configBase, 'nono', 'packages');
+    // claude: the T-490 state — a pack dir on disk with NO lockfile entry
+    // (nono fails every run with "has no lockfile entry").
+    const claudeDir = path.join(packagesDir, 'always-further', 'claude');
+    await fs.mkdir(claudeDir, { recursive: true });
+    await fs.writeFile(path.join(claudeDir, 'stale.txt'), 'old contents', 'utf8');
+    // acme/widget: a pack the user pulled themselves, which the merge must
+    // leave untouched.
     const userPackDir = path.join(packagesDir, 'acme', 'widget');
     await fs.mkdir(userPackDir, { recursive: true });
     await fs.writeFile(path.join(userPackDir, 'user.json'), '{}', 'utf8');
     const userEntry = { version: '2.0.0', artifacts: { 'user.json': { sha256: 'def' } }, wiring_record: [] };
+    // codex: the inverse broken half — a lockfile entry with no directory.
     await fs.writeFile(
       runtimeLockfilePath(),
       JSON.stringify({
         lockfile_version: 4,
         registry: 'https://example.com/custom',
-        packages: { 'acme/widget': userEntry },
+        packages: { 'acme/widget': userEntry, 'always-further/codex': { version: '9.9.9', artifacts: {} } },
       }),
       'utf8',
     );
@@ -183,13 +149,23 @@ describe('installUnionProfile', () => {
     await installUnionProfile(NONO);
 
     const lockfile = await readRuntimeLockfile();
+    for (const pack of PACKS) expect(lockfile.packages[pack]).toBeDefined();
+    // claude's stale dir was replaced wholesale so files always match the
+    // entry's digests (a mismatched pair trips nono's tamper check).
+    await expect(fs.access(path.join(claudeDir, 'stale.txt'))).rejects.toThrow();
+    await expect(fs.readFile(path.join(claudeDir, 'package.json'), 'utf8')).resolves.toContain('claude');
+    // codex's dangling entry was replaced together with its directory so the
+    // pair stays matched.
+    expect(lockfile.packages['always-further/codex'].version).toBe('0.0.1');
+    await expect(fs.access(path.join(packagesDir, 'always-further', 'codex', 'package.json'))).resolves.toBeUndefined();
+    // The user's own pack and top-level fields survive the merge untouched.
     expect(lockfile.packages['acme/widget']).toEqual(userEntry);
     expect(lockfile.registry).toBe('https://example.com/custom');
-    for (const pack of PACKS) expect(lockfile.packages[pack]).toBeDefined();
     await expect(fs.readFile(path.join(userPackDir, 'user.json'), 'utf8')).resolves.toBe('{}');
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
-  test('a corrupt runtime lockfile is healed rather than left blocking every spawn', async () => {
+  test('corrupt lockfiles are healed on both the bundled and the registry-pull path', async () => {
     await writeBundledFixture();
     await fs.mkdir(path.dirname(runtimeLockfilePath()), { recursive: true });
     // All flavors nono hard-errors on: unparseable JSON, valid JSON of the
@@ -205,23 +181,22 @@ describe('installUnionProfile', () => {
       for (const pack of PACKS) expect(lockfile.packages[pack]).toBeDefined();
       expect(lockfile.lockfile_version).toBe(4);
     }
-  });
+    expect(execFileMock).not.toHaveBeenCalled();
 
-  test('a corrupt lockfile is rewritten before registry pulls, so the pull fallback is not blocked (dev builds)', async () => {
+    // Dev builds (no bundled tree) must rewrite the corrupt file BEFORE the
+    // registry fallback runs — `nono pull` itself hard-errors on a lockfile it
+    // cannot parse, so leaving it in place would block the fallback forever.
     resolveBundledResourceDir.mockReturnValue(null);
-    await fs.mkdir(path.dirname(runtimeLockfilePath()), { recursive: true });
     await fs.writeFile(runtimeLockfilePath(), '{not json', 'utf8');
 
     await installUnionProfile(NONO);
 
-    // `nono pull` itself hard-errors on a lockfile it cannot parse, so the
-    // corrupt file must be replaced with a valid one before any pull runs.
-    const lockfile = await readRuntimeLockfile();
-    expect(typeof lockfile.lockfile_version).toBe('number');
+    const healed = await readRuntimeLockfile();
+    expect(typeof healed.lockfile_version).toBe('number');
     expect(execFileMock).toHaveBeenCalledTimes(PACKS.length);
   });
 
-  test('falls back to nono pull per missing pack when no bundled tree exists (dev builds)', async () => {
+  test('without a bundled tree every missing pack is registry-pulled, and a failed pull surfaces a clear error', async () => {
     resolveBundledResourceDir.mockReturnValue(null);
 
     await installUnionProfile(NONO);
@@ -230,12 +205,10 @@ describe('installUnionProfile', () => {
     for (const pack of PACKS) {
       expect(execFileMock).toHaveBeenCalledWith(NONO, ['pull', pack], expect.any(Function));
     }
-  });
 
-  test('surfaces a clear error naming the pack when the registry pull fails', async () => {
-    resolveBundledResourceDir.mockReturnValue(null);
+    // The mocked pulls installed nothing, so every pack is still missing; a
+    // failing registry now must reject with an error naming the pack.
     execFileMock.mockImplementation((_file, _args, cb) => cb(new Error('network down')));
-
     await expect(installUnionProfile(NONO)).rejects.toThrow(
       /Could not install the nono agent profile 'always-further\/claude'/,
     );

--- a/src/__tests__/nonoProfile.test.ts
+++ b/src/__tests__/nonoProfile.test.ts
@@ -1,0 +1,223 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Intercept `nono pull` (the registry fallback) and the bundled-resources
+// lookup; everything else (lockfile merge, pack copies, profile write) runs
+// against real files in per-test temp dirs.
+const execFileMock = vi.hoisted(() =>
+  vi.fn<(file: string, args: string[], cb: (err: Error | null, stdout?: string) => void) => void>(),
+);
+const resolveBundledResourceDir = vi.hoisted(() => vi.fn<(...segments: string[]) => string | null>());
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+}));
+vi.mock('../paths', () => ({
+  resolveBundledResourceDir: (...segments: string[]) => resolveBundledResourceDir(...segments),
+}));
+
+import { installUnionProfile } from '../sandbox/nono/profile';
+
+const PACKS = [
+  'always-further/claude',
+  'always-further/codex',
+  'always-further/opencode',
+  'always-further/pi',
+] as const;
+const NONO = '/opt/bin/nono';
+
+let configBase: string; // stands in for $XDG_CONFIG_HOME
+let bundledDir: string; // stands in for <resources>/share/nono/packages
+let savedXdg: string | undefined;
+
+/** The runtime lockfile installUnionProfile reads and merges. */
+function runtimeLockfilePath(): string {
+  return path.join(configBase, 'nono', 'packages', 'lockfile.json');
+}
+
+async function readRuntimeLockfile(): Promise<{
+  lockfile_version: number;
+  registry?: string;
+  packages: Record<string, Record<string, unknown>>;
+}> {
+  return JSON.parse(await fs.readFile(runtimeLockfilePath(), 'utf8'));
+}
+
+/**
+ * Write a vendored bundled tree: one dir per pack plus a lockfile whose
+ * entries carry vendor-machine wiring records (which the install must strip).
+ */
+async function writeBundledFixture(): Promise<void> {
+  const packages: Record<string, unknown> = {};
+  for (const pack of PACKS) {
+    const packDir = path.join(bundledDir, pack);
+    await fs.mkdir(packDir, { recursive: true });
+    await fs.writeFile(path.join(packDir, 'package.json'), `{"name":"${pack}"}\n`, 'utf8');
+    packages[pack] = {
+      version: '0.0.1',
+      installed_at: '2026-01-01T00:00:00Z',
+      pinned: false,
+      provenance: { signer_identity: 'https://github.com/always-further/nono-packs/.github/workflows/x.yml@tag' },
+      artifacts: { 'package.json': { sha256: 'abc', type: 'plugin' } },
+      wiring_record: [{ type: 'write_file', dest: '/vendor/machine/only/path' }],
+    };
+  }
+  await fs.writeFile(
+    path.join(bundledDir, 'lockfile.json'),
+    JSON.stringify({ lockfile_version: 4, registry: 'https://registry.nono.sh', packages }, null, 2),
+    'utf8',
+  );
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  configBase = await fs.mkdtemp(path.join(os.tmpdir(), 'nono-config-'));
+  bundledDir = await fs.mkdtemp(path.join(os.tmpdir(), 'nono-bundled-'));
+  savedXdg = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = configBase;
+  resolveBundledResourceDir.mockReturnValue(bundledDir);
+  execFileMock.mockImplementation((_file, _args, cb) => cb(null, ''));
+});
+
+afterEach(async () => {
+  if (savedXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = savedXdg;
+  await fs.rm(configBase, { recursive: true, force: true });
+  await fs.rm(bundledDir, { recursive: true, force: true });
+});
+
+describe('installUnionProfile', () => {
+  test('installs bundled packs as directory + lockfile entry pairs, offline, and is idempotent', async () => {
+    await writeBundledFixture();
+
+    await installUnionProfile(NONO);
+
+    // Every pack installed as a matched pair: dir on disk AND lockfile entry —
+    // nono hard-errors on a pack dir with no lockfile entry, so a bare copy is
+    // never enough.
+    const lockfile = await readRuntimeLockfile();
+    for (const pack of PACKS) {
+      expect(lockfile.packages[pack]).toMatchObject({ version: '0.0.1' });
+      // The copy performs no wiring, so the vendor machine's record is dropped.
+      expect(lockfile.packages[pack].wiring_record).toEqual([]);
+      await expect(
+        fs.readFile(path.join(configBase, 'nono', 'packages', pack, 'package.json'), 'utf8'),
+      ).resolves.toContain(pack);
+    }
+    expect(lockfile.lockfile_version).toBe(4);
+    // The union profile is resolvable by name.
+    const profile = JSON.parse(await fs.readFile(path.join(configBase, 'nono', 'profiles', 'ouijit.json'), 'utf8'));
+    expect(profile.meta.name).toBe('ouijit');
+    expect(profile.extends).toEqual(expect.arrayContaining([...PACKS]));
+    // Fully offline: the registry fallback never ran.
+    expect(execFileMock).not.toHaveBeenCalled();
+
+    // Second run: everything already installed, nothing pulled or rewritten.
+    const before = await fs.readFile(runtimeLockfilePath(), 'utf8');
+    await installUnionProfile(NONO);
+    expect(execFileMock).not.toHaveBeenCalled();
+    await expect(fs.readFile(runtimeLockfilePath(), 'utf8')).resolves.toBe(before);
+  });
+
+  test('treats a pack directory without a lockfile entry as missing and reinstalls the pair (T-490)', async () => {
+    await writeBundledFixture();
+    // The broken state the old dir-only check produced: pack dirs on disk,
+    // no lockfile — nono fails every run with "has no lockfile entry".
+    const staleDir = path.join(configBase, 'nono', 'packages', 'always-further', 'claude');
+    await fs.mkdir(staleDir, { recursive: true });
+    await fs.writeFile(path.join(staleDir, 'stale.txt'), 'old contents', 'utf8');
+
+    await installUnionProfile(NONO);
+
+    const lockfile = await readRuntimeLockfile();
+    for (const pack of PACKS) expect(lockfile.packages[pack]).toBeDefined();
+    // The stale dir was replaced wholesale so files always match the entry's
+    // digests (a mismatched pair trips nono's tamper check).
+    await expect(fs.access(path.join(staleDir, 'stale.txt'))).rejects.toThrow();
+    await expect(fs.readFile(path.join(staleDir, 'package.json'), 'utf8')).resolves.toContain('claude');
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  test('reinstalls the pair when the lockfile entry exists but the directory is missing', async () => {
+    await writeBundledFixture();
+    const packagesDir = path.join(configBase, 'nono', 'packages');
+    await fs.mkdir(packagesDir, { recursive: true });
+    await fs.writeFile(
+      runtimeLockfilePath(),
+      JSON.stringify({
+        lockfile_version: 4,
+        packages: { 'always-further/claude': { version: '9.9.9', artifacts: {} } },
+      }),
+      'utf8',
+    );
+
+    await installUnionProfile(NONO);
+
+    const lockfile = await readRuntimeLockfile();
+    // Entry replaced together with the directory so the pair stays matched.
+    expect(lockfile.packages['always-further/claude'].version).toBe('0.0.1');
+    await expect(
+      fs.access(path.join(packagesDir, 'always-further', 'claude', 'package.json')),
+    ).resolves.toBeUndefined();
+  });
+
+  test("merging never clobbers a user's own lockfile entries or packs", async () => {
+    await writeBundledFixture();
+    const packagesDir = path.join(configBase, 'nono', 'packages');
+    const userPackDir = path.join(packagesDir, 'acme', 'widget');
+    await fs.mkdir(userPackDir, { recursive: true });
+    await fs.writeFile(path.join(userPackDir, 'user.json'), '{}', 'utf8');
+    const userEntry = { version: '2.0.0', artifacts: { 'user.json': { sha256: 'def' } }, wiring_record: [] };
+    await fs.writeFile(
+      runtimeLockfilePath(),
+      JSON.stringify({
+        lockfile_version: 4,
+        registry: 'https://example.com/custom',
+        packages: { 'acme/widget': userEntry },
+      }),
+      'utf8',
+    );
+
+    await installUnionProfile(NONO);
+
+    const lockfile = await readRuntimeLockfile();
+    expect(lockfile.packages['acme/widget']).toEqual(userEntry);
+    expect(lockfile.registry).toBe('https://example.com/custom');
+    for (const pack of PACKS) expect(lockfile.packages[pack]).toBeDefined();
+    await expect(fs.readFile(path.join(userPackDir, 'user.json'), 'utf8')).resolves.toBe('{}');
+  });
+
+  test('an unparseable runtime lockfile is healed rather than left blocking every spawn', async () => {
+    await writeBundledFixture();
+    await fs.mkdir(path.dirname(runtimeLockfilePath()), { recursive: true });
+    await fs.writeFile(runtimeLockfilePath(), '{not json', 'utf8');
+
+    await installUnionProfile(NONO);
+
+    const lockfile = await readRuntimeLockfile();
+    for (const pack of PACKS) expect(lockfile.packages[pack]).toBeDefined();
+    expect(lockfile.lockfile_version).toBe(4);
+  });
+
+  test('falls back to nono pull per missing pack when no bundled tree exists (dev builds)', async () => {
+    resolveBundledResourceDir.mockReturnValue(null);
+
+    await installUnionProfile(NONO);
+
+    expect(execFileMock).toHaveBeenCalledTimes(PACKS.length);
+    for (const pack of PACKS) {
+      expect(execFileMock).toHaveBeenCalledWith(NONO, ['pull', pack], expect.any(Function));
+    }
+  });
+
+  test('surfaces a clear error naming the pack when the registry pull fails', async () => {
+    resolveBundledResourceDir.mockReturnValue(null);
+    execFileMock.mockImplementation((_file, _args, cb) => cb(new Error('network down')));
+
+    await expect(installUnionProfile(NONO)).rejects.toThrow(
+      /Could not install the nono agent profile 'always-further\/claude'/,
+    );
+  });
+});

--- a/src/__tests__/nonoProfile.test.ts
+++ b/src/__tests__/nonoProfile.test.ts
@@ -189,16 +189,36 @@ describe('installUnionProfile', () => {
     await expect(fs.readFile(path.join(userPackDir, 'user.json'), 'utf8')).resolves.toBe('{}');
   });
 
-  test('an unparseable runtime lockfile is healed rather than left blocking every spawn', async () => {
+  test('a corrupt runtime lockfile is healed rather than left blocking every spawn', async () => {
     await writeBundledFixture();
+    await fs.mkdir(path.dirname(runtimeLockfilePath()), { recursive: true });
+    // All flavors nono hard-errors on: unparseable JSON, valid JSON of the
+    // wrong shape, and an object missing the required lockfile_version. Each
+    // must be rewritten as a complete lockfile (entries AND version), or the
+    // "heal" leaves nono just as broken as before.
+    for (const corrupt of ['{not json', '[]', '"x"', '{"packages": {}}']) {
+      await fs.writeFile(runtimeLockfilePath(), corrupt, 'utf8');
+
+      await installUnionProfile(NONO);
+
+      const lockfile = await readRuntimeLockfile();
+      for (const pack of PACKS) expect(lockfile.packages[pack]).toBeDefined();
+      expect(lockfile.lockfile_version).toBe(4);
+    }
+  });
+
+  test('a corrupt lockfile is rewritten before registry pulls, so the pull fallback is not blocked (dev builds)', async () => {
+    resolveBundledResourceDir.mockReturnValue(null);
     await fs.mkdir(path.dirname(runtimeLockfilePath()), { recursive: true });
     await fs.writeFile(runtimeLockfilePath(), '{not json', 'utf8');
 
     await installUnionProfile(NONO);
 
+    // `nono pull` itself hard-errors on a lockfile it cannot parse, so the
+    // corrupt file must be replaced with a valid one before any pull runs.
     const lockfile = await readRuntimeLockfile();
-    for (const pack of PACKS) expect(lockfile.packages[pack]).toBeDefined();
-    expect(lockfile.lockfile_version).toBe(4);
+    expect(typeof lockfile.lockfile_version).toBe('number');
+    expect(execFileMock).toHaveBeenCalledTimes(PACKS.length);
   });
 
   test('falls back to nono pull per missing pack when no bundled tree exists (dev builds)', async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import started from 'electron-squirrel-startup';
 import fixPath from 'fix-path';
 import log from './log';
 import { setLogger, type Logger } from './logger';
-import { setUserDataPath, getDbPath, setCliPath } from './paths';
+import { setUserDataPath, getDbPath, setCliPath, setDevResourcesRoot } from './paths';
 import { setTrashItem } from './platform';
 import { registerIpcHandlers, cleanupIpc } from './ipc/register';
 import { getApiPort } from './hookServer';
@@ -86,6 +86,10 @@ if (process.env.OUIJIT_TEST_USER_DATA) {
 // Set CLI path so PTY sessions can find the bundled ouijit CLI
 if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
   setCliPath(path.join(app.getAppPath(), 'dist-cli', 'ouijit.js'));
+  // Resolve vendored binaries/resources (limactl, nono, agent packs) from the
+  // repo checkout so dev matches packaged builds instead of falling back to
+  // whatever happens to be on PATH.
+  setDevResourcesRoot(path.join(app.getAppPath(), 'resources'));
 } else {
   setCliPath(path.join(app.getAppPath(), 'cli', 'ouijit.js'));
 }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -15,25 +15,46 @@ const execFileAsync = promisify(execFile);
 
 let _userDataPath: string | null = null;
 let _cliPath: string | null = null;
+let _devResourcesRoot: string | null = null;
 const _bundledBinaryCache = new Map<string, string>();
 
 /**
+ * Point resolution at a repo checkout's `resources/` dir. In dev/unpackaged
+ * runs `process.resourcesPath` is Electron's own resources, so without this
+ * the vendored binaries and packs (fetched by postinstall) are invisible and
+ * dev silently diverges from packaged builds by falling back to PATH.
+ */
+export function setDevResourcesRoot(p: string): void {
+  _devResourcesRoot = p;
+  _bundledBinaryCache.clear();
+}
+
+/** Candidate absolute paths for a bundled resource, packaged root first. */
+function bundledCandidates(...segments: string[]): string[] {
+  const roots = [process.resourcesPath, _devResourcesRoot].filter((r): r is string => !!r);
+  return roots.map((root) => path.join(root, ...segments));
+}
+
+/**
  * Resolve a bundled CLI binary: the executable copy under the app's resources
- * if it exists, otherwise the bare name for PATH lookup (dev / user-installed).
- * Shared by the sandbox backends so they bundle and resolve the same way. The
- * bundled path is fixed for the process lifetime, so the `accessSync` probe is
- * memoized — the nono spawn path resolves each binary several times per spawn.
+ * (packaged) or the repo's `resources/` dir (dev) if it exists, otherwise the
+ * bare name for PATH lookup (user-installed). Shared by the sandbox backends
+ * so they bundle and resolve the same way. The bundled path is fixed for the
+ * process lifetime, so the `accessSync` probe is memoized — the nono spawn
+ * path resolves each binary several times per spawn.
  */
 export function resolveBundledBinary(name: string): string {
   const cached = _bundledBinaryCache.get(name);
   if (cached != null) return cached;
-  const bundled = path.join(process.resourcesPath ?? '', 'bin', name);
   let resolved = name;
-  try {
-    fsSync.accessSync(bundled, fsSync.constants.X_OK);
-    resolved = bundled;
-  } catch {
-    resolved = name;
+  for (const candidate of bundledCandidates('bin', name)) {
+    try {
+      fsSync.accessSync(candidate, fsSync.constants.X_OK);
+      resolved = candidate;
+      break;
+    } catch {
+      // keep looking
+    }
   }
   _bundledBinaryCache.set(name, resolved);
   return resolved;
@@ -41,19 +62,20 @@ export function resolveBundledBinary(name: string): string {
 
 /**
  * Resolve a bundled resource directory shipped under the app's `resources`
- * (e.g. `share/nono/packages`). Returns the absolute path when it exists,
- * else null so callers fall back to fetching at runtime — in dev/unpackaged
- * builds `process.resourcesPath` points at Electron's own resources, so the
- * dir is absent and the caller pulls from the network instead.
+ * (e.g. `share/nono/packages`), checking the packaged root then the dev repo
+ * root. Returns the absolute path when it exists, else null so callers fall
+ * back to fetching at runtime.
  */
 export function resolveBundledResourceDir(...segments: string[]): string | null {
-  const dir = path.join(process.resourcesPath ?? '', ...segments);
-  try {
-    fsSync.accessSync(dir);
-    return dir;
-  } catch {
-    return null;
+  for (const candidate of bundledCandidates(...segments)) {
+    try {
+      fsSync.accessSync(candidate);
+      return candidate;
+    } catch {
+      // keep looking
+    }
   }
+  return null;
 }
 
 /** Whether a binary is present, bundled or on PATH. */

--- a/src/sandbox/nono/profile.ts
+++ b/src/sandbox/nono/profile.ts
@@ -59,11 +59,17 @@ const UNION_PROFILE = {
   },
 } as const;
 
-/** nono's config root: `$NONO_CONFIG`, else `$XDG_CONFIG_HOME/nono`, else `~/.config/nono`. */
+/**
+ * nono's config root. Mirrors nono's own resolution (`resolve_user_config_dir`
+ * in nono-cli): `$XDG_CONFIG_HOME` when set to an absolute path, else
+ * `~/.config`, plus `/nono`. nono does NOT read a `$NONO_CONFIG` env var for
+ * this (that name is only a wiring expansion variable), so Ouijit must not
+ * honor one either — writing profiles under a root nono never reads makes
+ * every sandboxed spawn fail profile resolution.
+ */
 function nonoConfigRoot(): string {
-  if (process.env.NONO_CONFIG) return process.env.NONO_CONFIG;
   const xdg = process.env.XDG_CONFIG_HOME;
-  const base = xdg && xdg.length > 0 ? xdg : path.join(os.homedir(), '.config');
+  const base = xdg && path.isAbsolute(xdg) ? xdg : path.join(os.homedir(), '.config');
   return path.join(base, 'nono');
 }
 
@@ -71,7 +77,7 @@ let ensured: Promise<void> | undefined;
 
 /**
  * Ensure the union profile is installed and resolvable before a nono spawn:
- * pull any missing agent packs it inherits, then write the profile JSON to
+ * install any missing agent packs it inherits, then write the profile JSON to
  * nono's profiles dir. Memoized per process — the first spawn pays the cost,
  * the rest reuse it. Rethrows on failure so `prepare` surfaces a clear reason
  * and clears the memo so a transient failure can be retried on the next spawn.
@@ -86,42 +92,134 @@ export function ensureUnionProfile(nonoPath: string): Promise<void> {
   return ensured;
 }
 
-async function installUnionProfile(nonoPath: string): Promise<void> {
+/**
+ * Install (or refresh) the union profile and the agent packs it inherits.
+ * Exported for tests; runtime callers go through the memoized
+ * `ensureUnionProfile`.
+ */
+export async function installUnionProfile(nonoPath: string): Promise<void> {
   const root = nonoConfigRoot();
   await ensurePacks(nonoPath, root);
   await writeProfile(root);
 }
 
 /**
- * Ensure every inherited agent pack is present under the config root. Missing
- * packs are installed from the copy Ouijit bundles under `share/nono/packages`
- * so the first sandboxed spawn needs no network; only when no bundled copy
- * exists (dev / unpackaged builds) does it fall back to pulling from nono's
- * registry. Packs are platform-independent JSON, so the bundled tree is valid
- * on every OS.
+ * The two fields of nono's `packages/lockfile.json` Ouijit reads. Pack entries
+ * are relocated opaquely (nono owns their shape); the only field Ouijit
+ * touches inside an entry is `wiring_record`.
+ */
+interface NonoLockfile {
+  lockfile_version: number;
+  registry?: string;
+  packages: Record<string, Record<string, unknown>>;
+}
+
+/**
+ * Read a nono lockfile, returning null when absent. A present-but-unparseable
+ * file is also treated as absent (warned): nono itself hard-errors on a
+ * corrupt lockfile, so rewriting it with valid entries is a strict improvement
+ * over leaving every spawn broken.
+ */
+async function readLockfile(file: string): Promise<NonoLockfile | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(file, 'utf8');
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as NonoLockfile;
+    return { ...parsed, packages: parsed.packages ?? {} };
+  } catch (error) {
+    nonoLog.warn('unparseable nono lockfile; treating as empty', {
+      file,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/** Write a lockfile atomically (tmp + rename), matching nono's own writer. */
+async function writeLockfile(file: string, lockfile: NonoLockfile): Promise<void> {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  // Distinct suffix from nono's own `lockfile.json.tmp` so a concurrent
+  // `nono pull` can't collide with this write.
+  const tmp = `${file}.ouijit-tmp`;
+  await fs.writeFile(tmp, `${JSON.stringify(lockfile, null, 2)}\n`, 'utf8');
+  await fs.rename(tmp, file);
+}
+
+/**
+ * Ensure every inherited agent pack is installed under the config root.
+ *
+ * "Installed" means the pack directory exists AND `packages/lockfile.json`
+ * has an entry for it — nono's `verify_profile_packs` hard-errors on every
+ * real `nono run` when a pack directory has no lockfile entry, and profile
+ * resolution fails when the directory itself is missing. A bare directory
+ * copy is therefore never sufficient.
+ *
+ * Missing packs are installed as a matched pair from the tree Ouijit bundles
+ * under `share/nono/packages` (the pack directory plus its vendored lockfile
+ * entry, merged into the runtime lockfile), so the first sandboxed spawn
+ * needs no network. The vendored entry is the verbatim output of a real
+ * `nono pull` at vendor time — artifact digests and the Sigstore trust bundle
+ * still verify offline against nono's compiled-in root. Only when no bundled
+ * copy exists (dev / unpackaged builds) does this fall back to pulling from
+ * nono's registry. Packs are platform-independent JSON, so the bundled tree
+ * is valid on every OS.
  */
 async function ensurePacks(nonoPath: string, root: string): Promise<void> {
   const packagesDir = path.join(root, 'packages');
+  const lockfilePath = path.join(packagesDir, 'lockfile.json');
+  const lockfile = await readLockfile(lockfilePath);
+
   const missing: string[] = [];
   for (const pack of PROFILE_PACKAGES) {
-    try {
-      await fs.access(path.join(packagesDir, pack));
-    } catch {
-      missing.push(pack);
-    }
+    const locked = lockfile?.packages[pack] !== undefined;
+    if (!locked || !(await pathExists(path.join(packagesDir, pack)))) missing.push(pack);
   }
   if (missing.length === 0) return;
 
   const bundled = resolveBundledResourceDir('share', 'nono', 'packages');
+  const bundledLockfile = bundled ? await readLockfile(path.join(bundled, 'lockfile.json')) : null;
+
+  // Merge vendored entries into the user's existing lockfile (never clobber
+  // packs they pulled themselves). When creating it fresh, inherit the
+  // version/registry from the vendored file, which came from the same pinned
+  // nono binary Ouijit ships.
+  const merged: NonoLockfile = lockfile ?? {
+    lockfile_version: bundledLockfile?.lockfile_version ?? 4,
+    registry: bundledLockfile?.registry,
+    packages: {},
+  };
+
+  let mergedDirty = false;
+  const toPull: string[] = [];
   for (const pack of missing) {
-    const dest = path.join(packagesDir, pack);
+    const entry = bundledLockfile?.packages[pack];
     const bundledPack = bundled ? path.join(bundled, pack) : null;
-    if (bundledPack && (await pathExists(bundledPack))) {
-      nonoLog.info('installing bundled nono agent pack', { pack });
-      await fs.mkdir(path.dirname(dest), { recursive: true });
-      await fs.cp(bundledPack, dest, { recursive: true });
+    if (!entry || !bundledPack || !(await pathExists(bundledPack))) {
+      toPull.push(pack);
       continue;
     }
+    nonoLog.info('installing bundled nono agent pack', { pack });
+    const dest = path.join(packagesDir, pack);
+    // Replace any stale directory so the files always match the entry's
+    // digests — a mismatched pair fails nono's tamper check.
+    await fs.rm(dest, { recursive: true, force: true });
+    await fs.mkdir(path.dirname(dest), { recursive: true });
+    await fs.cp(bundledPack, dest, { recursive: true });
+    // The copy performs none of `nono pull`'s wiring, so an empty record is
+    // the honest state (verify never reads it).
+    merged.packages[pack] = { ...entry, wiring_record: [] };
+    mergedDirty = true;
+  }
+
+  // Write before any pulls: `nono pull` reads and rewrites the lockfile
+  // itself, so it must see the merged entries rather than race them.
+  if (mergedDirty) await writeLockfile(lockfilePath, merged);
+
+  for (const pack of toPull) {
     nonoLog.info('pulling nono agent pack for the union profile', { pack });
     try {
       await execFileAsync(nonoPath, ['pull', pack]);

--- a/src/sandbox/nono/profile.ts
+++ b/src/sandbox/nono/profile.ts
@@ -115,27 +115,42 @@ interface NonoLockfile {
 }
 
 /**
- * Read a nono lockfile, returning null when absent. A present-but-unparseable
- * file is also treated as absent (warned): nono itself hard-errors on a
- * corrupt lockfile, so rewriting it with valid entries is a strict improvement
- * over leaving every spawn broken.
+ * Read a nono lockfile. `lockfile` is null when the file is absent (normal on
+ * a fresh machine — nono treats a missing lockfile as empty) or when it is
+ * corrupt. `corrupt` distinguishes the two: nono hard-errors on a lockfile it
+ * cannot parse (including valid JSON of the wrong shape or one missing the
+ * required `lockfile_version`), which blocks `nono pull` itself — so a corrupt
+ * file must be rewritten, not just ignored.
  */
-async function readLockfile(file: string): Promise<NonoLockfile | null> {
+async function readLockfile(file: string): Promise<{ lockfile: NonoLockfile | null; corrupt: boolean }> {
   let raw: string;
   try {
     raw = await fs.readFile(file, 'utf8');
   } catch {
-    return null;
+    return { lockfile: null, corrupt: false };
   }
   try {
-    const parsed = JSON.parse(raw) as NonoLockfile;
-    return { ...parsed, packages: parsed.packages ?? {} };
+    const parsed: unknown = JSON.parse(raw);
+    // nono requires lockfile_version (no serde default) and packages must be
+    // an object; anything else is as fatal to nono as unparseable JSON.
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('lockfile is not a JSON object');
+    }
+    const candidate = parsed as NonoLockfile;
+    if (typeof candidate.lockfile_version !== 'number') {
+      throw new Error('lockfile has no numeric lockfile_version');
+    }
+    const packages = candidate.packages;
+    if (packages !== undefined && (typeof packages !== 'object' || packages === null || Array.isArray(packages))) {
+      throw new Error('lockfile packages is not an object');
+    }
+    return { lockfile: { ...candidate, packages: packages ?? {} }, corrupt: false };
   } catch (error) {
-    nonoLog.warn('unparseable nono lockfile; treating as empty', {
+    nonoLog.warn('corrupt nono lockfile; it will be rewritten', {
       file,
       error: error instanceof Error ? error.message : String(error),
     });
-    return null;
+    return { lockfile: null, corrupt: true };
   }
 }
 
@@ -171,7 +186,7 @@ async function writeLockfile(file: string, lockfile: NonoLockfile): Promise<void
 async function ensurePacks(nonoPath: string, root: string): Promise<void> {
   const packagesDir = path.join(root, 'packages');
   const lockfilePath = path.join(packagesDir, 'lockfile.json');
-  const lockfile = await readLockfile(lockfilePath);
+  const { lockfile, corrupt } = await readLockfile(lockfilePath);
 
   const missing: string[] = [];
   for (const pack of PROFILE_PACKAGES) {
@@ -181,12 +196,14 @@ async function ensurePacks(nonoPath: string, root: string): Promise<void> {
   if (missing.length === 0) return;
 
   const bundled = resolveBundledResourceDir('share', 'nono', 'packages');
-  const bundledLockfile = bundled ? await readLockfile(path.join(bundled, 'lockfile.json')) : null;
+  const bundledLockfile = bundled ? (await readLockfile(path.join(bundled, 'lockfile.json'))).lockfile : null;
 
   // Merge vendored entries into the user's existing lockfile (never clobber
   // packs they pulled themselves). When creating it fresh, inherit the
   // version/registry from the vendored file, which came from the same pinned
-  // nono binary Ouijit ships.
+  // nono binary Ouijit ships; without one (dev builds healing a corrupt file),
+  // fall back to the pinned binary's LOCKFILE_VERSION — nono never validates
+  // the number beyond bumping 0, so any real version parses fine.
   const merged: NonoLockfile = lockfile ?? {
     lockfile_version: bundledLockfile?.lockfile_version ?? 4,
     registry: bundledLockfile?.registry,
@@ -216,8 +233,10 @@ async function ensurePacks(nonoPath: string, root: string): Promise<void> {
   }
 
   // Write before any pulls: `nono pull` reads and rewrites the lockfile
-  // itself, so it must see the merged entries rather than race them.
-  if (mergedDirty) await writeLockfile(lockfilePath, merged);
+  // itself, so it must see the merged entries rather than race them. A corrupt
+  // file is rewritten even with nothing merged — `nono pull` hard-errors on a
+  // lockfile it cannot parse, so leaving it in place would block the fallback.
+  if (mergedDirty || corrupt) await writeLockfile(lockfilePath, merged);
 
   for (const pack of toPull) {
     nonoLog.info('pulling nono agent pack for the union profile', { pack });


### PR DESCRIPTION
## Summary
- Fix sandboxed terminals failing at startup with `Package verification failed for always-further/claude: pack has no lockfile entry`: nono verifies every pack in the profile's extends chain against `packages/lockfile.json` on each run, and the bundled-pack install copied only the pack directories without registering them.
- Vendor the lockfile produced by the throwaway-HOME pull alongside the packs in `download-nono.sh` (with `wiring_record` emptied, since the copy-install performs no wiring), and install each missing pack as a matched pair: the pack directory plus its vendored lockfile entry merged into the runtime lockfile. Verification stays fully offline; entries the user pulled themselves are preserved.
- Treat a pack as installed only when both the directory and the lockfile entry exist, replacing whichever half is stale so the pair always matches the entry's digests.
- Heal corrupt lockfiles: validate shape (not just JSON syntax) on read, and rewrite a corrupt file even when nothing was merged, since `nono pull` itself hard-errors on a lockfile it cannot parse.
- Stop honoring `NONO_CONFIG` when resolving nono's config root — nono only reads `XDG_CONFIG_HOME` (else `~/.config`), so profiles written under a `NONO_CONFIG` root were invisible to nono.
- Replace vendored pack dirs instead of `cp -R`-merging into them, so re-vendoring over an old tree cannot retain upstream-deleted files.