### PR TITLE
Fix nono 0.66 launch and resolve nono in every task terminal

### DIFF
--- a/src/__tests__/nonoArgv.test.ts
+++ b/src/__tests__/nonoArgv.test.ts
@@ -102,13 +102,16 @@ describe('buildNonoLaunch', () => {
     expect(reads).toEqual(['/Users/dev/code/proj/.git', '/Users/dev/.config/Ouijit']);
   });
 
-  test('grants the vendored nono binary (the file, not its dir) read so `nono why` runs in-sandbox', () => {
+  test('grants the vendored nono binary via --read-file so `nono why` runs in-sandbox', () => {
     const binPath = '/Applications/Ouijit.app/Contents/Resources/bin/nono';
     const { args } = build({ nonoBinPath: binPath });
-    const reads = args.reduce<string[]>((acc, a, i) => (a === '--read' ? [...acc, args[i + 1]] : acc), []);
-    expect(reads).toContain(binPath);
+    // A single file must use --read-file: nono rejects file paths on --read.
+    const fileReads = args.reduce<string[]>((acc, a, i) => (a === '--read-file' ? [...acc, args[i + 1]] : acc), []);
+    expect(fileReads).toContain(binPath);
     // Nothing else bundled next to the binary is exposed.
+    const reads = args.reduce<string[]>((acc, a, i) => (a === '--read' ? [...acc, args[i + 1]] : acc), []);
     expect(reads).not.toContain('/Applications/Ouijit.app/Contents/Resources/bin');
+    expect(reads).not.toContain(binPath);
   });
 
   test('adds block-net when configured', () => {

--- a/src/__tests__/nonoProvider.test.ts
+++ b/src/__tests__/nonoProvider.test.ts
@@ -110,12 +110,13 @@ describe('nonoProvider', () => {
     expect(wrapped.args).toContain('/Users/dev/code/proj/.git'); // main git dir (not the worktree's)
     const openPortIdx = wrapped.args.indexOf('--open-port');
     expect(wrapped.args[openPortIdx + 1]).toBe('7777');
-    // The vendored binary itself is read-granted so the agent can exec `nono why`.
-    const reads = wrapped.args.reduce<string[]>(
-      (acc, a, i) => (a === '--read' ? [...acc, wrapped.args[i + 1]] : acc),
+    // The vendored binary itself is read-granted (a single file, so via
+    // --read-file) so the agent can exec `nono why`.
+    const fileReads = wrapped.args.reduce<string[]>(
+      (acc, a, i) => (a === '--read-file' ? [...acc, wrapped.args[i + 1]] : acc),
       [],
     );
-    expect(reads).toContain('/opt/bin/nono');
+    expect(fileReads).toContain('/opt/bin/nono');
     // The original launch is the argv tail.
     expect(wrapped.args.slice(-3)).toEqual(['--', '/bin/zsh', '-il']);
   });

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -872,19 +872,21 @@ export const OPENCODE_WRAPPER = [
 // ── nono shim ────────────────────────────────────────────────────────
 
 /**
- * Bash shim that makes `nono` resolvable in sandboxed sessions. The vendored
- * binary lives inside the app bundle — not on PATH — so agents inside the
- * sandbox could not run `nono why` to diagnose denials. The nono provider
- * injects OUIJIT_NONO_PATH (and a read grant for it) at spawn time; in every
- * other context the env var is unset and the shim falls through to the real
- * nono on PATH, so a user-installed nono behaves exactly as before.
+ * Bash shim that makes `nono` resolvable in Ouijit terminals. The vendored
+ * binary lives inside the app bundle — not on PATH — so without this shim
+ * agents inside the sandbox could not run `nono why` to diagnose denials, and
+ * users in regular task terminals could not run `nono profile promote` to
+ * apply a profile draft. The PTY manager injects OUIJIT_NONO_PATH into every
+ * task terminal (the nono provider re-sets the same value and grants it read
+ * for sandboxed spawns); when nono is user-installed the env var is unset and
+ * the shim falls through to the real nono on PATH.
  */
 export const NONO_SHIM = [
   '#!/bin/bash',
-  '# Ouijit nono shim — resolves the vendored nono binary in sandboxed sessions.',
-  '# OUIJIT_NONO_PATH is set only by nono-sandboxed Ouijit terminals; it points',
-  '# at the same binary that supervises this session, so `nono why` answers',
-  '# with the version that actually enforced the denial.',
+  '# Ouijit nono shim — resolves the vendored nono binary in Ouijit terminals.',
+  '# OUIJIT_NONO_PATH is set by Ouijit task terminals; in a nono-sandboxed',
+  '# session it points at the same binary that supervises the session, so',
+  '# `nono why` answers with the version that actually enforced the denial.',
   'if [ -n "$OUIJIT_NONO_PATH" ] && [ -x "$OUIJIT_NONO_PATH" ]; then',
   '  exec "$OUIJIT_NONO_PATH" "$@"',
   'fi',
@@ -936,8 +938,8 @@ export function installWrapper(): void {
     // `opencode` run is unaffected.
     fs.writeFileSync(path.join(binDir, 'opencode'), OPENCODE_WRAPPER, { mode: 0o755 });
 
-    // Write nono shim (resolves the vendored nono binary in sandboxed sessions
-    // via OUIJIT_NONO_PATH; falls through to PATH everywhere else)
+    // Write nono shim (resolves the vendored nono binary via OUIJIT_NONO_PATH,
+    // set by every Ouijit task terminal; falls through to PATH everywhere else)
     fs.writeFileSync(path.join(binDir, 'nono'), NONO_SHIM, { mode: 0o755 });
     const opencodePluginPath = getOpencodePluginPath();
     fs.mkdirSync(path.dirname(opencodePluginPath), { recursive: true });

--- a/src/ptyManager.ts
+++ b/src/ptyManager.ts
@@ -8,6 +8,7 @@ import { getShellIntegrationDir, resolveShellIntegration } from './shellIntegrat
 import { typedPush } from './ipc/helpers';
 import { getLogger } from './logger';
 import { getUserDataPath, getCliPath } from './paths';
+import { getVendoredNonoPath } from './sandbox/nono/binary';
 import { issueToken, revokeToken, revokeAllTokens } from './apiAuth';
 
 const ptyLog = getLogger().scope('pty');
@@ -220,6 +221,14 @@ export async function spawnPty(
     finalEnv['OUIJIT_USER_DATA'] = getUserDataPath();
     const cliPath = getCliPath();
     if (cliPath) finalEnv['OUIJIT_CLI_PATH'] = cliPath;
+
+    // Point the `nono` shim at the vendored binary. Every task terminal needs
+    // it, not just sandboxed ones: nono's persistent-grant flow ends with the
+    // user running `nono profile promote` outside the sandbox, i.e. in a
+    // regular task terminal. Unset when nono is user-installed (the shim falls
+    // through to PATH); sandboxed spawns re-set the same value.
+    const vendoredNono = getVendoredNonoPath();
+    if (vendoredNono) finalEnv['OUIJIT_NONO_PATH'] = vendoredNono;
 
     // Build the command string to run in the spawned shell
     const expandedCommand = buildCommandString(options.command, options.env);

--- a/src/sandbox/nono/argv.ts
+++ b/src/sandbox/nono/argv.ts
@@ -95,8 +95,9 @@ export function buildNonoLaunch(nonoPath: string, launch: SandboxLaunch, ctx: No
   args.push('--read', ctx.wrapperDir);
   if (ctx.cliDir) args.push('--read', ctx.cliDir);
   // The vendored nono binary alone (not its dir), so `nono why` runs inside
-  // the sandbox without exposing anything else bundled next to it.
-  if (ctx.nonoBinPath) args.push('--read', ctx.nonoBinPath);
+  // the sandbox without exposing anything else bundled next to it. Granted
+  // with --read-file: nono rejects file paths on the directory flags.
+  if (ctx.nonoBinPath) args.push('--read-file', ctx.nonoBinPath);
 
   args.push('--', launch.file, ...launch.args);
 


### PR DESCRIPTION
## Summary
- Grant the vendored nono binary with `--read-file` instead of `--read`: nono 0.66 rejects file paths on the directory grant flags, which killed every sandboxed launch with a configuration parse error
- Inject `OUIJIT_NONO_PATH` into every task terminal so the `nono` shim resolves the vendored binary outside sandboxed sessions too; nono's persistent-grant flow ends with the user running `nono profile promote` outside the sandbox, which previously failed with "nono not found on PATH" unless nono was user-installed
- Update the shim comments and the argv/provider tests to match