### PR TITLE
Light mode, design tokens, and preset themes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ Dev userData is isolated per worktree via a hash of the repo path (`…/ouijit-d
 - Use hover/active states for visual feedback, not cursor changes
 - Follow macOS HIG patterns
 - Respect system light/dark mode
+- Never hardcode colors or shadows. Every color/shadow comes from a design token in `src/theme/tokens.css` (Tailwind utility like `bg-ink/10` / `border-bezel`, or `var(--token)` in inline styles). Themes override tokens at runtime via `src/theme/themeManager.ts`. Allowed exceptions: pure-black scrims/shadows and the project identity palette in `src/utils/projectIcon.ts`.
 
 ## Logging
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,10 +44,10 @@ class ViewErrorBoundary extends Component<{ children: ReactNode }, { error: Erro
       return (
         <div className="flex-1 flex items-center justify-center p-8">
           <div className="text-center w-full max-w-[28rem]">
-            <div className="text-sm text-red-400 font-mono mb-2">View crashed</div>
-            <div className="text-xs text-white/50 font-mono break-words">{this.state.error.message}</div>
+            <div className="text-sm text-error font-mono mb-2">View crashed</div>
+            <div className="text-xs text-ink/50 font-mono break-words">{this.state.error.message}</div>
             <button
-              className="mt-4 px-3 py-1.5 text-xs bg-white/10 rounded border border-white/20 text-white/70 hover:bg-white/20"
+              className="mt-4 px-3 py-1.5 text-xs bg-ink/10 rounded border border-ink/20 text-ink/70 hover:bg-ink/20"
               onClick={() => this.setState({ error: null })}
             >
               Retry

--- a/src/__tests__/apiRouterAuth.test.ts
+++ b/src/__tests__/apiRouterAuth.test.ts
@@ -46,6 +46,8 @@ vi.mock('../db', () => ({
   getScripts: vi.fn(() => []),
   saveScript: vi.fn(),
   deleteScript: vi.fn(),
+  getGlobalSetting: vi.fn(async () => undefined),
+  setGlobalSetting: vi.fn(async () => ({ success: true })),
 }));
 
 vi.mock('../taskLifecycle', () => ({
@@ -69,6 +71,7 @@ vi.mock('../cliPanels', () => ({
 import { startHookServer, stopHookServer, getApiPort } from '../hookServer';
 import { issueToken, revokeAllTokens } from '../apiAuth';
 import { getTaskWithWorkspace } from '../taskLifecycle';
+import { typedPush } from '../ipc/helpers';
 
 const mockSend = vi.fn();
 function mockWindow(): BrowserWindow {
@@ -214,6 +217,53 @@ describe('sandbox read-only, own-task scope', () => {
     const token = issueToken('pty-host', 'host');
     const res = await request('GET', `/api/tasks/9?project=${PROJECT}`, token);
     expect(res.status).toBe(200);
+  });
+});
+
+describe('theme routes', () => {
+  test('theme routes validate, persist, and push cli:theme-changed; sandbox is refused', async () => {
+    // Sandbox scope: read and write both refused (host-only routes).
+    const sandboxToken = issueToken('pty-sbx', 'sandbox');
+    expect((await request('GET', '/api/themes', sandboxToken)).status).toBe(403);
+    expect(
+      (
+        await request('PUT', '/api/themes/custom/x', sandboxToken, {
+          name: 'X',
+          base: 'dark',
+          tokens: {},
+        })
+      ).status,
+    ).toBe(403);
+
+    const token = issueToken('pty-host', 'host');
+
+    // GET returns presets plus (empty) custom themes and the default preference.
+    const list = await request('GET', '/api/themes', token);
+    expect(list.status).toBe(200);
+    const data = list.body.data as { preference: string; presets: unknown[]; customThemes: unknown[] };
+    expect(data.preference).toBe('system');
+    expect(data.presets.length).toBeGreaterThan(0);
+    expect(data.customThemes).toEqual([]);
+
+    // Invalid theme body → 400; valid body persists and pushes cli:theme-changed.
+    const bad = await request('PUT', '/api/themes/custom/my-theme', token, { base: 'sepia', tokens: {} });
+    expect(bad.status).toBe(400);
+    const good = await request('PUT', '/api/themes/custom/my-theme', token, {
+      name: 'My Theme',
+      base: 'dark',
+      tokens: { '--color-accent': '#ff2d55' },
+    });
+    expect(good.status).toBe(200);
+    expect(vi.mocked(typedPush)).toHaveBeenCalledWith(expect.anything(), 'cli:theme-changed');
+
+    // Preference validation: unknown custom id 404s, presets and built-ins work.
+    expect((await request('PUT', '/api/themes/preference', token, { preference: 'custom:nope' })).status).toBe(404);
+    expect((await request('PUT', '/api/themes/preference', token, { preference: 'sepia' })).status).toBe(400);
+    expect((await request('PUT', '/api/themes/preference', token, { preference: 'custom:dracula' })).status).toBe(200);
+    expect((await request('PUT', '/api/themes/preference', token, { preference: 'light' })).status).toBe(200);
+
+    // Deleting a theme that doesn't exist → 404 (settings mock stores nothing).
+    expect((await request('DELETE', '/api/themes/custom/nope', token)).status).toBe(404);
   });
 });
 

--- a/src/__tests__/renderer/setup.ts
+++ b/src/__tests__/renderer/setup.ts
@@ -10,6 +10,22 @@ afterEach(() => {
   cleanup();
 });
 
+// jsdom doesn't implement matchMedia; the theme manager queries the OS
+// appearance at module load.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
 // Stub the icon registry. The real module statically imports ~200 Phosphor
 // SVGs via Vite's `?raw` query, which Vitest's resolver chokes on (each
 // import is a separate fetch through the asset transform pipeline). Tests

--- a/src/__tests__/renderer/useIPCListeners.test.tsx
+++ b/src/__tests__/renderer/useIPCListeners.test.tsx
@@ -106,6 +106,7 @@ function installListenerStubs(): ListenerStubs {
   api['onShellUnsupported'] = vi.fn(() => () => {});
   api['onWhatsNew'] = vi.fn(() => () => {});
   api['onCliChange'] = vi.fn(() => () => {});
+  api['onCliThemeChanged'] = vi.fn(() => () => {});
   api['health'] = { onUpdate: vi.fn(() => () => {}) };
   api['onCliTaskStarted'] = vi.fn((cb: CliTaskStartedCb) => {
     stubs.cliTaskStartedCb = cb;

--- a/src/__tests__/themes.test.ts
+++ b/src/__tests__/themes.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from 'vitest';
+import {
+  isThemePreference,
+  parseCustomTheme,
+  parseCustomThemes,
+  resolveThemeBase,
+  selectedCustomTheme,
+  type CustomTheme,
+} from '../theme/themes';
+
+const midnight: CustomTheme = {
+  id: 'midnight',
+  name: 'Midnight',
+  base: 'dark',
+  tokens: { '--color-accent': '#ff2d55' },
+};
+
+describe('theme model', () => {
+  test('isThemePreference accepts built-ins and custom ids, rejects junk', () => {
+    expect(isThemePreference('system')).toBe(true);
+    expect(isThemePreference('dark')).toBe(true);
+    expect(isThemePreference('light')).toBe(true);
+    expect(isThemePreference('custom:midnight')).toBe(true);
+    expect(isThemePreference('sepia')).toBe(false);
+  });
+
+  test('resolveThemeBase follows the preference, custom base, and system fallback', () => {
+    expect(resolveThemeBase('dark', false, [])).toBe('dark');
+    expect(resolveThemeBase('light', true, [])).toBe('light');
+    expect(resolveThemeBase('system', true, [])).toBe('dark');
+    expect(resolveThemeBase('system', false, [])).toBe('light');
+    expect(resolveThemeBase('custom:midnight', false, [midnight])).toBe('dark');
+    // Unknown custom id degrades to system resolution
+    expect(resolveThemeBase('custom:gone', true, [midnight])).toBe('dark');
+    expect(resolveThemeBase('custom:gone', false, [midnight])).toBe('light');
+  });
+
+  test('selectedCustomTheme only matches an existing custom preference', () => {
+    expect(selectedCustomTheme('custom:midnight', [midnight])).toEqual(midnight);
+    expect(selectedCustomTheme('custom:gone', [midnight])).toBeNull();
+    expect(selectedCustomTheme('dark', [midnight])).toBeNull();
+  });
+
+  test('parseCustomTheme validates structure and rejects unsafe token names/values', () => {
+    expect(parseCustomTheme(midnight)).toEqual(midnight);
+    expect(parseCustomTheme(null)).toBeNull();
+    expect(parseCustomTheme({ ...midnight, base: 'sepia' })).toBeNull();
+    expect(parseCustomTheme({ ...midnight, tokens: { 'color-accent': '#fff' } })).toBeNull();
+    expect(parseCustomTheme({ ...midnight, tokens: { '--color-accent': 'red; } html { display: none' } })).toBeNull();
+    expect(parseCustomTheme({ ...midnight, id: '' })).toBeNull();
+  });
+
+  test('parseCustomThemes drops invalid entries and survives corrupt JSON', () => {
+    const json = JSON.stringify([midnight, { id: 'bad' }]);
+    expect(parseCustomThemes(json)).toEqual([midnight]);
+    expect(parseCustomThemes('not json')).toEqual([]);
+    expect(parseCustomThemes(undefined)).toEqual([]);
+    expect(parseCustomThemes('{}')).toEqual([]);
+  });
+});

--- a/src/__tests__/themes.test.ts
+++ b/src/__tests__/themes.test.ts
@@ -7,6 +7,7 @@ import {
   selectedCustomTheme,
   type CustomTheme,
 } from '../theme/themes';
+import { PRESET_THEMES, withPresets } from '../theme/presets';
 
 const midnight: CustomTheme = {
   id: 'midnight',
@@ -48,6 +49,23 @@ describe('theme model', () => {
     expect(parseCustomTheme({ ...midnight, tokens: { 'color-accent': '#fff' } })).toBeNull();
     expect(parseCustomTheme({ ...midnight, tokens: { '--color-accent': 'red; } html { display: none' } })).toBeNull();
     expect(parseCustomTheme({ ...midnight, id: '' })).toBeNull();
+  });
+
+  test('presets are valid themes, resolve like custom themes, and are shadowed by user copies', () => {
+    // Every bundled preset must survive the same validation as user themes.
+    for (const preset of PRESET_THEMES) {
+      expect(parseCustomTheme(preset)).toEqual(preset);
+    }
+
+    const dracula = PRESET_THEMES.find((t) => t.id === 'dracula')!;
+    expect(resolveThemeBase('custom:dracula', false, withPresets([]))).toBe(dracula.base);
+    expect(selectedCustomTheme('custom:dracula', withPresets([midnight]))).toEqual(dracula);
+
+    // A user theme with the same id wins; other presets stay available.
+    const userCopy: CustomTheme = { ...dracula, name: 'My Dracula', tokens: { '--color-accent': '#ff79c6' } };
+    const merged = withPresets([userCopy]);
+    expect(selectedCustomTheme('custom:dracula', merged)).toEqual(userCopy);
+    expect(merged.filter((t) => t.id === 'dracula')).toHaveLength(1);
   });
 
   test('parseCustomThemes drops invalid entries and survives corrupt JSON', () => {

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -25,7 +25,11 @@ import {
   saveScript,
   deleteScript,
   getTaskByNumber,
+  getGlobalSetting,
+  setGlobalSetting,
 } from '../db';
+import { isThemePreference, parseCustomTheme, parseCustomThemes, type CustomTheme } from '../theme/themes';
+import { PRESET_THEMES, withPresets } from '../theme/presets';
 import {
   beginTask,
   setTaskStatusWithHooks,
@@ -139,6 +143,13 @@ function parseHookControl(body: Record<string, unknown>): HookControl {
     return { hookMode: mode, hookCommand: command };
   }
   return { hookMode: mode };
+}
+
+const THEME_PREFERENCE_KEY = 'ui:theme';
+const CUSTOM_THEMES_KEY = 'ui:customThemes';
+
+async function readCustomThemes(): Promise<CustomTheme[]> {
+  return parseCustomThemes(await getGlobalSetting(CUSTOM_THEMES_KEY));
 }
 
 function isTaskStartRoute(method: string, segments: string[]): boolean {
@@ -510,6 +521,79 @@ const routes: Route[] = [
     true,
   ),
 
+  // ── Themes (global appearance — not project-scoped) ─────────────
+  // Same persistence the renderer theme manager uses (ui:theme /
+  // ui:customThemes in global settings); mutations push cli:theme-changed
+  // so the renderer re-reads and re-applies live.
+  route('GET', 'themes', async () => {
+    const stored = await getGlobalSetting(THEME_PREFERENCE_KEY);
+    return {
+      preference: stored && isThemePreference(stored) ? stored : 'system',
+      presets: PRESET_THEMES,
+      customThemes: await readCustomThemes(),
+    };
+  }),
+
+  route(
+    'PUT',
+    'themes/preference',
+    async (r) => {
+      const preference = r.body.preference;
+      if (typeof preference !== 'string' || !isThemePreference(preference)) {
+        throw new HttpError(400, 'Invalid preference: must be system, light, dark, or custom:<id>');
+      }
+      if (preference.startsWith('custom:')) {
+        const merged = withPresets(await readCustomThemes());
+        if (!merged.some((t) => `custom:${t.id}` === preference)) {
+          throw new HttpError(404, `No theme with id '${preference.slice('custom:'.length)}'`);
+        }
+      }
+      await setGlobalSetting(THEME_PREFERENCE_KEY, preference);
+      return { success: true, preference };
+    },
+    true,
+  ),
+
+  route(
+    'PUT',
+    'themes/custom/:id',
+    async (r) => {
+      const id = decodeURIComponent(r.segments[2]);
+      // The URL segment is authoritative for the id (PUT semantics).
+      const theme = parseCustomTheme({ ...r.body, id });
+      if (!theme) {
+        throw new HttpError(
+          400,
+          'Invalid theme: needs "name", "base" ("dark" or "light"), and a "tokens" object of --token overrides',
+        );
+      }
+      const list = await readCustomThemes();
+      const next = [...list.filter((t) => t.id !== theme.id), theme];
+      await setGlobalSetting(CUSTOM_THEMES_KEY, JSON.stringify(next));
+      return { success: true, theme };
+    },
+    true,
+  ),
+
+  route(
+    'DELETE',
+    'themes/custom/:id',
+    async (r) => {
+      const id = decodeURIComponent(r.segments[2]);
+      const list = await readCustomThemes();
+      if (!list.some((t) => t.id === id)) throw new HttpError(404, `No custom theme with id '${id}'`);
+      await setGlobalSetting(CUSTOM_THEMES_KEY, JSON.stringify(list.filter((t) => t.id !== id)));
+      // Mirrors the renderer's delete behavior: removing a user copy of a
+      // preset restores the preset, so the selection stays valid.
+      const preference = await getGlobalSetting(THEME_PREFERENCE_KEY);
+      if (preference === `custom:${id}` && !PRESET_THEMES.some((t) => t.id === id)) {
+        await setGlobalSetting(THEME_PREFERENCE_KEY, 'system');
+      }
+      return { success: true };
+    },
+    true,
+  ),
+
   // ── Panels ────────────────────────────────────────────────────────
   // The two user-addressable panel kinds on a terminal: markdown files and
   // web previews. A terminal can hold several of each, so these are plural
@@ -658,6 +742,12 @@ async function handleAsync(req: IncomingMessage, res: ServerResponse, window: Br
         action: `${method} /api/${apiPath}`,
         ts: Date.now(),
       });
+
+      // Theme mutations: the renderer theme manager holds module state, so
+      // tell it to re-read global settings and re-apply.
+      if (segments[0] === 'themes') {
+        typedPush(window, 'cli:theme-changed');
+      }
 
       // Task-start routes also need a terminal + hook in the renderer.
       // The HTTP handler only creates the worktree + DB row; the renderer

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -28,8 +28,16 @@ import {
   getGlobalSetting,
   setGlobalSetting,
 } from '../db';
-import { isThemePreference, parseCustomTheme, parseCustomThemes, type CustomTheme } from '../theme/themes';
-import { PRESET_THEMES, withPresets } from '../theme/presets';
+import {
+  THEME_PREFERENCE_KEY,
+  CUSTOM_THEMES_KEY,
+  isThemePreference,
+  parseCustomTheme,
+  parseCustomThemes,
+  upsertCustomTheme,
+  type CustomTheme,
+} from '../theme/themes';
+import { PRESET_THEMES, withPresets, selectionOrphanedByDelete } from '../theme/presets';
 import {
   beginTask,
   setTaskStatusWithHooks,
@@ -144,9 +152,6 @@ function parseHookControl(body: Record<string, unknown>): HookControl {
   }
   return { hookMode: mode };
 }
-
-const THEME_PREFERENCE_KEY = 'ui:theme';
-const CUSTOM_THEMES_KEY = 'ui:customThemes';
 
 async function readCustomThemes(): Promise<CustomTheme[]> {
   return parseCustomThemes(await getGlobalSetting(CUSTOM_THEMES_KEY));
@@ -568,8 +573,7 @@ const routes: Route[] = [
         );
       }
       const list = await readCustomThemes();
-      const next = [...list.filter((t) => t.id !== theme.id), theme];
-      await setGlobalSetting(CUSTOM_THEMES_KEY, JSON.stringify(next));
+      await setGlobalSetting(CUSTOM_THEMES_KEY, JSON.stringify(upsertCustomTheme(list, theme)));
       return { success: true, theme };
     },
     true,
@@ -583,10 +587,10 @@ const routes: Route[] = [
       const list = await readCustomThemes();
       if (!list.some((t) => t.id === id)) throw new HttpError(404, `No custom theme with id '${id}'`);
       await setGlobalSetting(CUSTOM_THEMES_KEY, JSON.stringify(list.filter((t) => t.id !== id)));
-      // Mirrors the renderer's delete behavior: removing a user copy of a
-      // preset restores the preset, so the selection stays valid.
+      // Same rule as the renderer's deleteCustomTheme: removing a user copy
+      // of a preset restores the preset, so the selection stays valid.
       const preference = await getGlobalSetting(THEME_PREFERENCE_KEY);
-      if (preference === `custom:${id}` && !PRESET_THEMES.some((t) => t.id === id)) {
+      if (selectionOrphanedByDelete(preference, id)) {
         await setGlobalSetting(THEME_PREFERENCE_KEY, 'system');
       }
       return { success: true };

--- a/src/cli/commands/theme.ts
+++ b/src/cli/commands/theme.ts
@@ -10,6 +10,7 @@ import * as fs from 'node:fs';
 import type { Command } from 'commander';
 import { get, put, del } from '../api';
 import { printJson, printError } from '../output';
+import { isThemePreference } from '../../theme/themes';
 
 export function registerThemeCommands(parent: Command) {
   const theme = parent
@@ -39,10 +40,8 @@ Examples:
     .description('Select a theme')
     .argument('<theme>', 'system | light | dark | a preset or custom theme id (e.g. dracula)')
     .action(async (value: string) => {
-      const preference =
-        value === 'system' || value === 'light' || value === 'dark' || value.startsWith('custom:')
-          ? value
-          : `custom:${value}`;
+      // A bare id ("dracula") is shorthand for the custom:<id> form.
+      const preference = isThemePreference(value) ? value : `custom:${value}`;
       printJson(await put('/api/themes/preference', { preference }));
     });
 

--- a/src/cli/commands/theme.ts
+++ b/src/cli/commands/theme.ts
@@ -1,0 +1,82 @@
+/**
+ * CLI theme commands — global appearance settings via REST API.
+ *
+ * Themes are app-wide, not project-scoped. A custom theme is a set of design
+ * token overrides on top of the dark or light base; the presets returned by
+ * `theme list` double as reference for the token vocabulary.
+ */
+
+import * as fs from 'node:fs';
+import type { Command } from 'commander';
+import { get, put, del } from '../api';
+import { printJson, printError } from '../output';
+
+export function registerThemeCommands(parent: Command) {
+  const theme = parent
+    .command('theme')
+    .description('Manage app themes (global, not project-scoped)')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  ouijit theme list
+  ouijit theme use dracula
+  ouijit theme use system
+  ouijit theme save '{"id":"my-theme","name":"My Theme","base":"dark","tokens":{"--color-accent":"#ff2d55"}}'
+  ouijit theme save --file my-theme.json
+  ouijit theme delete my-theme`,
+    );
+
+  theme
+    .command('list')
+    .description('List the current preference, built-in presets, and custom themes')
+    .action(async () => {
+      printJson(await get('/api/themes'));
+    });
+
+  theme
+    .command('use')
+    .description('Select a theme')
+    .argument('<theme>', 'system | light | dark | a preset or custom theme id (e.g. dracula)')
+    .action(async (value: string) => {
+      const preference =
+        value === 'system' || value === 'light' || value === 'dark' || value.startsWith('custom:')
+          ? value
+          : `custom:${value}`;
+      printJson(await put('/api/themes/preference', { preference }));
+    });
+
+  theme
+    .command('save')
+    .description('Create or update a custom theme from JSON')
+    .argument('[json]', 'theme JSON: {"id", "name", "base": "dark"|"light", "tokens": {"--token": "value", ...}}')
+    .option('--file <path>', 'read the theme JSON from a file instead of an argument')
+    .action(async (jsonArg: string | undefined, opts: { file?: string }) => {
+      let raw = jsonArg;
+      if (opts.file) {
+        try {
+          raw = fs.readFileSync(opts.file, 'utf8');
+        } catch (err) {
+          return printError(`Cannot read ${opts.file}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+      if (!raw) return printError('Provide theme JSON as an argument or via --file <path>');
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        return printError('Not valid JSON');
+      }
+      const id = (parsed as { id?: unknown } | null)?.id;
+      if (typeof id !== 'string' || !id) return printError('Theme JSON needs a string "id"');
+      printJson(await put(`/api/themes/custom/${encodeURIComponent(id)}`, parsed as Record<string, unknown>));
+    });
+
+  theme
+    .command('delete')
+    .description('Delete a custom theme')
+    .argument('<id>', 'custom theme id')
+    .action(async (id: string) => {
+      printJson(await del(`/api/themes/custom/${encodeURIComponent(id)}`));
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ import { registerProjectCommands } from './commands/project';
 import { registerScriptCommands } from './commands/script';
 import { registerMarkdownCommands } from './commands/markdown';
 import { registerPreviewCommands } from './commands/preview';
+import { registerThemeCommands } from './commands/theme';
 
 const program = new Command();
 
@@ -48,6 +49,7 @@ registerProjectCommands(program);
 registerScriptCommands(program, requireProject);
 registerMarkdownCommands(program);
 registerPreviewCommands(program);
+registerThemeCommands(program);
 
 // Command actions are async; parse() would let an API rejection surface as an
 // uncaught error with a raw stack trace. parseAsync + a single catch turns any

--- a/src/components/FontPickerRow.tsx
+++ b/src/components/FontPickerRow.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
-import { useFloating, offset, flip, shift, autoUpdate } from '@floating-ui/react';
-import { Icon } from './terminal/Icon';
+import { useEffect, useMemo, useState } from 'react';
+import { SettingsDropdown, SettingsDropdownOption, SettingsDropdownDivider } from './ui/SettingsDropdown';
 import log from 'electron-log/renderer';
 
 const fontPickerLog = log.scope('fontPicker');
@@ -112,19 +110,6 @@ export function FontPickerRow({ label, description, value, defaultLabel, onCommi
   const [open, setOpen] = useState(false);
   const [systemFonts, setSystemFonts] = useState<MonoFontOption[] | null>(cachedSystemFonts);
   const [loading, setLoading] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  const { refs, floatingStyles } = useFloating({
-    placement: 'bottom-end',
-    strategy: 'fixed',
-    middleware: [offset(6), flip(), shift({ padding: 8 })],
-    whileElementsMounted: autoUpdate,
-  });
-
-  useEffect(() => {
-    if (triggerRef.current) refs.setReference(triggerRef.current);
-  }, [refs]);
 
   // On first dropdown open, ask Chromium for the user's installed fonts.
   // The first call shows a permission prompt; subsequent calls are silent.
@@ -136,32 +121,6 @@ export function FontPickerRow({ label, description, value, defaultLabel, onCommi
       .then((list) => setSystemFonts(list))
       .finally(() => setLoading(false));
   }, [open, systemFonts]);
-
-  // Click-outside
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (dropdownRef.current?.contains(target)) return;
-      if (triggerRef.current?.contains(target)) return;
-      setOpen(false);
-    };
-    const timer = setTimeout(() => document.addEventListener('mousedown', handler), 0);
-    return () => {
-      clearTimeout(timer);
-      document.removeEventListener('mousedown', handler);
-    };
-  }, [open]);
-
-  // Escape
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
-    };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [open]);
 
   const options = systemFonts && systemFonts.length > 0 ? systemFonts : FALLBACK_FONT_OPTIONS;
   const usingFallback = !systemFonts || systemFonts.length === 0;
@@ -182,92 +141,41 @@ export function FontPickerRow({ label, description, value, defaultLabel, onCommi
         <div className="text-sm text-text-primary">{label}</div>
         <div className="text-xs text-text-tertiary mt-0.5">{description}</div>
       </div>
-      <button
-        ref={triggerRef}
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="w-[16rem] shrink-0 flex items-center justify-between gap-2 px-3 py-1.5 text-sm bg-ink/[0.04] border border-ink/10 rounded-md text-text-primary hover:bg-ink/[0.06] outline-none focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent-light"
+      <SettingsDropdown
+        open={open}
+        onOpenChange={setOpen}
+        widthClass="w-[16rem]"
+        ariaLabel="Choose terminal font"
+        triggerLabel={triggerLabel}
+        triggerStyle={triggerFont ? { fontFamily: triggerFont } : undefined}
       >
-        <span className="truncate" style={triggerFont ? { fontFamily: triggerFont } : undefined}>
-          {triggerLabel}
-        </span>
-        <Icon name="caret-down" className="w-3.5 h-3.5 text-text-tertiary shrink-0" />
-      </button>
-      {open &&
-        createPortal(
-          <div
-            ref={(el) => {
-              dropdownRef.current = el;
-              refs.setFloating(el);
-            }}
-            role="listbox"
-            aria-label="Choose terminal font"
-            style={{
-              ...floatingStyles,
-              background: 'var(--color-terminal-bg)',
-              boxShadow: 'var(--shadow-menu)',
-            }}
-            className="w-[16rem] max-h-[24rem] overflow-y-auto border border-bezel rounded-[12px] z-[1000] p-1"
-          >
-            <FontOptionRow
-              label={defaultLabel}
-              hint="System default"
-              selected={!trimmedValue}
-              onClick={() => select('')}
-            />
-            <div className="my-1 mx-1 border-t border-ink/[0.06]" />
-            {loading && <div className="px-2.5 py-2 text-xs text-text-tertiary">Loading installed fonts…</div>}
-            {!loading && options.length === 0 && (
-              <div className="px-2.5 py-2 text-xs text-text-tertiary">No monospace fonts found.</div>
-            )}
-            {!loading &&
-              options.map((opt) => (
-                <FontOptionRow
-                  key={opt.value}
-                  label={opt.label}
-                  fontFamily={opt.value}
-                  selected={trimmedValue === opt.value}
-                  onClick={() => select(opt.value)}
-                />
-              ))}
-            {!loading && usingFallback && (
-              <div className="px-2.5 pt-2 pb-1 text-[11px] text-text-tertiary border-t border-ink/[0.06] mt-1">
-                Showing fallback list — allow font access to see your installed fonts.
-              </div>
-            )}
-          </div>,
-          document.body,
+        <SettingsDropdownOption
+          label={defaultLabel}
+          hint="System default"
+          selected={!trimmedValue}
+          onClick={() => select('')}
+        />
+        <SettingsDropdownDivider />
+        {loading && <div className="px-2.5 py-2 text-xs text-text-tertiary">Loading installed fonts…</div>}
+        {!loading && options.length === 0 && (
+          <div className="px-2.5 py-2 text-xs text-text-tertiary">No monospace fonts found.</div>
         )}
+        {!loading &&
+          options.map((opt) => (
+            <SettingsDropdownOption
+              key={opt.value}
+              label={opt.label}
+              fontFamily={opt.value}
+              selected={trimmedValue === opt.value}
+              onClick={() => select(opt.value)}
+            />
+          ))}
+        {!loading && usingFallback && (
+          <div className="px-2.5 pt-2 pb-1 text-[11px] text-text-tertiary border-t border-ink/[0.06] mt-1">
+            Showing fallback list — allow font access to see your installed fonts.
+          </div>
+        )}
+      </SettingsDropdown>
     </div>
-  );
-}
-
-interface FontOptionRowProps {
-  label: string;
-  hint?: string;
-  fontFamily?: string;
-  selected: boolean;
-  onClick: () => void;
-}
-
-function FontOptionRow({ label, hint, fontFamily, selected, onClick }: FontOptionRowProps) {
-  return (
-    <button
-      role="option"
-      aria-selected={selected}
-      onMouseDown={(e) => {
-        e.preventDefault();
-        onClick();
-      }}
-      className={`w-full text-left px-2.5 py-1.5 rounded-[7px] text-sm flex items-center gap-2 hover:bg-ink/[0.08] transition-colors duration-100 ${
-        selected ? 'text-text-primary bg-ink/[0.04]' : 'text-text-secondary'
-      }`}
-    >
-      <span className="flex-1 truncate" style={fontFamily ? { fontFamily } : undefined}>
-        {label}
-      </span>
-      {hint && <span className="text-[11px] text-text-tertiary shrink-0">{hint}</span>}
-      {selected && <Icon name="check" className="w-3.5 h-3.5 text-text-primary shrink-0" />}
-    </button>
   );
 }

--- a/src/components/FontPickerRow.tsx
+++ b/src/components/FontPickerRow.tsx
@@ -177,7 +177,7 @@ export function FontPickerRow({ label, description, value, defaultLabel, onCommi
   };
 
   return (
-    <div className="flex items-center gap-4 px-4 py-3 hover:bg-white/[0.02]">
+    <div className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
       <div className="flex-1 min-w-0">
         <div className="text-sm text-text-primary">{label}</div>
         <div className="text-xs text-text-tertiary mt-0.5">{description}</div>
@@ -186,7 +186,7 @@ export function FontPickerRow({ label, description, value, defaultLabel, onCommi
         ref={triggerRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="w-[16rem] shrink-0 flex items-center justify-between gap-2 px-3 py-1.5 text-sm bg-white/[0.04] border border-white/10 rounded-md text-text-primary hover:bg-white/[0.06] outline-none focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent-light"
+        className="w-[16rem] shrink-0 flex items-center justify-between gap-2 px-3 py-1.5 text-sm bg-ink/[0.04] border border-ink/10 rounded-md text-text-primary hover:bg-ink/[0.06] outline-none focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent-light"
       >
         <span className="truncate" style={triggerFont ? { fontFamily: triggerFont } : undefined}>
           {triggerLabel}
@@ -204,10 +204,10 @@ export function FontPickerRow({ label, description, value, defaultLabel, onCommi
             aria-label="Choose terminal font"
             style={{
               ...floatingStyles,
-              background: 'var(--color-terminal-bg, #171717)',
-              boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 10px 30px rgba(0, 0, 0, 0.35)',
+              background: 'var(--color-terminal-bg)',
+              boxShadow: 'var(--shadow-menu)',
             }}
-            className="w-[16rem] max-h-[24rem] overflow-y-auto border border-black/60 rounded-[12px] z-[1000] p-1"
+            className="w-[16rem] max-h-[24rem] overflow-y-auto border border-bezel rounded-[12px] z-[1000] p-1"
           >
             <FontOptionRow
               label={defaultLabel}
@@ -215,7 +215,7 @@ export function FontPickerRow({ label, description, value, defaultLabel, onCommi
               selected={!trimmedValue}
               onClick={() => select('')}
             />
-            <div className="my-1 mx-1 border-t border-white/[0.06]" />
+            <div className="my-1 mx-1 border-t border-ink/[0.06]" />
             {loading && <div className="px-2.5 py-2 text-xs text-text-tertiary">Loading installed fonts…</div>}
             {!loading && options.length === 0 && (
               <div className="px-2.5 py-2 text-xs text-text-tertiary">No monospace fonts found.</div>
@@ -231,7 +231,7 @@ export function FontPickerRow({ label, description, value, defaultLabel, onCommi
                 />
               ))}
             {!loading && usingFallback && (
-              <div className="px-2.5 pt-2 pb-1 text-[11px] text-text-tertiary border-t border-white/[0.06] mt-1">
+              <div className="px-2.5 pt-2 pb-1 text-[11px] text-text-tertiary border-t border-ink/[0.06] mt-1">
                 Showing fallback list — allow font access to see your installed fonts.
               </div>
             )}
@@ -259,8 +259,8 @@ function FontOptionRow({ label, hint, fontFamily, selected, onClick }: FontOptio
         e.preventDefault();
         onClick();
       }}
-      className={`w-full text-left px-2.5 py-1.5 rounded-[7px] text-sm flex items-center gap-2 hover:bg-white/[0.08] transition-colors duration-100 ${
-        selected ? 'text-text-primary bg-white/[0.04]' : 'text-text-secondary'
+      className={`w-full text-left px-2.5 py-1.5 rounded-[7px] text-sm flex items-center gap-2 hover:bg-ink/[0.08] transition-colors duration-100 ${
+        selected ? 'text-text-primary bg-ink/[0.04]' : 'text-text-secondary'
       }`}
     >
       <span className="flex-1 truncate" style={fontFamily ? { fontFamily } : undefined}>

--- a/src/components/GlobalSettingsPanel.tsx
+++ b/src/components/GlobalSettingsPanel.tsx
@@ -170,12 +170,7 @@ export function GlobalSettingsPanel() {
           <ThemeSettingsSection />
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-4">Projects</h2>
-            <div
-              className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
-              style={{
-                boxShadow: 'var(--shadow-panel)',
-              }}
-            >
+            <div className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg">
               <PathRow
                 label="Projects folder"
                 description="New projects are created here. Changing it lets you move or forget existing projects."
@@ -188,12 +183,7 @@ export function GlobalSettingsPanel() {
 
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-4">Terminal</h2>
-            <div
-              className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
-              style={{
-                boxShadow: 'var(--shadow-panel)',
-              }}
-            >
+            <div className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg">
               <FontPickerRow
                 label="Font family"
                 description="Pick a monospace font. Falls back gracefully if not installed."
@@ -216,12 +206,7 @@ export function GlobalSettingsPanel() {
 
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-4">Updates</h2>
-            <div
-              className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
-              style={{
-                boxShadow: 'var(--shadow-panel)',
-              }}
-            >
+            <div className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg">
               <ToggleRow
                 label="Check for updates automatically"
                 description="When off, Ouijit won't contact the update service or download new versions."
@@ -233,12 +218,7 @@ export function GlobalSettingsPanel() {
 
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-4">Sound</h2>
-            <div
-              className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
-              style={{
-                boxShadow: 'var(--shadow-panel)',
-              }}
-            >
+            <div className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg">
               <ToggleRow
                 label="Play a sound when a task is ready"
                 description="Plays a chime when a terminal returns to the ready state."

--- a/src/components/GlobalSettingsPanel.tsx
+++ b/src/components/GlobalSettingsPanel.tsx
@@ -171,7 +171,7 @@ export function GlobalSettingsPanel() {
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-4">Projects</h2>
             <div
-              className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
+              className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
               style={{
                 boxShadow: 'var(--shadow-panel)',
               }}
@@ -189,7 +189,7 @@ export function GlobalSettingsPanel() {
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-4">Terminal</h2>
             <div
-              className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
+              className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
               style={{
                 boxShadow: 'var(--shadow-panel)',
               }}
@@ -217,7 +217,7 @@ export function GlobalSettingsPanel() {
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-4">Updates</h2>
             <div
-              className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
+              className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
               style={{
                 boxShadow: 'var(--shadow-panel)',
               }}
@@ -234,7 +234,7 @@ export function GlobalSettingsPanel() {
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-4">Sound</h2>
             <div
-              className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
+              className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
               style={{
                 boxShadow: 'var(--shadow-panel)',
               }}

--- a/src/components/GlobalSettingsPanel.tsx
+++ b/src/components/GlobalSettingsPanel.tsx
@@ -4,6 +4,7 @@ import { useProjectStore } from '../stores/projectStore';
 import { setTerminalFontFamily, setTerminalFontSize } from './terminal/terminalReact';
 import { setReadyAudioDisabled } from '../utils/notifications';
 import { FontPickerRow } from './FontPickerRow';
+import { ThemeSettingsSection } from './ThemeSettingsSection';
 import { MoveProjectsDialog } from './dialogs/MoveProjectsDialog';
 import type { AffectedProject, ProjectsFolderChangeAction } from '../types';
 import log from 'electron-log/renderer';
@@ -155,7 +156,7 @@ export function GlobalSettingsPanel() {
       {/* Fade overlay — content fades out under the header (mirrors ProjectSettingsPanel) */}
       <div
         className="pointer-events-none h-6 shrink-0 -mb-6 relative z-10"
-        style={{ background: 'linear-gradient(to bottom, var(--color-background-primary, #1c1c1e), transparent)' }}
+        style={{ background: 'linear-gradient(to bottom, var(--color-background), transparent)' }}
       />
       <div className="flex-1 overflow-y-auto settings-scrollable">
         <div className="px-6 pt-4 pb-16 min-w-full max-w-2xl space-y-8">
@@ -166,13 +167,13 @@ export function GlobalSettingsPanel() {
               project's settings.
             </p>
           </div>
+          <ThemeSettingsSection />
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-4">Projects</h2>
             <div
-              className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden divide-y divide-white/[0.06] bg-[var(--color-terminal-bg,#171717)]"
+              className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
               style={{
-                boxShadow:
-                  '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+                boxShadow: 'var(--shadow-panel)',
               }}
             >
               <PathRow
@@ -188,10 +189,9 @@ export function GlobalSettingsPanel() {
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-4">Terminal</h2>
             <div
-              className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden divide-y divide-white/[0.06] bg-[var(--color-terminal-bg,#171717)]"
+              className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
               style={{
-                boxShadow:
-                  '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+                boxShadow: 'var(--shadow-panel)',
               }}
             >
               <FontPickerRow
@@ -217,10 +217,9 @@ export function GlobalSettingsPanel() {
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-4">Updates</h2>
             <div
-              className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden divide-y divide-white/[0.06] bg-[var(--color-terminal-bg,#171717)]"
+              className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
               style={{
-                boxShadow:
-                  '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+                boxShadow: 'var(--shadow-panel)',
               }}
             >
               <ToggleRow
@@ -235,10 +234,9 @@ export function GlobalSettingsPanel() {
           <section>
             <h2 className="text-sm font-semibold text-text-primary mb-4">Sound</h2>
             <div
-              className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden divide-y divide-white/[0.06] bg-[var(--color-terminal-bg,#171717)]"
+              className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
               style={{
-                boxShadow:
-                  '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+                boxShadow: 'var(--shadow-panel)',
               }}
             >
               <ToggleRow
@@ -272,7 +270,7 @@ interface PathRowProps {
 
 function PathRow({ label, description, value, buttonLabel, onChoose }: PathRowProps) {
   return (
-    <div className="flex items-center gap-4 px-4 py-3 hover:bg-white/[0.02]">
+    <div className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
       <div className="flex-1 min-w-0">
         <div className="text-sm text-text-primary">{label}</div>
         <div className="text-xs text-text-tertiary mt-0.5">{description}</div>
@@ -296,7 +294,7 @@ interface ToggleRowProps {
 
 function ToggleRow({ label, description, checked, onChange }: ToggleRowProps) {
   return (
-    <label className="flex items-center gap-4 px-4 py-3 hover:bg-white/[0.02]">
+    <label className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
       <div className="flex-1 min-w-0">
         <div className="text-sm text-text-primary">{label}</div>
         <div className="text-xs text-text-tertiary mt-0.5">{description}</div>
@@ -307,11 +305,11 @@ function ToggleRow({ label, description, checked, onChange }: ToggleRowProps) {
         aria-checked={checked}
         onClick={onChange}
         className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-150 ${
-          checked ? 'bg-blue-500' : 'bg-white/15'
+          checked ? 'bg-accent' : 'bg-ink/15'
         }`}
       >
         <span
-          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-150 ${
+          className={`inline-block h-4 w-4 transform rounded-full bg-accent-ink transition-transform duration-150 ${
             checked ? 'translate-x-[18px]' : 'translate-x-[2px]'
           }`}
         />
@@ -388,7 +386,7 @@ function NumberRow({ label, description, value, placeholder, suffix, min, max, o
   }, []);
 
   return (
-    <div className="flex items-center gap-4 px-4 py-3 hover:bg-white/[0.02]">
+    <div className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
       <div className="flex-1 min-w-0">
         <div className="text-sm text-text-primary">{label}</div>
         <div className="text-xs text-text-tertiary mt-0.5">{description}</div>
@@ -408,7 +406,7 @@ function NumberRow({ label, description, value, placeholder, suffix, min, max, o
               (e.target as HTMLInputElement).blur();
             }
           }}
-          className="w-[5rem] px-3 py-1.5 text-sm bg-white/[0.04] border border-white/10 rounded-md text-text-primary placeholder:text-text-tertiary outline-none focus:border-accent focus:ring-2 focus:ring-accent-light"
+          className="w-[5rem] px-3 py-1.5 text-sm bg-ink/[0.04] border border-ink/10 rounded-md text-text-primary placeholder:text-text-tertiary outline-none focus:border-accent focus:ring-2 focus:ring-accent-light"
         />
         {suffix && <span className="text-xs text-text-tertiary">{suffix}</span>}
       </div>

--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -304,17 +304,16 @@ export function HomeView() {
           <div className="absolute inset-0 flex items-center justify-center overflow-hidden p-6">
             <div className="w-full max-w-[36rem]">
               <div
-                className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden"
+                className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden"
                 style={{
                   background: 'var(--color-terminal-bg)',
-                  boxShadow:
-                    '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+                  boxShadow: 'var(--shadow-panel)',
                 }}
               >
                 <div className="px-5 py-3">
                   <span className="text-sm text-text-primary leading-tight">Start a project</span>
                 </div>
-                <div className="border-t border-white/[0.06] divide-y divide-white/[0.04]">
+                <div className="border-t border-ink/[0.06] divide-y divide-ink/[0.04]">
                   <EmptyStateChoice
                     verb="Open"
                     noun="a folder you already have"
@@ -333,7 +332,7 @@ export function HomeView() {
           </div>
         ) : noRecents ? (
           <div
-            className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-text-tertiary rounded-[14px] border border-dashed border-white/10"
+            className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-text-tertiary rounded-[14px] border border-dashed border-ink/10"
             style={{ background: 'var(--color-terminal-bg)' }}
           >
             <div className="text-sm">No tasks yet.</div>
@@ -370,14 +369,13 @@ export function HomeView() {
         return (
           <div
             key={ptyId}
-            className={`glass-bevel absolute inset-0 rounded-[14px] border border-black/60 overflow-hidden flex flex-col${!isActive ? ' hover:border-accent' : ''}`}
+            className={`glass-bevel absolute inset-0 rounded-[14px] border border-bezel overflow-hidden flex flex-col${!isActive ? ' hover:border-accent' : ''}`}
             style={{
               ...getDepthStyle(depth),
-              background: 'var(--color-terminal-bg, #171717)',
+              background: 'var(--color-terminal-bg)',
               ...(isActive
                 ? {
-                    boxShadow:
-                      '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+                    boxShadow: 'var(--shadow-panel)',
                   }
                 : {}),
             }}
@@ -417,28 +415,28 @@ export function HomeView() {
           >
             {/* Card body below the tab — square TL so tab sits flush */}
             <div
-              className="absolute border border-black/60"
+              className="absolute border border-bezel"
               style={{
                 top: 27,
                 left: 0,
                 right: 0,
                 bottom: 0,
-                background: '#252528',
+                background: 'var(--color-surface-raised)',
                 borderRadius: '0 14px 14px 14px',
                 boxShadow:
-                  'inset 0 1px 0 rgba(255,255,255,0.14), inset -1px 0 0 rgba(255,255,255,0.05), inset 1px 0 0 rgba(255,255,255,0.05), inset 0 -1px 0 rgba(0,0,0,0.5)',
+                  'inset 0 1px 0 var(--bevel-top), inset -1px 0 0 var(--bevel-side), inset 1px 0 0 var(--bevel-side), inset 0 -1px 0 var(--bevel-bottom)',
               }}
             />
             <div
-              className="home-folder-tab absolute top-0 left-0 pointer-events-auto border border-black/60"
+              className="home-folder-tab absolute top-0 left-0 pointer-events-auto border border-bezel"
               style={{
                 width: 220,
                 height: 28,
-                background: '#252528',
+                background: 'var(--color-surface-raised)',
                 borderBottom: 'none',
                 borderRadius: '12px 12px 0 0',
                 boxShadow:
-                  'inset 0 1px 0 rgba(255,255,255,0.14), inset 1px 0 0 rgba(255,255,255,0.05), inset -1px 0 0 rgba(255,255,255,0.05), inset 0 2px 6px -3px rgba(255,255,255,0.08)',
+                  'inset 0 1px 0 var(--bevel-top), inset 1px 0 0 var(--bevel-side), inset -1px 0 0 var(--bevel-side), inset 0 2px 6px -3px var(--bevel-glow)',
                 transform: `scale(${Math.max(0.92, 1 - item.depth * 0.015)})`,
                 transformOrigin: 'bottom left',
                 transition: 'transform 200ms ease-out',
@@ -487,7 +485,7 @@ export function HomeView() {
                   style={{
                     fontSize: 10,
                     fontWeight: 600,
-                    color: 'rgba(255, 255, 255, 0.45)',
+                    color: 'color-mix(in srgb, var(--color-ink) 45%, transparent)',
                     textTransform: 'uppercase',
                     letterSpacing: '0.5px',
                     whiteSpace: 'nowrap',
@@ -518,7 +516,7 @@ function EmptyStateChoice({ verb, noun, detail, onClick }: EmptyStateChoiceProps
     <button
       type="button"
       onClick={onClick}
-      className="group flex items-baseline gap-3 w-full text-left px-5 py-3 hover:bg-white/[0.04] transition-colors duration-150 ease-out focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-light outline-none [-webkit-app-region:no-drag]"
+      className="group flex items-baseline gap-3 w-full text-left px-5 py-3 hover:bg-ink/[0.04] transition-colors duration-150 ease-out focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-light outline-none [-webkit-app-region:no-drag]"
     >
       <span className="text-[15px] text-text-tertiary group-hover:text-text-primary transition-colors w-3 shrink-0">
         →

--- a/src/components/RecentTasksPanel.tsx
+++ b/src/components/RecentTasksPanel.tsx
@@ -116,13 +116,13 @@ export function RecentTasksPanel({ projects }: RecentTasksPanelProps) {
 
   return (
     <div
-      className="w-full flex flex-col rounded-[14px] border border-black/60 glass-bevel relative overflow-hidden min-h-0"
+      className="w-full flex flex-col rounded-[14px] border border-bezel glass-bevel relative overflow-hidden min-h-0"
       style={{
         background: 'var(--color-terminal-bg)',
-        boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+        boxShadow: 'var(--shadow-panel)',
       }}
     >
-      <div className="flex items-center justify-between gap-3 px-5 pt-4 pb-3 shrink-0 border-b border-white/[0.06]">
+      <div className="flex items-center justify-between gap-3 px-5 pt-4 pb-3 shrink-0 border-b border-ink/[0.06]">
         <span className="text-[11px] uppercase tracking-wider text-text-tertiary">Pick up where you left off</span>
         <button
           type="button"
@@ -132,7 +132,7 @@ export function RecentTasksPanel({ projects }: RecentTasksPanelProps) {
           {allSelected ? 'Deselect all' : `Select all (${recents.length})`}
         </button>
       </div>
-      <ul className="flex flex-col overflow-y-auto min-h-0 settings-scrollable divide-y divide-white/[0.04]">
+      <ul className="flex flex-col overflow-y-auto min-h-0 settings-scrollable divide-y divide-ink/[0.04]">
         {recents.map((task) => {
           const key = taskKey(task);
           return (
@@ -153,7 +153,7 @@ export function RecentTasksPanel({ projects }: RecentTasksPanelProps) {
         })}
       </ul>
       {selected.size > 0 && (
-        <div className="flex items-center justify-between gap-3 px-5 py-3 border-t border-white/[0.06] shrink-0">
+        <div className="flex items-center justify-between gap-3 px-5 py-3 border-t border-ink/[0.06] shrink-0">
           <span className="text-xs text-text-tertiary tabular-nums">
             <span className="text-text-secondary">{selected.size}</span> selected
           </span>
@@ -161,14 +161,14 @@ export function RecentTasksPanel({ projects }: RecentTasksPanelProps) {
             <button
               type="button"
               onClick={clearSelection}
-              className="px-3 py-1.5 text-xs text-text-secondary rounded-full hover:bg-white/[0.04] transition-colors"
+              className="px-3 py-1.5 text-xs text-text-secondary rounded-full hover:bg-ink/[0.04] transition-colors"
             >
               Cancel
             </button>
             <button
               type="button"
               onClick={openSelection}
-              className="px-3 py-1.5 text-xs font-medium text-white bg-accent rounded-full hover:bg-accent-hover active:scale-[0.98] transition-all duration-150"
+              className="px-3 py-1.5 text-xs font-medium text-accent-ink bg-accent rounded-full hover:bg-accent-hover active:scale-[0.98] transition-all duration-150"
             >
               Open {selected.size} task{selected.size === 1 ? '' : 's'}
             </button>
@@ -202,7 +202,7 @@ function RecentTaskRow({ task, selected, onClick, onToggle }: RecentTaskRowProps
           }
         }}
         className={`group w-full flex items-center gap-3 pl-3 pr-5 py-2.5 text-left transition-colors duration-100 [-webkit-app-region:no-drag] cursor-default ${
-          selected ? 'bg-accent/15 hover:bg-accent/20' : 'hover:bg-white/[0.03]'
+          selected ? 'bg-accent/15 hover:bg-accent/20' : 'hover:bg-ink/[0.03]'
         }`}
       >
         <Checkbox
@@ -253,17 +253,17 @@ function Checkbox({ checked, onChange, onPointerEnter, onPointerLeave }: Checkbo
       onClick={onChange}
       onPointerEnter={onPointerEnter}
       onPointerLeave={onPointerLeave}
-      className="shrink-0 w-7 h-7 -ml-1.5 rounded-md flex items-center justify-center transition-colors duration-100 hover:bg-white/[0.08] active:bg-white/[0.12] [-webkit-app-region:no-drag]"
+      className="shrink-0 w-7 h-7 -ml-1.5 rounded-md flex items-center justify-center transition-colors duration-100 hover:bg-ink/[0.08] active:bg-ink/[0.12] [-webkit-app-region:no-drag]"
     >
       <span
         className={`w-[15px] h-[15px] rounded border transition-all duration-100 flex items-center justify-center ${
           checked
             ? 'bg-accent border-accent'
-            : 'border-white/30 bg-white/[0.04] group-hover:border-white/50 group-hover:bg-white/[0.06]'
+            : 'border-ink/30 bg-ink/[0.04] group-hover:border-ink/50 group-hover:bg-ink/[0.06]'
         }`}
       >
         {checked && (
-          <svg viewBox="0 0 12 12" className="w-3 h-3 text-white" aria-hidden>
+          <svg viewBox="0 0 12 12" className="w-3 h-3 text-accent-ink" aria-hidden>
             <path
               fill="none"
               stroke="currentColor"

--- a/src/components/RecentTasksPanel.tsx
+++ b/src/components/RecentTasksPanel.tsx
@@ -116,7 +116,7 @@ export function RecentTasksPanel({ projects }: RecentTasksPanelProps) {
 
   return (
     <div
-      className="w-full flex flex-col rounded-[14px] border border-bezel glass-bevel relative overflow-hidden min-h-0"
+      className="w-full flex flex-col rounded-[14px] border border-bezel-panel glass-bevel relative overflow-hidden min-h-0"
       style={{
         background: 'var(--color-terminal-bg)',
         boxShadow: 'var(--shadow-panel)',

--- a/src/components/ResumeBanner.tsx
+++ b/src/components/ResumeBanner.tsx
@@ -113,10 +113,10 @@ export function ResumeBanner() {
 
   return (
     <div
-      className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden shrink-0"
+      className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden shrink-0"
       style={{
         background: 'var(--color-terminal-bg)',
-        boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+        boxShadow: 'var(--shadow-panel)',
       }}
     >
       <div className="flex items-center gap-3 px-5 py-3">
@@ -141,7 +141,7 @@ export function ResumeBanner() {
             type="button"
             onClick={handleDismiss}
             disabled={resuming}
-            className="px-3 py-1.5 text-xs text-text-secondary rounded-full hover:bg-white/[0.04] transition-colors disabled:opacity-50"
+            className="px-3 py-1.5 text-xs text-text-secondary rounded-full hover:bg-ink/[0.04] transition-colors disabled:opacity-50"
           >
             Dismiss
           </button>
@@ -149,14 +149,14 @@ export function ResumeBanner() {
             type="button"
             onClick={handleResume}
             disabled={resuming}
-            className="px-4 py-1.5 text-xs font-medium text-white bg-accent rounded-full hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 disabled:opacity-60"
+            className="px-4 py-1.5 text-xs font-medium text-accent-ink bg-accent rounded-full hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 disabled:opacity-60"
           >
             {resuming ? 'Resuming…' : 'Resume'}
           </button>
         </div>
       </div>
       {expanded && (
-        <div className="border-t border-white/[0.06] max-h-[14rem] overflow-y-auto settings-scrollable">
+        <div className="border-t border-ink/[0.06] max-h-[14rem] overflow-y-auto settings-scrollable">
           {grouped.map((group, idx) => (
             <ProjectGroup key={group.project.path} group={group} isFirst={idx === 0} />
           ))}
@@ -174,7 +174,7 @@ function ProjectGroup({
   isFirst: boolean;
 }) {
   return (
-    <div className={isFirst ? '' : 'border-t border-white/[0.04]'}>
+    <div className={isFirst ? '' : 'border-t border-ink/[0.04]'}>
       <div className="flex items-center gap-2 px-5 pt-2.5 pb-1">
         <ProjectThumb project={group.project} />
         <span className="text-[11px] uppercase tracking-wider text-text-tertiary truncate">{group.project.name}</span>

--- a/src/components/SidebarReact.tsx
+++ b/src/components/SidebarReact.tsx
@@ -253,7 +253,7 @@ export function Sidebar({ onProjectSelect, onHomeSelect, onAddExisting, onCreate
               onClick={onHomeSelect}
             >
               <div
-                className={`absolute left-0 w-1 rounded-r-sm bg-white transition-all duration-200 ease-out ${
+                className={`absolute left-0 w-1 rounded-r-sm bg-ink transition-all duration-200 ease-out ${
                   activeView === 'home' ? 'h-9 opacity-100' : 'h-0 opacity-0 group-hover:h-5 group-hover:opacity-50'
                 }`}
               />
@@ -309,7 +309,7 @@ export function Sidebar({ onProjectSelect, onHomeSelect, onAddExisting, onCreate
               >
                 <button
                   ref={addBtnRef}
-                  className="w-10 h-10 flex items-center justify-center relative glass-bevel overflow-hidden rounded-[12px] bg-background-secondary border border-black/60 text-text-secondary transition-colors duration-200 ease-out [-webkit-app-region:no-drag] hover:bg-background-tertiary hover:text-text-primary [&>svg]:w-5 [&>svg]:h-5"
+                  className="w-10 h-10 flex items-center justify-center relative glass-bevel overflow-hidden rounded-[12px] bg-background-secondary border border-bezel text-text-secondary transition-colors duration-200 ease-out [-webkit-app-region:no-drag] hover:bg-background-tertiary hover:text-text-primary [&>svg]:w-5 [&>svg]:h-5"
                   onClick={(e) => {
                     e.stopPropagation();
                     setAddMenuOpen(!addMenuOpen);
@@ -339,7 +339,7 @@ export function Sidebar({ onProjectSelect, onHomeSelect, onAddExisting, onCreate
                 aria-label={sidebarPinned ? 'Unpin sidebar' : 'Pin sidebar open'}
               >
                 <div
-                  className={`absolute left-0 w-1 rounded-r-sm bg-white transition-all duration-200 ease-out ${
+                  className={`absolute left-0 w-1 rounded-r-sm bg-ink transition-all duration-200 ease-out ${
                     sidebarPinned ? 'h-7 opacity-100' : 'h-0 opacity-0 group-hover:h-4 group-hover:opacity-50'
                   }`}
                 />
@@ -368,12 +368,12 @@ export function Sidebar({ onProjectSelect, onHomeSelect, onAddExisting, onCreate
       {/* Context menu */}
       {contextMenu && (
         <div
-          className="sidebar-context-menu-react fixed z-[10002] p-1 glass-bevel border border-black/60 rounded-[12px] overflow-hidden opacity-100"
+          className="sidebar-context-menu-react fixed z-[10002] p-1 glass-bevel border border-bezel rounded-[12px] overflow-hidden opacity-100"
           style={{
             left: Math.min(contextMenu.x, window.innerWidth - 120),
             top: Math.min(contextMenu.y, window.innerHeight - 40),
-            background: 'var(--color-terminal-bg, #171717)',
-            boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 10px 30px rgba(0, 0, 0, 0.35)',
+            background: 'var(--color-terminal-bg)',
+            boxShadow: 'var(--shadow-menu)',
           }}
         >
           <button
@@ -451,7 +451,7 @@ function SortableProjectIcon({ project, isActive, onClick, onContextMenu }: Sort
         onContextMenu={onContextMenu}
       >
         <div
-          className={`absolute left-0 w-1 rounded-r-sm bg-white transition-all duration-200 ease-out ${
+          className={`absolute left-0 w-1 rounded-r-sm bg-ink transition-all duration-200 ease-out ${
             isActive ? 'h-9 opacity-100' : 'h-0 opacity-0 group-hover:h-5 group-hover:opacity-50'
           }`}
         />
@@ -465,7 +465,7 @@ function SortableProjectIcon({ project, isActive, onClick, onContextMenu }: Sort
         </div>
         {terminalCount > 0 && (
           <span
-            className="absolute bottom-0 right-2 flex items-center justify-center text-white font-bold"
+            className="absolute bottom-0 right-2 flex items-center justify-center text-accent-ink font-bold"
             style={{
               minWidth: 16,
               height: 16,
@@ -490,7 +490,7 @@ function SortableProjectIcon({ project, isActive, onClick, onContextMenu }: Sort
             style={tipStyles}
             {...getTipFloatProps()}
           >
-            <div className="px-3 py-1.5 text-[13px] font-medium text-white bg-neutral-800 border border-white/10 rounded-md shadow-lg whitespace-nowrap animate-tooltip-pop">
+            <div className="px-3 py-1.5 text-[13px] font-medium text-text-primary bg-terminal-surface border border-ink/10 rounded-md shadow-lg whitespace-nowrap animate-tooltip-pop">
               {project.name}
             </div>
           </div>,
@@ -537,7 +537,7 @@ function SidebarTooltipWrapper({
             style={floatingStyles}
             {...getFloatingProps()}
           >
-            <div className="px-3 py-1.5 text-[13px] font-medium text-white bg-neutral-800 border border-white/10 rounded-md shadow-lg whitespace-nowrap animate-tooltip-pop">
+            <div className="px-3 py-1.5 text-[13px] font-medium text-text-primary bg-terminal-surface border border-ink/10 rounded-md shadow-lg whitespace-nowrap animate-tooltip-pop">
               {label}
             </div>
           </div>,
@@ -577,17 +577,17 @@ function AddMenu({ anchorRef, onAddExisting, onCreateNew, onClose }: AddMenuProp
   return createPortal(
     <div
       ref={ref}
-      className="sidebar-add-menu-react fixed z-[10002] flex flex-col p-1 glass-bevel border border-black/60 rounded-[12px] overflow-hidden"
+      className="sidebar-add-menu-react fixed z-[10002] flex flex-col p-1 glass-bevel border border-bezel rounded-[12px] overflow-hidden"
       style={{
         left,
         bottom,
         top: 'auto',
-        background: 'var(--color-terminal-bg, #171717)',
-        boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 10px 30px rgba(0, 0, 0, 0.35)',
+        background: 'var(--color-terminal-bg)',
+        boxShadow: 'var(--shadow-menu)',
       }}
     >
       <button
-        className="w-full px-2.5 py-1.5 rounded-[7px] text-xs text-text-primary bg-transparent border-none text-left transition-colors duration-100 ease-out hover:bg-white/[0.08]"
+        className="w-full px-2.5 py-1.5 rounded-[7px] text-xs text-text-primary bg-transparent border-none text-left transition-colors duration-100 ease-out hover:bg-ink/[0.08]"
         onClick={() => {
           onClose();
           onAddExisting();
@@ -596,7 +596,7 @@ function AddMenu({ anchorRef, onAddExisting, onCreateNew, onClose }: AddMenuProp
         Add existing
       </button>
       <button
-        className="w-full px-2.5 py-1.5 rounded-[7px] text-xs text-text-primary bg-transparent border-none text-left transition-colors duration-100 ease-out hover:bg-white/[0.08]"
+        className="w-full px-2.5 py-1.5 rounded-[7px] text-xs text-text-primary bg-transparent border-none text-left transition-colors duration-100 ease-out hover:bg-ink/[0.08]"
         onClick={() => {
           onClose();
           onCreateNew();

--- a/src/components/SidebarReact.tsx
+++ b/src/components/SidebarReact.tsx
@@ -490,7 +490,7 @@ function SortableProjectIcon({ project, isActive, onClick, onContextMenu }: Sort
             style={tipStyles}
             {...getTipFloatProps()}
           >
-            <div className="px-3 py-1.5 text-[13px] font-medium text-text-primary bg-terminal-surface border border-ink/10 rounded-md shadow-lg whitespace-nowrap animate-tooltip-pop">
+            <div className="px-3 py-1.5 text-[13px] font-medium text-text-primary bg-terminal-surface border border-ink/10 rounded-md shadow-tooltip whitespace-nowrap animate-tooltip-pop">
               {project.name}
             </div>
           </div>,
@@ -537,7 +537,7 @@ function SidebarTooltipWrapper({
             style={floatingStyles}
             {...getFloatingProps()}
           >
-            <div className="px-3 py-1.5 text-[13px] font-medium text-text-primary bg-terminal-surface border border-ink/10 rounded-md shadow-lg whitespace-nowrap animate-tooltip-pop">
+            <div className="px-3 py-1.5 text-[13px] font-medium text-text-primary bg-terminal-surface border border-ink/10 rounded-md shadow-tooltip whitespace-nowrap animate-tooltip-pop">
               {label}
             </div>
           </div>,

--- a/src/components/ThemeSettingsSection.tsx
+++ b/src/components/ThemeSettingsSection.tsx
@@ -1,0 +1,216 @@
+import { useState, useSyncExternalStore } from 'react';
+import {
+  subscribeTheme,
+  getThemePreference,
+  getCustomThemes,
+  setThemePreference,
+  saveCustomTheme,
+  deleteCustomTheme,
+} from '../theme/themeManager';
+import { parseCustomTheme, type CustomTheme, type ThemePreference } from '../theme/themes';
+import { DialogOverlay } from './dialogs/DialogOverlay';
+
+const BUILT_IN_OPTIONS: { value: ThemePreference; label: string }[] = [
+  { value: 'system', label: 'System' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+];
+
+const CUSTOM_THEME_TEMPLATE = `{
+  "id": "my-theme",
+  "name": "My Theme",
+  "base": "dark",
+  "tokens": {
+    "--color-accent": "#ff2d55",
+    "--color-accent-hover": "#ff5c77"
+  }
+}`;
+
+/**
+ * Appearance settings: pick a built-in theme (system-following, light, dark)
+ * or a custom theme. Custom themes are token overrides on top of a built-in
+ * base — any token from src/theme/tokens.css can be overridden.
+ */
+export function ThemeSettingsSection() {
+  const preference = useSyncExternalStore(subscribeTheme, getThemePreference);
+  const customThemes = useSyncExternalStore(subscribeTheme, getCustomThemes);
+  const [editor, setEditor] = useState<{ initial: string; editingId: string | null } | null>(null);
+
+  return (
+    <section>
+      <h2 className="text-sm font-semibold text-text-primary mb-4">Appearance</h2>
+      <div
+        className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
+        style={{ boxShadow: 'var(--shadow-panel)' }}
+      >
+        <div className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
+          <div className="flex-1 min-w-0">
+            <div className="text-sm text-text-primary">Theme</div>
+            <div className="text-xs text-text-tertiary mt-0.5">System follows the OS light/dark appearance.</div>
+          </div>
+          <div className="flex items-center gap-1 shrink-0 rounded-full bg-ink/[0.06] p-0.5">
+            {BUILT_IN_OPTIONS.map((option) => (
+              <SegmentButton
+                key={option.value}
+                label={option.label}
+                selected={preference === option.value}
+                onSelect={() => void setThemePreference(option.value)}
+              />
+            ))}
+          </div>
+        </div>
+
+        {customThemes.map((theme) => (
+          <CustomThemeRow
+            key={theme.id}
+            theme={theme}
+            selected={preference === `custom:${theme.id}`}
+            onSelect={() => void setThemePreference(`custom:${theme.id}`)}
+            onEdit={() => setEditor({ initial: JSON.stringify(theme, null, 2), editingId: theme.id })}
+            onRemove={() => void deleteCustomTheme(theme.id)}
+          />
+        ))}
+
+        <div className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
+          <div className="flex-1 min-w-0">
+            <div className="text-sm text-text-primary">Custom themes</div>
+            <div className="text-xs text-text-tertiary mt-0.5">
+              A custom theme overrides design tokens on top of the light or dark base.
+            </div>
+          </div>
+          <button
+            type="button"
+            className="btn-secondary shrink-0"
+            onClick={() => setEditor({ initial: CUSTOM_THEME_TEMPLATE, editingId: null })}
+          >
+            Add…
+          </button>
+        </div>
+      </div>
+
+      {editor && (
+        <CustomThemeDialog
+          initial={editor.initial}
+          onClose={() => setEditor(null)}
+          onSave={async (theme) => {
+            await saveCustomTheme(theme);
+            await setThemePreference(`custom:${theme.id}`);
+            setEditor(null);
+          }}
+        />
+      )}
+    </section>
+  );
+}
+
+function SegmentButton({ label, selected, onSelect }: { label: string; selected: boolean; onSelect: () => void }) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      onClick={onSelect}
+      className={`px-3 py-1 rounded-full text-xs font-medium transition-colors duration-150 ${
+        selected ? 'bg-accent text-accent-ink' : 'text-text-secondary hover:text-text-primary hover:bg-ink/[0.06]'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+interface CustomThemeRowProps {
+  theme: CustomTheme;
+  selected: boolean;
+  onSelect: () => void;
+  onEdit: () => void;
+  onRemove: () => void;
+}
+
+function CustomThemeRow({ theme, selected, onSelect, onEdit, onRemove }: CustomThemeRowProps) {
+  return (
+    <div className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
+      <div className="flex-1 min-w-0">
+        <div className="text-sm text-text-primary truncate">{theme.name}</div>
+        <div className="text-xs text-text-tertiary mt-0.5">
+          {theme.base === 'dark' ? 'Dark' : 'Light'} base · {Object.keys(theme.tokens).length}{' '}
+          {Object.keys(theme.tokens).length === 1 ? 'token' : 'tokens'}
+        </div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={selected}
+          onClick={onSelect}
+          className={`px-3 py-1 rounded-full text-xs font-medium transition-colors duration-150 ${
+            selected ? 'bg-accent text-accent-ink' : 'bg-ink/[0.06] text-text-secondary hover:text-text-primary'
+          }`}
+        >
+          {selected ? 'Selected' : 'Use'}
+        </button>
+        <button type="button" className="btn-secondary" onClick={onEdit}>
+          Edit…
+        </button>
+        <button type="button" className="btn-secondary text-error" onClick={onRemove}>
+          Remove
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface CustomThemeDialogProps {
+  initial: string;
+  onClose: () => void;
+  onSave: (theme: CustomTheme) => Promise<void>;
+}
+
+function CustomThemeDialog({ initial, onClose, onSave }: CustomThemeDialogProps) {
+  const [draft, setDraft] = useState(initial);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(draft);
+    } catch {
+      setError('Not valid JSON.');
+      return;
+    }
+    const theme = parseCustomTheme(parsed);
+    if (!theme) {
+      setError('Needs "id", "name", "base" ("dark" or "light"), and a "tokens" object of --token overrides.');
+      return;
+    }
+    await onSave(theme);
+  };
+
+  return (
+    <DialogOverlay visible onDismiss={onClose} maxWidth={560}>
+      <h2 className="text-base font-semibold text-text-primary">Custom theme</h2>
+      <p className="text-xs text-text-tertiary mt-1">
+        Overrides design tokens from src/theme/tokens.css on top of the chosen base theme.
+      </p>
+      <textarea
+        value={draft}
+        onChange={(e) => {
+          setDraft(e.target.value);
+          setError(null);
+        }}
+        spellCheck={false}
+        rows={14}
+        className="w-full mt-4 px-3 py-2 text-[13px] font-mono leading-relaxed bg-ink/[0.04] border border-ink/10 rounded-md text-text-primary outline-none focus:border-accent focus:ring-2 focus:ring-accent-light resize-y"
+      />
+      {error && <div className="text-xs text-error mt-2">{error}</div>}
+      <div className="flex justify-end gap-2 mt-4">
+        <button type="button" className="btn-secondary" onClick={onClose}>
+          Cancel
+        </button>
+        <button type="button" className="btn-primary" onClick={() => void handleSave()}>
+          Save
+        </button>
+      </div>
+    </DialogOverlay>
+  );
+}

--- a/src/components/ThemeSettingsSection.tsx
+++ b/src/components/ThemeSettingsSection.tsx
@@ -8,6 +8,7 @@ import {
   setThemePreference,
   saveCustomTheme,
   deleteCustomTheme,
+  previewTheme,
 } from '../theme/themeManager';
 import { parseCustomTheme, type CustomTheme, type ThemePreference } from '../theme/themes';
 import { PRESET_THEMES } from '../theme/presets';
@@ -160,6 +161,14 @@ function ThemeDropdown({ value, groups, onSelect }: ThemeDropdownProps) {
     return () => document.removeEventListener('keydown', handler);
   }, [open]);
 
+  // Any way the dropdown closes (select, click-outside, escape, unmount)
+  // ends the hover preview. Selection commits first in select(), so the
+  // clear is a no-op there.
+  useEffect(() => {
+    if (!open) previewTheme(null);
+    return () => previewTheme(null);
+  }, [open]);
+
   const selected = groups.flat().find((o) => o.value === value) ?? null;
 
   const select = (next: ThemePreference) => {
@@ -187,6 +196,7 @@ function ThemeDropdown({ value, groups, onSelect }: ThemeDropdownProps) {
             }}
             role="listbox"
             aria-label="Choose theme"
+            onMouseLeave={() => previewTheme(null)}
             style={{
               ...floatingStyles,
               background: 'var(--color-terminal-bg)',
@@ -227,6 +237,7 @@ function ThemeOptionRow({
     <button
       role="option"
       aria-selected={selected}
+      onMouseEnter={() => previewTheme(option.value)}
       onMouseDown={(e) => {
         e.preventDefault();
         onClick();

--- a/src/components/ThemeSettingsSection.tsx
+++ b/src/components/ThemeSettingsSection.tsx
@@ -60,10 +60,7 @@ export function ThemeSettingsSection() {
   return (
     <section>
       <h2 className="text-sm font-semibold text-text-primary mb-4">Appearance</h2>
-      <div
-        className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg"
-        style={{ boxShadow: 'var(--shadow-panel)' }}
-      >
+      <div className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg">
         <div className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
           <div className="flex-1 min-w-0">
             <div className="text-sm text-text-primary">Theme</div>

--- a/src/components/ThemeSettingsSection.tsx
+++ b/src/components/ThemeSettingsSection.tsx
@@ -1,4 +1,6 @@
-import { useState, useSyncExternalStore } from 'react';
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
+import { useFloating, offset, flip, shift, autoUpdate } from '@floating-ui/react';
 import {
   subscribeTheme,
   getThemePreference,
@@ -9,13 +11,8 @@ import {
 } from '../theme/themeManager';
 import { parseCustomTheme, type CustomTheme, type ThemePreference } from '../theme/themes';
 import { PRESET_THEMES } from '../theme/presets';
+import { Icon } from './terminal/Icon';
 import { DialogOverlay } from './dialogs/DialogOverlay';
-
-const BUILT_IN_OPTIONS: { value: ThemePreference; label: string }[] = [
-  { value: 'system', label: 'System' },
-  { value: 'light', label: 'Light' },
-  { value: 'dark', label: 'Dark' },
-];
 
 const CUSTOM_THEME_TEMPLATE = `{
   "id": "my-theme",
@@ -27,19 +24,37 @@ const CUSTOM_THEME_TEMPLATE = `{
   }
 }`;
 
+interface ThemeOption {
+  value: ThemePreference;
+  label: string;
+  hint?: string;
+}
+
 /**
- * Appearance settings: pick a built-in theme (system-following, light, dark)
- * or a custom theme. Custom themes are token overrides on top of a built-in
- * base — any token from src/theme/tokens.css can be overridden.
+ * Appearance settings: one dropdown picks the theme — built-ins
+ * (system-following, light, dark), bundled presets, and user custom themes.
+ * Custom themes are token overrides on top of a built-in base — any token
+ * from src/theme/tokens.css can be overridden.
  */
 export function ThemeSettingsSection() {
   const preference = useSyncExternalStore(subscribeTheme, getThemePreference);
   const customThemes = useSyncExternalStore(subscribeTheme, getCustomThemes);
   const [editor, setEditor] = useState<{ initial: string; editingId: string | null } | null>(null);
 
-  // A user theme saved with a preset's id shadows it; the user copy renders
-  // in the custom list instead.
+  // A user theme saved with a preset's id shadows it; the user copy is
+  // listed in the custom group instead.
   const presets = PRESET_THEMES.filter((preset) => !customThemes.some((t) => t.id === preset.id));
+
+  const allGroups: ThemeOption[][] = [
+    [
+      { value: 'system', label: 'System' },
+      { value: 'light', label: 'Light' },
+      { value: 'dark', label: 'Dark' },
+    ],
+    presets.map((theme): ThemeOption => ({ value: `custom:${theme.id}`, label: theme.name, hint: 'Preset' })),
+    customThemes.map((theme): ThemeOption => ({ value: `custom:${theme.id}`, label: theme.name, hint: 'Custom' })),
+  ];
+  const optionGroups = allGroups.filter((group) => group.length > 0);
 
   return (
     <section>
@@ -53,34 +68,13 @@ export function ThemeSettingsSection() {
             <div className="text-sm text-text-primary">Theme</div>
             <div className="text-xs text-text-tertiary mt-0.5">System follows the OS light/dark appearance.</div>
           </div>
-          <div className="flex items-center gap-1 shrink-0 rounded-full bg-ink/[0.06] p-0.5">
-            {BUILT_IN_OPTIONS.map((option) => (
-              <SegmentButton
-                key={option.value}
-                label={option.label}
-                selected={preference === option.value}
-                onSelect={() => void setThemePreference(option.value)}
-              />
-            ))}
-          </div>
+          <ThemeDropdown value={preference} groups={optionGroups} onSelect={(next) => void setThemePreference(next)} />
         </div>
-
-        {presets.map((theme) => (
-          <PresetThemeRow
-            key={theme.id}
-            theme={theme}
-            selected={preference === `custom:${theme.id}`}
-            onSelect={() => void setThemePreference(`custom:${theme.id}`)}
-            onEdit={() => setEditor({ initial: JSON.stringify(theme, null, 2), editingId: theme.id })}
-          />
-        ))}
 
         {customThemes.map((theme) => (
           <CustomThemeRow
             key={theme.id}
             theme={theme}
-            selected={preference === `custom:${theme.id}`}
-            onSelect={() => void setThemePreference(`custom:${theme.id}`)}
             onEdit={() => setEditor({ initial: JSON.stringify(theme, null, 2), editingId: theme.id })}
             onRemove={() => void deleteCustomTheme(theme.id)}
           />
@@ -118,68 +112,143 @@ export function ThemeSettingsSection() {
   );
 }
 
-function SegmentButton({ label, selected, onSelect }: { label: string; selected: boolean; onSelect: () => void }) {
+interface ThemeDropdownProps {
+  value: ThemePreference;
+  groups: ThemeOption[][];
+  onSelect: (value: ThemePreference) => void;
+}
+
+function ThemeDropdown({ value, groups, onSelect }: ThemeDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const { refs, floatingStyles } = useFloating({
+    placement: 'bottom-end',
+    strategy: 'fixed',
+    middleware: [offset(6), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+  });
+
+  useEffect(() => {
+    if (triggerRef.current) refs.setReference(triggerRef.current);
+  }, [refs]);
+
+  // Click-outside
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (dropdownRef.current?.contains(target)) return;
+      if (triggerRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const timer = setTimeout(() => document.addEventListener('mousedown', handler), 0);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handler);
+    };
+  }, [open]);
+
+  // Escape
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open]);
+
+  const selected = groups.flat().find((o) => o.value === value) ?? null;
+
+  const select = (next: ThemePreference) => {
+    setOpen(false);
+    onSelect(next);
+  };
+
   return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={selected}
-      onClick={onSelect}
-      className={`px-3 py-1 rounded-full text-xs font-medium transition-colors duration-150 ${
-        selected ? 'bg-accent text-accent-ink' : 'text-text-secondary hover:text-text-primary hover:bg-ink/[0.06]'
-      }`}
-    >
-      {label}
-    </button>
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-[13rem] shrink-0 flex items-center justify-between gap-2 px-3 py-1.5 text-sm bg-ink/[0.04] border border-ink/10 rounded-md text-text-primary hover:bg-ink/[0.06] outline-none focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent-light"
+      >
+        <span className="truncate">{selected?.label ?? 'System'}</span>
+        <Icon name="caret-down" className="w-3.5 h-3.5 text-text-tertiary shrink-0" />
+      </button>
+      {open &&
+        createPortal(
+          <div
+            ref={(el) => {
+              dropdownRef.current = el;
+              refs.setFloating(el);
+            }}
+            role="listbox"
+            aria-label="Choose theme"
+            style={{
+              ...floatingStyles,
+              background: 'var(--color-terminal-bg)',
+              boxShadow: 'var(--shadow-menu)',
+            }}
+            className="w-[13rem] max-h-[24rem] overflow-y-auto border border-bezel rounded-[12px] z-[1000] p-1"
+          >
+            {groups.map((group, i) => (
+              <div key={i}>
+                {i > 0 && <div className="my-1 mx-1 border-t border-ink/[0.06]" />}
+                {group.map((option) => (
+                  <ThemeOptionRow
+                    key={option.value}
+                    option={option}
+                    selected={option.value === value}
+                    onClick={() => select(option.value)}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </>
   );
 }
 
-interface PresetThemeRowProps {
-  theme: CustomTheme;
+function ThemeOptionRow({
+  option,
+  selected,
+  onClick,
+}: {
+  option: ThemeOption;
   selected: boolean;
-  onSelect: () => void;
-  onEdit: () => void;
-}
-
-/** A built-in preset theme. Editing saves a user copy that shadows it. */
-function PresetThemeRow({ theme, selected, onSelect, onEdit }: PresetThemeRowProps) {
+  onClick: () => void;
+}) {
   return (
-    <div className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
-      <div className="flex-1 min-w-0">
-        <div className="text-sm text-text-primary truncate">{theme.name}</div>
-        <div className="text-xs text-text-tertiary mt-0.5">
-          Preset · {theme.base === 'dark' ? 'Dark' : 'Light'} base
-        </div>
-      </div>
-      <div className="flex items-center gap-2 shrink-0">
-        <button
-          type="button"
-          role="radio"
-          aria-checked={selected}
-          onClick={onSelect}
-          className={`px-3 py-1 rounded-full text-xs font-medium transition-colors duration-150 ${
-            selected ? 'bg-accent text-accent-ink' : 'bg-ink/[0.06] text-text-secondary hover:text-text-primary'
-          }`}
-        >
-          {selected ? 'Selected' : 'Use'}
-        </button>
-        <button type="button" className="btn-secondary" onClick={onEdit}>
-          Edit…
-        </button>
-      </div>
-    </div>
+    <button
+      role="option"
+      aria-selected={selected}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        onClick();
+      }}
+      className={`w-full text-left px-2.5 py-1.5 rounded-[7px] text-sm flex items-center gap-2 hover:bg-ink/[0.08] transition-colors duration-100 ${
+        selected ? 'text-text-primary bg-ink/[0.04]' : 'text-text-secondary'
+      }`}
+    >
+      <span className="flex-1 truncate">{option.label}</span>
+      {option.hint && <span className="text-[11px] text-text-tertiary shrink-0">{option.hint}</span>}
+      {selected && <Icon name="check" className="w-3.5 h-3.5 text-text-primary shrink-0" />}
+    </button>
   );
 }
 
 interface CustomThemeRowProps {
   theme: CustomTheme;
-  selected: boolean;
-  onSelect: () => void;
   onEdit: () => void;
   onRemove: () => void;
 }
 
-function CustomThemeRow({ theme, selected, onSelect, onEdit, onRemove }: CustomThemeRowProps) {
+function CustomThemeRow({ theme, onEdit, onRemove }: CustomThemeRowProps) {
   return (
     <div className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
       <div className="flex-1 min-w-0">
@@ -190,17 +259,6 @@ function CustomThemeRow({ theme, selected, onSelect, onEdit, onRemove }: CustomT
         </div>
       </div>
       <div className="flex items-center gap-2 shrink-0">
-        <button
-          type="button"
-          role="radio"
-          aria-checked={selected}
-          onClick={onSelect}
-          className={`px-3 py-1 rounded-full text-xs font-medium transition-colors duration-150 ${
-            selected ? 'bg-accent text-accent-ink' : 'bg-ink/[0.06] text-text-secondary hover:text-text-primary'
-          }`}
-        >
-          {selected ? 'Selected' : 'Use'}
-        </button>
         <button type="button" className="btn-secondary" onClick={onEdit}>
           Edit…
         </button>

--- a/src/components/ThemeSettingsSection.tsx
+++ b/src/components/ThemeSettingsSection.tsx
@@ -8,6 +8,7 @@ import {
   deleteCustomTheme,
 } from '../theme/themeManager';
 import { parseCustomTheme, type CustomTheme, type ThemePreference } from '../theme/themes';
+import { PRESET_THEMES } from '../theme/presets';
 import { DialogOverlay } from './dialogs/DialogOverlay';
 
 const BUILT_IN_OPTIONS: { value: ThemePreference; label: string }[] = [
@@ -36,6 +37,10 @@ export function ThemeSettingsSection() {
   const customThemes = useSyncExternalStore(subscribeTheme, getCustomThemes);
   const [editor, setEditor] = useState<{ initial: string; editingId: string | null } | null>(null);
 
+  // A user theme saved with a preset's id shadows it; the user copy renders
+  // in the custom list instead.
+  const presets = PRESET_THEMES.filter((preset) => !customThemes.some((t) => t.id === preset.id));
+
   return (
     <section>
       <h2 className="text-sm font-semibold text-text-primary mb-4">Appearance</h2>
@@ -59,6 +64,16 @@ export function ThemeSettingsSection() {
             ))}
           </div>
         </div>
+
+        {presets.map((theme) => (
+          <PresetThemeRow
+            key={theme.id}
+            theme={theme}
+            selected={preference === `custom:${theme.id}`}
+            onSelect={() => void setThemePreference(`custom:${theme.id}`)}
+            onEdit={() => setEditor({ initial: JSON.stringify(theme, null, 2), editingId: theme.id })}
+          />
+        ))}
 
         {customThemes.map((theme) => (
           <CustomThemeRow
@@ -116,6 +131,43 @@ function SegmentButton({ label, selected, onSelect }: { label: string; selected:
     >
       {label}
     </button>
+  );
+}
+
+interface PresetThemeRowProps {
+  theme: CustomTheme;
+  selected: boolean;
+  onSelect: () => void;
+  onEdit: () => void;
+}
+
+/** A built-in preset theme. Editing saves a user copy that shadows it. */
+function PresetThemeRow({ theme, selected, onSelect, onEdit }: PresetThemeRowProps) {
+  return (
+    <div className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
+      <div className="flex-1 min-w-0">
+        <div className="text-sm text-text-primary truncate">{theme.name}</div>
+        <div className="text-xs text-text-tertiary mt-0.5">
+          Preset · {theme.base === 'dark' ? 'Dark' : 'Light'} base
+        </div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={selected}
+          onClick={onSelect}
+          className={`px-3 py-1 rounded-full text-xs font-medium transition-colors duration-150 ${
+            selected ? 'bg-accent text-accent-ink' : 'bg-ink/[0.06] text-text-secondary hover:text-text-primary'
+          }`}
+        >
+          {selected ? 'Selected' : 'Use'}
+        </button>
+        <button type="button" className="btn-secondary" onClick={onEdit}>
+          Edit…
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/ThemeSettingsSection.tsx
+++ b/src/components/ThemeSettingsSection.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
-import { createPortal } from 'react-dom';
-import { useFloating, offset, flip, shift, autoUpdate } from '@floating-ui/react';
+import { useEffect, useState, useSyncExternalStore } from 'react';
 import {
   subscribeTheme,
   getThemePreference,
@@ -12,7 +10,7 @@ import {
 } from '../theme/themeManager';
 import { parseCustomTheme, type CustomTheme, type ThemePreference } from '../theme/themes';
 import { PRESET_THEMES } from '../theme/presets';
-import { Icon } from './terminal/Icon';
+import { SettingsDropdown, SettingsDropdownOption, SettingsDropdownDivider } from './ui/SettingsDropdown';
 import { DialogOverlay } from './dialogs/DialogOverlay';
 
 const CUSTOM_THEME_TEMPLATE = `{
@@ -60,7 +58,7 @@ export function ThemeSettingsSection() {
   return (
     <section>
       <h2 className="text-sm font-semibold text-text-primary mb-4">Appearance</h2>
-      <div className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg">
+      <div className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg">
         <div className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
           <div className="flex-1 min-w-0">
             <div className="text-sm text-text-primary">Theme</div>
@@ -118,45 +116,6 @@ interface ThemeDropdownProps {
 
 function ThemeDropdown({ value, groups, onSelect }: ThemeDropdownProps) {
   const [open, setOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  const { refs, floatingStyles } = useFloating({
-    placement: 'bottom-end',
-    strategy: 'fixed',
-    middleware: [offset(6), flip(), shift({ padding: 8 })],
-    whileElementsMounted: autoUpdate,
-  });
-
-  useEffect(() => {
-    if (triggerRef.current) refs.setReference(triggerRef.current);
-  }, [refs]);
-
-  // Click-outside
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (dropdownRef.current?.contains(target)) return;
-      if (triggerRef.current?.contains(target)) return;
-      setOpen(false);
-    };
-    const timer = setTimeout(() => document.addEventListener('mousedown', handler), 0);
-    return () => {
-      clearTimeout(timer);
-      document.removeEventListener('mousedown', handler);
-    };
-  }, [open]);
-
-  // Escape
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
-    };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [open]);
 
   // Any way the dropdown closes (select, click-outside, escape, unmount)
   // ends the hover preview. Selection commits first in select(), so the
@@ -174,79 +133,30 @@ function ThemeDropdown({ value, groups, onSelect }: ThemeDropdownProps) {
   };
 
   return (
-    <>
-      <button
-        ref={triggerRef}
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="w-[13rem] shrink-0 flex items-center justify-between gap-2 px-3 py-1.5 text-sm bg-ink/[0.04] border border-ink/10 rounded-md text-text-primary hover:bg-ink/[0.06] outline-none focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent-light"
-      >
-        <span className="truncate">{selected?.label ?? 'System'}</span>
-        <Icon name="caret-down" className="w-3.5 h-3.5 text-text-tertiary shrink-0" />
-      </button>
-      {open &&
-        createPortal(
-          <div
-            ref={(el) => {
-              dropdownRef.current = el;
-              refs.setFloating(el);
-            }}
-            role="listbox"
-            aria-label="Choose theme"
-            onMouseLeave={() => previewTheme(null)}
-            style={{
-              ...floatingStyles,
-              background: 'var(--color-terminal-bg)',
-              boxShadow: 'var(--shadow-menu)',
-            }}
-            className="w-[13rem] max-h-[24rem] overflow-y-auto border border-bezel rounded-[12px] z-[1000] p-1"
-          >
-            {groups.map((group, i) => (
-              <div key={i}>
-                {i > 0 && <div className="my-1 mx-1 border-t border-ink/[0.06]" />}
-                {group.map((option) => (
-                  <ThemeOptionRow
-                    key={option.value}
-                    option={option}
-                    selected={option.value === value}
-                    onClick={() => select(option.value)}
-                  />
-                ))}
-              </div>
-            ))}
-          </div>,
-          document.body,
-        )}
-    </>
-  );
-}
-
-function ThemeOptionRow({
-  option,
-  selected,
-  onClick,
-}: {
-  option: ThemeOption;
-  selected: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      role="option"
-      aria-selected={selected}
-      onMouseEnter={() => previewTheme(option.value)}
-      onMouseDown={(e) => {
-        e.preventDefault();
-        onClick();
-      }}
-      className={`w-full text-left px-2.5 py-1.5 rounded-[7px] text-sm flex items-center gap-2 hover:bg-ink/[0.08] transition-colors duration-100 ${
-        selected ? 'text-text-primary bg-ink/[0.04]' : 'text-text-secondary'
-      }`}
+    <SettingsDropdown
+      open={open}
+      onOpenChange={setOpen}
+      widthClass="w-[13rem]"
+      ariaLabel="Choose theme"
+      triggerLabel={selected?.label ?? 'System'}
+      onMenuMouseLeave={() => previewTheme(null)}
     >
-      <span className="flex-1 truncate">{option.label}</span>
-      {option.hint && <span className="text-[11px] text-text-tertiary shrink-0">{option.hint}</span>}
-      {selected && <Icon name="check" className="w-3.5 h-3.5 text-text-primary shrink-0" />}
-    </button>
+      {groups.map((group, i) => (
+        <div key={i}>
+          {i > 0 && <SettingsDropdownDivider />}
+          {group.map((option) => (
+            <SettingsDropdownOption
+              key={option.value}
+              label={option.label}
+              hint={option.hint}
+              selected={option.value === value}
+              onMouseEnter={() => previewTheme(option.value)}
+              onClick={() => select(option.value)}
+            />
+          ))}
+        </div>
+      ))}
+    </SettingsDropdown>
   );
 }
 

--- a/src/components/TitleBarReact.tsx
+++ b/src/components/TitleBarReact.tsx
@@ -79,7 +79,7 @@ export function TitleBar({ mode }: TitleBarProps) {
       className={`sticky top-0 relative [-webkit-app-region:drag] ${isProjectOrHome ? 'z-[10000] border-b-0' : 'z-[100] border-b border-border'}`}
       style={
         {
-          background: 'rgba(28, 28, 30, 0.97)',
+          background: 'color-mix(in srgb, var(--color-background) 97%, transparent)',
           WebkitAppRegion: 'drag',
           paddingTop: 'env(titlebar-area-height, 0px)',
         } as React.CSSProperties
@@ -119,7 +119,7 @@ export function TitleBar({ mode }: TitleBarProps) {
               </span>
             </div>
             <div style={{ flex: 1 }} />
-            <div className="flex items-center h-9 ml-3 bg-background-secondary glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden [-webkit-app-region:no-drag]">
+            <div className="flex items-center h-9 ml-3 bg-background-secondary glass-bevel relative border border-bezel rounded-[14px] overflow-hidden [-webkit-app-region:no-drag]">
               <TooltipButton
                 text="Board view"
                 className={`w-9 h-full flex items-center justify-center text-text-secondary transition-all duration-150 ease-out hover:text-text-primary hover:bg-background-tertiary [&>svg]:w-5 [&>svg]:h-5${activePanel !== 'settings' && kanbanVisible ? ' text-text-primary bg-background-tertiary' : ''}`}
@@ -153,7 +153,7 @@ export function TitleBar({ mode }: TitleBarProps) {
             </div>
             <Tooltip text="New terminal" placement="bottom">
               <button
-                className="w-9 h-9 flex items-center justify-center bg-background-secondary glass-bevel relative border border-black/60 rounded-[14px] text-text-secondary transition-all duration-150 ease-out ml-3 [-webkit-app-region:no-drag] hover:bg-background-tertiary hover:text-text-primary [&>svg]:w-5 [&>svg]:h-5"
+                className="w-9 h-9 flex items-center justify-center bg-background-secondary glass-bevel relative border border-bezel rounded-[14px] text-text-secondary transition-all duration-150 ease-out ml-3 [-webkit-app-region:no-drag] hover:bg-background-tertiary hover:text-text-primary [&>svg]:w-5 [&>svg]:h-5"
                 onClick={handleNewTerminal}
               >
                 <Icon name="terminal" />
@@ -161,7 +161,7 @@ export function TitleBar({ mode }: TitleBarProps) {
             </Tooltip>
             <Tooltip text="New task" placement="bottom-end">
               <button
-                className="w-9 h-9 flex items-center justify-center bg-background-secondary glass-bevel relative border border-black/60 rounded-[14px] text-text-secondary transition-all duration-150 ease-out ml-3 [-webkit-app-region:no-drag] hover:bg-background-tertiary hover:text-text-primary [&>svg]:w-5 [&>svg]:h-5"
+                className="w-9 h-9 flex items-center justify-center bg-background-secondary glass-bevel relative border border-bezel rounded-[14px] text-text-secondary transition-all duration-150 ease-out ml-3 [-webkit-app-region:no-drag] hover:bg-background-tertiary hover:text-text-primary [&>svg]:w-5 [&>svg]:h-5"
                 onClick={handleNewTask}
               >
                 <Icon name="plus" />
@@ -171,7 +171,7 @@ export function TitleBar({ mode }: TitleBarProps) {
         ) : activeView === 'home' ? (
           <div key="home-header" className="flex items-center gap-3 flex-1 px-4">
             <div style={{ flex: 1 }} />
-            <div className="flex items-center h-9 ml-3 bg-background-secondary glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden [-webkit-app-region:no-drag]">
+            <div className="flex items-center h-9 ml-3 bg-background-secondary glass-bevel relative border border-bezel rounded-[14px] overflow-hidden [-webkit-app-region:no-drag]">
               <TooltipButton
                 text="Group by project"
                 className={`w-9 h-full flex items-center justify-center text-text-secondary transition-all duration-150 ease-out hover:text-text-primary hover:bg-background-tertiary [&>svg]:w-5 [&>svg]:h-5${homeActivePanel !== 'settings' && homeGroupMode === 'project' ? ' text-text-primary bg-background-tertiary' : ''}`}
@@ -202,7 +202,7 @@ export function TitleBar({ mode }: TitleBarProps) {
             </div>
             <Tooltip text="New terminal" placement="bottom">
               <button
-                className="w-9 h-9 flex items-center justify-center bg-background-secondary glass-bevel relative border border-black/60 rounded-[14px] text-text-secondary transition-all duration-150 ease-out ml-3 [-webkit-app-region:no-drag] hover:bg-background-tertiary hover:text-text-primary [&>svg]:w-5 [&>svg]:h-5"
+                className="w-9 h-9 flex items-center justify-center bg-background-secondary glass-bevel relative border border-bezel rounded-[14px] text-text-secondary transition-all duration-150 ease-out ml-3 [-webkit-app-region:no-drag] hover:bg-background-tertiary hover:text-text-primary [&>svg]:w-5 [&>svg]:h-5"
                 onClick={async () => {
                   const homePath = await window.api.homePath();
                   addProjectTerminal(homePath);

--- a/src/components/canvas/CanvasControls.tsx
+++ b/src/components/canvas/CanvasControls.tsx
@@ -23,7 +23,7 @@ export const CanvasControls = memo(function CanvasControls({ projectPath }: Canv
 
   return (
     <div
-      className="glass-bevel flex items-center gap-0.5 px-1.5 rounded-lg border border-black/60"
+      className="glass-bevel flex items-center gap-0.5 px-1.5 rounded-lg border border-bezel"
       style={{
         position: 'absolute',
         top: -16,
@@ -31,7 +31,7 @@ export const CanvasControls = memo(function CanvasControls({ projectPath }: Canv
         transform: 'translateX(-50%)',
         zIndex: 10001,
         height: 32,
-        background: 'rgba(28, 28, 30, 0.8)',
+        background: 'color-mix(in srgb, var(--color-background) 80%, transparent)',
         backdropFilter: 'blur(12px)',
         WebkitBackdropFilter: 'blur(12px)',
       }}
@@ -41,7 +41,7 @@ export const CanvasControls = memo(function CanvasControls({ projectPath }: Canv
       </ControlButton>
 
       <button
-        className="px-1.5 font-mono text-xs text-white/50 bg-transparent border-none hover:text-white/80 transition-colors duration-150"
+        className="px-1.5 font-mono text-xs text-ink/50 bg-transparent border-none hover:text-ink/80 transition-colors duration-150"
         onClick={handleFitView}
         title="Fit view (Cmd+0)"
         style={{ minWidth: 40, textAlign: 'center' }}
@@ -53,7 +53,7 @@ export const CanvasControls = memo(function CanvasControls({ projectPath }: Canv
         <PlusIcon />
       </ControlButton>
 
-      <div className="w-px h-4 bg-white/10 mx-0.5" />
+      <div className="w-px h-4 bg-ink/10 mx-0.5" />
 
       <ControlButton onClick={handleFitView} title="Fit all (Cmd+Shift+F)">
         <FitIcon />
@@ -82,7 +82,7 @@ function ControlButton({
   return (
     <button
       className={`w-7 h-7 flex items-center justify-center rounded bg-transparent border-none transition-colors duration-150 ${
-        active ? 'text-accent' : 'text-white/40 hover:text-white/70'
+        active ? 'text-accent' : 'text-ink/40 hover:text-ink/70'
       }`}
       onClick={onClick}
       title={title}

--- a/src/components/canvas/TerminalCanvas.tsx
+++ b/src/components/canvas/TerminalCanvas.tsx
@@ -30,6 +30,8 @@ import { useChainEdges } from './useChainEdges';
 import { useSmartGuides } from './useSmartGuides';
 import { getChainColor, buildChainMap } from '../../utils/taskChain';
 import { useProjectStore } from '../../stores/projectStore';
+import { readToken } from '../../theme/themeManager';
+import { useResolvedTheme } from '../../hooks/useResolvedTheme';
 
 /**
  * Reconcile canvas nodes with the terminal store — add missing, remove stale.
@@ -124,21 +126,26 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
     [fitView],
   );
 
-  // Phase 3: minimap node color from chain info
+  // Phase 3: minimap node color from chain info.
+  // MiniMap colors land in SVG fill attributes where var() can't resolve, so
+  // read the tokens at render time; useResolvedTheme re-renders on theme change.
+  useResolvedTheme();
+  const minimapFallbackColor = readToken('--color-border-hover');
+  const minimapBgColor = readToken('--color-background');
   const tasks = useProjectStore((s) => s.tasks);
   const displayStates = useTerminalStore((s) => s.displayStates);
   const minimapNodeColor = useCallback(
     (node: TerminalNodeType) => {
       const ptyId = node.data?.ptyId;
-      if (!ptyId) return 'rgba(255, 255, 255, 0.15)';
+      if (!ptyId) return minimapFallbackColor;
       const display = displayStates[ptyId];
-      if (!display?.taskId) return 'rgba(255, 255, 255, 0.15)';
+      if (!display?.taskId) return minimapFallbackColor;
       const chainMap = buildChainMap(tasks);
       const info = chainMap.get(display.taskId);
-      if (!info) return 'rgba(255, 255, 255, 0.15)';
+      if (!info) return minimapFallbackColor;
       return getChainColor(info.rootTaskNumber, info.depth);
     },
-    [tasks, displayStates],
+    [tasks, displayStates, minimapFallbackColor],
   );
 
   // Load persisted canvas state on mount, then reconcile with current terminals
@@ -217,7 +224,7 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
         fitView
         proOptions={proOptions}
       >
-        <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="rgba(255,255,255,0.15)" />
+        <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
         {nodes.length >= 3 &&
           (minimapOpen ? (
             <MiniMap
@@ -226,15 +233,18 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
               position="bottom-right"
               nodeColor={minimapNodeColor as (node: any) => string}
               maskColor="rgba(0, 0, 0, 0.25)"
-              bgColor="#1c1c1e"
+              bgColor={minimapBgColor}
               nodeBorderRadius={16}
               onClick={handleToggleMinimap}
             />
           ) : (
             <Panel position="bottom-right">
               <button
-                className="flex items-center justify-center w-8 h-8 rounded-lg border border-white/10 text-white/40 hover:text-white/70 transition-colors duration-150"
-                style={{ background: 'rgba(28, 28, 30, 0.8)', backdropFilter: 'blur(12px)' }}
+                className="flex items-center justify-center w-8 h-8 rounded-lg border border-ink/10 text-ink/40 hover:text-ink/70 transition-colors duration-150"
+                style={{
+                  background: 'color-mix(in srgb, var(--color-background) 80%, transparent)',
+                  backdropFilter: 'blur(12px)',
+                }}
                 onClick={handleToggleMinimap}
                 title="Show minimap"
               >

--- a/src/components/canvas/TerminalCanvas.tsx
+++ b/src/components/canvas/TerminalCanvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -31,7 +31,7 @@ import { useSmartGuides } from './useSmartGuides';
 import { getChainColor, buildChainMap } from '../../utils/taskChain';
 import { useProjectStore } from '../../stores/projectStore';
 import { readToken } from '../../theme/themeManager';
-import { useResolvedTheme } from '../../hooks/useResolvedTheme';
+import { useThemeEpoch } from '../../hooks/useResolvedTheme';
 
 /**
  * Reconcile canvas nodes with the terminal store — add missing, remove stale.
@@ -128,10 +128,13 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
 
   // Phase 3: minimap node color from chain info.
   // MiniMap colors land in SVG fill attributes where var() can't resolve, so
-  // read the tokens at render time; useResolvedTheme re-renders on theme change.
-  useResolvedTheme();
-  const minimapFallbackColor = readToken('--color-border-hover');
-  const minimapBgColor = readToken('--color-background');
+  // read the tokens per applied theme (the epoch also covers switches between
+  // two themes with the same base, which the resolved base can't see).
+  const themeEpoch = useThemeEpoch();
+  const [minimapFallbackColor, minimapBgColor] = useMemo(() => {
+    void themeEpoch; // the tokens change when the applied theme does
+    return [readToken('--color-border-hover'), readToken('--color-background')];
+  }, [themeEpoch]);
   const tasks = useProjectStore((s) => s.tasks);
   const displayStates = useTerminalStore((s) => s.displayStates);
   const minimapNodeColor = useCallback(

--- a/src/components/canvas/TerminalCanvas.tsx
+++ b/src/components/canvas/TerminalCanvas.tsx
@@ -137,18 +137,20 @@ function TerminalCanvasInner({ projectPath }: TerminalCanvasProps) {
   }, [themeEpoch]);
   const tasks = useProjectStore((s) => s.tasks);
   const displayStates = useTerminalStore((s) => s.displayStates);
+  // React Flow calls nodeColor once per node on every minimap render, so build
+  // the chain map once here rather than rebuilding it inside the callback.
+  const chainMap = useMemo(() => buildChainMap(tasks), [tasks]);
   const minimapNodeColor = useCallback(
     (node: TerminalNodeType) => {
       const ptyId = node.data?.ptyId;
       if (!ptyId) return minimapFallbackColor;
       const display = displayStates[ptyId];
       if (!display?.taskId) return minimapFallbackColor;
-      const chainMap = buildChainMap(tasks);
       const info = chainMap.get(display.taskId);
       if (!info) return minimapFallbackColor;
       return getChainColor(info.rootTaskNumber, info.depth);
     },
-    [tasks, displayStates, minimapFallbackColor],
+    [chainMap, displayStates, minimapFallbackColor],
   );
 
   // Load persisted canvas state on mount, then reconcile with current terminals

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -17,7 +17,7 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
 function LoadingNode({ label }: { label?: string }) {
   return (
     <div
-      className="canvas-terminal-node glass-bevel absolute rounded-[14px] border border-bezel overflow-hidden flex flex-col items-center justify-center gap-3"
+      className="canvas-terminal-node glass-bevel absolute rounded-[14px] border border-bezel-panel overflow-hidden flex flex-col items-center justify-center gap-3"
       style={{
         top: INSET_TOP,
         left: INSET_SIDE,
@@ -72,7 +72,7 @@ const ActiveTerminalNode = memo(function ActiveTerminalNode({
       <Handle id="right" type="target" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
 
       <div
-        className="canvas-terminal-node glass-bevel absolute rounded-[14px] border border-bezel overflow-hidden flex flex-col"
+        className="canvas-terminal-node glass-bevel absolute rounded-[14px] border border-bezel-panel overflow-hidden flex flex-col"
         style={{
           top: INSET_TOP,
           left: INSET_SIDE,

--- a/src/components/canvas/TerminalNode.tsx
+++ b/src/components/canvas/TerminalNode.tsx
@@ -17,21 +17,21 @@ export const TerminalNode = memo(function TerminalNode({ data, selected }: NodeP
 function LoadingNode({ label }: { label?: string }) {
   return (
     <div
-      className="canvas-terminal-node glass-bevel absolute rounded-[14px] border border-black/60 overflow-hidden flex flex-col items-center justify-center gap-3"
+      className="canvas-terminal-node glass-bevel absolute rounded-[14px] border border-bezel overflow-hidden flex flex-col items-center justify-center gap-3"
       style={{
         top: INSET_TOP,
         left: INSET_SIDE,
         right: INSET_SIDE,
         bottom: INSET_BOTTOM,
-        background: 'var(--color-terminal-bg, #171717)',
-        boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+        background: 'var(--color-terminal-bg)',
+        boxShadow: 'var(--shadow-panel)',
       }}
     >
       <div
-        className="w-5 h-5 rounded-full border-2 border-white/20 border-t-accent"
+        className="w-5 h-5 rounded-full border-2 border-ink/20 border-t-accent"
         style={{ animation: 'spin 0.8s linear infinite' }}
       />
-      <span className="font-mono text-sm text-white/40">{label || 'Setting up workspace\u2026'}</span>
+      <span className="font-mono text-sm text-ink/40">{label || 'Setting up workspace\u2026'}</span>
     </div>
   );
 }
@@ -72,14 +72,14 @@ const ActiveTerminalNode = memo(function ActiveTerminalNode({
       <Handle id="right" type="target" position={Position.Right} className="!bg-transparent !border-none !w-0 !h-0" />
 
       <div
-        className="canvas-terminal-node glass-bevel absolute rounded-[14px] border border-black/60 overflow-hidden flex flex-col"
+        className="canvas-terminal-node glass-bevel absolute rounded-[14px] border border-bezel overflow-hidden flex flex-col"
         style={{
           top: INSET_TOP,
           left: INSET_SIDE,
           right: INSET_SIDE,
           bottom: INSET_BOTTOM,
-          background: 'var(--color-terminal-bg, #171717)',
-          boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+          background: 'var(--color-terminal-bg)',
+          boxShadow: 'var(--shadow-panel)',
         }}
       >
         <div className="terminal-drag-handle shrink-0" style={{ zIndex: 2 }}>

--- a/src/components/dialogs/AddSiblingProjectsDialog.tsx
+++ b/src/components/dialogs/AddSiblingProjectsDialog.tsx
@@ -47,7 +47,7 @@ export function AddSiblingProjectsDialog({ parentDir, siblings, onClose }: AddSi
         {siblings.length === 1 ? 'it' : 'them'} as {siblings.length === 1 ? 'a project' : 'projects'} too?
       </p>
       <p className="text-xs text-text-secondary/70 text-center mt-1 font-mono break-all">{parentDir}</p>
-      <ul className="mt-4 max-h-40 overflow-y-auto rounded-md border border-border bg-background divide-y divide-white/[0.06]">
+      <ul className="mt-4 max-h-40 overflow-y-auto rounded-md border border-border bg-background divide-y divide-ink/[0.06]">
         {siblings.map((sibling) => (
           <li key={sibling} className="px-3 py-1.5 text-xs font-mono text-text-secondary truncate" title={sibling}>
             {folderName(sibling)}

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -26,7 +26,7 @@ function HealthRow({ ok, label, hint }: { ok: boolean; label: string; hint?: str
     <div className="flex items-center gap-2 text-xs">
       <span
         className="shrink-0 w-2 h-2 rounded-full"
-        style={{ background: ok ? 'rgb(48, 209, 88)' : 'rgb(255, 159, 10)' }}
+        style={{ background: ok ? 'var(--color-success)' : 'var(--color-vcs-modified)' }}
       />
       <span className="text-text-primary font-medium w-20 shrink-0">{label}</span>
       <span className="text-text-secondary">{ok ? 'installed' : hint || 'not found'}</span>
@@ -51,7 +51,7 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
   return (
     <DialogOverlay visible={visible} onDismiss={dismiss} maxWidth={520}>
       <div className="flex items-center gap-2 mb-1">
-        <div className="w-7 h-7 rounded-full flex items-center justify-center text-text-secondary [&>svg]:w-4 [&>svg]:h-4 bg-white/5">
+        <div className="w-7 h-7 rounded-full flex items-center justify-center text-text-secondary [&>svg]:w-4 [&>svg]:h-4 bg-ink/5">
           <Icon name="question" />
         </div>
         <h2 className="text-lg font-semibold text-text-primary">Help &amp; Setup</h2>
@@ -82,10 +82,10 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
           <p className="text-xs text-text-secondary leading-relaxed">
             Configure a <span className="text-text-primary font-medium">start hook</span> on the kanban board (the chip
             on the In Progress column). A start hook is the command that runs when you drag a task to In Progress.
-            Usually it&apos;s just your agent: <code className="px-1 py-0.5 rounded bg-white/5 font-mono">claude</code>{' '}
-            or <code className="px-1 py-0.5 rounded bg-white/5 font-mono">codex</code>. The task description is passed
-            in as the prompt, and the agent figures out the rest using the{' '}
-            <code className="px-1 py-0.5 rounded bg-white/5 font-mono">ouijit</code> CLI.
+            Usually it&apos;s just your agent: <code className="px-1 py-0.5 rounded bg-ink/5 font-mono">claude</code> or{' '}
+            <code className="px-1 py-0.5 rounded bg-ink/5 font-mono">codex</code>. The task description is passed in as
+            the prompt, and the agent figures out the rest using the{' '}
+            <code className="px-1 py-0.5 rounded bg-ink/5 font-mono">ouijit</code> CLI.
           </p>
         </section>
 
@@ -97,7 +97,7 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
           <div className="flex flex-col gap-1.5 mt-3 font-mono text-[11px]">
             {CLI_EXAMPLES.map((ex) => (
               <div key={ex.command} className="flex items-baseline gap-3">
-                <code className="px-1.5 py-0.5 rounded bg-white/5 text-text-primary shrink-0">{ex.command}</code>
+                <code className="px-1.5 py-0.5 rounded bg-ink/5 text-text-primary shrink-0">{ex.command}</code>
                 <span className="text-text-tertiary text-xs">{ex.desc}</span>
               </div>
             ))}

--- a/src/components/dialogs/InitGitRepoDialog.tsx
+++ b/src/components/dialogs/InitGitRepoDialog.tsx
@@ -62,7 +62,7 @@ export function InitGitRepoDialog({ folderPath, onClose }: InitGitRepoDialogProp
           style={{ background: 'var(--color-git-light)', border: '1px solid var(--color-git)' }}
         >
           <strong className="font-medium">Git not found.</strong> Install via{' '}
-          <code className="px-1 py-0.5 rounded bg-white/10 font-mono">xcode-select --install</code> (macOS) or your
+          <code className="px-1 py-0.5 rounded bg-ink/10 font-mono">xcode-select --install</code> (macOS) or your
           package manager.
         </div>
       ) : (

--- a/src/components/dialogs/MoveProjectsDialog.tsx
+++ b/src/components/dialogs/MoveProjectsDialog.tsx
@@ -87,7 +87,7 @@ export function MoveProjectsDialog({ newFolder, projects, onClose }: MoveProject
                 ? 'border-border opacity-50'
                 : selected === option.action
                   ? 'border-accent bg-accent-light/20'
-                  : 'border-border hover:bg-white/[0.02]'
+                  : 'border-border hover:bg-ink/[0.02]'
             }`}
           >
             <input

--- a/src/components/dialogs/NewProjectDialog.tsx
+++ b/src/components/dialogs/NewProjectDialog.tsx
@@ -94,7 +94,7 @@ export function NewProjectDialog({ onClose }: NewProjectDialogProps) {
           style={{ background: 'var(--color-git-light)', border: '1px solid var(--color-git)' }}
         >
           <strong className="font-medium">Git not found.</strong> Install via{' '}
-          <code className="px-1 py-0.5 rounded bg-white/10 font-mono">xcode-select --install</code> (macOS) or your
+          <code className="px-1 py-0.5 rounded bg-ink/10 font-mono">xcode-select --install</code> (macOS) or your
           package manager.
         </div>
       )}

--- a/src/components/dialogs/RunHookDialog.tsx
+++ b/src/components/dialogs/RunHookDialog.tsx
@@ -129,13 +129,13 @@ export function RunHookDialog({
         {limaAvailable ? (
           <div className="flex items-center gap-2" onClick={() => setSandboxed((s) => !s)}>
             <div
-              className={`relative w-[34px] h-5 rounded-[10px] shrink-0 transition-[background] duration-200 ease-out ${sandboxed ? 'bg-accent' : 'bg-white/15'}`}
+              className={`relative w-[34px] h-5 rounded-[10px] shrink-0 transition-[background] duration-200 ease-out ${sandboxed ? 'bg-accent' : 'bg-ink/15'}`}
             >
               <div
-                className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.3)] transition-transform duration-200 ease-out ${sandboxed ? 'translate-x-3.5' : ''}`}
+                className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-accent-ink shadow-[0_1px_3px_rgba(0,0,0,0.3)] transition-transform duration-200 ease-out ${sandboxed ? 'translate-x-3.5' : ''}`}
               />
             </div>
-            <span className="text-xs text-white/40">Sandbox</span>
+            <span className="text-xs text-ink/40">Sandbox</span>
           </div>
         ) : (
           <div />

--- a/src/components/dialogs/WhatsNewDialog.tsx
+++ b/src/components/dialogs/WhatsNewDialog.tsx
@@ -46,7 +46,7 @@ function inlineFormat(s: string): string {
   // Bold
   out = out.replace(/\*\*(.+?)\*\*/g, '<strong class="text-text-primary font-medium">$1</strong>');
   // Inline code
-  out = out.replace(/`(.+?)`/g, '<code class="px-1 py-0.5 rounded bg-white/5 text-xs font-mono">$1</code>');
+  out = out.replace(/`(.+?)`/g, '<code class="px-1 py-0.5 rounded bg-ink/5 text-xs font-mono">$1</code>');
   // Links [text](url)
   out = out.replace(/\[(.+?)\]\((.+?)\)/g, '<a class="text-accent hover:underline" data-href="$2">$1</a>');
   return out;

--- a/src/components/diff/DiffPanel.tsx
+++ b/src/components/diff/DiffPanel.tsx
@@ -156,7 +156,7 @@ export function DiffPanel({ ptyId, projectPath, mode, onClose }: DiffPanelProps)
   const modeLabel = effectiveMode === 'worktree' ? 'Branch changes' : 'Uncommitted changes';
 
   return (
-    <div className="flex flex-1 min-h-0 overflow-hidden" style={{ background: 'var(--color-terminal-bg, #171717)' }}>
+    <div className="flex flex-1 min-h-0 overflow-hidden" style={{ background: 'var(--color-terminal-bg)' }}>
       <div
         className={
           sidebarCollapsed
@@ -169,29 +169,29 @@ export function DiffPanel({ ptyId, projectPath, mode, onClose }: DiffPanelProps)
       </div>
       {!sidebarCollapsed && (
         <div
-          className="w-[3px] shrink-0 bg-white/10 hover:bg-accent/60 active:bg-accent transition-colors duration-100"
+          className="w-[3px] shrink-0 bg-ink/10 hover:bg-accent/60 active:bg-accent transition-colors duration-100"
           style={{ cursor: 'col-resize' }}
           onMouseDown={handleSidebarDragStart}
         />
       )}
       <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
-        <div className="px-3 py-2 text-sm text-white/70 flex items-center gap-2 shrink-0">
+        <div className="px-3 py-2 text-sm text-ink/70 flex items-center gap-2 shrink-0">
           <button
-            className="w-7 h-7 rounded-md bg-transparent border-none text-white/60 flex items-center justify-center shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90"
+            className="w-7 h-7 rounded-md bg-transparent border-none text-ink/60 flex items-center justify-center shrink-0 transition-all duration-150 ease-out hover:bg-ink/10 hover:text-ink/90"
             onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
             title={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
           >
             <Icon name={sidebarCollapsed ? 'caret-right' : 'caret-left'} />
           </button>
           <span
-            className="text-xs bg-white/[0.06] pl-2 pr-1 py-1 text-white/50 flex items-center gap-1.5 relative"
+            className="text-xs bg-ink/[0.06] pl-2 pr-1 py-1 text-ink/50 flex items-center gap-1.5 relative"
             style={{ borderRadius: '5px' }}
           >
             {modeLabel}
           </span>
           <span className="text-xs text-text-tertiary ml-auto relative">{stats}</span>
           <button
-            className="w-7 h-7 rounded-md bg-transparent border-none text-white/60 flex items-center justify-center shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90 [&>svg]:w-4 [&>svg]:h-4"
+            className="w-7 h-7 rounded-md bg-transparent border-none text-ink/60 flex items-center justify-center shrink-0 transition-all duration-150 ease-out hover:bg-ink/10 hover:text-ink/90 [&>svg]:w-4 [&>svg]:h-4"
             onClick={onClose}
             title="Close"
           >
@@ -210,7 +210,7 @@ export function DiffPanel({ ptyId, projectPath, mode, onClose }: DiffPanelProps)
           {!loading &&
             files.map((file) => <DiffFileSection key={file.path} file={file} diff={diffs.get(file.path) ?? null} />)}
           {!loading && truncated && (
-            <div className="px-4 py-3 text-xs text-white/40 text-center border-t border-white/[0.06]">
+            <div className="px-4 py-3 text-xs text-ink/40 text-center border-t border-ink/[0.06]">
               Showing {files.length} of {totalFileCount} changed files
             </div>
           )}
@@ -227,21 +227,21 @@ function UntrackedFilesSection({ files }: { files: string[] }) {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="border-t border-white/[0.08]">
+    <div className="border-t border-ink/[0.08]">
       <div
-        className="flex items-center gap-2 px-4 py-2 bg-[#252525] border-b border-white/[0.06] text-sm text-white/50 hover:text-white/70 transition-colors duration-150"
+        className="flex items-center gap-2 px-4 py-2 bg-terminal-surface border-b border-ink/[0.06] text-sm text-ink/50 hover:text-ink/70 transition-colors duration-150"
         onClick={() => setExpanded(!expanded)}
       >
         <Icon name={expanded ? 'caret-down' : 'caret-right'} className="!w-3 !h-3" />
-        <Icon name="file-plus" className="w-3.5 h-3.5 text-[#FF9F0A]" />
+        <Icon name="file-plus" className="w-3.5 h-3.5 text-vcs-modified" />
         <span>
           {files.length} untracked {files.length === 1 ? 'file' : 'files'}
         </span>
       </div>
       {expanded && (
-        <div className="bg-[#1a1a1a]">
+        <div className="bg-terminal-surface-alt">
           {files.map((filePath) => (
-            <div key={filePath} className="flex items-center gap-2 px-4 py-1 text-sm text-white/50 font-mono">
+            <div key={filePath} className="flex items-center gap-2 px-4 py-1 text-sm text-ink/50 font-mono">
               <span className="truncate">{filePath}</span>
             </div>
           ))}
@@ -320,7 +320,7 @@ function DiffFileTree({
       {untrackedFiles.length > 0 && (
         <>
           <div
-            className="flex items-center gap-1.5 py-1 pl-3 pr-3 mt-1 border-t border-white/[0.06] text-[13px] text-white/40 transition-colors duration-150 ease-out hover:bg-white/5 hover:text-white/60"
+            className="flex items-center gap-1.5 py-1 pl-3 pr-3 mt-1 border-t border-ink/[0.06] text-[13px] text-ink/40 transition-colors duration-150 ease-out hover:bg-ink/5 hover:text-ink/60"
             onClick={() => setUntrackedExpanded(!untrackedExpanded)}
           >
             <Icon name={untrackedExpanded ? 'caret-down' : 'caret-right'} className="!w-3 !h-3" />
@@ -328,8 +328,8 @@ function DiffFileTree({
           </div>
           {untrackedExpanded &&
             untrackedFiles.map((filePath) => (
-              <div key={filePath} className="flex items-center gap-1.5 py-1 pl-6 pr-3 text-[13px] text-white/40">
-                <Icon name="file-plus" className="w-4 h-4 text-[#FF9F0A]" />
+              <div key={filePath} className="flex items-center gap-1.5 py-1 pl-6 pr-3 text-[13px] text-ink/40">
+                <Icon name="file-plus" className="w-4 h-4 text-vcs-modified" />
                 <span className="flex-1 min-w-0 truncate">{filePath}</span>
               </div>
             ))}
@@ -345,7 +345,7 @@ function TreeNodeView({ node, onFileClick }: { node: TreeNode; onFileClick: (pat
   if (node.isFile && node.file) {
     return (
       <div
-        className="flex items-center gap-1.5 py-1 pl-3 pr-3 text-[13px] text-white/70 transition-colors duration-150 ease-out hover:bg-white/5"
+        className="flex items-center gap-1.5 py-1 pl-3 pr-3 text-[13px] text-ink/70 transition-colors duration-150 ease-out hover:bg-ink/5"
         data-path={node.file.path}
         onClick={() => onFileClick(node.file!.path)}
       >
@@ -358,9 +358,9 @@ function TreeNodeView({ node, onFileClick }: { node: TreeNode; onFileClick: (pat
         )}
         {(node.file.additions > 0 || node.file.deletions > 0) && (
           <span className="shrink-0 font-mono text-[13px]">
-            {node.file.additions > 0 && <span className="text-[#3fb950]">+{node.file.additions}</span>}
+            {node.file.additions > 0 && <span className="text-diff-added">+{node.file.additions}</span>}
             {node.file.additions > 0 && node.file.deletions > 0 && ' '}
-            {node.file.deletions > 0 && <span className="text-[#f85149]">-{node.file.deletions}</span>}
+            {node.file.deletions > 0 && <span className="text-diff-removed">-{node.file.deletions}</span>}
           </span>
         )}
       </div>
@@ -371,7 +371,7 @@ function TreeNodeView({ node, onFileClick }: { node: TreeNode; onFileClick: (pat
   return (
     <div data-expanded={expanded}>
       <div
-        className="flex items-center gap-1.5 py-1 pl-3 pr-3 text-[13px] text-white/50 transition-colors duration-150 ease-out hover:bg-white/5 hover:text-white/70"
+        className="flex items-center gap-1.5 py-1 pl-3 pr-3 text-[13px] text-ink/50 transition-colors duration-150 ease-out hover:bg-ink/5 hover:text-ink/70"
         onClick={() => setExpanded(!expanded)}
       >
         <Icon name={expanded ? 'caret-down' : 'caret-right'} className="!w-3 !h-3" />
@@ -412,30 +412,30 @@ function statusIcon(status: string): string {
 function statusColorClass(status: string): string {
   switch (status) {
     case 'A':
-      return 'text-[#34C759]';
+      return 'text-vcs-added';
     case 'D':
-      return 'text-[#FF3B30]';
+      return 'text-vcs-deleted';
     case 'R':
-      return 'text-[#5856D6]';
+      return 'text-vcs-renamed';
     case '?':
-      return 'text-[#FF9F0A]';
+      return 'text-vcs-modified';
     default:
-      return 'text-white/50';
+      return 'text-ink/50';
   }
 }
 
 function badgeColorClass(status: string): string {
   switch (status) {
     case 'A':
-      return 'bg-[#34C759]/15 text-[#34C759]';
+      return 'bg-vcs-added/15 text-vcs-added';
     case 'D':
-      return 'bg-[#FF3B30]/15 text-[#FF3B30]';
+      return 'bg-vcs-deleted/15 text-vcs-deleted';
     case 'R':
-      return 'bg-[#5856D6]/15 text-[#5856D6]';
+      return 'bg-vcs-renamed/15 text-vcs-renamed';
     case '?':
-      return 'bg-[#FF9F0A]/15 text-[#FF9F0A]';
+      return 'bg-vcs-modified/15 text-vcs-modified';
     default:
-      return 'bg-white/[0.06] text-white/40';
+      return 'bg-ink/[0.06] text-ink/40';
   }
 }
 
@@ -456,9 +456,9 @@ function DiffFileSection({ file, diff }: { file: ChangedFile; diff: FileDiff | n
             : 'modified';
 
   return (
-    <div className="border-b border-white/[0.08] last:border-b-0" data-path={file.path}>
-      <div className="sticky top-0 z-10 flex items-center gap-2 px-4 py-2 bg-[#252525] border-b border-white/[0.06]">
-        <span className="flex-1 min-w-0 truncate text-sm text-white/90" title={file.path}>
+    <div className="border-b border-ink/[0.08] last:border-b-0" data-path={file.path}>
+      <div className="sticky top-0 z-10 flex items-center gap-2 px-4 py-2 bg-terminal-surface border-b border-ink/[0.06]">
+        <span className="flex-1 min-w-0 truncate text-sm text-ink/90" title={file.path}>
           {file.path}
         </span>
         <span className={`shrink-0 text-[11px] px-1 py-px rounded font-medium ${badgeColorClass(file.status)}`}>
@@ -466,8 +466,8 @@ function DiffFileSection({ file, diff }: { file: ChangedFile; diff: FileDiff | n
         </span>
         {(file.additions > 0 || file.deletions > 0) && (
           <span className="shrink-0 font-mono text-[13px]">
-            {file.additions > 0 && <span className="text-[#3fb950]">+{file.additions}</span>}
-            {file.deletions > 0 && <span className="text-[#f85149]">-{file.deletions}</span>}
+            {file.additions > 0 && <span className="text-diff-added">+{file.additions}</span>}
+            {file.deletions > 0 && <span className="text-diff-removed">-{file.deletions}</span>}
           </span>
         )}
       </div>
@@ -496,7 +496,7 @@ function DiffFileSection({ file, diff }: { file: ChangedFile; diff: FileDiff | n
 function HunkHeader({ header }: { header: string }) {
   return (
     <div
-      className="py-1 pr-4 bg-[rgba(88,86,214,0.10)] text-[#8b8bcd] font-mono text-xs truncate"
+      className="py-1 pr-4 bg-vcs-renamed/10 text-diff-hunk font-mono text-xs truncate"
       style={{ paddingLeft: '106px' }}
     >
       {header}
@@ -526,29 +526,29 @@ function DiffLineView({
   wordHighlight?: WordHighlight;
 }) {
   const lineBg =
-    line.type === 'addition'
-      ? 'bg-[rgba(63,185,80,0.10)]'
-      : line.type === 'deletion'
-        ? 'bg-[rgba(248,81,73,0.08)]'
-        : '';
+    line.type === 'addition' ? 'bg-diff-added/10' : line.type === 'deletion' ? 'bg-diff-removed/[0.08]' : '';
   const gutterBg =
     line.type === 'addition'
-      ? 'bg-[rgba(63,185,80,0.12)]'
+      ? 'bg-diff-added/[0.12]'
       : line.type === 'deletion'
-        ? 'bg-[rgba(248,81,73,0.10)]'
-        : 'bg-[#141414]';
+        ? 'bg-diff-removed/10'
+        : 'bg-terminal-inset';
   const prefixColor =
-    line.type === 'addition' ? 'text-[#3fb950]' : line.type === 'deletion' ? 'text-[#f85149]' : 'text-transparent';
+    line.type === 'addition' ? 'text-diff-added' : line.type === 'deletion' ? 'text-diff-removed' : 'text-transparent';
   const wordBg =
-    line.type === 'addition' ? 'rgba(63,185,80,0.25)' : line.type === 'deletion' ? 'rgba(248,81,73,0.22)' : undefined;
+    line.type === 'addition'
+      ? 'color-mix(in srgb, var(--color-diff-added) 25%, transparent)'
+      : line.type === 'deletion'
+        ? 'color-mix(in srgb, var(--color-diff-removed) 22%, transparent)'
+        : undefined;
 
   return (
     <div className={`flex font-mono text-sm leading-normal ${lineBg}`}>
       <span className="flex shrink-0 select-none sticky left-0 z-[1]">
-        <span className={`w-[45px] px-2 text-right text-white/25 ${gutterBg} border-r border-white/5`}>
+        <span className={`w-[45px] px-2 text-right text-ink/25 ${gutterBg} border-r border-ink/5`}>
           {line.oldLineNo ?? ''}
         </span>
-        <span className={`w-[45px] px-2 text-right text-white/25 ${gutterBg} border-r border-white/5`}>
+        <span className={`w-[45px] px-2 text-right text-ink/25 ${gutterBg} border-r border-ink/5`}>
           {line.newLineNo ?? ''}
         </span>
       </span>
@@ -649,7 +649,7 @@ function renderPlainWithHighlights(
   wordBg: string | undefined,
 ): React.ReactNode {
   if (!wordHighlight || wordHighlight.ranges.length === 0 || !wordBg) {
-    return <span className="text-[#e6edf3]">{content}</span>;
+    return <span className="text-diff-fg">{content}</span>;
   }
 
   const elements: React.ReactNode[] = [];
@@ -658,13 +658,13 @@ function renderPlainWithHighlights(
   for (const [start, end] of wordHighlight.ranges) {
     if (start > pos) {
       elements.push(
-        <span key={pos} className="text-[#e6edf3]">
+        <span key={pos} className="text-diff-fg">
           {content.slice(pos, start)}
         </span>,
       );
     }
     elements.push(
-      <span key={start} className="text-[#e6edf3]" style={{ backgroundColor: wordBg, borderRadius: '2px' }}>
+      <span key={start} className="text-diff-fg" style={{ backgroundColor: wordBg, borderRadius: '2px' }}>
         {content.slice(start, end)}
       </span>,
     );
@@ -673,7 +673,7 @@ function renderPlainWithHighlights(
 
   if (pos < content.length) {
     elements.push(
-      <span key={pos} className="text-[#e6edf3]">
+      <span key={pos} className="text-diff-fg">
         {content.slice(pos)}
       </span>,
     );

--- a/src/components/diff/useSyntaxHighlight.ts
+++ b/src/components/diff/useSyntaxHighlight.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import type { FileDiff } from '../../types';
 import type { HunkTokens } from '../../utils/syntaxHighlight';
+import { useResolvedTheme } from '../../hooks/useResolvedTheme';
 
 /**
  * Hook that tokenizes diff hunks for syntax highlighting.
@@ -9,6 +10,8 @@ import type { HunkTokens } from '../../utils/syntaxHighlight';
 export function useSyntaxHighlight(diff: FileDiff | null, filePath: string): HunkTokens[] | null {
   const [tokens, setTokens] = useState<HunkTokens[] | null>(null);
   const cancelRef = useRef(false);
+  // Tokenization reads the resolved theme; re-tokenize when it changes.
+  const resolvedTheme = useResolvedTheme();
 
   useEffect(() => {
     cancelRef.current = false;
@@ -31,7 +34,7 @@ export function useSyntaxHighlight(diff: FileDiff | null, filePath: string): Hun
       cancelled = true;
       cancelRef.current = true;
     };
-  }, [diff, filePath]);
+  }, [diff, filePath, resolvedTheme]);
 
   return tokens;
 }

--- a/src/components/diff/useSyntaxHighlight.ts
+++ b/src/components/diff/useSyntaxHighlight.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import type { FileDiff } from '../../types';
-import type { HunkTokens } from '../../utils/syntaxHighlight';
+import { tokenizeDiffHunks, type HunkTokens } from '../../utils/syntaxHighlight';
 import { useResolvedTheme } from '../../hooks/useResolvedTheme';
 
 /**
@@ -9,30 +9,46 @@ import { useResolvedTheme } from '../../hooks/useResolvedTheme';
  */
 export function useSyntaxHighlight(diff: FileDiff | null, filePath: string): HunkTokens[] | null {
   const [tokens, setTokens] = useState<HunkTokens[] | null>(null);
-  const cancelRef = useRef(false);
   // Tokenization reads the resolved theme; re-tokenize when it changes.
   const resolvedTheme = useResolvedTheme();
+  // Tokens per theme for the current diff, so flipping themes back and forth
+  // (e.g. sweeping the theme dropdown's hover preview) reuses earlier passes
+  // instead of re-tokenizing the whole diff each flip.
+  const cacheRef = useRef<{ diff: FileDiff | null; filePath: string; byTheme: Map<string, HunkTokens[]> }>({
+    diff: null,
+    filePath: '',
+    byTheme: new Map(),
+  });
 
   useEffect(() => {
-    cancelRef.current = false;
-    setTokens(null);
+    const cache = cacheRef.current;
+    if (cache.diff !== diff || cache.filePath !== filePath) {
+      cache.diff = diff;
+      cache.filePath = filePath;
+      cache.byTheme.clear();
+    }
 
+    const cached = cache.byTheme.get(resolvedTheme);
+    if (cached) {
+      setTokens(cached);
+      return;
+    }
+
+    setTokens(null);
     if (!diff || diff.hunks.length === 0) return;
 
     let cancelled = false;
-    cancelRef.current = false;
 
-    // Dynamic import to avoid blocking initial render with shiki's WASM load
-    import('../../utils/syntaxHighlight').then(({ tokenizeDiffHunks }) => {
+    // The highlighter itself loads lazily inside tokenizeDiffHunks, so the
+    // first call absorbs shiki's WASM setup; later calls are pure CPU.
+    void tokenizeDiffHunks(diff.hunks, filePath).then((result) => {
       if (cancelled) return;
-      tokenizeDiffHunks(diff.hunks, filePath).then((result) => {
-        if (!cancelled) setTokens(result);
-      });
+      cache.byTheme.set(resolvedTheme, result);
+      setTokens(result);
     });
 
     return () => {
       cancelled = true;
-      cancelRef.current = true;
     };
   }, [diff, filePath, resolvedTheme]);
 

--- a/src/components/kanban/BulkActionBar.tsx
+++ b/src/components/kanban/BulkActionBar.tsx
@@ -84,9 +84,9 @@ export function BulkActionBar({ projectPath, onOpenTerminal }: BulkActionBarProp
         bottom: 56,
         left: '50%',
         transform: 'translateX(-50%)',
-        background: 'rgba(30, 30, 30, 0.95)',
+        background: 'color-mix(in srgb, var(--color-background) 95%, transparent)',
         backdropFilter: 'blur(20px)',
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: '1px solid var(--color-border)',
         borderRadius: 10,
         boxShadow: '0 8px 24px rgba(0, 0, 0, 0.4)',
       }}
@@ -112,7 +112,7 @@ export function BulkActionBar({ projectPath, onOpenTerminal }: BulkActionBarProp
 }
 
 function Divider() {
-  return <div className="w-px h-4 mx-1" style={{ background: 'rgba(255, 255, 255, 0.1)' }} />;
+  return <div className="w-px h-4 mx-1" style={{ background: 'var(--color-border)' }} />;
 }
 
 function ActionButton({
@@ -130,8 +130,8 @@ function ActionButton({
     <button
       className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border-none text-xs font-medium transition-colors duration-100 [&>svg]:w-3.5 [&>svg]:h-3.5 ${
         danger
-          ? 'text-text-secondary bg-transparent hover:text-red-400 hover:bg-red-500/10'
-          : 'text-text-secondary bg-transparent hover:text-text-primary hover:bg-white/[0.08]'
+          ? 'text-text-secondary bg-transparent hover:text-error hover:bg-error/10'
+          : 'text-text-secondary bg-transparent hover:text-text-primary hover:bg-ink/[0.08]'
       }`}
       onClick={onClick}
     >

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -125,8 +125,8 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
       <input
         ref={inputRef}
         type="text"
-        className="kanban-add-input w-full font-mono text-sm font-medium text-text-primary bg-transparent px-3 py-3.5 outline-none transition-all duration-150 ease-out border-none focus:bg-white/[0.04]"
-        style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
+        className="kanban-add-input w-full font-mono text-sm font-medium text-text-primary bg-transparent px-3 py-3.5 outline-none transition-all duration-150 ease-out border-none focus:bg-ink/[0.04]"
+        style={{ borderBottom: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
         placeholder="New task..."
         value={name}
         onChange={(e) => setName(e.target.value)}
@@ -143,14 +143,14 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
             placeholder="Description (optional)"
             onKeyDown={handleDescriptionKeyDown}
             onFocus={handleDescriptionFocus}
-            className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none focus:bg-white/[0.04]"
+            className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none focus:bg-ink/[0.04]"
             style={{ minHeight: '4.5rem', whiteSpace: 'pre-wrap', wordWrap: 'break-word', lineHeight: 1.5 }}
           />
           {/* DOM order is [Create, Cancel] so Tab from the description lands
               on Create first; flex-row-reverse keeps Cancel on the visual left. */}
           <div
             className="flex flex-row-reverse items-center justify-start gap-2 px-2 py-1.5"
-            style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}
+            style={{ borderBottom: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
           >
             <button
               type="button"
@@ -164,7 +164,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
             <button
               type="button"
               onClick={reset}
-              className="kanban-add-button text-text-tertiary hover:text-text-primary hover:bg-white/[0.04]"
+              className="kanban-add-button text-text-tertiary hover:text-text-primary hover:bg-ink/[0.04]"
             >
               Cancel
               <CancelHint />

--- a/src/components/kanban/KanbanBadgeView.tsx
+++ b/src/components/kanban/KanbanBadgeView.tsx
@@ -34,9 +34,13 @@ export function KanbanBadgeView({
 }: KanbanBadgeViewProps) {
   const isInChain = isChainMember(chainInfo);
   const color =
-    isInChain && chainInfo ? getChainColor(chainInfo.rootTaskNumber, chainInfo.depth) : 'rgba(255, 255, 255, 0.2)';
+    isInChain && chainInfo
+      ? getChainColor(chainInfo.rootTaskNumber, chainInfo.depth)
+      : 'color-mix(in srgb, var(--color-ink) 20%, transparent)';
   const background =
-    isInChain && chainInfo ? getChainBgColor(chainInfo.rootTaskNumber, chainInfo.depth) : 'rgba(255, 255, 255, 0.04)';
+    isInChain && chainInfo
+      ? getChainBgColor(chainInfo.rootTaskNumber, chainInfo.depth)
+      : 'color-mix(in srgb, var(--color-ink) 4%, transparent)';
 
   const style: CSSProperties = {
     color,

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -679,13 +679,13 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       }}
     >
       <div
-        className="kanban-board glass-bevel fixed top-[82px] bottom-4 z-[140] flex flex-col opacity-100 rounded-[14px] overflow-hidden border border-black/60"
+        className="kanban-board glass-bevel fixed top-[82px] bottom-4 z-[140] flex flex-col opacity-100 rounded-[14px] overflow-hidden border border-bezel"
         style={{
           left: 'calc(var(--sidebar-offset, 0px) + 16px)',
           right: showTrash ? 144 : 16,
           transition: 'left 0.2s ease-out, right 0.2s ease-out',
-          background: 'var(--color-terminal-bg, #171717)',
-          boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+          background: 'var(--color-terminal-bg)',
+          boxShadow: 'var(--shadow-panel)',
         }}
       >
         {missingWorktreeDialog && (
@@ -759,8 +759,8 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
           <div
             className="px-3 py-3.5 relative"
             style={{
-              background: '#111111',
-              border: '1px solid rgba(255, 255, 255, 0.1)',
+              background: 'var(--color-terminal-inset)',
+              border: '1px solid var(--color-border)',
               boxShadow: '0 8px 24px rgba(0, 0, 0, 0.5)',
               borderRadius: 0,
             }}
@@ -772,8 +772,8 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
             </div>
             {selectedTaskCount > 1 && (
               <span
-                className="absolute -top-2 -right-2 flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full text-[11px] font-semibold text-white"
-                style={{ background: '#0A84FF' }}
+                className="absolute -top-2 -right-2 flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full text-[11px] font-semibold text-accent-ink"
+                style={{ background: 'var(--color-accent)' }}
               >
                 {selectedTaskCount}
               </span>
@@ -784,8 +784,8 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
           <span
             className="inline-flex items-center gap-0.5 font-mono text-[11px] leading-none px-2 py-1 rounded-full whitespace-nowrap"
             style={{
-              color: 'rgba(255, 255, 255, 0.7)',
-              background: 'rgba(255, 255, 255, 0.12)',
+              color: 'color-mix(in srgb, var(--color-ink) 70%, transparent)',
+              background: 'var(--color-background-tertiary)',
               boxShadow: '0 4px 12px rgba(0, 0, 0, 0.4)',
             }}
           >
@@ -819,8 +819,8 @@ const KanbanTrashZone = forwardRef<HTMLDivElement, { visible: boolean; isOver: b
         opacity: visible ? 1 : 0,
         transition: 'width 0.2s ease-out, opacity 0.2s ease-out, background 150ms ease, color 150ms ease',
 
-        background: isOver ? 'rgba(255, 69, 58, 0.12)' : 'var(--color-background)',
-        color: isOver ? 'var(--color-error, #ff453a)' : 'var(--color-text-tertiary)',
+        background: isOver ? 'color-mix(in srgb, var(--color-error) 12%, transparent)' : 'var(--color-background)',
+        color: isOver ? 'var(--color-error)' : 'var(--color-text-tertiary)',
       }}
     >
       <div className="[&>svg]:w-6 [&>svg]:h-6">

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -679,7 +679,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
       }}
     >
       <div
-        className="kanban-board glass-bevel fixed top-[82px] bottom-4 z-[140] flex flex-col opacity-100 rounded-[14px] overflow-hidden border border-bezel"
+        className="kanban-board glass-bevel fixed top-[82px] bottom-4 z-[140] flex flex-col opacity-100 rounded-[14px] overflow-hidden border border-bezel-panel"
         style={{
           left: 'calc(var(--sidebar-offset, 0px) + 16px)',
           right: showTrash ? 144 : 16,

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -445,7 +445,7 @@ function DraggableBadge({
     task.parentTaskNumber != null ? (
       <Tooltip text={`Detach from #${task.parentTaskNumber}`} placement="bottom" delay={300}>
         <button
-          className="w-0 overflow-hidden group-hover/badge:w-4 flex items-center justify-center border-none bg-transparent text-white/30 hover:text-red-400 transition-all duration-150 [-webkit-app-region:no-drag] [&>svg]:w-2.5 [&>svg]:h-2.5 shrink-0 p-0"
+          className="w-0 overflow-hidden group-hover/badge:w-4 flex items-center justify-center border-none bg-transparent text-ink/30 hover:text-error transition-all duration-150 [-webkit-app-region:no-drag] [&>svg]:w-2.5 [&>svg]:h-2.5 shrink-0 p-0"
           onPointerDown={(e) => e.stopPropagation()}
           onClick={async (e) => {
             e.stopPropagation();

--- a/src/components/kanban/KanbanCardView.tsx
+++ b/src/components/kanban/KanbanCardView.tsx
@@ -218,7 +218,7 @@ export const KanbanCardView = memo(function KanbanCardView({
               : 'var(--color-terminal-bg)',
         transition:
           'background 150ms ease-out, opacity 150ms ease-out, outline-color 150ms ease-out, box-shadow 150ms ease-out',
-        borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
+        borderBottom: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)',
         outline: isHoveredBadgeTarget
           ? '1px solid color-mix(in srgb, var(--color-accent) 60%, transparent)'
           : isValidBadgeTarget
@@ -226,7 +226,7 @@ export const KanbanCardView = memo(function KanbanCardView({
             : 'none',
         outlineOffset: -1,
         ...(isInvalidBadgeTarget && { opacity: 0.4 }),
-        ...(isSelected && { boxShadow: 'inset 2px 0 0 0 #0A84FF' }),
+        ...(isSelected && { boxShadow: 'inset 2px 0 0 0 var(--color-accent)' }),
       }}
       data-task-number={task.taskNumber}
       onMouseDown={(e) => {
@@ -285,7 +285,7 @@ export const KanbanCardView = memo(function KanbanCardView({
                 └─
               </span>
               <span
-                className="w-2 h-2 rounded-full bg-transparent border-[1.5px] border-white/30 border-t-white/80 shrink-0"
+                className="w-2 h-2 rounded-full bg-transparent border-[1.5px] border-ink/30 border-t-ink/80 shrink-0"
                 style={{ animation: 'loading-dot-spin 0.8s linear infinite' }}
               />
               <span className="font-mono text-[10px] leading-tight text-text-secondary truncate min-w-0">
@@ -302,7 +302,7 @@ export const KanbanCardView = memo(function KanbanCardView({
             return (
               <div
                 key={display.ptyId}
-                className="flex flex-row items-center gap-1.5 hover:bg-white/[0.06] active:bg-white/[0.03]"
+                className="flex flex-row items-center gap-1.5 hover:bg-ink/[0.06] active:bg-ink/[0.03]"
                 style={{ padding: '3px 2px', borderRadius: 3, transition: 'background 0.1s ease' }}
                 onClick={(e) => {
                   e.stopPropagation();
@@ -343,7 +343,7 @@ export const KanbanCardView = memo(function KanbanCardView({
 
       {expanded && (
         <div
-          className="grid mt-2 pt-2 border-t border-white/[0.04] gap-2"
+          className="grid mt-2 pt-2 border-t border-ink/[0.04] gap-2"
           // Keep the card's drag activator (dnd-kit listeners on the wrapper)
           // out of the expanded area so selecting description text doesn't
           // start a card drag.
@@ -367,7 +367,7 @@ export const KanbanCardView = memo(function KanbanCardView({
             />
           </div>
           {task.branch && (
-            <div className="flex items-center gap-1 font-mono text-[13px] text-white/50 min-w-0 overflow-hidden [&>svg]:w-3 [&>svg]:h-3 [&>svg]:shrink-0">
+            <div className="flex items-center gap-1 font-mono text-[13px] text-ink/50 min-w-0 overflow-hidden [&>svg]:w-3 [&>svg]:h-3 [&>svg]:shrink-0">
               <Icon name="git-branch" />
               <span className="truncate min-w-0">{task.branch}</span>
             </div>

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -165,7 +165,10 @@ function SortableCard({
         {...listeners}
         className="[&>*]:opacity-0"
       >
-        <div className="px-3 py-3.5" style={{ borderBottom: '1px solid rgba(255, 255, 255, 0.06)' }}>
+        <div
+          className="px-3 py-3.5"
+          style={{ borderBottom: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
+        >
           <div className="flex items-start gap-2">
             <span className="flex-1 font-mono text-sm font-medium text-text-primary min-w-0 break-words">
               {task.name}

--- a/src/components/kanban/KanbanColumnView.tsx
+++ b/src/components/kanban/KanbanColumnView.tsx
@@ -40,7 +40,11 @@ export function KanbanColumnView({
   return (
     <div
       className="kanban-column flex flex-col transition-all duration-150 ease-out shrink-0 last:border-r-0"
-      style={{ minWidth: 240, flex: '1 0 240px', borderRight: '1px solid rgba(255, 255, 255, 0.06)' }}
+      style={{
+        minWidth: 240,
+        flex: '1 0 240px',
+        borderRight: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)',
+      }}
       data-status={status}
     >
       <div className="flex items-center gap-2 px-3 py-2.5 shrink-0 h-[46px]">
@@ -54,7 +58,7 @@ export function KanbanColumnView({
         </span>
         {hookTypes.length > 0 && onConfigureHook && (
           <button
-            className={`flex items-center justify-center border-none text-text-tertiary transition-all duration-150 ease-out rounded-md hover:text-text-secondary hover:bg-white/[0.08] [&>svg]:w-[18px] [&>svg]:h-[18px]${hasConfiguredHook ? ' !text-accent hover:!text-accent-hover' : ''}`}
+            className={`flex items-center justify-center border-none text-text-tertiary transition-all duration-150 ease-out rounded-md hover:text-text-secondary hover:bg-ink/[0.08] [&>svg]:w-[18px] [&>svg]:h-[18px]${hasConfiguredHook ? ' !text-accent hover:!text-accent-hover' : ''}`}
             style={{ padding: '4px 10px', background: 'transparent' }}
             onClick={() => onConfigureHook(hookTypes)}
           >
@@ -66,7 +70,7 @@ export function KanbanColumnView({
         ref={bodyRef}
         className="kanban-column-body flex flex-col overflow-y-auto flex-1 min-h-0"
         style={{
-          borderTop: '1px solid rgba(255, 255, 255, 0.06)',
+          borderTop: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)',
           scrollbarColor: 'transparent transparent',
           transition: 'background 150ms ease',
           minHeight: 80,

--- a/src/components/kanban/KanbanShellBar.tsx
+++ b/src/components/kanban/KanbanShellBar.tsx
@@ -36,7 +36,7 @@ export function KanbanShellBar({ projectPath, onSwitchToTerminal }: KanbanShellB
   return (
     <div
       className="shrink-0 flex items-center gap-2 px-3 py-2 overflow-x-auto"
-      style={{ borderTop: '1px solid rgba(255, 255, 255, 0.06)' }}
+      style={{ borderTop: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
     >
       <span className="flex items-center gap-1.5 shrink-0 text-text-tertiary [&>svg]:w-3.5 [&>svg]:h-3.5">
         <Icon name="terminal" />
@@ -48,7 +48,7 @@ export function KanbanShellBar({ projectPath, onSwitchToTerminal }: KanbanShellB
           return (
             <button
               key={shell.ptyId}
-              className="group/shell relative flex items-center gap-1.5 shrink-0 h-7 px-2.5 rounded-[12px] bg-background-secondary glass-bevel border border-black/60 overflow-hidden text-text-secondary hover:bg-background-tertiary transition-colors duration-150 ease-out [-webkit-app-region:no-drag] max-w-[200px]"
+              className="group/shell relative flex items-center gap-1.5 shrink-0 h-7 px-2.5 rounded-[12px] bg-background-secondary glass-bevel border border-bezel overflow-hidden text-text-secondary hover:bg-background-tertiary transition-colors duration-150 ease-out [-webkit-app-region:no-drag] max-w-[200px]"
               onClick={() => onSwitchToTerminal(shell.ptyId)}
             >
               <StatusDot summaryType={shell.summaryType} sandboxProvider={shell.sandboxProvider} />

--- a/src/components/kanban/OnboardingPanel.tsx
+++ b/src/components/kanban/OnboardingPanel.tsx
@@ -176,13 +176,13 @@ export function OnboardingPanel({ projectPath, onConfigureCliAgent, onOpenHelp }
   return (
     <div
       className="mb-2 px-4 py-3 flex items-start gap-3 onboarding-stage-enter"
-      style={{ background: 'rgba(255, 255, 255, 0.03)' }}
+      style={{ background: 'color-mix(in srgb, var(--color-ink) 3%, transparent)' }}
     >
       <div className="flex-1 min-w-0">
         <StageCrossfade stage={stage} renderStage={renderStageBody} />
       </div>
       <button
-        className="shrink-0 w-7 h-7 flex items-center justify-center rounded-full text-text-tertiary hover:text-text-primary hover:bg-white/10 transition-colors [&>svg]:w-4 [&>svg]:h-4"
+        className="shrink-0 w-7 h-7 flex items-center justify-center rounded-full text-text-tertiary hover:text-text-primary hover:bg-ink/10 transition-colors [&>svg]:w-4 [&>svg]:h-4"
         onClick={handleDismiss}
         aria-label={stage === 'intro' ? 'Hide onboarding for now' : 'Dismiss onboarding'}
         title={stage === 'intro' ? 'Hide for now' : 'Dismiss'}
@@ -254,7 +254,7 @@ function StageCtas({
     <div className="flex items-center gap-2 flex-wrap mt-4">
       {stage === 'intro' && (
         <button
-          className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out disabled:opacity-60"
+          className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-accent-ink bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out disabled:opacity-60"
           onClick={onSeedPracticeTask}
           disabled={seeding}
         >
@@ -264,7 +264,7 @@ function StageCtas({
       )}
       {stage === 'complete' && (
         <button
-          className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
+          className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-accent-ink bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
           onClick={onDismiss}
         >
           Got it
@@ -274,8 +274,8 @@ function StageCtas({
         <button
           className={`inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full active:scale-[0.98] transition-all duration-150 ease-out ${
             startHookConfigured
-              ? 'text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary'
-              : 'text-white bg-accent hover:bg-accent-hover'
+              ? 'text-text-secondary bg-ink/5 hover:bg-ink/10 hover:text-text-primary'
+              : 'text-accent-ink bg-accent hover:bg-accent-hover'
           }`}
           onClick={onConfigureCliAgent}
         >
@@ -285,7 +285,7 @@ function StageCtas({
       )}
       {stage === 'in-flight' && stuck && !startHookConfigured && (
         <button
-          className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
+          className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-accent-ink bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
           onClick={onConfigureCliAgent}
         >
           <Icon name="terminal" className="w-3.5 h-3.5" />
@@ -296,8 +296,8 @@ function StageCtas({
         <button
           className={`inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full active:scale-[0.98] transition-all duration-150 ease-out ${
             startHookConfigured
-              ? 'text-white bg-accent hover:bg-accent-hover'
-              : 'text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary'
+              ? 'text-accent-ink bg-accent hover:bg-accent-hover'
+              : 'text-text-secondary bg-ink/5 hover:bg-ink/10 hover:text-text-primary'
           }`}
           onClick={onMoveBackToTodo}
         >
@@ -306,14 +306,14 @@ function StageCtas({
         </button>
       )}
       <button
-        className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
+        className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-ink/5 hover:bg-ink/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
         onClick={onOpenHelp}
       >
         <Icon name="question" className="w-3.5 h-3.5" />
         Help & setup
       </button>
       <button
-        className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-white/5 hover:bg-white/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
+        className="inline-flex items-center justify-center gap-1.5 px-3 py-1 text-xs font-medium rounded-full text-text-secondary bg-ink/5 hover:bg-ink/10 hover:text-text-primary active:scale-[0.98] transition-all duration-150 ease-out"
         onClick={() => window.api.openExternal('https://ouijit.com/docs')}
       >
         <Icon name="file-text" className="w-3.5 h-3.5" />
@@ -339,7 +339,7 @@ function StepBadge({ done, number }: { done: boolean; number: number }) {
   return (
     <span
       className={`relative shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-[11px] font-semibold transition-colors duration-300 ease-out ${
-        done ? 'bg-accent text-white' : 'bg-white/10 text-text-primary'
+        done ? 'bg-accent text-accent-ink' : 'bg-ink/10 text-text-primary'
       } ${popping ? 'onboarding-badge-check' : ''}`}
     >
       <span
@@ -371,7 +371,7 @@ function IntroStage({ source }: { source: FirstProjectSource | undefined }) {
             <div className="text-xs font-medium text-text-primary mb-1">Try a practice task</div>
             <div className="text-xs text-text-secondary leading-relaxed">
               A dry run that shows how hooks and the{' '}
-              <code className="px-1 py-0.5 rounded bg-white/5 font-mono text-[11px]">ouijit</code> CLI work together.
+              <code className="px-1 py-0.5 rounded bg-ink/5 font-mono text-[11px]">ouijit</code> CLI work together.
             </div>
           </div>
         </li>
@@ -396,14 +396,14 @@ function SetupStage({ configured, onUseExampleHook }: { configured: boolean; onU
               The command Ouijit runs when a task enters In Progress. For example:
             </div>
             <div className="flex items-center gap-2 flex-wrap">
-              <code className="inline-block font-mono text-[12px] text-text-primary bg-white/5 rounded-md px-2.5 py-1.5 max-w-full overflow-x-auto whitespace-nowrap">
+              <code className="inline-block font-mono text-[12px] text-text-primary bg-ink/5 rounded-md px-2.5 py-1.5 max-w-full overflow-x-auto whitespace-nowrap">
                 {EXAMPLE_START_HOOK_COMMAND}
               </code>
               {!configured && (
                 <button
                   type="button"
                   onClick={onUseExampleHook}
-                  className="inline-flex items-center justify-center gap-1.5 px-2.5 py-1 text-[11px] font-medium rounded-full text-white bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
+                  className="inline-flex items-center justify-center gap-1.5 px-2.5 py-1 text-[11px] font-medium rounded-full text-accent-ink bg-accent hover:bg-accent-hover active:scale-[0.98] transition-all duration-150 ease-out"
                 >
                   Use this
                 </button>
@@ -441,7 +441,7 @@ function InFlightStage({ stuck, startHookConfigured }: InFlightStageProps) {
     return (
       <>
         <div className="flex items-center gap-2 mb-2">
-          <span className="shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-[11px] font-semibold bg-amber-500/20 text-amber-300">
+          <span className="shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-[11px] font-semibold bg-claude/20 text-claude">
             !
           </span>
           <div className="text-xs text-text-primary font-medium">
@@ -485,8 +485,8 @@ function CompleteStage() {
           <span className="text-text-tertiary shrink-0">•</span>
           <span>
             Supported agents automatically get the{' '}
-            <code className="px-1 py-0.5 rounded bg-white/5 font-mono text-[11px]">ouijit</code> CLI in their context,
-            so they know how to see and manage tasks, hooks, tags, plans, and scripts.
+            <code className="px-1 py-0.5 rounded bg-ink/5 font-mono text-[11px]">ouijit</code> CLI in their context, so
+            they know how to see and manage tasks, hooks, tags, plans, and scripts.
           </span>
         </li>
         <li className="flex gap-2">

--- a/src/components/plan/PlanPanel.tsx
+++ b/src/components/plan/PlanPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { renderPlanMarkdown } from '../../utils/renderPlanMarkdown';
+import { useResolvedTheme } from '../../hooks/useResolvedTheme';
 import { terminalInstances } from '../terminal/terminalReact';
 import { useProjectStore } from '../../stores/projectStore';
 import { Icon } from '../terminal/Icon';
@@ -84,6 +85,9 @@ export function PlanPanel({
 
   const contentRef = useRef<HTMLDivElement>(null);
 
+  // Syntax highlighting follows the resolved theme; re-render when it flips.
+  const resolvedTheme = useResolvedTheme();
+
   // Render markdown with syntax highlighting whenever content changes (debounced)
   useEffect(() => {
     if (!content) {
@@ -109,7 +113,7 @@ export function PlanPanel({
     return () => {
       clearTimeout(timer);
     };
-  }, [content]);
+  }, [content, resolvedTheme]);
 
   // Fetch file existence when rendered HTML changes, cache results for re-application
   const fileExistenceRef = useRef<Record<string, boolean>>({});
@@ -216,9 +220,9 @@ export function PlanPanel({
     <div className="flex flex-col h-full overflow-hidden">
       {/* Header */}
       <div className="flex items-center gap-2 px-3 py-1.5 shrink-0">
-        <Icon name="file-text" className="w-3.5 h-3.5 text-white/50 shrink-0" />
+        <Icon name="file-text" className="w-3.5 h-3.5 text-ink/50 shrink-0" />
         <button
-          className="text-[13px] text-white/50 truncate flex-1 font-mono bg-transparent border-none p-0 text-left transition-colors duration-150 hover:text-white/80"
+          className="text-[13px] text-ink/50 truncate flex-1 font-mono bg-transparent border-none p-0 text-left transition-colors duration-150 hover:text-ink/80"
           title={planPath}
           onClick={async () => {
             const inst = terminalInstances.get(ptyId);
@@ -234,10 +238,10 @@ export function PlanPanel({
         <TooltipButton
           text={copied ? 'Copied!' : 'Copy to clipboard'}
           placement="bottom"
-          className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/40 shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90 [&>svg]:w-3.5 [&>svg]:h-3.5"
+          className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-ink/40 shrink-0 transition-all duration-150 ease-out hover:bg-ink/10 hover:text-ink/90 [&>svg]:w-3.5 [&>svg]:h-3.5"
           onClick={handleCopy}
         >
-          <Icon name={copied ? 'check' : 'clipboard-text'} className={copied ? 'text-[#69db7c]' : ''} />
+          <Icon name={copied ? 'check' : 'clipboard-text'} className={copied ? 'text-ansi-green' : ''} />
         </TooltipButton>
         <FullWidthToggle fullWidth={fullWidth} onToggle={onToggleFullWidth} />
         <MinimizeButton onMinimize={onMinimize} />
@@ -247,9 +251,9 @@ export function PlanPanel({
       {/* Content */}
       <div className="flex-1 overflow-y-auto px-6 py-4" onClick={handleClick}>
         {loading ? (
-          <div className="text-sm text-white/40">Loading</div>
+          <div className="text-sm text-ink/40">Loading</div>
         ) : content === null ? (
-          <div className="text-sm text-white/40">Markdown file not found</div>
+          <div className="text-sm text-ink/40">Markdown file not found</div>
         ) : (
           <div ref={contentRef} className="plan-markdown" dangerouslySetInnerHTML={{ __html: renderedHtml }} />
         )}

--- a/src/components/scripts/ExperimentalFeaturesSection.tsx
+++ b/src/components/scripts/ExperimentalFeaturesSection.tsx
@@ -26,7 +26,7 @@ export function ExperimentalFeaturesSection({ projectPath }: ExperimentalFeature
   };
 
   return (
-    <div className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden divide-y divide-white/[0.06] bg-[var(--color-terminal-bg,#171717)]">
+    <div className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg">
       <ToggleRow
         label="Canvas layout"
         description="React-flow based free-form terminal canvas with grouping and chain edges."
@@ -52,7 +52,7 @@ interface ToggleRowProps {
 
 function ToggleRow({ label, description, checked, onChange }: ToggleRowProps) {
   return (
-    <label className="flex items-center gap-4 px-4 py-3 hover:bg-white/[0.02]">
+    <label className="flex items-center gap-4 px-4 py-3 hover:bg-ink/[0.02]">
       <div className="flex-1 min-w-0">
         <div className="text-sm text-text-primary">{label}</div>
         <div className="text-xs text-text-tertiary mt-0.5">{description}</div>
@@ -63,11 +63,11 @@ function ToggleRow({ label, description, checked, onChange }: ToggleRowProps) {
         aria-checked={checked}
         onClick={onChange}
         className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-150 ${
-          checked ? 'bg-blue-500' : 'bg-white/15'
+          checked ? 'bg-accent' : 'bg-ink/15'
         }`}
       >
         <span
-          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-150 ${
+          className={`inline-block h-4 w-4 transform rounded-full bg-accent-ink transition-transform duration-150 ${
             checked ? 'translate-x-[18px]' : 'translate-x-[2px]'
           }`}
         />

--- a/src/components/scripts/HookList.tsx
+++ b/src/components/scripts/HookList.tsx
@@ -63,10 +63,10 @@ export function HookList({ projectPath, hooks: hookEntries, bare }: HookListProp
         rows
       ) : (
         <div
-          className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden divide-y divide-white/[0.06]"
+          className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06]"
           style={{
-            background: 'var(--color-terminal-bg, #171717)',
-            boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+            background: 'var(--color-terminal-bg)',
+            boxShadow: 'var(--shadow-panel)',
           }}
         >
           {rows}

--- a/src/components/scripts/HookList.tsx
+++ b/src/components/scripts/HookList.tsx
@@ -66,7 +66,6 @@ export function HookList({ projectPath, hooks: hookEntries, bare }: HookListProp
           className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06]"
           style={{
             background: 'var(--color-terminal-bg)',
-            boxShadow: 'var(--shadow-panel)',
           }}
         >
           {rows}

--- a/src/components/scripts/HookRowView.tsx
+++ b/src/components/scripts/HookRowView.tsx
@@ -18,7 +18,7 @@ export interface HookRowViewProps {
 export function HookRowView({ label, description, command, onAction, actionLabel }: HookRowViewProps) {
   const buttonLabel = actionLabel ?? (command ? 'Edit' : '+ Configure');
   return (
-    <div className="group flex items-center gap-3 px-3 py-2 hover:bg-white/[0.04] transition-colors duration-100">
+    <div className="group flex items-center gap-3 px-3 py-2 hover:bg-ink/[0.04] transition-colors duration-100">
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <span className="text-xs font-medium text-text-primary">{label}</span>

--- a/src/components/scripts/IconColorSection.tsx
+++ b/src/components/scripts/IconColorSection.tsx
@@ -46,9 +46,9 @@ export function IconColorSection({ projectPath }: IconColorSectionProps) {
   };
 
   return (
-    <div className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden bg-[var(--color-terminal-bg,#171717)]">
+    <div className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden bg-terminal-bg">
       <label
-        className="group flex items-center gap-4 px-4 py-4 transition-colors hover:bg-white/[0.03]"
+        className="group flex items-center gap-4 px-4 py-4 transition-colors hover:bg-ink/[0.03]"
         title="Choose a color"
       >
         <div className="w-12 h-12 shrink-0 rounded-md overflow-hidden">
@@ -78,7 +78,7 @@ export function IconColorSection({ projectPath }: IconColorSectionProps) {
             </button>
           )}
           <span
-            className="relative w-8 h-8 rounded-full overflow-hidden border border-white/15 transition-colors group-hover:border-white/30"
+            className="relative w-8 h-8 rounded-full overflow-hidden border border-ink/15 transition-colors group-hover:border-ink/30"
             style={{ backgroundColor: color }}
           >
             <input

--- a/src/components/scripts/LimaSandboxSection.tsx
+++ b/src/components/scripts/LimaSandboxSection.tsx
@@ -277,7 +277,6 @@ export function LimaSandboxSection({ projectPath }: LimaSandboxSectionProps) {
         className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden"
         style={{
           background: 'var(--color-terminal-bg)',
-          boxShadow: 'var(--shadow-panel)',
         }}
       >
         <div className="flex items-center justify-between px-3 py-2">

--- a/src/components/scripts/LimaSandboxSection.tsx
+++ b/src/components/scripts/LimaSandboxSection.tsx
@@ -15,7 +15,7 @@ const VM_STATUS_LABELS: Record<string, string> = {
 // Beveled action button matching the app's house style (glass-bevel rim + crisp
 // outline + radius), shared by the VM action row.
 const VM_BUTTON =
-  'relative glass-bevel overflow-hidden px-3 py-1.5 text-xs font-medium text-text-secondary bg-background-secondary border border-black/60 rounded-[12px] hover:bg-background-tertiary hover:text-text-primary transition-colors';
+  'relative glass-bevel overflow-hidden px-3 py-1.5 text-xs font-medium text-text-secondary bg-background-secondary border border-bezel rounded-[12px] hover:bg-background-tertiary hover:text-text-primary transition-colors';
 
 interface LimaSandboxSectionProps {
   projectPath: string;
@@ -274,17 +274,17 @@ export function LimaSandboxSection({ projectPath }: LimaSandboxSectionProps) {
 
       {/* YAML config editor */}
       <div
-        className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden"
+        className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden"
         style={{
-          background: 'var(--color-terminal-bg, #171717)',
-          boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+          background: 'var(--color-terminal-bg)',
+          boxShadow: 'var(--shadow-panel)',
         }}
       >
         <div className="flex items-center justify-between px-3 py-2">
           <span className="text-xs font-medium text-text-secondary">Configuration</span>
           <div className="flex items-center gap-2">
             <button
-              className={`text-[10px] px-1.5 py-0.5 rounded ${showMerged ? 'bg-white/10 text-text-primary' : 'text-text-secondary hover:text-text-primary'}`}
+              className={`text-[10px] px-1.5 py-0.5 rounded ${showMerged ? 'bg-ink/10 text-text-primary' : 'text-text-secondary hover:text-text-primary'}`}
               onClick={() => setShowMerged(!showMerged)}
             >
               {showMerged ? 'Edit' : 'Merged'}
@@ -303,7 +303,7 @@ export function LimaSandboxSection({ projectPath }: LimaSandboxSectionProps) {
         {showMerged ? (
           <textarea
             ref={mergedRef}
-            className="w-full max-h-[80vh] overflow-y-auto text-[13px] leading-5 font-mono bg-transparent border-t border-white/[0.06] p-4 text-text-secondary resize-none outline-none tabular-nums"
+            className="w-full max-h-[80vh] overflow-y-auto text-[13px] leading-5 font-mono bg-transparent border-t border-ink/[0.06] p-4 text-text-secondary resize-none outline-none tabular-nums"
             value={mergedYaml}
             readOnly
             spellCheck={false}
@@ -311,7 +311,7 @@ export function LimaSandboxSection({ projectPath }: LimaSandboxSectionProps) {
         ) : (
           <textarea
             ref={editRef}
-            className="w-full max-h-[80vh] overflow-y-auto text-[13px] leading-5 font-mono bg-transparent border-t border-white/[0.06] p-4 text-text-primary resize-none outline-none tabular-nums"
+            className="w-full max-h-[80vh] overflow-y-auto text-[13px] leading-5 font-mono bg-transparent border-t border-ink/[0.06] p-4 text-text-primary resize-none outline-none tabular-nums"
             value={editorValue}
             onChange={(e) => handleEditorChange(e.target.value)}
             onKeyDown={handleKeyDown}
@@ -322,7 +322,7 @@ export function LimaSandboxSection({ projectPath }: LimaSandboxSectionProps) {
           />
         )}
 
-        {yamlError && <p className="text-[11px] text-red-400 px-3 pb-2">{yamlError}</p>}
+        {yamlError && <p className="text-[11px] text-error px-3 pb-2">{yamlError}</p>}
       </div>
 
       {/* Recreate prompt */}

--- a/src/components/scripts/NonoSandboxSection.tsx
+++ b/src/components/scripts/NonoSandboxSection.tsx
@@ -6,10 +6,10 @@ interface NonoSandboxSectionProps {
 }
 
 const CARD =
-  'glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden bg-[var(--color-terminal-bg,#171717)] divide-y divide-white/[0.06]';
+  'glass-bevel relative border border-bezel rounded-[14px] overflow-hidden bg-terminal-bg divide-y divide-ink/[0.06]';
 
 const PILL_BTN =
-  'shrink-0 text-xs font-medium text-text-secondary bg-background-secondary border border-black/60 rounded-[10px] px-2.5 py-1.5 hover:bg-background-tertiary hover:text-text-primary transition-colors';
+  'shrink-0 text-xs font-medium text-text-secondary bg-background-secondary border border-bezel rounded-[10px] px-2.5 py-1.5 hover:bg-background-tertiary hover:text-text-primary transition-colors';
 
 /** Config surface for the nono backend. Controls only — no exposition. */
 const STARTER_PROFILE = `{
@@ -151,7 +151,7 @@ export function NonoSandboxSection({ projectPath }: NonoSandboxSectionProps) {
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') addPort();
                 }}
-                className="w-16 rounded-[10px] border border-black/60 bg-background-secondary px-2 py-1.5 text-xs text-text-primary"
+                className="w-16 rounded-[10px] border border-bezel bg-background-secondary px-2 py-1.5 text-xs text-text-primary"
               />
               <button type="button" onClick={addPort} className={PILL_BTN}>
                 Add
@@ -163,7 +163,7 @@ export function NonoSandboxSection({ projectPath }: NonoSandboxSectionProps) {
               {openPorts.map((n) => (
                 <span
                   key={n}
-                  className="inline-flex items-center gap-1 rounded-full border border-black/60 bg-background-secondary py-0.5 pl-2 pr-1 text-xs text-text-secondary"
+                  className="inline-flex items-center gap-1 rounded-full border border-bezel bg-background-secondary py-0.5 pl-2 pr-1 text-xs text-text-secondary"
                 >
                   {n}
                   <button
@@ -209,9 +209,9 @@ export function NonoSandboxSection({ projectPath }: NonoSandboxSectionProps) {
                 }}
                 spellCheck={false}
                 aria-label="nono profile JSON"
-                className="h-56 w-full resize-y rounded-[10px] border border-black/60 bg-background-secondary px-3 py-2 font-mono text-xs leading-relaxed text-text-primary outline-none"
+                className="h-56 w-full resize-y rounded-[10px] border border-bezel bg-background-secondary px-3 py-2 font-mono text-xs leading-relaxed text-text-primary outline-none"
               />
-              {profileError && <div className="text-xs text-red-400">{profileError}</div>}
+              {profileError && <div className="text-xs text-error">{profileError}</div>}
               <div className="flex items-center gap-1.5">
                 <button type="button" onClick={saveProfile} className={PILL_BTN}>
                   Save
@@ -246,11 +246,11 @@ function Toggle({ checked, label, onClick }: { checked: boolean; label: string; 
       aria-label={label}
       onClick={onClick}
       className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-150 ${
-        checked ? 'bg-blue-500' : 'bg-white/15'
+        checked ? 'bg-accent' : 'bg-ink/15'
       }`}
     >
       <span
-        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-150 ${
+        className={`inline-block h-4 w-4 transform rounded-full bg-accent-ink transition-transform duration-150 ${
           checked ? 'translate-x-[18px]' : 'translate-x-[2px]'
         }`}
       />

--- a/src/components/scripts/ProjectSettingsPanel.tsx
+++ b/src/components/scripts/ProjectSettingsPanel.tsx
@@ -54,7 +54,7 @@ export function ProjectSettingsPanel({ projectPath }: ProjectSettingsPanelProps)
       {/* Fade overlay — content fades out under the header */}
       <div
         className="pointer-events-none h-6 shrink-0 -mb-6 relative z-10"
-        style={{ background: 'linear-gradient(to bottom, var(--color-background-primary, #1c1c1e), transparent)' }}
+        style={{ background: 'linear-gradient(to bottom, var(--color-background), transparent)' }}
       />
       <div className="flex-1 overflow-y-auto settings-scrollable">
         <div className="px-6 pt-4 pb-16 min-w-full max-w-2xl space-y-8">
@@ -96,11 +96,10 @@ export function ProjectSettingsPanel({ projectPath }: ProjectSettingsPanelProps)
             <h2 className="text-sm font-semibold text-text-primary mb-2">Run Commands</h2>
             <p className="text-xs text-text-tertiary mb-4">Commands you can launch from a terminal's + menu.</p>
             <div
-              className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden divide-y divide-white/[0.06]"
+              className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06]"
               style={{
-                background: 'var(--color-terminal-bg, #171717)',
-                boxShadow:
-                  '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+                background: 'var(--color-terminal-bg)',
+                boxShadow: 'var(--shadow-panel)',
               }}
             >
               <HookList projectPath={projectPath} hooks={RUN_HOOK} bare />

--- a/src/components/scripts/ProjectSettingsPanel.tsx
+++ b/src/components/scripts/ProjectSettingsPanel.tsx
@@ -96,7 +96,7 @@ export function ProjectSettingsPanel({ projectPath }: ProjectSettingsPanelProps)
             <h2 className="text-sm font-semibold text-text-primary mb-2">Run Commands</h2>
             <p className="text-xs text-text-tertiary mb-4">Commands you can launch from a terminal's + menu.</p>
             <div
-              className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06]"
+              className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06]"
               style={{
                 background: 'var(--color-terminal-bg)',
                 boxShadow: 'var(--shadow-panel)',

--- a/src/components/scripts/ProjectSettingsPanel.tsx
+++ b/src/components/scripts/ProjectSettingsPanel.tsx
@@ -99,7 +99,6 @@ export function ProjectSettingsPanel({ projectPath }: ProjectSettingsPanelProps)
               className="glass-bevel relative border border-bezel-panel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06]"
               style={{
                 background: 'var(--color-terminal-bg)',
-                boxShadow: 'var(--shadow-panel)',
               }}
             >
               <HookList projectPath={projectPath} hooks={RUN_HOOK} bare />

--- a/src/components/scripts/SandboxSection.tsx
+++ b/src/components/scripts/SandboxSection.tsx
@@ -40,7 +40,7 @@ export function SandboxSection({ projectPath }: SandboxSectionProps) {
     <div className="flex flex-col gap-3">
       {both && (
         <div className="flex flex-col gap-1.5">
-          <div className="flex gap-1 self-start rounded-[12px] border border-black/60 bg-background-secondary p-1">
+          <div className="flex gap-1 self-start rounded-[12px] border border-bezel bg-background-secondary p-1">
             {providers.map((p) => (
               <button
                 key={p}

--- a/src/components/scripts/ScriptList.tsx
+++ b/src/components/scripts/ScriptList.tsx
@@ -122,7 +122,6 @@ export function ScriptList({ projectPath, bare }: ScriptListProps) {
         className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06]"
         style={{
           background: 'var(--color-terminal-bg)',
-          boxShadow: 'var(--shadow-panel)',
         }}
       >
         {scripts.length === 0 && !addingNew && (

--- a/src/components/scripts/ScriptList.tsx
+++ b/src/components/scripts/ScriptList.tsx
@@ -90,7 +90,7 @@ export function ScriptList({ projectPath, bare }: ScriptListProps) {
   ));
 
   const addButton = (
-    <div className="px-3 py-2 hover:bg-white/[0.04] transition-colors duration-100" onClick={handleAddNew}>
+    <div className="px-3 py-2 hover:bg-ink/[0.04] transition-colors duration-100" onClick={handleAddNew}>
       <span className="flex items-center gap-2 text-xs text-text-tertiary hover:text-text-primary transition-colors duration-150">
         <Icon name="plus" className="w-3.5 h-3.5" />
         Add Script
@@ -119,10 +119,10 @@ export function ScriptList({ projectPath, bare }: ScriptListProps) {
   return (
     <div>
       <div
-        className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden divide-y divide-white/[0.06]"
+        className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06]"
         style={{
-          background: 'var(--color-terminal-bg, #171717)',
-          boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+          background: 'var(--color-terminal-bg)',
+          boxShadow: 'var(--shadow-panel)',
         }}
       >
         {scripts.length === 0 && !addingNew && (
@@ -258,7 +258,7 @@ function ScriptForm({
       <div className="flex items-center gap-2 pt-1">
         {onDelete && (
           <button
-            className="px-3 py-1.5 text-xs text-[#ff6b6b] bg-transparent border border-[#ff6b6b]/30 rounded-md hover:bg-[#ff6b6b]/10 transition-colors duration-150"
+            className="px-3 py-1.5 text-xs text-ansi-red bg-transparent border border-ansi-red/30 rounded-md hover:bg-ansi-red/10 transition-colors duration-150"
             onClick={onDelete}
           >
             Delete
@@ -273,7 +273,7 @@ function ScriptForm({
         </button>
         <button
           className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors duration-150 ${
-            isValid ? 'text-white bg-accent hover:bg-accent-hover' : 'text-text-tertiary bg-background-tertiary'
+            isValid ? 'text-accent-ink bg-accent hover:bg-accent-hover' : 'text-text-tertiary bg-background-tertiary'
           }`}
           disabled={!isValid}
           onClick={handleSubmit}

--- a/src/components/scripts/ScriptRowView.tsx
+++ b/src/components/scripts/ScriptRowView.tsx
@@ -31,7 +31,7 @@ export function ScriptRowView({
   return (
     <div ref={containerRef} style={containerStyle}>
       <div
-        className="flex items-center gap-2 px-3 py-2 hover:bg-white/[0.04] transition-colors duration-100"
+        className="flex items-center gap-2 px-3 py-2 hover:bg-ink/[0.04] transition-colors duration-100"
         onClick={onClick}
       >
         <button

--- a/src/components/scripts/WorktreeSection.tsx
+++ b/src/components/scripts/WorktreeSection.tsx
@@ -34,7 +34,7 @@ export function WorktreeSection({ projectPath }: WorktreeSectionProps) {
   };
 
   return (
-    <div className="glass-bevel relative border border-black/60 rounded-[14px] overflow-hidden divide-y divide-white/[0.06] bg-[var(--color-terminal-bg,#171717)]">
+    <div className="glass-bevel relative border border-bezel rounded-[14px] overflow-hidden divide-y divide-ink/[0.06] bg-terminal-bg">
       {MODE_OPTIONS.map((option) => (
         <ModeRow
           key={option.value}
@@ -62,15 +62,15 @@ function ModeRow({ label, description, checked, onSelect }: ModeRowProps) {
       role="radio"
       aria-checked={checked}
       onClick={onSelect}
-      className="w-full flex items-center gap-4 px-4 py-3 text-left hover:bg-white/[0.02] focus:outline-none focus-visible:bg-white/[0.03]"
+      className="w-full flex items-center gap-4 px-4 py-3 text-left hover:bg-ink/[0.02] focus:outline-none focus-visible:bg-ink/[0.03]"
     >
       <span
         aria-hidden="true"
         className={`relative inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors duration-150 ${
-          checked ? 'border-blue-500 bg-blue-500' : 'border-white/30 bg-transparent'
+          checked ? 'border-accent bg-accent' : 'border-ink/30 bg-transparent'
         }`}
       >
-        {checked && <span className="h-1.5 w-1.5 rounded-full bg-white" />}
+        {checked && <span className="h-1.5 w-1.5 rounded-full bg-accent-ink" />}
       </span>
       <span className="flex-1 min-w-0">
         <span className="block text-sm text-text-primary">{label}</span>

--- a/src/components/terminal/FullWidthToggle.tsx
+++ b/src/components/terminal/FullWidthToggle.tsx
@@ -2,7 +2,7 @@ import { Icon } from './Icon';
 import { Tooltip } from '../ui/Tooltip';
 
 const PANEL_HEADER_BUTTON =
-  'w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/60 shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90 [&>svg]:w-3.5 [&>svg]:h-3.5';
+  'w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-ink/60 shrink-0 transition-all duration-150 ease-out hover:bg-ink/10 hover:text-ink/90 [&>svg]:w-3.5 [&>svg]:h-3.5';
 
 /** Panel-level toggle between full-width and split-with-terminal layout. */
 export function FullWidthToggle({ fullWidth, onToggle }: { fullWidth: boolean; onToggle: () => void }) {

--- a/src/components/terminal/RunnerPanel.tsx
+++ b/src/components/terminal/RunnerPanel.tsx
@@ -36,11 +36,11 @@ export function RunnerPanel({
   return (
     <div className="flex flex-col h-full overflow-hidden">
       <div className="flex items-center gap-2 px-3 py-1.5 shrink-0">
-        <span className="text-[13px] text-white/50 truncate flex-1 font-mono">{panelTitle}</span>
+        <span className="text-[13px] text-ink/50 truncate flex-1 font-mono">{panelTitle}</span>
         {runnerPtyId && (
           <Tooltip text="Kill">
             <button
-              className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/40 shrink-0 transition-all duration-150 ease-out hover:bg-red-500/20 hover:text-[#ff6b6b] [&>svg]:w-3.5 [&>svg]:h-3.5"
+              className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-ink/40 shrink-0 transition-all duration-150 ease-out hover:bg-error/20 hover:text-ansi-red [&>svg]:w-3.5 [&>svg]:h-3.5"
               onClick={(e) => {
                 e.stopPropagation();
                 onKill();
@@ -52,7 +52,7 @@ export function RunnerPanel({
         )}
         <Tooltip text="Restart">
           <button
-            className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/60 shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90 [&>svg]:w-3.5 [&>svg]:h-3.5"
+            className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-ink/60 shrink-0 transition-all duration-150 ease-out hover:bg-ink/10 hover:text-ink/90 [&>svg]:w-3.5 [&>svg]:h-3.5"
             onClick={(e) => {
               e.stopPropagation();
               onRestart();
@@ -69,10 +69,10 @@ export function RunnerPanel({
         {runnerPtyId ? (
           <XTermContainer ptyId={runnerPtyId} className="runner-xterm-container w-full h-full overflow-hidden" />
         ) : (
-          <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-white/40">
+          <div className="w-full h-full flex flex-col items-center justify-center gap-3 text-ink/40">
             <div className="font-mono text-sm">Runner stopped</div>
             <button
-              className="px-3 py-1 rounded-md bg-white/10 hover:bg-white/15 text-white/80 text-xs border-none transition-colors flex items-center gap-1.5 [&>svg]:w-3.5 [&>svg]:h-3.5"
+              className="px-3 py-1 rounded-md bg-ink/10 hover:bg-ink/15 text-ink/80 text-xs border-none transition-colors flex items-center gap-1.5 [&>svg]:w-3.5 [&>svg]:h-3.5"
               onClick={(e) => {
                 e.stopPropagation();
                 onRestart();

--- a/src/components/terminal/StatusDot.tsx
+++ b/src/components/terminal/StatusDot.tsx
@@ -15,10 +15,10 @@ export function sandboxSuffix(sandboxProvider?: SandboxProviderId): string {
 }
 
 const COLORS: Record<string, string> = {
-  thinking: '#da77f2',
-  ready: '#4ee82e',
-  success: '#4ee82e',
-  error: '#ff453a',
+  thinking: 'var(--color-status-thinking)',
+  ready: 'var(--color-status-ready)',
+  success: 'var(--color-status-ready)',
+  error: 'var(--color-error)',
 };
 
 const LABELS: Record<string, string> = {
@@ -45,7 +45,12 @@ export function StatusDot({ summaryType, sandboxProvider, size = 6 }: StatusDotP
           height: size,
           background,
           ...(isThinking ? { animation: 'terminal-status-pulse 1s ease-in-out infinite' } : {}),
-          ...(sandboxed ? { outline: '1.5px solid rgba(116, 192, 252, 0.6)', outlineOffset: '2px' } : {}),
+          ...(sandboxed
+            ? {
+                outline: '1.5px solid color-mix(in srgb, var(--color-ansi-blue) 60%, transparent)',
+                outlineOffset: '2px',
+              }
+            : {}),
         }}
       />
     </Tooltip>

--- a/src/components/terminal/TagInput.tsx
+++ b/src/components/terminal/TagInput.tsx
@@ -162,7 +162,7 @@ export function TagInput({ ptyId, onClose }: TagInputProps) {
       />
       {suggestions.length > 0 && (
         <div
-          className="absolute left-0 bg-surface border border-ink/10 rounded-lg shadow-lg z-50 max-h-48 overflow-y-auto"
+          className="absolute left-0 bg-surface border border-ink/10 rounded-lg shadow-menu z-50 max-h-48 overflow-y-auto"
           style={{ top: '100%', marginTop: 4, minWidth: 120, display: 'block' }}
         >
           {suggestions.map((s) => (

--- a/src/components/terminal/TagInput.tsx
+++ b/src/components/terminal/TagInput.tsx
@@ -136,11 +136,11 @@ export function TagInput({ ptyId, onClose }: TagInputProps) {
       {tags.map((tag) => (
         <span
           key={tag}
-          className="inline-flex items-center gap-1 font-mono text-[11px] font-medium text-white/55 bg-white/[0.05] rounded-full px-2 py-0.5 shrink-0"
+          className="inline-flex items-center gap-1 font-mono text-[11px] font-medium text-ink/55 bg-ink/[0.05] rounded-full px-2 py-0.5 shrink-0"
         >
           {tag}
           <button
-            className="inline-flex items-center justify-center w-3 h-3 text-white/30 bg-transparent border-none text-xs leading-none hover:text-white/60"
+            className="inline-flex items-center justify-center w-3 h-3 text-ink/30 bg-transparent border-none text-xs leading-none hover:text-ink/60"
             onClick={(e) => {
               e.stopPropagation();
               removeTag(tag);
@@ -153,7 +153,7 @@ export function TagInput({ ptyId, onClose }: TagInputProps) {
       <input
         ref={inputRef}
         type="text"
-        className="bg-transparent border-none outline-none font-mono text-[11px] font-medium text-white/70 min-w-[60px] py-0.5 placeholder:text-white/25"
+        className="bg-transparent border-none outline-none font-mono text-[11px] font-medium text-ink/70 min-w-[60px] py-0.5 placeholder:text-ink/25"
         style={{ width: 60 }}
         placeholder={tags.length ? '' : 'Add tag\u2026'}
         value={inputValue}
@@ -162,13 +162,13 @@ export function TagInput({ ptyId, onClose }: TagInputProps) {
       />
       {suggestions.length > 0 && (
         <div
-          className="absolute left-0 bg-surface border border-white/10 rounded-lg shadow-lg z-50 max-h-48 overflow-y-auto"
+          className="absolute left-0 bg-surface border border-ink/10 rounded-lg shadow-lg z-50 max-h-48 overflow-y-auto"
           style={{ top: '100%', marginTop: 4, minWidth: 120, display: 'block' }}
         >
           {suggestions.map((s) => (
             <div
               key={s}
-              className="block w-full text-left font-mono text-[11px] text-white/60 px-3 py-1.5 bg-transparent border-none hover:bg-white/[0.08] hover:text-white/80"
+              className="block w-full text-left font-mono text-[11px] text-ink/60 px-3 py-1.5 bg-transparent border-none hover:bg-ink/[0.08] hover:text-ink/80"
               onMouseDown={(e) => {
                 e.preventDefault();
                 addTag(s);

--- a/src/components/terminal/TerminalBody.tsx
+++ b/src/components/terminal/TerminalBody.tsx
@@ -149,27 +149,27 @@ export function TerminalBody({ ptyId, projectPath }: TerminalBodyProps) {
             transition,
             // Collapse padding too when hidden, so basis 0 means truly zero width.
             ...(activePanel && !split ? { padding: 0 } : {}),
-            background: 'var(--color-terminal-bg, #171717)',
+            background: 'var(--color-terminal-bg)',
           }}
         />
         {split && (
           <div
             ref={handleRef}
-            className="shrink-0 relative hover:bg-white/15 active:bg-white/15 after:content-[''] after:absolute after:top-0 after:bottom-0 after:-left-2 after:-right-2"
+            className="shrink-0 relative hover:bg-ink/15 active:bg-ink/15 after:content-[''] after:absolute after:top-0 after:bottom-0 after:-left-2 after:-right-2"
             style={{ width: 4, cursor: 'col-resize', background: 'transparent', transition: 'background 0.15s ease' }}
           />
         )}
         {activePanel && (
           <div
             ref={panelRef}
-            className="relative flex flex-col min-h-0 overflow-hidden glass-bevel border border-black/60 rounded-[14px] m-3"
+            className="relative flex flex-col min-h-0 overflow-hidden glass-bevel border border-bezel rounded-[14px] m-3"
             style={{
               flexGrow: 0,
               flexShrink: 1,
               flexBasis: panelBasis,
               transition,
-              background: 'var(--color-terminal-bg, #171717)',
-              boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 2px 10px rgba(0, 0, 0, 0.18)',
+              background: 'var(--color-terminal-bg)',
+              boxShadow: 'var(--shadow-inset-panel)',
               ...(dragging ? { pointerEvents: 'none' } : {}),
             }}
           >
@@ -185,10 +185,10 @@ export function TerminalBody({ ptyId, projectPath }: TerminalBodyProps) {
       </div>
       {diffPanelOpen && (
         <div
-          className="absolute inset-0 z-20 flex flex-col m-3 glass-bevel border border-black/60 rounded-[14px] overflow-hidden"
+          className="absolute inset-0 z-20 flex flex-col m-3 glass-bevel border border-bezel rounded-[14px] overflow-hidden"
           style={{
-            background: 'var(--color-terminal-bg, #171717)',
-            boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 2px 10px rgba(0, 0, 0, 0.18)',
+            background: 'var(--color-terminal-bg)',
+            boxShadow: 'var(--shadow-inset-panel)',
           }}
         >
           <DiffPanel

--- a/src/components/terminal/TerminalBody.tsx
+++ b/src/components/terminal/TerminalBody.tsx
@@ -162,7 +162,7 @@ export function TerminalBody({ ptyId, projectPath }: TerminalBodyProps) {
         {activePanel && (
           <div
             ref={panelRef}
-            className="relative flex flex-col min-h-0 overflow-hidden glass-bevel border border-bezel rounded-[14px] m-3"
+            className="relative flex flex-col min-h-0 overflow-hidden glass-bevel border border-bezel-panel rounded-[14px] m-3"
             style={{
               flexGrow: 0,
               flexShrink: 1,
@@ -185,7 +185,7 @@ export function TerminalBody({ ptyId, projectPath }: TerminalBodyProps) {
       </div>
       {diffPanelOpen && (
         <div
-          className="absolute inset-0 z-20 flex flex-col m-3 glass-bevel border border-bezel rounded-[14px] overflow-hidden"
+          className="absolute inset-0 z-20 flex flex-col m-3 glass-bevel border border-bezel-panel rounded-[14px] overflow-hidden"
           style={{
             background: 'var(--color-terminal-bg)',
             boxShadow: 'var(--shadow-inset-panel)',

--- a/src/components/terminal/TerminalCard.tsx
+++ b/src/components/terminal/TerminalCard.tsx
@@ -102,17 +102,17 @@ function LoadingContents({ label, isActive }: { label: string; isActive: boolean
       <div className="flex items-center justify-between pl-3 pr-3 py-2 min-h-9">
         <div className="flex items-center gap-2 min-w-0">
           <span
-            className="w-2 h-2 rounded-full bg-transparent border-[1.5px] border-white/30 border-t-white/80 shrink-0"
+            className="w-2 h-2 rounded-full bg-transparent border-[1.5px] border-ink/30 border-t-ink/80 shrink-0"
             style={{ animation: 'loading-dot-spin 0.8s linear infinite' }}
           />
-          <span className="font-mono text-xs font-medium text-white/85 truncate">{label}</span>
+          <span className="font-mono text-xs font-medium text-ink/85 truncate">{label}</span>
         </div>
         <div className="flex items-center gap-1 shrink-0 justify-end" />
       </div>
       {isActive && (
         <div className="relative flex-1 flex flex-row min-h-0 overflow-hidden">
           <div className="flex-1 flex items-center justify-center">
-            <div className="font-mono text-sm text-white/40">Setting up workspace{'…'}</div>
+            <div className="font-mono text-sm text-ink/40">Setting up workspace{'…'}</div>
           </div>
         </div>
       )}

--- a/src/components/terminal/TerminalCardStack.tsx
+++ b/src/components/terminal/TerminalCardStack.tsx
@@ -49,18 +49,18 @@ export function TerminalCardStack({ projectPath }: TerminalCardStackProps) {
 function EmptyState() {
   return (
     <div
-      className="project-stack-empty project-stack-empty--visible absolute inset-0 flex flex-col items-center justify-center text-center rounded-[14px] border border-dashed border-white/10 p-12 opacity-100"
+      className="project-stack-empty project-stack-empty--visible absolute inset-0 flex flex-col items-center justify-center text-center rounded-[14px] border border-dashed border-ink/10 p-12 opacity-100"
       style={{ background: 'var(--color-terminal-bg)' }}
     >
-      <div className="text-sm text-white/30">No active terminals</div>
+      <div className="text-sm text-ink/30">No active terminals</div>
       <div className="flex justify-center gap-6 mt-6">
         <span
           className="flex items-center gap-1.5"
-          style={{ fontSize: 'var(--font-size-xs)', color: 'rgba(255, 255, 255, 0.35)' }}
+          style={{ fontSize: 'var(--font-size-xs)', color: 'color-mix(in srgb, var(--color-ink) 35%, transparent)' }}
         >
           <span
             className="inline-flex items-center font-mono"
-            style={{ fontSize: 16, color: 'rgba(255, 255, 255, 0.25)' }}
+            style={{ fontSize: 16, color: 'color-mix(in srgb, var(--color-ink) 25%, transparent)' }}
           >
             {isMac ? '⌘' : '⌃'}
             <span className="text-xs">N</span>
@@ -69,11 +69,11 @@ function EmptyState() {
         </span>
         <span
           className="flex items-center gap-1.5"
-          style={{ fontSize: 'var(--font-size-xs)', color: 'rgba(255, 255, 255, 0.35)' }}
+          style={{ fontSize: 'var(--font-size-xs)', color: 'color-mix(in srgb, var(--color-ink) 35%, transparent)' }}
         >
           <span
             className="inline-flex items-center font-mono"
-            style={{ fontSize: 16, color: 'rgba(255, 255, 255, 0.25)' }}
+            style={{ fontSize: 16, color: 'color-mix(in srgb, var(--color-ink) 25%, transparent)' }}
           >
             {isMac ? '⌘' : '⌃'}
             <span className="text-xs">T</span>
@@ -109,7 +109,7 @@ function Pagination({ page, totalPages, projectPath }: { page: number; totalPage
       }}
     >
       <button
-        className="w-6 h-6 flex items-center justify-center bg-transparent border-none rounded text-white/35 transition-colors duration-150 ease-out hover:text-white/70"
+        className="w-6 h-6 flex items-center justify-center bg-transparent border-none rounded text-ink/35 transition-colors duration-150 ease-out hover:text-ink/70"
         style={{ visibility: page > 0 ? 'visible' : 'hidden' }}
         onClick={(e) => {
           e.stopPropagation();
@@ -129,11 +129,11 @@ function Pagination({ page, totalPages, projectPath }: { page: number; totalPage
           <polyline points="15 18 9 12 15 6" />
         </svg>
       </button>
-      <span className="project-stack-page-indicator text-xs font-mono text-white/35">
+      <span className="project-stack-page-indicator text-xs font-mono text-ink/35">
         {page + 1} / {totalPages}
       </span>
       <button
-        className="w-6 h-6 flex items-center justify-center bg-transparent border-none rounded text-white/35 transition-colors duration-150 ease-out hover:text-white/70"
+        className="w-6 h-6 flex items-center justify-center bg-transparent border-none rounded text-ink/35 transition-colors duration-150 ease-out hover:text-ink/70"
         style={{ visibility: page < totalPages - 1 ? 'visible' : 'hidden' }}
         onClick={(e) => {
           e.stopPropagation();

--- a/src/components/terminal/TerminalCardView.tsx
+++ b/src/components/terminal/TerminalCardView.tsx
@@ -37,7 +37,7 @@ const DEPTH_STYLES: Record<number, DepthStyle> = {
 const ACTIVE_STYLE: CSSProperties = {
   zIndex: 10,
   transform: 'translateY(0) scaleX(1)',
-  boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2)',
+  boxShadow: 'var(--shadow-panel)',
 };
 
 export interface TerminalCardViewProps {
@@ -73,7 +73,7 @@ export function TerminalCardView({
   const depthBase = !isActive && backDepth > 0 ? DEPTH_STYLES[Math.min(backDepth, 4)] : undefined;
 
   const style: CSSProperties = {
-    background: 'var(--color-terminal-bg, #171717)',
+    background: 'var(--color-terminal-bg)',
     transition: 'transform 0.2s ease, box-shadow 0.2s ease',
     contain: 'layout style paint',
     ...(isActive
@@ -89,7 +89,7 @@ export function TerminalCardView({
 
   return (
     <div
-      className={`project-card glass-bevel absolute inset-0 rounded-[14px] border border-black/60 overflow-hidden flex flex-col ${isActive ? 'project-card--active' : 'hover:border-accent'}${className ? ' ' + className : ''}`}
+      className={`project-card glass-bevel absolute inset-0 rounded-[14px] border border-bezel overflow-hidden flex flex-col ${isActive ? 'project-card--active' : 'hover:border-accent'}${className ? ' ' + className : ''}`}
       style={style}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/src/components/terminal/TerminalCardView.tsx
+++ b/src/components/terminal/TerminalCardView.tsx
@@ -7,30 +7,32 @@ interface DepthStyle {
   boxShadow: string;
 }
 
+/* Blurred shadows only — a 1px ring here would stack with the card's
+   bezel-panel border and read as a doubled, thicker edge on light themes. */
 const DEPTH_STYLES: Record<number, DepthStyle> = {
   1: {
     translateY: -24,
     scaleX: 0.98,
     zIndex: 9,
-    boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.12)',
+    boxShadow: '0 2px 8px rgba(0, 0, 0, 0.12)',
   },
   2: {
     translateY: -48,
     scaleX: 0.96,
     zIndex: 8,
-    boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.1), 0 1px 4px rgba(0, 0, 0, 0.08)',
+    boxShadow: '0 1px 4px rgba(0, 0, 0, 0.08)',
   },
   3: {
     translateY: -72,
     scaleX: 0.94,
     zIndex: 7,
-    boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.08)',
+    boxShadow: 'none',
   },
   4: {
     translateY: -96,
     scaleX: 0.92,
     zIndex: 6,
-    boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.06)',
+    boxShadow: 'none',
   },
 };
 
@@ -89,7 +91,7 @@ export function TerminalCardView({
 
   return (
     <div
-      className={`project-card glass-bevel absolute inset-0 rounded-[14px] border border-bezel overflow-hidden flex flex-col ${isActive ? 'project-card--active' : 'hover:border-accent'}${className ? ' ' + className : ''}`}
+      className={`project-card glass-bevel absolute inset-0 rounded-[14px] border border-bezel-panel overflow-hidden flex flex-col ${isActive ? 'project-card--active' : 'hover:border-accent'}${className ? ' ' + className : ''}`}
       style={style}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -226,7 +226,7 @@ export const TerminalHeader = memo(function TerminalHeader({
   const nameContent = renameTarget ? (
     <input
       ref={renameInputRef}
-      className="font-mono text-xs font-medium text-white/85 bg-transparent border-0 border-b border-accent p-0 outline-none min-w-0 shrink-0 [-webkit-app-region:no-drag]"
+      className="font-mono text-xs font-medium text-ink/85 bg-transparent border-0 border-b border-accent p-0 outline-none min-w-0 shrink-0 [-webkit-app-region:no-drag]"
       onBlur={commitRename}
       onKeyDown={(e) => {
         if (e.key === 'Enter') commitRename();
@@ -245,7 +245,7 @@ export const TerminalHeader = memo(function TerminalHeader({
         {tags.map((tag) => (
           <button
             key={tag}
-            className={`${METADATA_CHIP} border-none hover:bg-white/[0.1] hover:text-white/75 transition-colors duration-150`}
+            className={`${METADATA_CHIP} border-none hover:bg-ink/[0.1] hover:text-ink/75 transition-colors duration-150`}
             onMouseDown={handleTagButtonClick}
           >
             {tag}
@@ -253,7 +253,7 @@ export const TerminalHeader = memo(function TerminalHeader({
         ))}
         {tags.length === 0 && (
           <button
-            className="inline-flex items-center gap-1 font-mono text-[11px] text-white/35 bg-transparent border-none px-2 py-0.5 rounded-full shrink-0 opacity-0 group-hover/meta:opacity-100 hover:text-white/70 hover:bg-white/[0.05] transition-all duration-150"
+            className="inline-flex items-center gap-1 font-mono text-[11px] text-ink/35 bg-transparent border-none px-2 py-0.5 rounded-full shrink-0 opacity-0 group-hover/meta:opacity-100 hover:text-ink/70 hover:bg-ink/[0.05] transition-all duration-150"
             onMouseDown={handleTagButtonClick}
             aria-label="Add tag"
           >
@@ -358,7 +358,7 @@ export const TerminalHeader = memo(function TerminalHeader({
 // ── Sub-components ───────────────────────────────────────────────────
 
 const METADATA_CHIP =
-  'inline-flex items-center gap-1 font-mono text-[11px] font-medium text-white/55 bg-white/[0.05] rounded-full px-2 py-0.5 shrink-0';
+  'inline-flex items-center gap-1 font-mono text-[11px] font-medium text-ink/55 bg-ink/[0.05] rounded-full px-2 py-0.5 shrink-0';
 
 function BranchCopy({ branch }: { branch: string }) {
   const [copied, setCopied] = useState(false);
@@ -385,12 +385,12 @@ function BranchCopy({ branch }: { branch: string }) {
   return (
     <button
       type="button"
-      className="inline-flex items-center gap-1 font-mono text-[11px] text-white/45 bg-transparent border-none p-0 min-w-0 self-start shrink-0 transition-colors duration-150 hover:text-white/75"
+      className="inline-flex items-center gap-1 font-mono text-[11px] text-ink/45 bg-transparent border-none p-0 min-w-0 self-start shrink-0 transition-colors duration-150 hover:text-ink/75"
       onClick={handleClick}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      <Icon name={iconName} className="w-3 h-3 shrink-0 text-white/35" />
+      <Icon name={iconName} className="w-3 h-3 shrink-0 text-ink/35" />
       <span className="truncate">{copied ? 'Copied' : branch}</span>
     </button>
   );
@@ -402,13 +402,13 @@ function BranchCopy({ branch }: { branch: string }) {
 const groupButtonBase =
   'group/seg h-full px-2.5 flex items-center gap-1 border-none font-sans text-[13px] font-medium transition-colors duration-150 ease-out';
 const groupButtonInactive = 'bg-transparent text-text-secondary hover:text-text-primary hover:bg-background-tertiary';
-const groupButtonActive = 'bg-accent text-white hover:bg-accent';
+const groupButtonActive = 'bg-accent text-accent-ink hover:bg-accent';
 
 const RUNNER_DOT: Record<string, string> = {
-  running: 'bg-[#4ee82e]',
-  success: 'bg-[#4ee82e]',
-  error: 'bg-[#ff6b6b]',
-  idle: 'bg-white/30',
+  running: 'bg-status-ready',
+  success: 'bg-status-ready',
+  error: 'bg-ansi-red',
+  idle: 'bg-ink/30',
 };
 
 function PanelControls({
@@ -456,7 +456,7 @@ function PanelControls({
         onClick={() => (active ? onMinimize() : onActivate(panel.id))}
       >
         {panel.kind === 'runner' ? (
-          <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${RUNNER_DOT[panel.status] ?? 'bg-white/30'}`} />
+          <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${RUNNER_DOT[panel.status] ?? 'bg-ink/30'}`} />
         ) : (
           <Icon name={panelIcon(panel)} className="w-3.5 h-3.5 shrink-0" />
         )}
@@ -468,7 +468,7 @@ function PanelControls({
             e.stopPropagation();
             onClosePanel(panel.id);
           }}
-          className="-mr-1 ml-0.5 w-4 h-4 flex items-center justify-center rounded shrink-0 opacity-0 group-hover/seg:opacity-100 hover:bg-white/15 transition-all duration-150 [&>svg]:w-3 [&>svg]:h-3"
+          className="-mr-1 ml-0.5 w-4 h-4 flex items-center justify-center rounded shrink-0 opacity-0 group-hover/seg:opacity-100 hover:bg-ink/15 transition-all duration-150 [&>svg]:w-3 [&>svg]:h-3"
         >
           <Icon name="x" />
         </span>
@@ -488,8 +488,8 @@ function PanelControls({
             <span>
               {dirtyFileCount} {dirtyFileCount === 1 ? 'file' : 'files'}
             </span>
-            {insertions > 0 && <span className={diffPanelOpen ? '' : 'text-[#4ee82e]'}>+{insertions}</span>}
-            {deletions > 0 && <span className={diffPanelOpen ? '' : 'text-[#ff6b6b]'}>-{deletions}</span>}
+            {insertions > 0 && <span className={diffPanelOpen ? '' : 'text-status-ready'}>+{insertions}</span>}
+            {deletions > 0 && <span className={diffPanelOpen ? '' : 'text-ansi-red'}>-{deletions}</span>}
           </>
         ) : (
           <span>Compare</span>
@@ -511,10 +511,10 @@ function PanelControls({
   );
 
   return (
-    <div className="inline-flex items-center h-7 bg-background-secondary glass-bevel relative border border-black/60 rounded-[12px] overflow-hidden">
+    <div className="inline-flex items-center h-7 bg-background-secondary glass-bevel relative border border-bezel rounded-[12px] overflow-hidden">
       {slots.map((slot, i) => (
         <Fragment key={i}>
-          {i > 0 && <div aria-hidden className="w-px h-3 bg-white/10 self-center" />}
+          {i > 0 && <div aria-hidden className="w-px h-3 bg-ink/10 self-center" />}
           {slot}
         </Fragment>
       ))}

--- a/src/components/terminal/TerminalHeaderView.tsx
+++ b/src/components/terminal/TerminalHeaderView.tsx
@@ -6,7 +6,7 @@ import { StatusDot } from './StatusDot';
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
 
 const METADATA_CHIP =
-  'inline-flex items-center gap-1 font-mono text-[11px] font-medium text-white/55 bg-white/[0.05] rounded-full px-2 py-0.5 shrink-0';
+  'inline-flex items-center gap-1 font-mono text-[11px] font-medium text-ink/55 bg-ink/[0.05] rounded-full px-2 py-0.5 shrink-0';
 
 export interface TerminalHeaderViewProps {
   summaryType: string;
@@ -71,7 +71,7 @@ export function TerminalHeaderView({
           <div className="group/meta flex items-center gap-2 min-w-0">
             <StatusDot summaryType={summaryType} sandboxProvider={sandboxProvider} />
             {!isActive && stackPosition != null && stackPosition <= 9 && (
-              <kbd className="inline-flex items-center font-mono text-base text-white/40 shrink-0">
+              <kbd className="inline-flex items-center font-mono text-base text-ink/40 shrink-0">
                 {isMac ? '⌘' : '⌃'}
                 <span className="text-xs">{stackPosition}</span>
               </kbd>
@@ -85,7 +85,7 @@ export function TerminalHeaderView({
           {actions}
           {showCloseButton && (
             <button
-              className="w-7 h-7 flex items-center justify-center bg-transparent border-none text-white/40 hover:text-white/90 transition-colors duration-150 ml-1 [&_svg]:w-4 [&_svg]:h-4"
+              className="w-7 h-7 flex items-center justify-center bg-transparent border-none text-ink/40 hover:text-ink/90 transition-colors duration-150 ml-1 [&_svg]:w-4 [&_svg]:h-4"
               onClick={onClose}
             >
               <Icon name="x" />
@@ -105,9 +105,9 @@ export function TerminalHeaderView({
 export function TerminalHeaderName({ label, lastOscTitle }: { label?: string; lastOscTitle?: string }) {
   return (
     <Fragment>
-      {label && <span className="font-mono text-xs font-medium text-white/85 shrink-0">{label}</span>}
+      {label && <span className="font-mono text-xs font-medium text-ink/85 shrink-0">{label}</span>}
       {lastOscTitle && (
-        <span className="font-mono text-xs font-medium text-white/40 min-w-0 truncate">{lastOscTitle}</span>
+        <span className="font-mono text-xs font-medium text-ink/40 min-w-0 truncate">{lastOscTitle}</span>
       )}
     </Fragment>
   );

--- a/src/components/terminal/XTermContainer.tsx
+++ b/src/components/terminal/XTermContainer.tsx
@@ -53,7 +53,7 @@ export function XTermContainer({ ptyId, className, style }: XTermContainerProps)
     <div
       ref={containerRef}
       className={className ?? 'terminal-xterm-container flex-1 min-h-0 min-w-0 overflow-hidden pt-4 pl-4 pr-2 pb-2'}
-      style={{ background: 'var(--color-terminal-bg, #171717)', ...style }}
+      style={{ background: 'var(--color-terminal-bg)', ...style }}
     />
   );
 }

--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -9,6 +9,8 @@
 import { Terminal as XTerminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
+import { subscribeTheme } from '../../theme/themeManager';
+import { buildXtermTheme } from '../../theme/xtermTheme';
 import type { PtyId, PtySpawnOptions, GitFileStatus, SandboxProviderId } from '../../types';
 import { isActiveSandbox } from '../../types';
 import { notifyReady, readyBody } from '../../utils/notifications';
@@ -62,35 +64,6 @@ export function scheduleAutoCloseOnSuccess(ptyId: PtyId, isDisposed: () => boole
     if (isDisposed()) return;
     closeProjectTerminal(ptyId);
   }, AUTO_CLOSE_GRACE_MS);
-}
-
-function getTerminalTheme(): Record<string, string> {
-  return {
-    background: '#171717',
-    foreground: '#e4e4e4',
-    cursor: '#e4e4e4',
-    cursorAccent: '#171717',
-    selectionBackground: 'rgba(255, 255, 255, 0.15)',
-    scrollbarSliderBackground: 'rgba(255, 255, 255, 0.15)',
-    scrollbarSliderHoverBackground: 'rgba(255, 255, 255, 0.3)',
-    scrollbarSliderActiveBackground: 'rgba(255, 255, 255, 0.4)',
-    black: '#171717',
-    red: '#ff6b6b',
-    green: '#69db7c',
-    yellow: '#ffd43b',
-    blue: '#74c0fc',
-    magenta: '#da77f2',
-    cyan: '#66d9e8',
-    white: '#e4e4e4',
-    brightBlack: '#5c5c5c',
-    brightRed: '#ff8787',
-    brightGreen: '#8ce99a',
-    brightYellow: '#ffe066',
-    brightBlue: '#a5d8ff',
-    brightMagenta: '#e599f7',
-    brightCyan: '#99e9f2',
-    brightWhite: '#ffffff',
-  };
 }
 
 // Platform detection
@@ -232,6 +205,18 @@ export function resolveTerminalLabel(
 
 /** Global registry of OuijitTerminal instances by ptyId */
 export const terminalInstances = new Map<string, OuijitTerminal>();
+
+// Re-skin every live terminal (including runner children not yet in the
+// registry) when the resolved theme changes — xterm repaints on assignment.
+subscribeTheme(() => {
+  const theme = buildXtermTheme();
+  for (const instance of terminalInstances.values()) {
+    instance.xterm.options.theme = theme;
+    for (const child of instance.runnerChildren.values()) {
+      child.xterm.options.theme = theme;
+    }
+  }
+});
 
 // ── Terminal font (global setting cache) ─────────────────────────────
 
@@ -469,7 +454,7 @@ export class OuijitTerminal {
 
     // Create xterm instance
     this.xterm = new XTerminal({
-      theme: getTerminalTheme(),
+      theme: buildXtermTheme(),
       fontFamily: cachedTerminalFontFamily,
       fontSize: cachedTerminalFontSize,
       lineHeight: 1.2,

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -30,12 +30,12 @@ interface ContextMenuProps {
 }
 
 const ITEM_CLASS =
-  'context-menu-item w-full px-2.5 py-1.5 rounded-[7px] text-xs text-text-primary bg-transparent border-none text-left transition-colors duration-100 ease-out flex items-center gap-1.5 whitespace-nowrap hover:bg-white/[0.08] [&>svg]:w-3 [&>svg]:h-3 [&>svg]:opacity-60';
+  'context-menu-item w-full px-2.5 py-1.5 rounded-[7px] text-xs text-text-primary bg-transparent border-none text-left transition-colors duration-100 ease-out flex items-center gap-1.5 whitespace-nowrap hover:bg-ink/[0.08] [&>svg]:w-3 [&>svg]:h-3 [&>svg]:opacity-60';
 
-const PANEL_CLASS = 'p-1 glass-bevel border border-black/60 rounded-[12px]';
+const PANEL_CLASS = 'p-1 glass-bevel border border-bezel rounded-[12px]';
 const PANEL_STYLE = {
-  background: 'var(--color-terminal-bg, #171717)',
-  boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 10px 30px rgba(0, 0, 0, 0.35)',
+  background: 'var(--color-terminal-bg)',
+  boxShadow: 'var(--shadow-menu)',
 } as const;
 
 /** Renders the entries of a menu (or submenu). `onSelect` fires a leaf action. */
@@ -52,7 +52,7 @@ function MenuList({
     <>
       {items.map((item, i) => {
         if ('separator' in item) {
-          return <div key={`sep-${i}`} className="border-t border-white/10 mx-1 my-1" />;
+          return <div key={`sep-${i}`} className="border-t border-ink/10 mx-1 my-1" />;
         }
         if ('submenu' in item) {
           return (

--- a/src/components/ui/SettingsDropdown.tsx
+++ b/src/components/ui/SettingsDropdown.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef, type CSSProperties, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { useFloating, offset, flip, shift, autoUpdate } from '@floating-ui/react';
+import { Icon } from '../terminal/Icon';
+
+interface SettingsDropdownProps {
+  open: boolean;
+  /** Pass the state setter directly; a stable identity keeps the outside-click listener from re-binding per render. */
+  onOpenChange: (open: boolean) => void;
+  /** Tailwind width class applied to both the trigger and the menu, e.g. 'w-[13rem]'. */
+  widthClass: string;
+  ariaLabel: string;
+  triggerLabel: ReactNode;
+  triggerStyle?: CSSProperties;
+  onMenuMouseLeave?: () => void;
+  children: ReactNode;
+}
+
+/**
+ * Settings-row dropdown: a fixed-width trigger button and a portaled,
+ * floating listbox. Owns the floating-ui wiring, click-outside, and Escape
+ * handling shared by the settings-panel pickers (theme, terminal font).
+ */
+export function SettingsDropdown({
+  open,
+  onOpenChange,
+  widthClass,
+  ariaLabel,
+  triggerLabel,
+  triggerStyle,
+  onMenuMouseLeave,
+  children,
+}: SettingsDropdownProps) {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const { refs, floatingStyles } = useFloating({
+    placement: 'bottom-end',
+    strategy: 'fixed',
+    middleware: [offset(6), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+  });
+
+  useEffect(() => {
+    if (triggerRef.current) refs.setReference(triggerRef.current);
+  }, [refs]);
+
+  // Click-outside, deferred a tick so the click that opened the menu
+  // doesn't immediately close it.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (dropdownRef.current?.contains(target)) return;
+      if (triggerRef.current?.contains(target)) return;
+      onOpenChange(false);
+    };
+    const timer = setTimeout(() => document.addEventListener('mousedown', handler), 0);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handler);
+    };
+  }, [open, onOpenChange]);
+
+  // Escape
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onOpenChange(false);
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open, onOpenChange]);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        className={`${widthClass} shrink-0 flex items-center justify-between gap-2 px-3 py-1.5 text-sm bg-ink/[0.04] border border-ink/10 rounded-md text-text-primary hover:bg-ink/[0.06] outline-none focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent-light`}
+      >
+        <span className="truncate" style={triggerStyle}>
+          {triggerLabel}
+        </span>
+        <Icon name="caret-down" className="w-3.5 h-3.5 text-text-tertiary shrink-0" />
+      </button>
+      {open &&
+        createPortal(
+          <div
+            ref={(el) => {
+              dropdownRef.current = el;
+              refs.setFloating(el);
+            }}
+            role="listbox"
+            aria-label={ariaLabel}
+            onMouseLeave={onMenuMouseLeave}
+            style={{
+              ...floatingStyles,
+              background: 'var(--color-terminal-bg)',
+              boxShadow: 'var(--shadow-menu)',
+            }}
+            className={`${widthClass} max-h-[24rem] overflow-y-auto border border-bezel rounded-[12px] z-[1000] p-1`}
+          >
+            {children}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+interface SettingsDropdownOptionProps {
+  label: string;
+  hint?: string;
+  fontFamily?: string;
+  selected: boolean;
+  onClick: () => void;
+  onMouseEnter?: () => void;
+}
+
+export function SettingsDropdownOption({
+  label,
+  hint,
+  fontFamily,
+  selected,
+  onClick,
+  onMouseEnter,
+}: SettingsDropdownOptionProps) {
+  return (
+    <button
+      role="option"
+      aria-selected={selected}
+      onMouseEnter={onMouseEnter}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        onClick();
+      }}
+      className={`w-full text-left px-2.5 py-1.5 rounded-[7px] text-sm flex items-center gap-2 hover:bg-ink/[0.08] transition-colors duration-100 ${
+        selected ? 'text-text-primary bg-ink/[0.04]' : 'text-text-secondary'
+      }`}
+    >
+      <span className="flex-1 truncate" style={fontFamily ? { fontFamily } : undefined}>
+        {label}
+      </span>
+      {hint && <span className="text-[11px] text-text-tertiary shrink-0">{hint}</span>}
+      {selected && <Icon name="check" className="w-3.5 h-3.5 text-text-primary shrink-0" />}
+    </button>
+  );
+}
+
+export function SettingsDropdownDivider() {
+  return <div className="my-1 mx-1 border-t border-ink/[0.06]" />;
+}

--- a/src/components/ui/ToastContainer.tsx
+++ b/src/components/ui/ToastContainer.tsx
@@ -10,7 +10,7 @@ import { Icon } from '../terminal/Icon';
 const TYPE_BADGE: Record<'info' | 'success' | 'error', { icon: string; className: string }> = {
   success: { icon: 'check', className: 'bg-success/15 text-success' },
   error: { icon: 'prohibit', className: 'bg-error/15 text-error' },
-  info: { icon: 'info', className: 'bg-white/[0.08] text-text-secondary' },
+  info: { icon: 'info', className: 'bg-ink/[0.08] text-text-secondary' },
 };
 
 export function ToastContainer() {
@@ -28,13 +28,12 @@ export function ToastContainer() {
         return (
           <div
             key={toast.id}
-            className="glass-bevel animate-toast-in pointer-events-auto relative flex items-center gap-2.5 max-w-[90vw] py-2.5 pl-2.5 pr-3.5 rounded-[14px] border border-black/60 text-sm text-text-primary"
+            className="glass-bevel animate-toast-in pointer-events-auto relative flex items-center gap-2.5 max-w-[90vw] py-2.5 pl-2.5 pr-3.5 rounded-[14px] border border-bezel text-sm text-text-primary"
             style={{
               background: 'var(--color-surface)',
               backdropFilter: 'blur(20px)',
               WebkitBackdropFilter: 'blur(20px)',
-              boxShadow:
-                '0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.2), 0 16px 32px rgba(0, 0, 0, 0.28)',
+              boxShadow: 'var(--shadow-toast)',
             }}
           >
             <span className={`flex items-center justify-center w-5 h-5 rounded-full shrink-0 ${badge.className}`}>
@@ -43,7 +42,7 @@ export function ToastContainer() {
             <span className="leading-snug">{toast.message}</span>
             {toast.actionLabel && toast.onAction && (
               <button
-                className="ml-1 shrink-0 px-2.5 py-1 text-xs font-medium rounded-full bg-white/[0.08] hover:bg-white/[0.12] active:bg-white/[0.05] transition-colors duration-150 [-webkit-app-region:no-drag]"
+                className="ml-1 shrink-0 px-2.5 py-1 text-xs font-medium rounded-full bg-ink/[0.08] hover:bg-ink/[0.12] active:bg-ink/[0.05] transition-colors duration-150 [-webkit-app-region:no-drag]"
                 onClick={() => {
                   toast.onAction?.();
                   removeToast(toast.id);
@@ -54,7 +53,7 @@ export function ToastContainer() {
             )}
             {toast.persistent && (
               <button
-                className="ml-0.5 shrink-0 flex items-center justify-center w-5 h-5 rounded-full text-text-tertiary hover:text-text-secondary hover:bg-white/[0.06] active:bg-white/[0.03] transition-colors duration-150 [-webkit-app-region:no-drag]"
+                className="ml-0.5 shrink-0 flex items-center justify-center w-5 h-5 rounded-full text-text-tertiary hover:text-text-secondary hover:bg-ink/[0.06] active:bg-ink/[0.03] transition-colors duration-150 [-webkit-app-region:no-drag]"
                 onClick={() => removeToast(toast.id)}
                 aria-label="Dismiss"
               >

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -77,7 +77,7 @@ export function Tooltip({
             style={floatingStyles}
             {...getFloatingProps()}
           >
-            <div className="px-3 py-1.5 text-[13px] font-medium text-text-primary bg-terminal-surface border border-ink/10 rounded-md shadow-lg whitespace-nowrap animate-tooltip-pop">
+            <div className="px-3 py-1.5 text-[13px] font-medium text-text-primary bg-terminal-surface border border-ink/10 rounded-md shadow-tooltip whitespace-nowrap animate-tooltip-pop">
               {text}
             </div>
           </div>,

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -77,7 +77,7 @@ export function Tooltip({
             style={floatingStyles}
             {...getFloatingProps()}
           >
-            <div className="px-3 py-1.5 text-[13px] font-medium text-white bg-neutral-800 border border-white/10 rounded-md shadow-lg whitespace-nowrap animate-tooltip-pop">
+            <div className="px-3 py-1.5 text-[13px] font-medium text-text-primary bg-terminal-surface border border-ink/10 rounded-md shadow-lg whitespace-nowrap animate-tooltip-pop">
               {text}
             </div>
           </div>,

--- a/src/components/ui/TooltipButton.tsx
+++ b/src/components/ui/TooltipButton.tsx
@@ -72,7 +72,7 @@ export function TooltipButton({
             style={floatingStyles}
             {...getFloatingProps()}
           >
-            <div className="px-3 py-1.5 text-[13px] font-medium text-text-primary bg-terminal-surface border border-ink/10 rounded-md shadow-lg whitespace-nowrap animate-tooltip-pop">
+            <div className="px-3 py-1.5 text-[13px] font-medium text-text-primary bg-terminal-surface border border-ink/10 rounded-md shadow-tooltip whitespace-nowrap animate-tooltip-pop">
               {text}
             </div>
           </div>,

--- a/src/components/ui/TooltipButton.tsx
+++ b/src/components/ui/TooltipButton.tsx
@@ -72,7 +72,7 @@ export function TooltipButton({
             style={floatingStyles}
             {...getFloatingProps()}
           >
-            <div className="px-3 py-1.5 text-[13px] font-medium text-white bg-neutral-800 border border-white/10 rounded-md shadow-lg whitespace-nowrap animate-tooltip-pop">
+            <div className="px-3 py-1.5 text-[13px] font-medium text-text-primary bg-terminal-surface border border-ink/10 rounded-md shadow-lg whitespace-nowrap animate-tooltip-pop">
               {text}
             </div>
           </div>,

--- a/src/components/webPreview/WebPreviewPanel.tsx
+++ b/src/components/webPreview/WebPreviewPanel.tsx
@@ -181,7 +181,7 @@ export function WebPreviewPanel({
         <TooltipButton
           text="Back"
           placement="bottom"
-          className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/60 shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90 disabled:text-white/20 disabled:hover:bg-transparent [&>svg]:w-3.5 [&>svg]:h-3.5"
+          className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-ink/60 shrink-0 transition-all duration-150 ease-out hover:bg-ink/10 hover:text-ink/90 disabled:text-ink/20 disabled:hover:bg-transparent [&>svg]:w-3.5 [&>svg]:h-3.5"
           onClick={handleBack}
           disabled={!canGoBack}
         >
@@ -190,7 +190,7 @@ export function WebPreviewPanel({
         <TooltipButton
           text="Forward"
           placement="bottom"
-          className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/60 shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90 disabled:text-white/20 disabled:hover:bg-transparent [&>svg]:w-3.5 [&>svg]:h-3.5"
+          className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-ink/60 shrink-0 transition-all duration-150 ease-out hover:bg-ink/10 hover:text-ink/90 disabled:text-ink/20 disabled:hover:bg-transparent [&>svg]:w-3.5 [&>svg]:h-3.5"
           onClick={handleForward}
           disabled={!canGoForward}
         >
@@ -199,7 +199,7 @@ export function WebPreviewPanel({
         <TooltipButton
           text={loading ? 'Stop' : 'Reload'}
           placement="bottom"
-          className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-white/60 shrink-0 transition-all duration-150 ease-out hover:bg-white/10 hover:text-white/90 [&>svg]:w-3.5 [&>svg]:h-3.5"
+          className="w-7 h-7 flex items-center justify-center p-0 bg-transparent border-none rounded-md text-ink/60 shrink-0 transition-all duration-150 ease-out hover:bg-ink/10 hover:text-ink/90 [&>svg]:w-3.5 [&>svg]:h-3.5"
           onClick={loading ? () => webviewRef.current?.stop() : handleReload}
         >
           <Icon name={loading ? 'x' : 'arrows-clockwise'} />
@@ -218,11 +218,11 @@ export function WebPreviewPanel({
               }
             }}
             placeholder="http://localhost:3000"
-            className="text-[13px] text-white/80 flex-1 min-w-0 font-mono bg-white/5 border border-white/10 rounded px-2 py-0.5 outline-none focus:border-accent [-webkit-app-region:no-drag]"
+            className="text-[13px] text-ink/80 flex-1 min-w-0 font-mono bg-ink/5 border border-ink/10 rounded px-2 py-0.5 outline-none focus:border-accent [-webkit-app-region:no-drag]"
           />
         ) : (
           <button
-            className="text-[13px] text-white/60 truncate flex-1 min-w-0 font-mono bg-transparent border-none py-0.5 px-2 text-left transition-colors duration-150 hover:text-white/90 rounded"
+            className="text-[13px] text-ink/60 truncate flex-1 min-w-0 font-mono bg-transparent border-none py-0.5 px-2 text-left transition-colors duration-150 hover:text-ink/90 rounded"
             title={currentUrl}
             onClick={startEditingUrl}
           >
@@ -249,17 +249,17 @@ export function WebPreviewPanel({
             }}
           />
         ) : (
-          <div className="absolute inset-0 flex items-center justify-center text-sm text-white/40 bg-[var(--color-terminal-bg,#171717)]">
+          <div className="absolute inset-0 flex items-center justify-center text-sm text-ink/40 bg-terminal-bg">
             Enter a URL above to preview it
           </div>
         )}
         {loadError && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-sm text-white/70 bg-[var(--color-terminal-bg,#171717)] p-6 text-center">
-            <Icon name="globe-simple" className="w-8 h-8 text-white/30" />
-            <div className="font-mono text-white/80">{loadError}</div>
-            <div className="font-mono text-[11px] text-white/40 break-all">{currentUrl}</div>
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-sm text-ink/70 bg-terminal-bg p-6 text-center">
+            <Icon name="globe-simple" className="w-8 h-8 text-ink/30" />
+            <div className="font-mono text-ink/80">{loadError}</div>
+            <div className="font-mono text-[11px] text-ink/40 break-all">{currentUrl}</div>
             <button
-              className="mt-2 px-3 py-1 rounded-md bg-white/10 hover:bg-white/15 text-white/80 text-xs border-none transition-colors"
+              className="mt-2 px-3 py-1 rounded-md bg-ink/10 hover:bg-ink/15 text-ink/80 text-xs border-none transition-colors"
               onClick={handleReload}
             >
               Retry

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -430,6 +430,17 @@ ouijit preview remove <url>                   # close that preview panel
 ## Project Commands
 ouijit project list                           # → all registered projects
 
+## Theme Commands (global appearance, not project-scoped)
+ouijit theme list                             # → {preference, presets: [...], customThemes: [...]}
+ouijit theme use <theme>                      # system | light | dark | a preset/custom id (e.g. dracula)
+ouijit theme save '<json>'                    # create or update a custom theme (also: --file <path.json>)
+ouijit theme delete <id>                      # remove a custom theme
+
+# A theme is design-token overrides on a "dark" or "light" base:
+# {"id":"my-theme","name":"My Theme","base":"dark","tokens":{"--color-accent":"#ff2d55"}}
+# The presets in \`ouijit theme list\` show the full token vocabulary (colors,
+# ANSI palette, shadows). Saving an id that matches a preset overrides it.
+
 ## Key Behaviors
 - All mutating commands notify the Ouijit app UI in real-time.
 - Task statuses: todo → in_progress → in_review → done (set any directly).

--- a/src/hooks/useIPCListeners.ts
+++ b/src/hooks/useIPCListeners.ts
@@ -9,6 +9,7 @@ import {
 import { useTerminalStore } from '../stores/terminalStore';
 import { beginTransition } from '../services/taskStartService';
 import { completeTask } from '../services/taskCompletion';
+import { reloadTheme } from '../theme/themeManager';
 import log from 'electron-log/renderer';
 
 const ipcLog = log.scope('ipcListeners');
@@ -169,6 +170,15 @@ export function useIPCListeners() {
             useProjectStore.getState().addToast(payload.message, 'info');
           }
         }
+      }),
+    );
+
+    // CLI theme mutation — the main process wrote global settings directly,
+    // so re-read and re-apply the theme.
+    cleanups.push(
+      window.api.onCliThemeChanged(() => {
+        ipcLog.info('CLI theme change detected, reloading theme');
+        void reloadTheme();
       }),
     );
 

--- a/src/hooks/useResolvedTheme.ts
+++ b/src/hooks/useResolvedTheme.ts
@@ -1,8 +1,18 @@
 import { useSyncExternalStore } from 'react';
-import { subscribeTheme, getResolvedTheme } from '../theme/themeManager';
+import { subscribeTheme, getResolvedTheme, getThemeEpoch } from '../theme/themeManager';
 import type { ResolvedThemeBase } from '../theme/themes';
 
 /** The currently rendered base theme; re-renders the component on change. */
 export function useResolvedTheme(): ResolvedThemeBase {
   return useSyncExternalStore(subscribeTheme, getResolvedTheme);
+}
+
+/**
+ * Re-renders on every applied-theme change, including between two themes
+ * with the same base, which useResolvedTheme cannot see. Use this in
+ * components that read token values (readToken/getComputedStyle) at render
+ * time.
+ */
+export function useThemeEpoch(): number {
+  return useSyncExternalStore(subscribeTheme, getThemeEpoch);
 }

--- a/src/hooks/useResolvedTheme.ts
+++ b/src/hooks/useResolvedTheme.ts
@@ -1,0 +1,8 @@
+import { useSyncExternalStore } from 'react';
+import { subscribeTheme, getResolvedTheme } from '../theme/themeManager';
+import type { ResolvedThemeBase } from '../theme/themes';
+
+/** The currently rendered base theme; re-renders the component on change. */
+export function useResolvedTheme(): ResolvedThemeBase {
+  return useSyncExternalStore(subscribeTheme, getResolvedTheme);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,8 @@
+/* All design tokens (colors, shadows, spacing, typography, theming) live in
+   src/theme/tokens.css. This file holds base styles, animations, and
+   third-party overrides — none of which should declare raw colors. */
+@import './theme/tokens.css';
+
 @font-face {
   font-family: 'Iosevka Extended';
   font-style: normal;
@@ -15,96 +20,6 @@
 }
 
 /* ===================================
-   ouijit - Apple-Inspired Design System
-   Tailwind CSS v4 Theme Configuration
-   =================================== */
-
-@theme {
-  /* Colors - Dark Mode Only */
-  --color-background: #1c1c1e;
-  --color-background-secondary: rgba(255, 255, 255, 0.06);
-  --color-background-tertiary: rgba(255, 255, 255, 0.12);
-  --color-surface: #2c2c2e;
-  --color-text-primary: #f5f5f7;
-  --color-text-secondary: #98989d;
-  --color-text-tertiary: #636366;
-  --color-border: rgba(255, 255, 255, 0.1);
-  --color-border-hover: rgba(255, 255, 255, 0.15);
-
-  /* Accent / brand — Ouijit blue. App-wide accent: links, selection, focus
-     rings, primary buttons, the homepage Run button. --color-accent-ink is the
-     text color on filled accent buttons. */
-  --color-accent: #0a84ff;
-  --color-accent-hover: #409cff;
-  --color-accent-light: rgba(10, 132, 255, 0.2);
-  --color-accent-ink: #ffffff;
-
-  /* Status Colors */
-  --color-git: #ff6b4a;
-  --color-git-light: rgba(255, 107, 74, 0.15);
-  --color-claude: #f59e0b;
-  --color-claude-light: rgba(245, 158, 11, 0.15);
-  --color-success: #30d158;
-  --color-success-subtle: rgba(48, 209, 88, 0.15);
-  --color-error: #ff453a;
-
-  /* Shadows */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
-  --shadow-hover: 0 12px 32px rgba(0, 0, 0, 0.6);
-
-  /* Spacing */
-  --spacing-xs: 4px;
-  --spacing-sm: 8px;
-  --spacing-md: 16px;
-  --spacing-lg: 24px;
-  --spacing-xl: 32px;
-  --spacing-2xl: 48px;
-
-  /* Border Radius */
-  --radius-sm: 8px;
-  --radius-md: 12px;
-  --radius-lg: 16px;
-  --radius-xl: 24px;
-  --radius-full: 9999px;
-
-  /* Typography */
-  --font-family:
-    system-ui, -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text', 'Helvetica Neue', Arial, sans-serif;
-  --font-mono: 'Iosevka Extended', 'SF Mono', Monaco, Menlo, monospace;
-  --font-size-xs: 13px;
-  --font-size-sm: 16px;
-  --font-size-base: 18px;
-  --font-size-md: 18px;
-  --font-size-lg: 20px;
-  --font-size-xl: 26px;
-  --font-size-2xl: 34px;
-  --font-weight-normal: 400;
-  --font-weight-medium: 500;
-  --font-weight-semibold: 600;
-  --font-weight-bold: 700;
-
-  /* Transitions */
-  --transition-fast: 150ms ease;
-  --transition-normal: 200ms ease;
-  --transition-slow: 300ms ease;
-
-  /* Layout */
-  --header-height: 72px;
-  --sidebar-width: 72px;
-  --content-max-width: 1200px;
-  --content-padding: 24px;
-
-  /* Animations */
-  --animate-tooltip-pop: tooltip-pop 80ms ease-out forwards;
-  --animate-toast-in: toast-in 240ms cubic-bezier(0.32, 0.72, 0, 1) both;
-
-  /* Terminal */
-  --color-terminal-bg: #171717;
-}
-
-/* ===================================
    Base Styles & Reset
    =================================== */
 
@@ -112,7 +27,6 @@ html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
-  color-scheme: dark;
   overflow: hidden;
   /* Paint the themed background on the root element too, not just <body>.
      During async window resize macOS exposes newly grown pixels before the
@@ -156,12 +70,12 @@ textarea,
 }
 
 .settings-scrollable::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--terminal-scrollbar);
   border-radius: 3px;
 }
 
 .settings-scrollable::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.25);
+  background: var(--terminal-scrollbar-hover);
 }
 
 /* ===================================
@@ -195,13 +109,13 @@ textarea,
   }
 
   .btn-secondary {
-    @apply inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none outline-none text-text-primary transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-white/15 active:scale-[0.98] disabled:opacity-50;
+    @apply inline-flex items-center justify-center gap-2 px-4 py-1.5 font-sans text-sm font-medium no-underline border-none outline-none text-text-primary transition-all duration-150 ease-out [-webkit-app-region:no-drag] focus-visible:ring-3 focus-visible:ring-ink/15 active:scale-[0.98] disabled:opacity-50;
     border-radius: 9999px;
-    background: rgba(255, 255, 255, 0.06);
+    background: var(--color-background-secondary);
   }
 
   .btn-secondary:hover:not(:disabled) {
-    background: rgba(255, 255, 255, 0.1);
+    background: var(--color-background-tertiary);
   }
 }
 
@@ -480,11 +394,11 @@ textarea,
   pointer-events: none;
   border-radius: inherit;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.14),
-    inset 1px 0 0 rgba(255, 255, 255, 0.05),
-    inset -1px 0 0 rgba(255, 255, 255, 0.05),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.5),
-    inset 0 2px 6px -3px rgba(255, 255, 255, 0.08);
+    inset 0 1px 0 var(--bevel-top),
+    inset 1px 0 0 var(--bevel-side),
+    inset -1px 0 0 var(--bevel-side),
+    inset 0 -1px 0 var(--bevel-bottom),
+    inset 0 2px 6px -3px var(--bevel-glow);
   z-index: 1;
 }
 
@@ -539,10 +453,10 @@ textarea,
 }
 
 .react-flow__node.react-flow__node-terminal:not(.selected):hover .terminal-drag-handle {
-  background-color: rgba(255, 255, 255, 0.025);
+  background-color: color-mix(in srgb, var(--color-ink) 2.5%, transparent);
   box-shadow:
-    inset 0 -1px 0 rgba(0, 0, 0, 0.45),
-    0 1px 0 rgba(255, 255, 255, 0.06);
+    inset 0 -1px 0 var(--bevel-bottom),
+    0 1px 0 color-mix(in srgb, var(--color-ink) 6%, transparent);
 }
 
 /* Resize handle hover / active affordance (targets NodeResizer corners) */
@@ -590,23 +504,23 @@ textarea,
    =================================== */
 
 .plan-markdown {
-  @apply text-sm text-white/80 leading-relaxed;
+  @apply text-sm text-ink/80 leading-relaxed;
 }
 
 .plan-markdown h1 {
-  @apply text-lg font-semibold text-white mt-0 mb-3;
+  @apply text-lg font-semibold text-text-primary mt-0 mb-3;
 }
 
 .plan-markdown h2 {
-  @apply text-base font-semibold text-white mt-6 mb-2;
+  @apply text-base font-semibold text-text-primary mt-6 mb-2;
 }
 
 .plan-markdown h3 {
-  @apply text-sm font-semibold text-white mt-4 mb-1;
+  @apply text-sm font-semibold text-text-primary mt-4 mb-1;
 }
 
 .plan-markdown h4 {
-  @apply text-sm font-medium text-white/90 mt-3 mb-1;
+  @apply text-sm font-medium text-ink/90 mt-3 mb-1;
 }
 
 .plan-markdown p {
@@ -638,19 +552,19 @@ textarea,
 .plan-markdown code {
   @apply px-1 py-0.5 rounded text-[13px] font-mono;
   background: var(--color-background-secondary);
-  color: #ff6b6b;
+  color: var(--color-ansi-red);
 }
 
 .plan-markdown pre {
-  @apply relative my-3 p-3 rounded-[14px] border border-black/60 bg-white/[0.06] overflow-x-auto;
+  @apply relative my-3 p-3 rounded-[14px] border border-bezel bg-ink/[0.06] overflow-x-auto;
 }
 
 .plan-markdown pre code {
-  @apply p-0 bg-transparent text-white/70;
+  @apply p-0 bg-transparent text-ink/70;
 }
 
 .plan-markdown blockquote {
-  @apply my-2 pl-3 border-l-2 border-white/20 text-white/60;
+  @apply my-2 pl-3 border-l-2 border-ink/20 text-ink/60;
 }
 
 .plan-markdown a {
@@ -660,11 +574,13 @@ textarea,
 /* File ref — muted by default, transitions when existence is resolved */
 .plan-markdown a.file-ref {
   @apply no-underline;
-  color: rgba(255, 255, 255, 0.4);
+  color: color-mix(in srgb, var(--color-ink) 40%, transparent);
   transition: color 0.4s ease;
 }
 
-/* Shared tooltip for resolved file refs */
+/* Shared tooltip for resolved file refs. Deliberately theme-independent:
+   the embedded SVG icons are baked white in data URIs, so the tooltip keeps
+   a dark chrome in every theme. */
 .plan-markdown a.file-ref[data-file-exists] {
   position: relative;
 }
@@ -733,11 +649,11 @@ textarea,
 }
 
 .plan-markdown strong {
-  @apply text-white font-medium;
+  @apply text-text-primary font-medium;
 }
 
 .plan-markdown hr {
-  @apply my-4 border-white/10;
+  @apply my-4 border-ink/10;
 }
 
 .plan-markdown table {
@@ -745,11 +661,11 @@ textarea,
 }
 
 .plan-markdown th {
-  @apply px-3 py-1.5 text-left text-xs font-medium text-white/60 border-b border-white/10;
+  @apply px-3 py-1.5 text-left text-xs font-medium text-ink/60 border-b border-ink/10;
 }
 
 .plan-markdown td {
-  @apply px-3 py-1.5 text-sm border-b border-white/[0.06];
+  @apply px-3 py-1.5 text-sm border-b border-ink/[0.06];
 }
 
 /* Task list checkboxes */
@@ -759,7 +675,7 @@ textarea,
 }
 
 .plan-markdown input[type='checkbox'] {
-  @apply appearance-none w-4 h-4 mr-2 rounded border border-white/25 bg-white/[0.06] align-middle relative;
+  @apply appearance-none w-4 h-4 mr-2 rounded border border-ink/25 bg-ink/[0.06] align-middle relative;
   transition: all 0.15s ease-out;
 }
 
@@ -767,6 +683,8 @@ textarea,
   @apply bg-accent border-accent;
 }
 
+/* Check mark is baked white in the data URI — fine in every theme because it
+   always sits on the accent fill. */
 .plan-markdown input[type='checkbox']:checked::after {
   content: '';
   @apply absolute inset-0;
@@ -778,7 +696,7 @@ textarea,
 
 /* Shiki highlighted code blocks */
 .plan-markdown .shiki {
-  @apply relative my-3 p-3 rounded-[14px] border border-black/60 overflow-x-auto text-[13px] leading-relaxed;
+  @apply relative my-3 p-3 rounded-[14px] border border-bezel overflow-x-auto text-[13px] leading-relaxed;
 }
 
 .plan-markdown .shiki code {
@@ -788,7 +706,7 @@ textarea,
 /* Mermaid diagrams */
 .plan-markdown .mermaid-diagram {
   @apply my-4 flex justify-center overflow-x-auto rounded-lg p-3;
-  background: rgba(255, 255, 255, 0.02);
+  background: color-mix(in srgb, var(--color-ink) 2%, transparent);
 }
 
 .plan-markdown .mermaid-diagram svg {
@@ -815,6 +733,8 @@ textarea,
 .terminal-canvas .react-flow {
   --xy-background-color-default: var(--color-background);
   --xy-background-color: var(--color-background);
+  --xy-background-pattern-dots-color-default: color-mix(in srgb, var(--color-ink) 15%, transparent);
+  --xy-background-pattern-color: color-mix(in srgb, var(--color-ink) 15%, transparent);
   background-color: var(--color-background);
 }
 
@@ -841,10 +761,10 @@ textarea,
 
 /* Minimap — styled to match controls bar */
 .terminal-canvas .react-flow__minimap {
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-sm);
 }
 
 /* ── Kanban add-task form buttons ─────────────────────────────────── */
@@ -910,8 +830,8 @@ textarea,
   padding: 0 5px;
   margin: 0 1px;
   border-radius: 3px;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: color-mix(in srgb, var(--color-ink) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-ink) 6%, transparent);
   color: var(--color-text-secondary);
   font-family: 'Iosevka Term Extended', ui-monospace, monospace;
   font-size: 11px;

--- a/src/index.css
+++ b/src/index.css
@@ -555,12 +555,15 @@ textarea,
   color: var(--color-ansi-red);
 }
 
+/* The pre is the visual frame (border, bevel); the inner code is the scroll
+   container. If the pre itself scrolled, the absolutely-positioned
+   .glass-bevel::before overlay would scroll away with the content. */
 .plan-markdown pre {
-  @apply relative my-3 p-3 rounded-[14px] border border-bezel bg-ink/[0.06] overflow-x-auto;
+  @apply relative my-3 p-3 rounded-[14px] border border-bezel bg-ink/[0.06] overflow-hidden;
 }
 
 .plan-markdown pre code {
-  @apply p-0 bg-transparent text-ink/70;
+  @apply block p-0 bg-transparent text-ink/70 overflow-x-auto;
 }
 
 .plan-markdown blockquote {

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -269,6 +269,8 @@ export interface IpcPushContract {
   'shell-unsupported': { args: [info: { shell: string }] };
   'whats-new': { args: [info: { version: string; notes: string }] };
   'cli-change': { args: [payload: { project: string; action: string; message?: string; ts: number }] };
+  /** A CLI theme mutation wrote global settings — re-read and re-apply. */
+  'cli:theme-changed': { args: [] };
   'cli:task-started': {
     args: [
       payload: {

--- a/src/ipc/handlers/settings.ts
+++ b/src/ipc/handlers/settings.ts
@@ -1,3 +1,4 @@
+import { BrowserWindow } from 'electron';
 import { typedHandle } from '../helpers';
 import { getGlobalSetting, setGlobalSetting } from '../../db';
 
@@ -29,6 +30,14 @@ export function registerSettingsHandlers(): void {
   typedHandle('settings:set-global', (key, value) => {
     if (!isAllowedKey(key)) return { success: false };
     if (value.length > MAX_VALUE_LENGTH) return { success: false };
+    // The renderer mirrors the resolved theme background here (see
+    // src/theme/themeManager.ts); repaint the native window chrome to match
+    // so live resize doesn't flash the previous theme's color.
+    if (key === 'ui:themeBackground' && /^#[0-9a-fA-F]{6}$/.test(value)) {
+      for (const window of BrowserWindow.getAllWindows()) {
+        window.setBackgroundColor(value);
+      }
+    }
     return setGlobalSetting(key, value);
   });
 }

--- a/src/ipc/handlers/settings.ts
+++ b/src/ipc/handlers/settings.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow } from 'electron';
 import { typedHandle } from '../helpers';
 import { getGlobalSetting, setGlobalSetting } from '../../db';
+import { WINDOW_BACKGROUND_KEY, isWindowBackgroundColor } from '../../theme/themes';
 
 /** Check if a settings key is allowed through the IPC boundary */
 function isAllowedKey(key: string): boolean {
@@ -33,7 +34,7 @@ export function registerSettingsHandlers(): void {
     // The renderer mirrors the resolved theme background here (see
     // src/theme/themeManager.ts); repaint the native window chrome to match
     // so live resize doesn't flash the previous theme's color.
-    if (key === 'ui:themeBackground' && /^#[0-9a-fA-F]{6}$/.test(value)) {
+    if (key === WINDOW_BACKGROUND_KEY && isWindowBackgroundColor(value)) {
       for (const window of BrowserWindow.getAllWindows()) {
         window.setBackgroundColor(value);
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import { initUpdater, cleanupUpdater } from './updater';
 import { checkHealth } from './healthCheck';
 import { setGlobalSetting } from './db';
 import { GlobalSettingsRepo } from './db/repos/globalSettingsRepo';
+import { THEME_PREFERENCE_KEY, WINDOW_BACKGROUND_KEY, isWindowBackgroundColor } from './theme/themes';
 import {
   CAPTURE_READY_SENTINEL,
   CAPTURE_WINDOW_HEIGHT,
@@ -103,28 +104,31 @@ if (started) {
   app.quit();
 }
 
-// Built-in theme window backgrounds — must match --color-background in
-// src/theme/tokens.css. The native window background has to match the
-// renderer theme: the WebContents surface lags behind the native frame
-// during live resize and a mismatched window background flashes through as
-// bars on the bottom and right edges.
-const DARK_WINDOW_BACKGROUND = '#1C1C1E';
-const LIGHT_WINDOW_BACKGROUND = '#F5F5F7';
+// First-launch fallbacks only: after the first theme apply the renderer
+// mirrors the exact tokens.css --color-background into `ui:themeBackground`,
+// which resolveWindowBackgroundColor prefers. The native window background
+// has to match the renderer theme: the WebContents surface lags behind the
+// native frame during live resize and a mismatched window background flashes
+// through as bars on the bottom and right edges.
+const DARK_WINDOW_BACKGROUND = '#1c1c1e';
+const LIGHT_WINDOW_BACKGROUND = '#f5f5f7';
 
 /**
  * Resolve the native window background from the persisted theme settings.
- * Custom themes mirror their resolved background into `ui:themeBackground`
- * (written by src/theme/themeManager.ts on every theme apply).
+ * Any explicit preference uses the `ui:themeBackground` mirror (written by
+ * src/theme/themeManager.ts on every theme apply), so retuning tokens.css
+ * propagates here without touching the fallback constants. 'system' can't
+ * trust the mirror: the OS appearance may have changed since the last run.
  */
 const resolveWindowBackgroundColor = (): string => {
   const settings = new GlobalSettingsRepo(getDatabase());
-  const preference = settings.get('ui:theme') ?? 'system';
+  const preference = settings.get(THEME_PREFERENCE_KEY) ?? 'system';
+  if (preference !== 'system') {
+    const stored = settings.get(WINDOW_BACKGROUND_KEY);
+    if (stored && isWindowBackgroundColor(stored)) return stored;
+  }
   if (preference === 'dark') return DARK_WINDOW_BACKGROUND;
   if (preference === 'light') return LIGHT_WINDOW_BACKGROUND;
-  if (preference.startsWith('custom:')) {
-    const stored = settings.get('ui:themeBackground');
-    if (stored && /^#[0-9a-fA-F]{6}$/.test(stored)) return stored;
-  }
   return nativeTheme.shouldUseDarkColors ? DARK_WINDOW_BACKGROUND : LIGHT_WINDOW_BACKGROUND;
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, dialog, shell } from 'electron';
+import { app, BrowserWindow, Menu, dialog, nativeTheme, shell } from 'electron';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import started from 'electron-squirrel-startup';
@@ -12,7 +12,7 @@ import { getApiPort } from './hookServer';
 import { getActiveSessionCount } from './ptyManager';
 import { typedPush } from './ipc/helpers';
 import * as fs from 'node:fs';
-import { initDatabase, closeDatabase } from './db/database';
+import { initDatabase, getDatabase, closeDatabase } from './db/database';
 import { ProjectRepo } from './db/repos/projectRepo';
 import { TaskRepo } from './db/repos/taskRepo';
 import { HookRepo } from './db/repos/hookRepo';
@@ -20,6 +20,7 @@ import { importAll } from './services/dataImportService';
 import { initUpdater, cleanupUpdater } from './updater';
 import { checkHealth } from './healthCheck';
 import { setGlobalSetting } from './db';
+import { GlobalSettingsRepo } from './db/repos/globalSettingsRepo';
 import {
   CAPTURE_READY_SENTINEL,
   CAPTURE_WINDOW_HEIGHT,
@@ -102,13 +103,33 @@ if (started) {
   app.quit();
 }
 
+// Built-in theme window backgrounds — must match --color-background in
+// src/theme/tokens.css. The native window background has to match the
+// renderer theme: the WebContents surface lags behind the native frame
+// during live resize and a mismatched window background flashes through as
+// bars on the bottom and right edges.
+const DARK_WINDOW_BACKGROUND = '#1C1C1E';
+const LIGHT_WINDOW_BACKGROUND = '#F5F5F7';
+
+/**
+ * Resolve the native window background from the persisted theme settings.
+ * Custom themes mirror their resolved background into `ui:themeBackground`
+ * (written by src/theme/themeManager.ts on every theme apply).
+ */
+const resolveWindowBackgroundColor = (): string => {
+  const settings = new GlobalSettingsRepo(getDatabase());
+  const preference = settings.get('ui:theme') ?? 'system';
+  if (preference === 'dark') return DARK_WINDOW_BACKGROUND;
+  if (preference === 'light') return LIGHT_WINDOW_BACKGROUND;
+  if (preference.startsWith('custom:')) {
+    const stored = settings.get('ui:themeBackground');
+    if (stored && /^#[0-9a-fA-F]{6}$/.test(stored)) return stored;
+  }
+  return nativeTheme.shouldUseDarkColors ? DARK_WINDOW_BACKGROUND : LIGHT_WINDOW_BACKGROUND;
+};
+
 const createWindow = (): BrowserWindow => {
-  // The renderer UI is always dark (see --color-background / color-scheme:dark
-  // in index.css), so the native window background must be dark too regardless
-  // of the system theme. Otherwise, in light mode the WebContents surface lags
-  // behind the native frame during live resize and the near-white window
-  // background flashes through as bars on the bottom and right edges.
-  const backgroundColor = '#1C1C1E';
+  const backgroundColor = resolveWindowBackgroundColor();
 
   // Create the browser window.
   const isMac = process.platform === 'darwin';

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -236,6 +236,8 @@ contextBridge.exposeInMainWorld('api', {
   onCliChange: (callback: (payload: { project: string; action: string; message?: string; ts: number }) => void) =>
     typedListen('cli-change', callback),
 
+  onCliThemeChanged: (callback: () => void) => typedListen('cli:theme-changed', callback),
+
   onCliTaskStarted: (
     callback: (payload: {
       project: string;

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -3,8 +3,14 @@ import '@xterm/xterm/css/xterm.css';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import { initIcons } from './utils/icons';
+import { initThemeSync, initTheme } from './theme/themeManager';
 import { useAppStore } from './stores/appStore';
 import { useProjectStore } from './stores/projectStore';
+
+// Apply the cached theme before first render (no dark flash for light-mode
+// users), then reconcile with the persisted settings asynchronously.
+initThemeSync();
+void initTheme();
 
 initIcons();
 

--- a/src/stores/canvasStore.ts
+++ b/src/stores/canvasStore.ts
@@ -276,8 +276,8 @@ export const useCanvasStore = create<CanvasStore>()((set, get) => ({
       style: {
         width: bounds.maxX - bounds.minX + padding * 2,
         height: bounds.maxY - bounds.minY + padding * 2,
-        background: 'rgba(255, 255, 255, 0.02)',
-        border: '1px dashed rgba(255, 255, 255, 0.1)',
+        background: 'color-mix(in srgb, var(--color-ink) 2%, transparent)',
+        border: '1px dashed color-mix(in srgb, var(--color-ink) 10%, transparent)',
         borderRadius: 16,
       },
     } as TerminalNode;

--- a/src/theme/presets.ts
+++ b/src/theme/presets.ts
@@ -1,0 +1,85 @@
+/**
+ * Built-in preset themes — bundled CustomTheme definitions selectable without
+ * any setup. A preset behaves exactly like a user custom theme (token
+ * overrides on a built-in base) but ships with the app. A user theme saved
+ * with the same id shadows the preset, so "editing" a preset really edits a
+ * user copy; deleting that copy restores the preset.
+ */
+
+import type { CustomTheme } from './themes';
+
+/** Dracula — https://draculatheme.com/contribute (official palette + ANSI). */
+const dracula: CustomTheme = {
+  id: 'dracula',
+  name: 'Dracula',
+  base: 'dark',
+  tokens: {
+    // App chrome sits on the darker Dracula background; terminals use the
+    // canonical #282a36 so cards read as raised surfaces.
+    '--color-background': '#21222c',
+    '--color-surface': '#343746',
+    '--color-surface-raised': '#2f313d',
+
+    '--color-text-primary': '#f8f8f2',
+    '--color-text-secondary': '#a0a8cc',
+    '--color-text-tertiary': '#6272a4',
+
+    '--color-accent': '#bd93f9',
+    '--color-accent-hover': '#d6acff',
+    '--color-accent-light': 'rgba(189, 147, 249, 0.2)',
+    '--color-accent-ink': '#282a36',
+
+    '--color-git': '#ffb86c',
+    '--color-git-light': 'rgba(255, 184, 108, 0.15)',
+    '--color-success': '#50fa7b',
+    '--color-success-subtle': 'rgba(80, 250, 123, 0.15)',
+    '--color-error': '#ff5555',
+    '--color-status-ready': '#50fa7b',
+    '--color-status-thinking': '#ff79c6',
+
+    '--color-terminal-bg': '#282a36',
+    '--color-terminal-fg': '#f8f8f2',
+    '--color-terminal-surface': '#343746',
+    '--color-terminal-surface-alt': '#2b2d3a',
+    '--color-terminal-inset': '#21222c',
+
+    '--color-ansi-black': '#21222c',
+    '--color-ansi-red': '#ff5555',
+    '--color-ansi-green': '#50fa7b',
+    '--color-ansi-yellow': '#f1fa8c',
+    '--color-ansi-blue': '#bd93f9',
+    '--color-ansi-magenta': '#ff79c6',
+    '--color-ansi-cyan': '#8be9fd',
+    '--color-ansi-white': '#f8f8f2',
+    '--color-ansi-bright-black': '#6272a4',
+    '--color-ansi-bright-red': '#ff6e6e',
+    '--color-ansi-bright-green': '#69ff94',
+    '--color-ansi-bright-yellow': '#ffffa5',
+    '--color-ansi-bright-blue': '#d6acff',
+    '--color-ansi-bright-magenta': '#ff92df',
+    '--color-ansi-bright-cyan': '#a4ffff',
+    '--color-ansi-bright-white': '#ffffff',
+
+    '--color-diff-fg': '#f8f8f2',
+    '--color-diff-added': '#50fa7b',
+    '--color-diff-removed': '#ff5555',
+    '--color-diff-hunk': '#bd93f9',
+    '--color-vcs-added': '#50fa7b',
+    '--color-vcs-deleted': '#ff5555',
+    '--color-vcs-renamed': '#bd93f9',
+    '--color-vcs-modified': '#ffb86c',
+
+    '--terminal-selection': 'rgba(68, 71, 90, 0.8)',
+  },
+};
+
+export const PRESET_THEMES: CustomTheme[] = [dracula];
+
+/**
+ * User themes plus the presets they don't shadow. Resolution order matters:
+ * a user theme with a preset's id wins, so edits to a preset are stored as a
+ * regular custom theme and removing that copy restores the preset.
+ */
+export function withPresets(customThemes: CustomTheme[]): CustomTheme[] {
+  return [...customThemes, ...PRESET_THEMES.filter((preset) => !customThemes.some((t) => t.id === preset.id))];
+}

--- a/src/theme/presets.ts
+++ b/src/theme/presets.ts
@@ -359,3 +359,12 @@ export const PRESET_THEMES: CustomTheme[] = [dracula, tokyoNight, matrix, hotPin
 export function withPresets(customThemes: CustomTheme[]): CustomTheme[] {
   return [...customThemes, ...PRESET_THEMES.filter((preset) => !customThemes.some((t) => t.id === preset.id))];
 }
+
+/**
+ * Whether deleting the custom theme `id` orphans a preference pointing at it.
+ * Removing a user copy of a preset restores the preset, so that selection
+ * stays valid and must be kept.
+ */
+export function selectionOrphanedByDelete(preference: string | undefined, id: string): boolean {
+  return preference === `custom:${id}` && !PRESET_THEMES.some((t) => t.id === id);
+}

--- a/src/theme/presets.ts
+++ b/src/theme/presets.ts
@@ -138,7 +138,205 @@ const tokyoNight: CustomTheme = {
   },
 };
 
-export const PRESET_THEMES: CustomTheme[] = [dracula, tokyoNight];
+/** Matrix — green phosphor on near-black. Red/yellow keep distinct hues so
+ * diffs and terminal error output stay readable. */
+const matrix: CustomTheme = {
+  id: 'matrix',
+  name: 'Matrix',
+  base: 'dark',
+  tokens: {
+    '--color-background': '#060906',
+    '--color-surface': '#122012',
+    '--color-surface-raised': '#0e180e',
+
+    '--color-text-primary': '#c1ffc1',
+    '--color-text-secondary': '#56c956',
+    '--color-text-tertiary': '#2e7d2e',
+
+    '--color-border': 'rgba(0, 255, 65, 0.12)',
+    '--color-border-hover': 'rgba(0, 255, 65, 0.2)',
+
+    '--color-accent': '#00ff41',
+    '--color-accent-hover': '#4dff77',
+    '--color-accent-light': 'rgba(0, 255, 65, 0.18)',
+    '--color-accent-ink': '#031003',
+
+    '--color-git': '#ccff33',
+    '--color-git-light': 'rgba(204, 255, 51, 0.15)',
+    '--color-success': '#00ff41',
+    '--color-success-subtle': 'rgba(0, 255, 65, 0.15)',
+    '--color-error': '#ff4d4d',
+    '--color-status-ready': '#00ff41',
+    '--color-status-thinking': '#66ffcc',
+
+    '--color-terminal-bg': '#0a0f0a',
+    '--color-terminal-fg': '#00ff41',
+    '--color-terminal-surface': '#122012',
+    '--color-terminal-surface-alt': '#0d160d',
+    '--color-terminal-inset': '#060906',
+
+    '--color-ansi-black': '#0f1f0f',
+    '--color-ansi-red': '#ff4d4d',
+    '--color-ansi-green': '#00ff41',
+    '--color-ansi-yellow': '#ccff33',
+    '--color-ansi-blue': '#33ff99',
+    '--color-ansi-magenta': '#66ff66',
+    '--color-ansi-cyan': '#99ffcc',
+    '--color-ansi-white': '#c1ffc1',
+    '--color-ansi-bright-black': '#2e7d2e',
+    '--color-ansi-bright-red': '#ff8080',
+    '--color-ansi-bright-green': '#4dff77',
+    '--color-ansi-bright-yellow': '#e0ff80',
+    '--color-ansi-bright-blue': '#80ffbf',
+    '--color-ansi-bright-magenta': '#a3ffa3',
+    '--color-ansi-bright-cyan': '#ccffe6',
+    '--color-ansi-bright-white': '#eaffea',
+
+    '--color-diff-fg': '#c1ffc1',
+    '--color-diff-added': '#00ff41',
+    '--color-diff-removed': '#ff4d4d',
+    '--color-diff-hunk': '#66ffcc',
+    '--color-vcs-added': '#00ff41',
+    '--color-vcs-deleted': '#ff4d4d',
+    '--color-vcs-renamed': '#66ffcc',
+    '--color-vcs-modified': '#ccff33',
+
+    '--terminal-selection': 'rgba(0, 255, 65, 0.22)',
+  },
+};
+
+/** Hot Pink — neon pink on a dark plum base. */
+const hotPink: CustomTheme = {
+  id: 'hot-pink',
+  name: 'Hot Pink',
+  base: 'dark',
+  tokens: {
+    '--color-background': '#171115',
+    '--color-surface': '#2c1c27',
+    '--color-surface-raised': '#241620',
+
+    '--color-text-primary': '#ffe4f1',
+    '--color-text-secondary': '#d8a8c4',
+    '--color-text-tertiary': '#8a5f78',
+
+    '--color-accent': '#ff2d95',
+    '--color-accent-hover': '#ff5cab',
+    '--color-accent-light': 'rgba(255, 45, 149, 0.22)',
+    '--color-accent-ink': '#1e0812',
+
+    '--color-git': '#ffa657',
+    '--color-git-light': 'rgba(255, 166, 87, 0.15)',
+    '--color-success': '#3dd68c',
+    '--color-success-subtle': 'rgba(61, 214, 140, 0.15)',
+    '--color-error': '#ff4d6d',
+    '--color-status-ready': '#3dd68c',
+    '--color-status-thinking': '#c792ea',
+
+    '--color-terminal-bg': '#1e141b',
+    '--color-terminal-fg': '#f5dcea',
+    '--color-terminal-surface': '#2c1c27',
+    '--color-terminal-surface-alt': '#251721',
+    '--color-terminal-inset': '#171115',
+
+    '--color-ansi-black': '#382431',
+    '--color-ansi-red': '#ff5c8a',
+    '--color-ansi-green': '#3dd68c',
+    '--color-ansi-yellow': '#ffd166',
+    '--color-ansi-blue': '#82aaff',
+    '--color-ansi-magenta': '#ff79c6',
+    '--color-ansi-cyan': '#7fdbff',
+    '--color-ansi-white': '#f5dcea',
+    '--color-ansi-bright-black': '#8a5f78',
+    '--color-ansi-bright-red': '#ff85a8',
+    '--color-ansi-bright-green': '#6ee7ac',
+    '--color-ansi-bright-yellow': '#ffe08a',
+    '--color-ansi-bright-blue': '#a5c4ff',
+    '--color-ansi-bright-magenta': '#ffa1d8',
+    '--color-ansi-bright-cyan': '#a8e8ff',
+    '--color-ansi-bright-white': '#fff0f8',
+
+    '--color-diff-fg': '#ffe4f1',
+    '--color-diff-added': '#3dd68c',
+    '--color-diff-removed': '#ff5c8a',
+    '--color-diff-hunk': '#c792ea',
+    '--color-vcs-added': '#3dd68c',
+    '--color-vcs-deleted': '#ff4d6d',
+    '--color-vcs-renamed': '#c792ea',
+    '--color-vcs-modified': '#ffa657',
+
+    '--terminal-selection': 'rgba(255, 45, 149, 0.25)',
+  },
+};
+
+/** Sepia — warm paper tones on the light base. */
+const sepia: CustomTheme = {
+  id: 'sepia',
+  name: 'Sepia',
+  base: 'light',
+  tokens: {
+    '--color-background': '#f0e7d8',
+    '--color-surface': '#faf4e8',
+    '--color-surface-raised': '#e6dcc8',
+
+    '--color-text-primary': '#3d2f1f',
+    '--color-text-secondary': '#7a6a52',
+    '--color-text-tertiary': '#a89a80',
+    '--color-ink': '#2e2416',
+
+    '--color-border': 'rgba(74, 58, 36, 0.14)',
+    '--color-border-hover': 'rgba(74, 58, 36, 0.22)',
+    '--color-bezel-panel': 'rgba(74, 58, 36, 0.3)',
+
+    '--color-accent': '#a4632a',
+    '--color-accent-hover': '#8a5222',
+    '--color-accent-light': 'rgba(164, 99, 42, 0.15)',
+    '--color-accent-ink': '#ffffff',
+
+    '--color-git': '#b3541e',
+    '--color-git-light': 'rgba(179, 84, 30, 0.12)',
+    '--color-success': '#5a7a29',
+    '--color-success-subtle': 'rgba(90, 122, 41, 0.15)',
+    '--color-error': '#b3392f',
+    '--color-status-ready': '#5a7a29',
+    '--color-status-thinking': '#94518d',
+
+    '--color-terminal-bg': '#f7efe0',
+    '--color-terminal-fg': '#433422',
+    '--color-terminal-surface': '#e9dfc9',
+    '--color-terminal-surface-alt': '#f0e7d5',
+    '--color-terminal-inset': '#efe5d2',
+
+    '--color-ansi-black': '#433422',
+    '--color-ansi-red': '#b3392f',
+    '--color-ansi-green': '#5a7a29',
+    '--color-ansi-yellow': '#b07d10',
+    '--color-ansi-blue': '#4a6a8f',
+    '--color-ansi-magenta': '#94518d',
+    '--color-ansi-cyan': '#3d7a70',
+    '--color-ansi-white': '#e6dcc8',
+    '--color-ansi-bright-black': '#7a6a52',
+    '--color-ansi-bright-red': '#d24a3e',
+    '--color-ansi-bright-green': '#6f9433',
+    '--color-ansi-bright-yellow': '#cf9415',
+    '--color-ansi-bright-blue': '#5d81ab',
+    '--color-ansi-bright-magenta': '#b06aa8',
+    '--color-ansi-bright-cyan': '#4d9488',
+    '--color-ansi-bright-white': '#faf4e8',
+
+    '--color-diff-fg': '#3d2f1f',
+    '--color-diff-added': '#5a7a29',
+    '--color-diff-removed': '#b3392f',
+    '--color-diff-hunk': '#94518d',
+    '--color-vcs-added': '#5a7a29',
+    '--color-vcs-deleted': '#b3392f',
+    '--color-vcs-renamed': '#94518d',
+    '--color-vcs-modified': '#b07d10',
+
+    '--terminal-selection': 'rgba(164, 99, 42, 0.2)',
+  },
+};
+
+export const PRESET_THEMES: CustomTheme[] = [dracula, tokyoNight, matrix, hotPink, sepia];
 
 /**
  * User themes plus the presets they don't shadow. Resolution order matters:

--- a/src/theme/presets.ts
+++ b/src/theme/presets.ts
@@ -1,9 +1,9 @@
 /**
- * Built-in preset themes — bundled CustomTheme definitions selectable without
- * any setup. A preset behaves exactly like a user custom theme (token
- * overrides on a built-in base) but ships with the app. A user theme saved
- * with the same id shadows the preset, so "editing" a preset really edits a
- * user copy; deleting that copy restores the preset.
+ * Built-in preset themes — bundled CustomTheme definitions. A preset behaves
+ * like a user custom theme (token overrides on a built-in base) but ships
+ * with the app. A user theme saved with the same id shadows the preset, so
+ * "editing" a preset really edits a user copy; deleting that copy restores
+ * the preset.
  */
 
 import type { CustomTheme } from './themes';
@@ -14,8 +14,8 @@ const dracula: CustomTheme = {
   name: 'Dracula',
   base: 'dark',
   tokens: {
-    // App chrome sits on the darker Dracula background; terminals use the
-    // canonical #282a36 so cards read as raised surfaces.
+    // App chrome uses the darker Dracula background; terminals use the
+    // palette's #282a36 editor background.
     '--color-background': '#21222c',
     '--color-surface': '#343746',
     '--color-surface-raised': '#2f313d',
@@ -79,7 +79,7 @@ const tokyoNight: CustomTheme = {
   name: 'Tokyo Night',
   base: 'dark',
   tokens: {
-    // App chrome on the darker sidebar tone; terminals use the canonical
+    // App chrome uses the darker sidebar tone; terminals use the palette's
     // #1a1b26 editor background.
     '--color-background': '#16161e',
     '--color-surface': '#24283b',

--- a/src/theme/presets.ts
+++ b/src/theme/presets.ts
@@ -285,7 +285,20 @@ const sepia: CustomTheme = {
 
     '--color-border': 'rgba(74, 58, 36, 0.14)',
     '--color-border-hover': 'rgba(74, 58, 36, 0.22)',
+    '--color-bezel': 'rgba(74, 58, 36, 0.18)',
     '--color-bezel-panel': 'rgba(74, 58, 36, 0.3)',
+
+    // Warm-tinted elevation — pure black shadows read cold on paper.
+    '--shadow-sm': '0 1px 2px rgba(58, 42, 20, 0.1)',
+    '--shadow-md': '0 4px 12px rgba(58, 42, 20, 0.12)',
+    '--shadow-lg': '0 8px 24px rgba(58, 42, 20, 0.14)',
+    '--shadow-hover': '0 12px 32px rgba(58, 42, 20, 0.18)',
+    '--shadow-panel': '0 4px 12px rgba(58, 42, 20, 0.1), 0 20px 40px rgba(58, 42, 20, 0.12)',
+    '--shadow-menu': '0 0 0 1px rgba(58, 42, 20, 0.08), 0 10px 30px rgba(58, 42, 20, 0.18)',
+    '--shadow-toast':
+      '0 0 0 1px rgba(58, 42, 20, 0.08), 0 4px 12px rgba(58, 42, 20, 0.12), 0 16px 32px rgba(58, 42, 20, 0.16)',
+    '--shadow-inset-panel': '0 2px 10px rgba(58, 42, 20, 0.1)',
+    '--shadow-tooltip': '0 2px 8px rgba(58, 42, 20, 0.15)',
 
     '--color-accent': '#a4632a',
     '--color-accent-hover': '#8a5222',

--- a/src/theme/presets.ts
+++ b/src/theme/presets.ts
@@ -73,7 +73,72 @@ const dracula: CustomTheme = {
   },
 };
 
-export const PRESET_THEMES: CustomTheme[] = [dracula];
+/** Tokyo Night — https://github.com/enkia/tokyo-night-vscode-theme (night variant). */
+const tokyoNight: CustomTheme = {
+  id: 'tokyo-night',
+  name: 'Tokyo Night',
+  base: 'dark',
+  tokens: {
+    // App chrome on the darker sidebar tone; terminals use the canonical
+    // #1a1b26 editor background.
+    '--color-background': '#16161e',
+    '--color-surface': '#24283b',
+    '--color-surface-raised': '#1f2335',
+
+    '--color-text-primary': '#c0caf5',
+    '--color-text-secondary': '#a9b1d6',
+    '--color-text-tertiary': '#565f89',
+
+    '--color-accent': '#7aa2f7',
+    '--color-accent-hover': '#94b2f9',
+    '--color-accent-light': 'rgba(122, 162, 247, 0.2)',
+    '--color-accent-ink': '#16161e',
+
+    '--color-git': '#ff9e64',
+    '--color-git-light': 'rgba(255, 158, 100, 0.15)',
+    '--color-success': '#9ece6a',
+    '--color-success-subtle': 'rgba(158, 206, 106, 0.15)',
+    '--color-error': '#f7768e',
+    '--color-status-ready': '#9ece6a',
+    '--color-status-thinking': '#bb9af7',
+
+    '--color-terminal-bg': '#1a1b26',
+    '--color-terminal-fg': '#a9b1d6',
+    '--color-terminal-surface': '#24283b',
+    '--color-terminal-surface-alt': '#1f2335',
+    '--color-terminal-inset': '#16161e',
+
+    '--color-ansi-black': '#414868',
+    '--color-ansi-red': '#f7768e',
+    '--color-ansi-green': '#9ece6a',
+    '--color-ansi-yellow': '#e0af68',
+    '--color-ansi-blue': '#7aa2f7',
+    '--color-ansi-magenta': '#bb9af7',
+    '--color-ansi-cyan': '#7dcfff',
+    '--color-ansi-white': '#a9b1d6',
+    '--color-ansi-bright-black': '#565f89',
+    '--color-ansi-bright-red': '#f7768e',
+    '--color-ansi-bright-green': '#9ece6a',
+    '--color-ansi-bright-yellow': '#e0af68',
+    '--color-ansi-bright-blue': '#7aa2f7',
+    '--color-ansi-bright-magenta': '#bb9af7',
+    '--color-ansi-bright-cyan': '#7dcfff',
+    '--color-ansi-bright-white': '#c0caf5',
+
+    '--color-diff-fg': '#c0caf5',
+    '--color-diff-added': '#9ece6a',
+    '--color-diff-removed': '#f7768e',
+    '--color-diff-hunk': '#bb9af7',
+    '--color-vcs-added': '#9ece6a',
+    '--color-vcs-deleted': '#f7768e',
+    '--color-vcs-renamed': '#bb9af7',
+    '--color-vcs-modified': '#e0af68',
+
+    '--terminal-selection': 'rgba(51, 70, 124, 0.8)',
+  },
+};
+
+export const PRESET_THEMES: CustomTheme[] = [dracula, tokyoNight];
 
 /**
  * User themes plus the presets they don't shadow. Resolution order matters:

--- a/src/theme/shikiTheme.ts
+++ b/src/theme/shikiTheme.ts
@@ -1,0 +1,12 @@
+/**
+ * Shiki syntax-highlighting theme for each resolved base: the one owner of
+ * the mapping for all shiki consumers (diff panel, plan markdown).
+ */
+
+import { getResolvedTheme } from './themeManager';
+
+export const SHIKI_THEMES = { dark: 'github-dark', light: 'github-light' } as const;
+
+export function currentShikiTheme(): (typeof SHIKI_THEMES)[keyof typeof SHIKI_THEMES] {
+  return SHIKI_THEMES[getResolvedTheme()];
+}

--- a/src/theme/themeManager.ts
+++ b/src/theme/themeManager.ts
@@ -1,0 +1,182 @@
+/**
+ * Renderer theme runtime.
+ *
+ * Applies the selected theme to <html> (a `data-theme` attribute picks the
+ * built-in base from tokens.css; custom themes additionally set inline
+ * `--token` overrides), follows the OS appearance in 'system' mode, and
+ * notifies subscribers (xterm, shiki consumers) when the resolved theme
+ * changes.
+ *
+ * Persistence: the source of truth is global settings (`ui:theme`,
+ * `ui:customThemes`). A localStorage mirror lets the very first paint apply
+ * the right theme synchronously, before the async settings round-trip. The
+ * resolved background color is mirrored to `ui:themeBackground` so the main
+ * process can paint new windows the right color before the renderer loads.
+ */
+
+import log from 'electron-log/renderer';
+import {
+  type ThemePreference,
+  type ResolvedThemeBase,
+  type CustomTheme,
+  isThemePreference,
+  parseCustomThemes,
+  resolveThemeBase,
+  selectedCustomTheme,
+} from './themes';
+
+const themeLog = log.scope('theme');
+
+const PREFERENCE_KEY = 'ui:theme';
+const CUSTOM_THEMES_KEY = 'ui:customThemes';
+const WINDOW_BACKGROUND_KEY = 'ui:themeBackground';
+const LOCAL_CACHE_KEY = 'ouijit:theme-cache';
+
+let preference: ThemePreference = 'system';
+let customThemes: CustomTheme[] = [];
+/** Token names currently overridden inline by a custom theme. */
+let appliedTokenNames: string[] = [];
+const subscribers = new Set<() => void>();
+
+// Created lazily: this module is transitively imported by code that also runs
+// in Node test environments where window doesn't exist.
+let prefersDarkQueryCache: MediaQueryList | null = null;
+function prefersDarkQuery(): MediaQueryList | null {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return null;
+  prefersDarkQueryCache ??= window.matchMedia('(prefers-color-scheme: dark)');
+  return prefersDarkQueryCache;
+}
+
+export function getThemePreference(): ThemePreference {
+  return preference;
+}
+
+export function getResolvedTheme(): ResolvedThemeBase {
+  return resolveThemeBase(preference, prefersDarkQuery()?.matches ?? true, customThemes);
+}
+
+export function getCustomThemes(): CustomTheme[] {
+  return customThemes;
+}
+
+/** Subscribe to theme changes. Returns an unsubscribe function. */
+export function subscribeTheme(callback: () => void): () => void {
+  subscribers.add(callback);
+  return () => subscribers.delete(callback);
+}
+
+/** Read a design token's current computed value, e.g. readToken('--color-accent'). */
+export function readToken(name: string): string {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+function applyTheme(): void {
+  const root = document.documentElement;
+  const base = getResolvedTheme();
+
+  if (base === 'light') {
+    root.setAttribute('data-theme', 'light');
+  } else {
+    root.removeAttribute('data-theme');
+  }
+
+  for (const name of appliedTokenNames) {
+    root.style.removeProperty(name);
+  }
+  appliedTokenNames = [];
+
+  const custom = selectedCustomTheme(preference, customThemes);
+  if (custom) {
+    for (const [name, value] of Object.entries(custom.tokens)) {
+      root.style.setProperty(name, value);
+      appliedTokenNames.push(name);
+    }
+  }
+
+  for (const callback of subscribers) callback();
+
+  // Mirror the resolved window background for the main process. Only plain
+  // hex values are useful there (BrowserWindow.setBackgroundColor).
+  const background = readToken('--color-background');
+  if (/^#[0-9a-fA-F]{6}$/.test(background)) {
+    void window.api.globalSettings.set(WINDOW_BACKGROUND_KEY, background);
+  }
+
+  try {
+    localStorage.setItem(LOCAL_CACHE_KEY, JSON.stringify({ preference, customThemes }));
+  } catch {
+    // localStorage is best-effort; the settings DB remains the source of truth.
+  }
+}
+
+/**
+ * Apply the cached theme synchronously before first render so light-mode
+ * users don't get a dark flash on every launch.
+ */
+export function initThemeSync(): void {
+  try {
+    const raw = localStorage.getItem(LOCAL_CACHE_KEY);
+    if (!raw) return;
+    const cached: unknown = JSON.parse(raw);
+    if (typeof cached !== 'object' || cached === null) return;
+    const obj = cached as { preference?: unknown; customThemes?: unknown };
+    if (typeof obj.preference === 'string' && isThemePreference(obj.preference)) {
+      preference = obj.preference;
+    }
+    customThemes = parseCustomThemes(JSON.stringify(obj.customThemes ?? []));
+    applyTheme();
+  } catch {
+    // Corrupt cache — stay on the default theme until initTheme() reconciles.
+  }
+}
+
+/** Load the persisted theme from global settings and start following the OS. */
+export async function initTheme(): Promise<void> {
+  try {
+    const [storedPreference, storedCustomThemes] = await Promise.all([
+      window.api.globalSettings.get(PREFERENCE_KEY),
+      window.api.globalSettings.get(CUSTOM_THEMES_KEY),
+    ]);
+    customThemes = parseCustomThemes(storedCustomThemes);
+    if (storedPreference && isThemePreference(storedPreference)) {
+      preference = storedPreference;
+    }
+  } catch (error) {
+    themeLog.error('failed to load theme settings', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  prefersDarkQuery()?.addEventListener('change', () => {
+    if (preference === 'system') applyTheme();
+  });
+
+  applyTheme();
+}
+
+export async function setThemePreference(next: ThemePreference): Promise<void> {
+  preference = next;
+  applyTheme();
+  await window.api.globalSettings.set(PREFERENCE_KEY, next);
+  themeLog.info('theme preference changed', { preference: next });
+}
+
+/** Add or update a custom theme. Does not select it. */
+export async function saveCustomTheme(theme: CustomTheme): Promise<void> {
+  customThemes = [...customThemes.filter((t) => t.id !== theme.id), theme];
+  await persistCustomThemes();
+  applyTheme();
+}
+
+export async function deleteCustomTheme(id: string): Promise<void> {
+  customThemes = customThemes.filter((t) => t.id !== id);
+  if (preference === `custom:${id}`) {
+    await setThemePreference('system');
+  }
+  await persistCustomThemes();
+  applyTheme();
+}
+
+async function persistCustomThemes(): Promise<void> {
+  await window.api.globalSettings.set(CUSTOM_THEMES_KEY, JSON.stringify(customThemes));
+}

--- a/src/theme/themeManager.ts
+++ b/src/theme/themeManager.ts
@@ -24,6 +24,7 @@ import {
   resolveThemeBase,
   selectedCustomTheme,
 } from './themes';
+import { PRESET_THEMES, withPresets } from './presets';
 
 const themeLog = log.scope('theme');
 
@@ -52,7 +53,7 @@ export function getThemePreference(): ThemePreference {
 }
 
 export function getResolvedTheme(): ResolvedThemeBase {
-  return resolveThemeBase(preference, prefersDarkQuery()?.matches ?? true, customThemes);
+  return resolveThemeBase(preference, prefersDarkQuery()?.matches ?? true, withPresets(customThemes));
 }
 
 export function getCustomThemes(): CustomTheme[] {
@@ -85,7 +86,7 @@ function applyTheme(): void {
   }
   appliedTokenNames = [];
 
-  const custom = selectedCustomTheme(preference, customThemes);
+  const custom = selectedCustomTheme(preference, withPresets(customThemes));
   if (custom) {
     for (const [name, value] of Object.entries(custom.tokens)) {
       root.style.setProperty(name, value);
@@ -170,7 +171,8 @@ export async function saveCustomTheme(theme: CustomTheme): Promise<void> {
 
 export async function deleteCustomTheme(id: string): Promise<void> {
   customThemes = customThemes.filter((t) => t.id !== id);
-  if (preference === `custom:${id}`) {
+  // Removing a user copy of a preset restores the preset — keep it selected.
+  if (preference === `custom:${id}` && !PRESET_THEMES.some((t) => t.id === id)) {
     await setThemePreference('system');
   }
   await persistCustomThemes();

--- a/src/theme/themeManager.ts
+++ b/src/theme/themeManager.ts
@@ -19,18 +19,20 @@ import {
   type ThemePreference,
   type ResolvedThemeBase,
   type CustomTheme,
+  THEME_PREFERENCE_KEY,
+  CUSTOM_THEMES_KEY,
+  WINDOW_BACKGROUND_KEY,
   isThemePreference,
+  isWindowBackgroundColor,
   parseCustomThemes,
+  upsertCustomTheme,
   resolveThemeBase,
   selectedCustomTheme,
 } from './themes';
-import { PRESET_THEMES, withPresets } from './presets';
+import { withPresets, selectionOrphanedByDelete } from './presets';
 
 const themeLog = log.scope('theme');
 
-const PREFERENCE_KEY = 'ui:theme';
-const CUSTOM_THEMES_KEY = 'ui:customThemes';
-const WINDOW_BACKGROUND_KEY = 'ui:themeBackground';
 const LOCAL_CACHE_KEY = 'ouijit:theme-cache';
 
 let preference: ThemePreference = 'system';
@@ -39,7 +41,23 @@ let previewPreference: ThemePreference | null = null;
 let customThemes: CustomTheme[] = [];
 /** Token names currently overridden inline by a custom theme. */
 let appliedTokenNames: string[] = [];
+/** Bumped on every applied-theme change; lets consumers cache token reads per applied theme. */
+let themeEpoch = 0;
+/** Last values written to the persistence mirrors, to skip redundant writes. */
+let mirroredBackground: string | null = null;
+let cachedThemeJson: string | null = null;
 const subscribers = new Set<() => void>();
+
+// customThemes is replaced (never mutated), so the merged list can be cached
+// per array identity; getResolvedTheme() is a useSyncExternalStore snapshot
+// called on every render of subscribed components.
+let mergedThemesCache: { source: CustomTheme[]; merged: CustomTheme[] } | null = null;
+function mergedThemes(): CustomTheme[] {
+  if (mergedThemesCache?.source !== customThemes) {
+    mergedThemesCache = { source: customThemes, merged: withPresets(customThemes) };
+  }
+  return mergedThemesCache.merged;
+}
 
 // Created lazily: this module is transitively imported by code that also runs
 // in Node test environments where window doesn't exist.
@@ -55,11 +73,16 @@ export function getThemePreference(): ThemePreference {
 }
 
 export function getResolvedTheme(): ResolvedThemeBase {
-  return resolveThemeBase(
-    previewPreference ?? preference,
-    prefersDarkQuery()?.matches ?? true,
-    withPresets(customThemes),
-  );
+  return resolveThemeBase(previewPreference ?? preference, prefersDarkQuery()?.matches ?? true, mergedThemes());
+}
+
+/**
+ * Identity of the currently applied theme. Unlike the resolved base, this
+ * changes on every theme switch, including between two themes with the same
+ * base, so consumers that read token values can use it as a cache key.
+ */
+export function getThemeEpoch(): number {
+  return themeEpoch;
 }
 
 export function getCustomThemes(): CustomTheme[] {
@@ -92,7 +115,7 @@ function applyTheme(): void {
   }
   appliedTokenNames = [];
 
-  const custom = selectedCustomTheme(previewPreference ?? preference, withPresets(customThemes));
+  const custom = selectedCustomTheme(previewPreference ?? preference, mergedThemes());
   if (custom) {
     for (const [name, value] of Object.entries(custom.tokens)) {
       root.style.setProperty(name, value);
@@ -100,6 +123,7 @@ function applyTheme(): void {
     }
   }
 
+  themeEpoch++;
   for (const callback of subscribers) callback();
 
   // A hover preview must leave no trace — skip the persistence mirrors.
@@ -108,14 +132,19 @@ function applyTheme(): void {
   // Mirror the resolved window background for the main process. Only plain
   // hex values are useful there (BrowserWindow.setBackgroundColor).
   const background = readToken('--color-background');
-  if (/^#[0-9a-fA-F]{6}$/.test(background)) {
+  if (background !== mirroredBackground && isWindowBackgroundColor(background)) {
+    mirroredBackground = background;
     void window.api.globalSettings.set(WINDOW_BACKGROUND_KEY, background);
   }
 
-  try {
-    localStorage.setItem(LOCAL_CACHE_KEY, JSON.stringify({ preference, customThemes }));
-  } catch {
-    // localStorage is best-effort; the settings DB remains the source of truth.
+  const cacheJson = JSON.stringify({ preference, customThemes });
+  if (cacheJson !== cachedThemeJson) {
+    cachedThemeJson = cacheJson;
+    try {
+      localStorage.setItem(LOCAL_CACHE_KEY, cacheJson);
+    } catch {
+      // localStorage is best-effort; the settings DB remains the source of truth.
+    }
   }
 }
 
@@ -140,22 +169,27 @@ export function initThemeSync(): void {
   }
 }
 
-/** Load the persisted theme from global settings and start following the OS. */
-export async function initTheme(): Promise<void> {
+/** Re-read the persisted theme from global settings into module state. Returns false when the read failed. */
+async function loadPersistedTheme(): Promise<boolean> {
   try {
     const [storedPreference, storedCustomThemes] = await Promise.all([
-      window.api.globalSettings.get(PREFERENCE_KEY),
+      window.api.globalSettings.get(THEME_PREFERENCE_KEY),
       window.api.globalSettings.get(CUSTOM_THEMES_KEY),
     ]);
     customThemes = parseCustomThemes(storedCustomThemes);
-    if (storedPreference && isThemePreference(storedPreference)) {
-      preference = storedPreference;
-    }
+    preference = storedPreference && isThemePreference(storedPreference) ? storedPreference : 'system';
+    return true;
   } catch (error) {
     themeLog.error('failed to load theme settings', {
       error: error instanceof Error ? error.message : String(error),
     });
+    return false;
   }
+}
+
+/** Load the persisted theme from global settings and start following the OS. */
+export async function initTheme(): Promise<void> {
+  await loadPersistedTheme();
 
   prefersDarkQuery()?.addEventListener('change', () => {
     if (preference === 'system') applyTheme();
@@ -170,20 +204,7 @@ export async function initTheme(): Promise<void> {
  * DB directly, so this module's state must be refreshed).
  */
 export async function reloadTheme(): Promise<void> {
-  try {
-    const [storedPreference, storedCustomThemes] = await Promise.all([
-      window.api.globalSettings.get(PREFERENCE_KEY),
-      window.api.globalSettings.get(CUSTOM_THEMES_KEY),
-    ]);
-    customThemes = parseCustomThemes(storedCustomThemes);
-    preference = storedPreference && isThemePreference(storedPreference) ? storedPreference : 'system';
-  } catch (error) {
-    themeLog.error('failed to reload theme settings', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return;
-  }
-  applyTheme();
+  if (await loadPersistedTheme()) applyTheme();
 }
 
 /**
@@ -200,21 +221,20 @@ export async function setThemePreference(next: ThemePreference): Promise<void> {
   preference = next;
   previewPreference = null;
   applyTheme();
-  await window.api.globalSettings.set(PREFERENCE_KEY, next);
+  await window.api.globalSettings.set(THEME_PREFERENCE_KEY, next);
   themeLog.info('theme preference changed', { preference: next });
 }
 
 /** Add or update a custom theme. Does not select it. */
 export async function saveCustomTheme(theme: CustomTheme): Promise<void> {
-  customThemes = [...customThemes.filter((t) => t.id !== theme.id), theme];
+  customThemes = upsertCustomTheme(customThemes, theme);
   await persistCustomThemes();
   applyTheme();
 }
 
 export async function deleteCustomTheme(id: string): Promise<void> {
   customThemes = customThemes.filter((t) => t.id !== id);
-  // Removing a user copy of a preset restores the preset — keep it selected.
-  if (preference === `custom:${id}` && !PRESET_THEMES.some((t) => t.id === id)) {
+  if (selectionOrphanedByDelete(preference, id)) {
     await setThemePreference('system');
   }
   await persistCustomThemes();

--- a/src/theme/themeManager.ts
+++ b/src/theme/themeManager.ts
@@ -34,6 +34,8 @@ const WINDOW_BACKGROUND_KEY = 'ui:themeBackground';
 const LOCAL_CACHE_KEY = 'ouijit:theme-cache';
 
 let preference: ThemePreference = 'system';
+/** Hover-preview override; non-null renders this theme instead of `preference` without persisting. */
+let previewPreference: ThemePreference | null = null;
 let customThemes: CustomTheme[] = [];
 /** Token names currently overridden inline by a custom theme. */
 let appliedTokenNames: string[] = [];
@@ -53,7 +55,11 @@ export function getThemePreference(): ThemePreference {
 }
 
 export function getResolvedTheme(): ResolvedThemeBase {
-  return resolveThemeBase(preference, prefersDarkQuery()?.matches ?? true, withPresets(customThemes));
+  return resolveThemeBase(
+    previewPreference ?? preference,
+    prefersDarkQuery()?.matches ?? true,
+    withPresets(customThemes),
+  );
 }
 
 export function getCustomThemes(): CustomTheme[] {
@@ -86,7 +92,7 @@ function applyTheme(): void {
   }
   appliedTokenNames = [];
 
-  const custom = selectedCustomTheme(preference, withPresets(customThemes));
+  const custom = selectedCustomTheme(previewPreference ?? preference, withPresets(customThemes));
   if (custom) {
     for (const [name, value] of Object.entries(custom.tokens)) {
       root.style.setProperty(name, value);
@@ -95,6 +101,9 @@ function applyTheme(): void {
   }
 
   for (const callback of subscribers) callback();
+
+  // A hover preview must leave no trace — skip the persistence mirrors.
+  if (previewPreference !== null) return;
 
   // Mirror the resolved window background for the main process. Only plain
   // hex values are useful there (BrowserWindow.setBackgroundColor).
@@ -155,8 +164,41 @@ export async function initTheme(): Promise<void> {
   applyTheme();
 }
 
+/**
+ * Re-read persisted theme settings and re-apply. Called when the CLI
+ * mutates themes through the REST API (main process writes the settings
+ * DB directly, so this module's state must be refreshed).
+ */
+export async function reloadTheme(): Promise<void> {
+  try {
+    const [storedPreference, storedCustomThemes] = await Promise.all([
+      window.api.globalSettings.get(PREFERENCE_KEY),
+      window.api.globalSettings.get(CUSTOM_THEMES_KEY),
+    ]);
+    customThemes = parseCustomThemes(storedCustomThemes);
+    preference = storedPreference && isThemePreference(storedPreference) ? storedPreference : 'system';
+  } catch (error) {
+    themeLog.error('failed to reload theme settings', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+  applyTheme();
+}
+
+/**
+ * Temporarily render a theme without persisting anything (dropdown hover
+ * preview). Pass null to restore the committed preference.
+ */
+export function previewTheme(pref: ThemePreference | null): void {
+  if (previewPreference === pref) return;
+  previewPreference = pref;
+  applyTheme();
+}
+
 export async function setThemePreference(next: ThemePreference): Promise<void> {
   preference = next;
+  previewPreference = null;
   applyTheme();
   await window.api.globalSettings.set(PREFERENCE_KEY, next);
   themeLog.info('theme preference changed', { preference: next });

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -10,6 +10,16 @@
 /** Built-in selection values plus `custom:<id>` for user themes. */
 export type ThemePreference = 'system' | 'dark' | 'light' | `custom:${string}`;
 
+/** Global-settings keys shared by the renderer theme manager, the REST API, and the main process. */
+export const THEME_PREFERENCE_KEY = 'ui:theme';
+export const CUSTOM_THEMES_KEY = 'ui:customThemes';
+export const WINDOW_BACKGROUND_KEY = 'ui:themeBackground';
+
+/** Six-digit hex: the only form both BrowserWindow.setBackgroundColor and the `ui:themeBackground` mirror accept. */
+export function isWindowBackgroundColor(value: string): boolean {
+  return /^#[0-9a-fA-F]{6}$/.test(value);
+}
+
 export type ResolvedThemeBase = 'dark' | 'light';
 
 export interface CustomTheme {
@@ -74,6 +84,11 @@ export function resolveThemeBase(
     if (custom) return custom.base;
   }
   return systemPrefersDark ? 'dark' : 'light';
+}
+
+/** Add or replace a theme by id. */
+export function upsertCustomTheme(list: CustomTheme[], theme: CustomTheme): CustomTheme[] {
+  return [...list.filter((t) => t.id !== theme.id), theme];
 }
 
 /** The custom theme selected by a preference, if any. */

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -1,0 +1,83 @@
+/**
+ * Theme model — pure types and helpers, no DOM or Electron dependencies.
+ *
+ * The app ships two built-in themes, dark (the default) and light, defined
+ * entirely in src/theme/tokens.css. A custom theme layers token overrides on
+ * top of one of those bases; it can override any token defined in tokens.css
+ * (colors, shadows, ANSI palette, …).
+ */
+
+/** Built-in selection values plus `custom:<id>` for user themes. */
+export type ThemePreference = 'system' | 'dark' | 'light' | `custom:${string}`;
+
+export type ResolvedThemeBase = 'dark' | 'light';
+
+export interface CustomTheme {
+  id: string;
+  name: string;
+  /** Which built-in theme supplies the tokens this theme doesn't override. */
+  base: ResolvedThemeBase;
+  /** CSS custom property overrides, e.g. { '--color-accent': '#ff2d55' }. */
+  tokens: Record<string, string>;
+}
+
+const TOKEN_NAME_RE = /^--[a-z0-9-]+$/;
+/** Reject values that could escape a CSS declaration. */
+const TOKEN_VALUE_RE = /^[^;{}<>]+$/;
+
+export function isThemePreference(value: string): value is ThemePreference {
+  return value === 'system' || value === 'dark' || value === 'light' || value.startsWith('custom:');
+}
+
+/** Validate an untrusted parsed JSON value into a CustomTheme, or null. */
+export function parseCustomTheme(value: unknown): CustomTheme | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.id !== 'string' || obj.id.length === 0 || obj.id.length > 64) return null;
+  if (typeof obj.name !== 'string' || obj.name.length === 0 || obj.name.length > 64) return null;
+  if (obj.base !== 'dark' && obj.base !== 'light') return null;
+  if (typeof obj.tokens !== 'object' || obj.tokens === null) return null;
+  const tokens: Record<string, string> = {};
+  for (const [key, val] of Object.entries(obj.tokens as Record<string, unknown>)) {
+    if (typeof val !== 'string') return null;
+    if (!TOKEN_NAME_RE.test(key) || !TOKEN_VALUE_RE.test(val)) return null;
+    tokens[key] = val;
+  }
+  return { id: obj.id, name: obj.name, base: obj.base, tokens };
+}
+
+/** Parse the persisted `ui:customThemes` JSON, dropping invalid entries. */
+export function parseCustomThemes(json: string | undefined): CustomTheme[] {
+  if (!json) return [];
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map(parseCustomTheme).filter((t): t is CustomTheme => t !== null);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Resolve a preference to the base theme the DOM should render.
+ * Unknown custom ids fall back to system resolution.
+ */
+export function resolveThemeBase(
+  preference: ThemePreference,
+  systemPrefersDark: boolean,
+  customThemes: CustomTheme[],
+): ResolvedThemeBase {
+  if (preference === 'dark') return 'dark';
+  if (preference === 'light') return 'light';
+  if (preference.startsWith('custom:')) {
+    const custom = customThemes.find((t) => `custom:${t.id}` === preference);
+    if (custom) return custom.base;
+  }
+  return systemPrefersDark ? 'dark' : 'light';
+}
+
+/** The custom theme selected by a preference, if any. */
+export function selectedCustomTheme(preference: ThemePreference, customThemes: CustomTheme[]): CustomTheme | null {
+  if (!preference.startsWith('custom:')) return null;
+  return customThemes.find((t) => `custom:${t.id}` === preference) ?? null;
+}

--- a/src/theme/tokens.css
+++ b/src/theme/tokens.css
@@ -1,5 +1,5 @@
 /* ===================================
-   Ouijit Design Tokens — single source of truth
+   Ouijit design tokens
    ===================================
 
    Every color, shadow, radius, spacing, and typography value the app uses is
@@ -41,7 +41,7 @@
   --color-border-hover: rgba(255, 255, 255, 0.15);
   /* Dark lip around cards/panels (was border-black/60 everywhere) */
   --color-bezel: rgba(0, 0, 0, 0.6);
-  /* Crisp edge on large floating panels (terminal cards, kanban board,
+  /* Border on large floating panels (terminal cards, kanban board,
      settings cards) — darker than --color-bezel on light themes */
   --color-bezel-panel: rgba(0, 0, 0, 0.6);
 
@@ -119,7 +119,7 @@
   --shadow-toast: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.2), 0 16px 32px rgba(0, 0, 0, 0.28);
   /* Small inset panels (terminal body split panes) */
   --shadow-inset-panel: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 2px 10px rgba(0, 0, 0, 0.18);
-  /* Tooltips — small floating pills need a tight shadow, not panel-scale blur */
+  /* Tooltips — tighter than the panel-scale shadows */
   --shadow-tooltip: 0 4px 12px rgba(0, 0, 0, 0.4);
 
   /* ── Spacing ───────────────────────────────────────────────────── */
@@ -260,8 +260,8 @@
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.12);
   --shadow-hover: 0 12px 32px rgba(0, 0, 0, 0.16);
-  /* No 1px rings on panel shadows in light mode — the bezel-panel border is
-     the crisp edge; a ring outside it reads as a doubled, thicker border. */
+  /* Panel shadows carry no 1px ring on light themes — a ring stacks with
+     the bezel-panel border and reads as a double border. */
   --shadow-panel: 0 4px 12px rgba(0, 0, 0, 0.08), 0 20px 40px rgba(0, 0, 0, 0.1);
   --shadow-menu: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 10px 30px rgba(0, 0, 0, 0.16);
   --shadow-toast: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 4px 12px rgba(0, 0, 0, 0.1), 0 16px 32px rgba(0, 0, 0, 0.14);

--- a/src/theme/tokens.css
+++ b/src/theme/tokens.css
@@ -15,7 +15,7 @@
      overrides on <html>. See src/theme/themeManager.ts.
 
    JS consumers (xterm, React Flow, the main-process window background) read
-   tokens with getComputedStyle — see src/theme/readToken.ts. */
+   tokens with getComputedStyle; see readToken() in src/theme/themeManager.ts. */
 
 @theme {
   /* ── Core surfaces ─────────────────────────────────────────────── */

--- a/src/theme/tokens.css
+++ b/src/theme/tokens.css
@@ -119,6 +119,8 @@
   --shadow-toast: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.2), 0 16px 32px rgba(0, 0, 0, 0.28);
   /* Small inset panels (terminal body split panes) */
   --shadow-inset-panel: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 2px 10px rgba(0, 0, 0, 0.18);
+  /* Tooltips — small floating pills need a tight shadow, not panel-scale blur */
+  --shadow-tooltip: 0 4px 12px rgba(0, 0, 0, 0.4);
 
   /* ── Spacing ───────────────────────────────────────────────────── */
   --spacing-xs: 4px;
@@ -264,6 +266,7 @@
   --shadow-menu: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 10px 30px rgba(0, 0, 0, 0.16);
   --shadow-toast: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 4px 12px rgba(0, 0, 0, 0.1), 0 16px 32px rgba(0, 0, 0, 0.14);
   --shadow-inset-panel: 0 2px 10px rgba(0, 0, 0, 0.08);
+  --shadow-tooltip: 0 2px 8px rgba(0, 0, 0, 0.12);
 
   --terminal-selection: rgba(0, 0, 0, 0.12);
   --terminal-scrollbar: rgba(0, 0, 0, 0.18);

--- a/src/theme/tokens.css
+++ b/src/theme/tokens.css
@@ -1,0 +1,271 @@
+/* ===================================
+   Ouijit Design Tokens — single source of truth
+   ===================================
+
+   Every color, shadow, radius, spacing, and typography value the app uses is
+   defined here. Nothing outside this file should declare a raw color.
+
+   Theming model:
+   - The @theme block defines the token set and its DARK values (the default
+     theme — no attribute needed). Tailwind v4 emits each token as a CSS
+     custom property and utilities resolve them with var(), so overriding a
+     token at runtime re-skins every usage.
+   - Light mode overrides live under `:root[data-theme='light']`.
+   - Custom themes pick a base ('dark' | 'light') and set inline `--token`
+     overrides on <html>. See src/theme/themeManager.ts.
+
+   JS consumers (xterm, React Flow, the main-process window background) read
+   tokens with getComputedStyle — see src/theme/readToken.ts. */
+
+@theme {
+  /* ── Core surfaces ─────────────────────────────────────────────── */
+  --color-background: #1c1c1e;
+  --color-background-secondary: rgba(255, 255, 255, 0.06);
+  --color-background-tertiary: rgba(255, 255, 255, 0.12);
+  --color-surface: #2c2c2e;
+  /* Raised bevel knobs (home card corner buttons) */
+  --color-surface-raised: #252528;
+
+  /* ── Text ──────────────────────────────────────────────────────── */
+  --color-text-primary: #f5f5f7;
+  --color-text-secondary: #98989d;
+  --color-text-tertiary: #636366;
+
+  /* Foreground base for alpha overlays (text-ink/60, bg-ink/5, …).
+     White on dark themes, black on light themes — the counterpart of the
+     background, used anywhere the old code said white/N or black-on-light. */
+  --color-ink: #ffffff;
+
+  /* ── Borders & edges ───────────────────────────────────────────── */
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-border-hover: rgba(255, 255, 255, 0.15);
+  /* Dark lip around cards/panels (was border-black/60 everywhere) */
+  --color-bezel: rgba(0, 0, 0, 0.6);
+
+  /* ── Accent / brand — Ouijit blue. App-wide accent: links, selection,
+     focus rings, primary buttons. --color-accent-ink is the text color on
+     filled accent buttons. ─────────────────────────────────────────── */
+  --color-accent: #0a84ff;
+  --color-accent-hover: #409cff;
+  --color-accent-light: rgba(10, 132, 255, 0.2);
+  --color-accent-ink: #ffffff;
+
+  /* ── Status colors ─────────────────────────────────────────────── */
+  --color-git: #ff6b4a;
+  --color-git-light: rgba(255, 107, 74, 0.15);
+  --color-claude: #f59e0b;
+  --color-claude-light: rgba(245, 158, 11, 0.15);
+  --color-success: #30d158;
+  --color-success-subtle: rgba(48, 209, 88, 0.15);
+  --color-error: #ff453a;
+  /* Terminal status dots + header +/- counters */
+  --color-status-ready: #4ee82e;
+  --color-status-thinking: #da77f2;
+
+  /* ── Terminal surfaces ─────────────────────────────────────────── */
+  --color-terminal-bg: #171717;
+  --color-terminal-fg: #e4e4e4;
+  /* Sticky headers inside terminal-toned panels (diff file headers) */
+  --color-terminal-surface: #252525;
+  /* Slightly raised areas on terminal-toned panels (diff file tree) */
+  --color-terminal-surface-alt: #1a1a1a;
+  /* Recessed areas on terminal-toned panels (diff context lines) */
+  --color-terminal-inset: #141414;
+
+  /* ── ANSI palette — xterm theme + UI accents that echo terminal
+     colors (insertion/deletion counters, sandbox outline). ────────── */
+  --color-ansi-black: #171717;
+  --color-ansi-red: #ff6b6b;
+  --color-ansi-green: #69db7c;
+  --color-ansi-yellow: #ffd43b;
+  --color-ansi-blue: #74c0fc;
+  --color-ansi-magenta: #da77f2;
+  --color-ansi-cyan: #66d9e8;
+  --color-ansi-white: #e4e4e4;
+  --color-ansi-bright-black: #5c5c5c;
+  --color-ansi-bright-red: #ff8787;
+  --color-ansi-bright-green: #8ce99a;
+  --color-ansi-bright-yellow: #ffe066;
+  --color-ansi-bright-blue: #a5d8ff;
+  --color-ansi-bright-magenta: #e599f7;
+  --color-ansi-bright-cyan: #99e9f2;
+  --color-ansi-bright-white: #ffffff;
+
+  /* ── Diff panel ────────────────────────────────────────────────── */
+  --color-diff-fg: #e6edf3;
+  --color-diff-added: #3fb950;
+  --color-diff-removed: #f85149;
+  --color-diff-hunk: #8b8bcd;
+  /* File status colors (git porcelain letters) */
+  --color-vcs-added: #34c759;
+  --color-vcs-deleted: #ff3b30;
+  --color-vcs-renamed: #5856d6;
+  --color-vcs-modified: #ff9f0a;
+
+  /* ── Shadows ───────────────────────────────────────────────────── */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
+  --shadow-hover: 0 12px 32px rgba(0, 0, 0, 0.6);
+  /* Floating panel / card resting shadow (settings groups, home cards,
+     canvas nodes, recent-tasks panel) */
+  --shadow-panel: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.15), 0 20px 40px rgba(0, 0, 0, 0.2);
+  /* Popover / dropdown / context-menu shadow */
+  --shadow-menu: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 10px 30px rgba(0, 0, 0, 0.35);
+  /* Toast shadow */
+  --shadow-toast: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.2), 0 16px 32px rgba(0, 0, 0, 0.28);
+  /* Small inset panels (terminal body split panes) */
+  --shadow-inset-panel: 0 0 0 1px rgba(0, 0, 0, 0.05), 0 2px 10px rgba(0, 0, 0, 0.18);
+
+  /* ── Spacing ───────────────────────────────────────────────────── */
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 16px;
+  --spacing-lg: 24px;
+  --spacing-xl: 32px;
+  --spacing-2xl: 48px;
+
+  /* ── Border radius ─────────────────────────────────────────────── */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --radius-full: 9999px;
+
+  /* ── Typography ────────────────────────────────────────────────── */
+  --font-family:
+    system-ui, -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text', 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: 'Iosevka Extended', 'SF Mono', Monaco, Menlo, monospace;
+  --font-size-xs: 13px;
+  --font-size-sm: 16px;
+  --font-size-base: 18px;
+  --font-size-md: 18px;
+  --font-size-lg: 20px;
+  --font-size-xl: 26px;
+  --font-size-2xl: 34px;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* ── Transitions ───────────────────────────────────────────────── */
+  --transition-fast: 150ms ease;
+  --transition-normal: 200ms ease;
+  --transition-slow: 300ms ease;
+
+  /* ── Layout ────────────────────────────────────────────────────── */
+  --header-height: 72px;
+  --sidebar-width: 72px;
+  --content-max-width: 1200px;
+  --content-padding: 24px;
+
+  /* ── Animations ────────────────────────────────────────────────── */
+  --animate-tooltip-pop: tooltip-pop 80ms ease-out forwards;
+  --animate-toast-in: toast-in 240ms cubic-bezier(0.32, 0.72, 0, 1) both;
+}
+
+/* Tokens consumed only via var() (no Tailwind utilities generated). */
+:root {
+  color-scheme: dark;
+
+  /* xterm chrome */
+  --terminal-selection: rgba(255, 255, 255, 0.15);
+  --terminal-scrollbar: rgba(255, 255, 255, 0.15);
+  --terminal-scrollbar-hover: rgba(255, 255, 255, 0.3);
+  --terminal-scrollbar-active: rgba(255, 255, 255, 0.4);
+
+  /* Glass bevel pieces (see .glass-bevel in index.css) */
+  --bevel-top: rgba(255, 255, 255, 0.14);
+  --bevel-side: rgba(255, 255, 255, 0.05);
+  --bevel-bottom: rgba(0, 0, 0, 0.5);
+  --bevel-glow: rgba(255, 255, 255, 0.08);
+}
+
+/* ===================================
+   Light theme
+   =================================== */
+
+:root[data-theme='light'] {
+  color-scheme: light;
+
+  --color-background: #f5f5f7;
+  --color-background-secondary: rgba(0, 0, 0, 0.05);
+  --color-background-tertiary: rgba(0, 0, 0, 0.1);
+  --color-surface: #ffffff;
+  --color-surface-raised: #e8e8ec;
+
+  --color-text-primary: #1d1d1f;
+  --color-text-secondary: #6e6e73;
+  --color-text-tertiary: #aeaeb2;
+  --color-ink: #000000;
+
+  --color-border: rgba(0, 0, 0, 0.1);
+  --color-border-hover: rgba(0, 0, 0, 0.16);
+  --color-bezel: rgba(0, 0, 0, 0.14);
+
+  --color-accent: #007aff;
+  --color-accent-hover: #0071e3;
+  --color-accent-light: rgba(0, 122, 255, 0.15);
+  --color-accent-ink: #ffffff;
+
+  --color-git: #e0502b;
+  --color-git-light: rgba(224, 80, 43, 0.12);
+  --color-claude: #c77400;
+  --color-claude-light: rgba(199, 116, 0, 0.12);
+  --color-success: #248a3d;
+  --color-success-subtle: rgba(52, 199, 89, 0.15);
+  --color-error: #d70015;
+  --color-status-ready: #17a533;
+  --color-status-thinking: #9c36b5;
+
+  --color-terminal-bg: #ffffff;
+  --color-terminal-fg: #1d1d1f;
+  --color-terminal-surface: #ececef;
+  --color-terminal-surface-alt: #f4f4f6;
+  --color-terminal-inset: #fafafa;
+
+  --color-ansi-black: #212529;
+  --color-ansi-red: #c92a2a;
+  --color-ansi-green: #2f9e44;
+  --color-ansi-yellow: #e67700;
+  --color-ansi-blue: #1971c2;
+  --color-ansi-magenta: #9c36b5;
+  --color-ansi-cyan: #0c8599;
+  --color-ansi-white: #adb5bd;
+  --color-ansi-bright-black: #868e96;
+  --color-ansi-bright-red: #e03131;
+  --color-ansi-bright-green: #37b24d;
+  --color-ansi-bright-yellow: #f08c00;
+  --color-ansi-bright-blue: #1c7ed6;
+  --color-ansi-bright-magenta: #ae3ec9;
+  --color-ansi-bright-cyan: #1098ad;
+  --color-ansi-bright-white: #f8f9fa;
+
+  --color-diff-fg: #1f2328;
+  --color-diff-added: #1a7f37;
+  --color-diff-removed: #cf222e;
+  --color-diff-hunk: #6a6ac0;
+  --color-vcs-added: #248a3d;
+  --color-vcs-deleted: #d70015;
+  --color-vcs-renamed: #5856d6;
+  --color-vcs-modified: #ad5f00;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.12);
+  --shadow-hover: 0 12px 32px rgba(0, 0, 0, 0.16);
+  --shadow-panel: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 4px 12px rgba(0, 0, 0, 0.08), 0 20px 40px rgba(0, 0, 0, 0.1);
+  --shadow-menu: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 10px 30px rgba(0, 0, 0, 0.16);
+  --shadow-toast: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 4px 12px rgba(0, 0, 0, 0.1), 0 16px 32px rgba(0, 0, 0, 0.14);
+  --shadow-inset-panel: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 2px 10px rgba(0, 0, 0, 0.08);
+
+  --terminal-selection: rgba(0, 0, 0, 0.12);
+  --terminal-scrollbar: rgba(0, 0, 0, 0.18);
+  --terminal-scrollbar-hover: rgba(0, 0, 0, 0.32);
+  --terminal-scrollbar-active: rgba(0, 0, 0, 0.42);
+
+  --bevel-top: rgba(255, 255, 255, 0.75);
+  --bevel-side: rgba(255, 255, 255, 0.35);
+  --bevel-bottom: rgba(0, 0, 0, 0.12);
+  --bevel-glow: rgba(255, 255, 255, 0.5);
+}

--- a/src/theme/tokens.css
+++ b/src/theme/tokens.css
@@ -41,6 +41,9 @@
   --color-border-hover: rgba(255, 255, 255, 0.15);
   /* Dark lip around cards/panels (was border-black/60 everywhere) */
   --color-bezel: rgba(0, 0, 0, 0.6);
+  /* Crisp edge on large floating panels (terminal cards, kanban board,
+     settings cards) — darker than --color-bezel on light themes */
+  --color-bezel-panel: rgba(0, 0, 0, 0.6);
 
   /* ── Accent / brand — Ouijit blue. App-wide accent: links, selection,
      focus rings, primary buttons. --color-accent-ink is the text color on
@@ -202,6 +205,7 @@
   --color-border: rgba(0, 0, 0, 0.1);
   --color-border-hover: rgba(0, 0, 0, 0.16);
   --color-bezel: rgba(0, 0, 0, 0.14);
+  --color-bezel-panel: rgba(0, 0, 0, 0.25);
 
   --color-accent: #007aff;
   --color-accent-hover: #0071e3;
@@ -254,10 +258,12 @@
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.12);
   --shadow-hover: 0 12px 32px rgba(0, 0, 0, 0.16);
-  --shadow-panel: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 4px 12px rgba(0, 0, 0, 0.08), 0 20px 40px rgba(0, 0, 0, 0.1);
+  /* No 1px rings on panel shadows in light mode — the bezel-panel border is
+     the crisp edge; a ring outside it reads as a doubled, thicker border. */
+  --shadow-panel: 0 4px 12px rgba(0, 0, 0, 0.08), 0 20px 40px rgba(0, 0, 0, 0.1);
   --shadow-menu: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 10px 30px rgba(0, 0, 0, 0.16);
   --shadow-toast: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 4px 12px rgba(0, 0, 0, 0.1), 0 16px 32px rgba(0, 0, 0, 0.14);
-  --shadow-inset-panel: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 2px 10px rgba(0, 0, 0, 0.08);
+  --shadow-inset-panel: 0 2px 10px rgba(0, 0, 0, 0.08);
 
   --terminal-selection: rgba(0, 0, 0, 0.12);
   --terminal-scrollbar: rgba(0, 0, 0, 0.18);

--- a/src/theme/xtermTheme.ts
+++ b/src/theme/xtermTheme.ts
@@ -1,0 +1,42 @@
+/**
+ * Builds the xterm.js theme object from the design tokens in
+ * src/theme/tokens.css, so terminals re-skin with the rest of the app.
+ * Call again after a theme change (see subscribeTheme) and assign the result
+ * to `terminal.options.theme` — xterm repaints on theme assignment.
+ */
+
+import { readToken } from './themeManager';
+
+export interface XtermThemeColors extends Record<string, string> {
+  background: string;
+  foreground: string;
+}
+
+export function buildXtermTheme(): XtermThemeColors {
+  return {
+    background: readToken('--color-terminal-bg'),
+    foreground: readToken('--color-terminal-fg'),
+    cursor: readToken('--color-terminal-fg'),
+    cursorAccent: readToken('--color-terminal-bg'),
+    selectionBackground: readToken('--terminal-selection'),
+    scrollbarSliderBackground: readToken('--terminal-scrollbar'),
+    scrollbarSliderHoverBackground: readToken('--terminal-scrollbar-hover'),
+    scrollbarSliderActiveBackground: readToken('--terminal-scrollbar-active'),
+    black: readToken('--color-ansi-black'),
+    red: readToken('--color-ansi-red'),
+    green: readToken('--color-ansi-green'),
+    yellow: readToken('--color-ansi-yellow'),
+    blue: readToken('--color-ansi-blue'),
+    magenta: readToken('--color-ansi-magenta'),
+    cyan: readToken('--color-ansi-cyan'),
+    white: readToken('--color-ansi-white'),
+    brightBlack: readToken('--color-ansi-bright-black'),
+    brightRed: readToken('--color-ansi-bright-red'),
+    brightGreen: readToken('--color-ansi-bright-green'),
+    brightYellow: readToken('--color-ansi-bright-yellow'),
+    brightBlue: readToken('--color-ansi-bright-blue'),
+    brightMagenta: readToken('--color-ansi-bright-magenta'),
+    brightCyan: readToken('--color-ansi-bright-cyan'),
+    brightWhite: readToken('--color-ansi-bright-white'),
+  };
+}

--- a/src/theme/xtermTheme.ts
+++ b/src/theme/xtermTheme.ts
@@ -3,40 +3,52 @@
  * src/theme/tokens.css, so terminals re-skin with the rest of the app.
  * Call again after a theme change (see subscribeTheme) and assign the result
  * to `terminal.options.theme` — xterm repaints on theme assignment.
+ *
+ * The built object is cached per applied theme (see getThemeEpoch).
  */
 
-import { readToken } from './themeManager';
+import { getThemeEpoch } from './themeManager';
 
 export interface XtermThemeColors extends Record<string, string> {
   background: string;
   foreground: string;
 }
 
+let cache: { epoch: number; theme: XtermThemeColors } | null = null;
+
 export function buildXtermTheme(): XtermThemeColors {
-  return {
-    background: readToken('--color-terminal-bg'),
-    foreground: readToken('--color-terminal-fg'),
-    cursor: readToken('--color-terminal-fg'),
-    cursorAccent: readToken('--color-terminal-bg'),
-    selectionBackground: readToken('--terminal-selection'),
-    scrollbarSliderBackground: readToken('--terminal-scrollbar'),
-    scrollbarSliderHoverBackground: readToken('--terminal-scrollbar-hover'),
-    scrollbarSliderActiveBackground: readToken('--terminal-scrollbar-active'),
-    black: readToken('--color-ansi-black'),
-    red: readToken('--color-ansi-red'),
-    green: readToken('--color-ansi-green'),
-    yellow: readToken('--color-ansi-yellow'),
-    blue: readToken('--color-ansi-blue'),
-    magenta: readToken('--color-ansi-magenta'),
-    cyan: readToken('--color-ansi-cyan'),
-    white: readToken('--color-ansi-white'),
-    brightBlack: readToken('--color-ansi-bright-black'),
-    brightRed: readToken('--color-ansi-bright-red'),
-    brightGreen: readToken('--color-ansi-bright-green'),
-    brightYellow: readToken('--color-ansi-bright-yellow'),
-    brightBlue: readToken('--color-ansi-bright-blue'),
-    brightMagenta: readToken('--color-ansi-bright-magenta'),
-    brightCyan: readToken('--color-ansi-bright-cyan'),
-    brightWhite: readToken('--color-ansi-bright-white'),
+  const epoch = getThemeEpoch();
+  if (cache?.epoch === epoch) return cache.theme;
+
+  const style = getComputedStyle(document.documentElement);
+  const token = (name: string): string => style.getPropertyValue(name).trim();
+
+  const theme: XtermThemeColors = {
+    background: token('--color-terminal-bg'),
+    foreground: token('--color-terminal-fg'),
+    cursor: token('--color-terminal-fg'),
+    cursorAccent: token('--color-terminal-bg'),
+    selectionBackground: token('--terminal-selection'),
+    scrollbarSliderBackground: token('--terminal-scrollbar'),
+    scrollbarSliderHoverBackground: token('--terminal-scrollbar-hover'),
+    scrollbarSliderActiveBackground: token('--terminal-scrollbar-active'),
+    black: token('--color-ansi-black'),
+    red: token('--color-ansi-red'),
+    green: token('--color-ansi-green'),
+    yellow: token('--color-ansi-yellow'),
+    blue: token('--color-ansi-blue'),
+    magenta: token('--color-ansi-magenta'),
+    cyan: token('--color-ansi-cyan'),
+    white: token('--color-ansi-white'),
+    brightBlack: token('--color-ansi-bright-black'),
+    brightRed: token('--color-ansi-bright-red'),
+    brightGreen: token('--color-ansi-bright-green'),
+    brightYellow: token('--color-ansi-bright-yellow'),
+    brightBlue: token('--color-ansi-bright-blue'),
+    brightMagenta: token('--color-ansi-bright-magenta'),
+    brightCyan: token('--color-ansi-bright-cyan'),
+    brightWhite: token('--color-ansi-bright-white'),
   };
+  cache = { epoch, theme };
+  return theme;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -535,6 +535,8 @@ export interface ElectronAPI {
   onCliChange(
     callback: (payload: { project: string; action: string; message?: string; ts: number }) => void,
   ): () => void;
+  /** Listen for a CLI theme mutation — re-read and re-apply theme settings */
+  onCliThemeChanged(callback: () => void): () => void;
   /** Listen for a CLI-initiated task start that requires spawning a terminal */
   onCliTaskStarted(
     callback: (payload: {

--- a/src/utils/renderPlanMarkdown.ts
+++ b/src/utils/renderPlanMarkdown.ts
@@ -6,14 +6,9 @@ import mermaid from 'mermaid';
 import log from 'electron-log/renderer';
 import { linkifyFilePaths } from './linkifyFilePaths';
 import { getResolvedTheme } from '../theme/themeManager';
+import { SHIKI_THEMES, currentShikiTheme } from '../theme/shikiTheme';
 
 const planRenderLog = log.scope('planRender');
-
-const THEMES = { dark: 'github-dark', light: 'github-light' } as const;
-
-function currentTheme(): string {
-  return THEMES[getResolvedTheme()];
-}
 
 const PRELOADED_LANGS: BundledLanguage[] = [
   'typescript',
@@ -43,12 +38,13 @@ let highlighterPromise: Promise<HighlighterGeneric<BundledLanguage, BundledTheme
 
 function getHighlighter() {
   if (!highlighterPromise) {
-    highlighterPromise = createHighlighter({ themes: [THEMES.dark, THEMES.light], langs: PRELOADED_LANGS }).catch(
-      (err) => {
-        highlighterPromise = null;
-        throw err;
-      },
-    );
+    highlighterPromise = createHighlighter({
+      themes: [SHIKI_THEMES.dark, SHIKI_THEMES.light],
+      langs: PRELOADED_LANGS,
+    }).catch((err) => {
+      highlighterPromise = null;
+      throw err;
+    });
   }
   return highlighterPromise;
 }
@@ -142,7 +138,7 @@ export async function renderPlanMarkdown(md: string): Promise<string> {
     if (lang && hl.getLoadedLanguages().includes(lang)) {
       try {
         return hl
-          .codeToHtml(text, { lang, theme: currentTheme() })
+          .codeToHtml(text, { lang, theme: currentShikiTheme() })
           .replace('<pre class="shiki', '<pre class="shiki glass-bevel');
       } catch {
         // Fall through to plain code block

--- a/src/utils/renderPlanMarkdown.ts
+++ b/src/utils/renderPlanMarkdown.ts
@@ -5,10 +5,15 @@ import type { BundledLanguage, HighlighterGeneric, BundledTheme } from 'shiki';
 import mermaid from 'mermaid';
 import log from 'electron-log/renderer';
 import { linkifyFilePaths } from './linkifyFilePaths';
+import { getResolvedTheme } from '../theme/themeManager';
 
 const planRenderLog = log.scope('planRender');
 
-const THEME = 'github-dark';
+const THEMES = { dark: 'github-dark', light: 'github-light' } as const;
+
+function currentTheme(): string {
+  return THEMES[getResolvedTheme()];
+}
 
 const PRELOADED_LANGS: BundledLanguage[] = [
   'typescript',
@@ -38,24 +43,29 @@ let highlighterPromise: Promise<HighlighterGeneric<BundledLanguage, BundledTheme
 
 function getHighlighter() {
   if (!highlighterPromise) {
-    highlighterPromise = createHighlighter({ themes: [THEME], langs: PRELOADED_LANGS }).catch((err) => {
-      highlighterPromise = null;
-      throw err;
-    });
+    highlighterPromise = createHighlighter({ themes: [THEMES.dark, THEMES.light], langs: PRELOADED_LANGS }).catch(
+      (err) => {
+        highlighterPromise = null;
+        throw err;
+      },
+    );
   }
   return highlighterPromise;
 }
 
-let mermaidInitialized = false;
+let mermaidTheme: 'dark' | 'default' | null = null;
 let mermaidCounter = 0;
 
 const MERMAID_FONT_FAMILY = '-apple-system, BlinkMacSystemFont, system-ui, sans-serif';
 
 function ensureMermaid(): void {
-  if (mermaidInitialized) return;
+  // Re-initialize when the app theme flipped since the last render; the plan
+  // panel re-renders markdown on theme changes, so diagrams follow along.
+  const theme = getResolvedTheme() === 'light' ? 'default' : 'dark';
+  if (mermaidTheme === theme) return;
   mermaid.initialize({
     startOnLoad: false,
-    theme: 'dark',
+    theme,
     securityLevel: 'strict',
     fontFamily: MERMAID_FONT_FAMILY,
     // Render labels as native SVG <text> elements rather than <foreignObject>
@@ -63,7 +73,7 @@ function ensureMermaid(): void {
     // namespace edge cases that strip child content of foreignObject.
     flowchart: { htmlLabels: false },
   });
-  mermaidInitialized = true;
+  mermaidTheme = theme;
 }
 
 async function renderMermaidBlock(source: string): Promise<string | null> {
@@ -132,7 +142,7 @@ export async function renderPlanMarkdown(md: string): Promise<string> {
     if (lang && hl.getLoadedLanguages().includes(lang)) {
       try {
         return hl
-          .codeToHtml(text, { lang, theme: THEME })
+          .codeToHtml(text, { lang, theme: currentTheme() })
           .replace('<pre class="shiki', '<pre class="shiki glass-bevel');
       } catch {
         // Fall through to plain code block

--- a/src/utils/syntaxHighlight.ts
+++ b/src/utils/syntaxHighlight.ts
@@ -2,13 +2,18 @@ import { createHighlighter, bundledLanguages } from 'shiki';
 import type { BundledLanguage } from 'shiki';
 import type { ThemedToken, HighlighterGeneric } from '@shikijs/types';
 import type { DiffHunk } from '../git';
+import { getResolvedTheme } from '../theme/themeManager';
 
 export type { ThemedToken };
 
 /** Tokens for each line in a hunk, indexed by line position within the hunk */
 export type HunkTokens = (ThemedToken[] | null)[];
 
-const THEME = 'github-dark';
+const THEMES = { dark: 'github-dark', light: 'github-light' } as const;
+
+function currentTheme(): string {
+  return THEMES[getResolvedTheme()];
+}
 
 const PRELOADED_LANGS: BundledLanguage[] = [
   'typescript',
@@ -98,7 +103,7 @@ let highlighterPromise: Promise<HighlighterGeneric<any, any>> | null = null;
 function getHighlighter() {
   if (!highlighterPromise) {
     highlighterPromise = createHighlighter({
-      themes: [THEME],
+      themes: [THEMES.dark, THEMES.light],
       langs: PRELOADED_LANGS,
     });
   }
@@ -228,6 +233,6 @@ function tokenizeLines(hl: HighlighterGeneric<any, any>, lines: string[], lang: 
   if (lines.length === 0) return [];
 
   const code = lines.join('\n');
-  const { tokens } = hl.codeToTokens(code, { lang, theme: THEME });
+  const { tokens } = hl.codeToTokens(code, { lang, theme: currentTheme() });
   return tokens;
 }

--- a/src/utils/syntaxHighlight.ts
+++ b/src/utils/syntaxHighlight.ts
@@ -2,18 +2,12 @@ import { createHighlighter, bundledLanguages } from 'shiki';
 import type { BundledLanguage } from 'shiki';
 import type { ThemedToken, HighlighterGeneric } from '@shikijs/types';
 import type { DiffHunk } from '../git';
-import { getResolvedTheme } from '../theme/themeManager';
+import { SHIKI_THEMES, currentShikiTheme } from '../theme/shikiTheme';
 
 export type { ThemedToken };
 
 /** Tokens for each line in a hunk, indexed by line position within the hunk */
 export type HunkTokens = (ThemedToken[] | null)[];
-
-const THEMES = { dark: 'github-dark', light: 'github-light' } as const;
-
-function currentTheme(): string {
-  return THEMES[getResolvedTheme()];
-}
 
 const PRELOADED_LANGS: BundledLanguage[] = [
   'typescript',
@@ -103,7 +97,7 @@ let highlighterPromise: Promise<HighlighterGeneric<any, any>> | null = null;
 function getHighlighter() {
   if (!highlighterPromise) {
     highlighterPromise = createHighlighter({
-      themes: [THEMES.dark, THEMES.light],
+      themes: [SHIKI_THEMES.dark, SHIKI_THEMES.light],
       langs: PRELOADED_LANGS,
     });
   }
@@ -233,6 +227,6 @@ function tokenizeLines(hl: HighlighterGeneric<any, any>, lines: string[], lang: 
   if (lines.length === 0) return [];
 
   const code = lines.join('\n');
-  const { tokens } = hl.codeToTokens(code, { lang, theme: currentTheme() });
+  const { tokens } = hl.codeToTokens(code, { lang, theme: currentShikiTheme() });
   return tokens;
 }


### PR DESCRIPTION
## Summary
- Centralize every color, shadow, radius, and typography value into design tokens (`src/theme/tokens.css`) with a runtime theme manager
- Add light mode plus custom themes as token overrides on a dark or light base
- Give large floating panels (terminal cards, kanban board, settings cards, canvas nodes) a dedicated bezel token so they keep a crisp thin border on light themes, and remove the 1px shadow rings that doubled the edge
- Ship built-in preset themes: Dracula, Tokyo Night, Matrix, Hot Pink, and Sepia; editing a preset saves a user copy that shadows it, and deleting the copy restores the preset
- Simplify Appearance settings to a single theme dropdown (built-ins, presets, custom themes) with live preview on option hover; custom theme rows keep Edit/Remove
- Add a dedicated tooltip shadow token to replace the panel-scale blur on tooltips, and warm-tint Sepia's shadows and bezel
- Add `ouijit theme list/use/save/delete` CLI commands backed by new REST routes, with real-time renderer sync via a cli:theme-changed push