### PR TITLE
Make the vendored nono binary discoverable inside sandboxed sessions

### DIFF
--- a/src/__tests__/hookServer.test.ts
+++ b/src/__tests__/hookServer.test.ts
@@ -51,6 +51,7 @@ import {
   PI_EXTENSION,
   OPENCODE_WRAPPER,
   OPENCODE_PLUGIN,
+  NONO_SHIM,
 } from '../hookServer';
 import { issueToken, revokeAllTokens } from '../apiAuth';
 
@@ -446,6 +447,19 @@ describe('installWrapper', () => {
     expect(plugin).toContain('OUIJIT_HOOK_BIN');
   });
 
+  test('creates nono shim preferring OUIJIT_NONO_PATH with a PATH fallthrough', () => {
+    installWrapper();
+
+    const shimPath = path.join(tmpHome, '.config', 'Ouijit', 'bin', 'nono');
+    const shim = fs.readFileSync(shimPath, 'utf-8');
+    expect(shim).toContain('#!/bin/bash');
+    // Sandboxed sessions: exec the vendored binary the provider injected.
+    expect(shim).toContain('exec "$OUIJIT_NONO_PATH" "$@"');
+    // Everywhere else: resolve the real nono on PATH via the shared resolver.
+    expect(shim).toContain('REAL_BIN=');
+    expect(shim).toContain('exec "$REAL_BIN" "$@"');
+  });
+
   test('creates CLI reference file with command documentation', () => {
     installWrapper();
 
@@ -558,6 +572,47 @@ describe('wrapper resolver (shared)', () => {
       }
     });
   }
+});
+
+describe('NONO_SHIM', () => {
+  test('execs the vendored binary when OUIJIT_NONO_PATH is set, else the real nono on PATH', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nono-shim-'));
+    try {
+      const wrapperDir = path.join(tmp, 'wrapper-bin');
+      const realDir = path.join(tmp, 'real-bin');
+      fs.mkdirSync(wrapperDir);
+      fs.mkdirSync(realDir);
+      const shimPath = path.join(wrapperDir, 'nono');
+      fs.writeFileSync(shimPath, NONO_SHIM, { mode: 0o755 });
+
+      // Stand-ins for the vendored binary (as the app resources would hold it)
+      // and a user-installed nono on PATH.
+      const vendored = path.join(tmp, 'vendored-nono');
+      fs.writeFileSync(vendored, '#!/bin/bash\necho VENDORED_OK\nprintf "%s\\n" "$@"\n', { mode: 0o755 });
+      fs.writeFileSync(path.join(realDir, 'nono'), '#!/bin/bash\necho PATH_NONO_OK\n', { mode: 0o755 });
+
+      const fakePath = [wrapperDir, realDir, '/usr/bin', '/bin'].join(':');
+
+      // Sandboxed session: the provider-injected env var wins and argv passes through.
+      const sandboxed = execFileSync('bash', [shimPath, 'why', '--path', '/x'], {
+        env: { PATH: fakePath, HOME: tmp, OUIJIT_NONO_PATH: vendored },
+        encoding: 'utf8',
+        timeout: 10_000,
+      });
+      expect(sandboxed).toContain('VENDORED_OK');
+      expect(sandboxed).toContain('why');
+
+      // Host session (no env var): falls through to the user's nono on PATH.
+      const host = execFileSync('bash', [shimPath, 'why'], {
+        env: { PATH: fakePath, HOME: tmp },
+        encoding: 'utf8',
+        timeout: 10_000,
+      });
+      expect(host).toContain('PATH_NONO_OK');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });
 
 // ── CLAUDE_WRAPPER constant ──────────────────────────────────────────

--- a/src/__tests__/nonoArgv.test.ts
+++ b/src/__tests__/nonoArgv.test.ts
@@ -102,6 +102,15 @@ describe('buildNonoLaunch', () => {
     expect(reads).toEqual(['/Users/dev/code/proj/.git', '/Users/dev/.config/Ouijit']);
   });
 
+  test('grants the vendored nono binary (the file, not its dir) read so `nono why` runs in-sandbox', () => {
+    const binPath = '/Applications/Ouijit.app/Contents/Resources/bin/nono';
+    const { args } = build({ nonoBinPath: binPath });
+    const reads = args.reduce<string[]>((acc, a, i) => (a === '--read' ? [...acc, args[i + 1]] : acc), []);
+    expect(reads).toContain(binPath);
+    // Nothing else bundled next to the binary is exposed.
+    expect(reads).not.toContain('/Applications/Ouijit.app/Contents/Resources/bin');
+  });
+
   test('adds block-net when configured', () => {
     const { args } = build({ config: { blockNet: true } });
     expect(args).toContain('--block-net');

--- a/src/__tests__/nonoBinary.test.ts
+++ b/src/__tests__/nonoBinary.test.ts
@@ -15,7 +15,7 @@ vi.mock('node:os', async (importOriginal) => {
   return { ...actual, release: () => osReleaseMock() };
 });
 
-import { getNonoPath, checkPlatformSupport } from '../sandbox/nono/binary';
+import { getNonoPath, getVendoredNonoPath, checkPlatformSupport } from '../sandbox/nono/binary';
 
 const realPlatform = process.platform;
 
@@ -42,6 +42,15 @@ describe('getNonoPath', () => {
   test('falls back to `nono` on PATH when the bundled binary is absent', () => {
     resolveBundledBinaryMock.mockReturnValue('nono');
     expect(getNonoPath()).toBe('nono');
+  });
+});
+
+describe('getVendoredNonoPath', () => {
+  test('returns the bundled path when vendored, null when nono resolves to PATH', () => {
+    resolveBundledBinaryMock.mockReturnValue('/app/resources/bin/nono');
+    expect(getVendoredNonoPath()).toBe('/app/resources/bin/nono');
+    resolveBundledBinaryMock.mockReturnValue('nono');
+    expect(getVendoredNonoPath()).toBeNull();
   });
 });
 

--- a/src/__tests__/nonoProvider.test.ts
+++ b/src/__tests__/nonoProvider.test.ts
@@ -7,9 +7,13 @@ const checkPlatformSupport = vi.fn<() => { supported: boolean; reason?: string }
 const getMainGitDir = vi.fn<(wt: string) => Promise<string | null>>();
 const getNonoConfig = vi.fn();
 const ensureUnionProfile = vi.fn<() => Promise<void>>();
+const getNonoPath = vi.fn<() => string>();
 
 vi.mock('../sandbox/nono/binary', () => ({
-  getNonoPath: () => '/opt/bin/nono',
+  getNonoPath: () => getNonoPath(),
+  // Mirrors the real derivation: the resolved path when bundled (absolute),
+  // null when nono resolves to bare `nono` on PATH.
+  getVendoredNonoPath: () => (getNonoPath().startsWith('/') ? getNonoPath() : null),
   isNonoInstalled: () => isNonoInstalled(),
   checkPlatformSupport: () => checkPlatformSupport(),
   getMainGitDir: (wt: string) => getMainGitDir(wt),
@@ -48,6 +52,7 @@ beforeEach(() => {
   getMainGitDir.mockResolvedValue('/Users/dev/code/proj/.git');
   getNonoConfig.mockResolvedValue({});
   ensureUnionProfile.mockResolvedValue(undefined);
+  getNonoPath.mockReturnValue('/opt/bin/nono');
 });
 
 describe('nonoProvider', () => {
@@ -65,7 +70,24 @@ describe('nonoProvider', () => {
     // dir; only caches are relocated, never CARGO_HOME (credentials/binaries).
     expect(result.env?.npm_config_cache).toMatch(/sandbox-cache\/.+\/npm$/);
     expect(result.env?.CARGO_HOME).toBeUndefined();
+    // The `nono` shim resolves the vendored binary through this env var so
+    // agents can run `nono why` inside the sandbox.
+    expect(result.env?.OUIJIT_NONO_PATH).toBe('/opt/bin/nono');
     expect(ensureUnionProfile).toHaveBeenCalledTimes(1);
+  });
+
+  test('vendored-binary plumbing is absent when nono resolves to PATH (user-installed)', async () => {
+    getNonoPath.mockReturnValue('nono');
+    // No env var for the shim — it falls through to the user's nono on PATH.
+    const prepared = await nonoProvider.prepare(ctx);
+    expect(prepared.env?.OUIJIT_NONO_PATH).toBeUndefined();
+    // And no read grant, since there is no bundled path to expose.
+    const wrapped = await nonoProvider.wrapLaunch(launch, ctx);
+    const reads = wrapped.args.reduce<string[]>(
+      (acc, a, i) => (a === '--read' ? [...acc, wrapped.args[i + 1]] : acc),
+      [],
+    );
+    expect(reads).toEqual(['/Users/dev/code/proj/.git', '/Users/dev/.config/Ouijit']);
   });
 
   test('prepare rejects with a clear error when nono is not installed', async () => {
@@ -88,6 +110,12 @@ describe('nonoProvider', () => {
     expect(wrapped.args).toContain('/Users/dev/code/proj/.git'); // main git dir (not the worktree's)
     const openPortIdx = wrapped.args.indexOf('--open-port');
     expect(wrapped.args[openPortIdx + 1]).toBe('7777');
+    // The vendored binary itself is read-granted so the agent can exec `nono why`.
+    const reads = wrapped.args.reduce<string[]>(
+      (acc, a, i) => (a === '--read' ? [...acc, wrapped.args[i + 1]] : acc),
+      [],
+    );
+    expect(reads).toContain('/opt/bin/nono');
     // The original launch is the argv tail.
     expect(wrapped.args.slice(-3)).toEqual(['--', '/bin/zsh', '-il']);
   });

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -869,6 +869,32 @@ export const OPENCODE_WRAPPER = [
   '',
 ].join('\n');
 
+// ── nono shim ────────────────────────────────────────────────────────
+
+/**
+ * Bash shim that makes `nono` resolvable in sandboxed sessions. The vendored
+ * binary lives inside the app bundle — not on PATH — so agents inside the
+ * sandbox could not run `nono why` to diagnose denials. The nono provider
+ * injects OUIJIT_NONO_PATH (and a read grant for it) at spawn time; in every
+ * other context the env var is unset and the shim falls through to the real
+ * nono on PATH, so a user-installed nono behaves exactly as before.
+ */
+export const NONO_SHIM = [
+  '#!/bin/bash',
+  '# Ouijit nono shim — resolves the vendored nono binary in sandboxed sessions.',
+  '# OUIJIT_NONO_PATH is set only by nono-sandboxed Ouijit terminals; it points',
+  '# at the same binary that supervises this session, so `nono why` answers',
+  '# with the version that actually enforced the denial.',
+  'if [ -n "$OUIJIT_NONO_PATH" ] && [ -x "$OUIJIT_NONO_PATH" ]; then',
+  '  exec "$OUIJIT_NONO_PATH" "$@"',
+  'fi',
+  '',
+  buildWrapperResolver('nono'),
+  '',
+  'exec "$REAL_BIN" "$@"',
+  '',
+].join('\n');
+
 /**
  * Install the ouijit-hook helper script and claude wrapper into
  * ~/.config/Ouijit/bin/. The wrapper injects hooks via --settings
@@ -909,6 +935,10 @@ export function installWrapper(): void {
     // plugin is inert until the wrapper exports OUIJIT_HOOK_BIN, so a plain
     // `opencode` run is unaffected.
     fs.writeFileSync(path.join(binDir, 'opencode'), OPENCODE_WRAPPER, { mode: 0o755 });
+
+    // Write nono shim (resolves the vendored nono binary in sandboxed sessions
+    // via OUIJIT_NONO_PATH; falls through to PATH everywhere else)
+    fs.writeFileSync(path.join(binDir, 'nono'), NONO_SHIM, { mode: 0o755 });
     const opencodePluginPath = getOpencodePluginPath();
     fs.mkdirSync(path.dirname(opencodePluginPath), { recursive: true });
     fs.writeFileSync(opencodePluginPath, OPENCODE_PLUGIN, { mode: 0o644 });

--- a/src/sandbox/nono/argv.ts
+++ b/src/sandbox/nono/argv.ts
@@ -26,6 +26,13 @@ export interface NonoArgvContext {
    */
   cacheDir?: string;
   /**
+   * Absolute path of the vendored nono binary (under the app's resources),
+   * granted read so the sandboxed agent can exec it — the `nono` shim on PATH
+   * points here via OUIJIT_NONO_PATH, letting agents self-diagnose denials
+   * with `nono why`. Unset when nono is user-installed (already on PATH).
+   */
+  nonoBinPath?: string;
+  /**
    * Profile to run under. Defaults to Ouijit's managed `ouijit` profile; a
    * per-project override profile (the profile editor) replaces it by name.
    */
@@ -87,6 +94,9 @@ export function buildNonoLaunch(nonoPath: string, launch: SandboxLaunch, ctx: No
   // Ouijit wrapper scripts (first on PATH) and the bundled CLI they exec.
   args.push('--read', ctx.wrapperDir);
   if (ctx.cliDir) args.push('--read', ctx.cliDir);
+  // The vendored nono binary alone (not its dir), so `nono why` runs inside
+  // the sandbox without exposing anything else bundled next to it.
+  if (ctx.nonoBinPath) args.push('--read', ctx.nonoBinPath);
 
   args.push('--', launch.file, ...launch.args);
 

--- a/src/sandbox/nono/binary.ts
+++ b/src/sandbox/nono/binary.ts
@@ -1,4 +1,5 @@
 import * as os from 'node:os';
+import * as path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { getLogger } from '../../logger';
@@ -13,6 +14,18 @@ const nonoLog = getLogger().scope('nono');
  */
 export function getNonoPath(): string {
   return resolveBundledBinary('nono');
+}
+
+/**
+ * Absolute path of the vendored nono binary, or null when nono resolves to
+ * PATH (user-installed / dev without the download). Sandboxed sessions need
+ * the vendored path explicitly: it is neither on PATH nor readable inside the
+ * sandbox by default, so the spawn injects it via OUIJIT_NONO_PATH (for the
+ * `nono` shim) and grants it read (so the agent can exec `nono why`).
+ */
+export function getVendoredNonoPath(): string | null {
+  const resolved = getNonoPath();
+  return path.isAbsolute(resolved) ? resolved : null;
 }
 
 /** Minimum Linux kernel for Landlock filesystem mediation nono relies on. */

--- a/src/sandbox/nono/provider.ts
+++ b/src/sandbox/nono/provider.ts
@@ -6,7 +6,7 @@ import { getCliPath, getUserDataPath } from '../../paths';
 import { getLogger } from '../../logger';
 import type { WrapperSandboxProvider } from '../provider';
 import type { SandboxLaunch, SandboxProviderStatus, SandboxSpawnContext } from '../types';
-import { getNonoPath, isNonoInstalled, checkPlatformSupport, getMainGitDir } from './binary';
+import { getNonoPath, getVendoredNonoPath, isNonoInstalled, checkPlatformSupport, getMainGitDir } from './binary';
 import { getNonoConfig } from './config';
 import { ensureUnionProfile, ensureProjectProfile } from './profile';
 import { sandboxCacheEnv } from './cacheEnv';
@@ -92,7 +92,13 @@ export const nonoProvider: WrapperSandboxProvider = {
     // print a lock error at every prompt. The integration neutralizes HISTFILE
     // after the user's rc runs (a plain env var loses to an rc that re-sets it).
     // The cache vars are injected the same way, so a user's rc still overrides.
-    return { cwd: ctx.cwd, env: { OUIJIT_SANDBOX_NO_HISTORY: '1', ...sandboxCacheEnv(cacheDir) } };
+    const env: Record<string, string> = { OUIJIT_SANDBOX_NO_HISTORY: '1', ...sandboxCacheEnv(cacheDir) };
+    // Point the `nono` shim (wrapper bin dir, first on PATH) at the vendored
+    // binary so agents can run `nono why` inside the sandbox. Skipped when
+    // nono resolves to PATH (user-installed) — the shim falls through to it.
+    const vendoredNono = getVendoredNonoPath();
+    if (vendoredNono) env.OUIJIT_NONO_PATH = vendoredNono;
+    return { cwd: ctx.cwd, env };
   },
 
   async wrapLaunch(launch: SandboxLaunch, ctx: SandboxSpawnContext): Promise<SandboxLaunch> {
@@ -123,6 +129,7 @@ export const nonoProvider: WrapperSandboxProvider = {
       wrapperDir: ouijitDir(),
       cliDir,
       cacheDir,
+      nonoBinPath: getVendoredNonoPath() ?? undefined,
       profileName,
       config,
     });


### PR DESCRIPTION
## Summary
- Install a `nono` shim into `~/.config/Ouijit/bin` (already first on PATH and read-granted in the sandbox): it execs `$OUIJIT_NONO_PATH` when set, otherwise falls through to the real nono on PATH via the shared wrapper resolver, so a user-installed nono behaves exactly as before
- The nono provider injects `OUIJIT_NONO_PATH` at spawn time when nono resolves to the vendored binary under the app's resources, so agents inside the sandbox can run `nono why` to diagnose denials with the same binary version that supervises the session
- `buildNonoLaunch` grants `--read` on the vendored binary file alone (not its directory), so nothing else bundled next to it is exposed