### PR TITLE
Remove auto preview

### DIFF
--- a/src/__tests__/renderer/sessionSnapshot.test.tsx
+++ b/src/__tests__/renderer/sessionSnapshot.test.tsx
@@ -34,8 +34,7 @@ interface FakeTermOpts {
   planPath?: string | null;
   planPanelOpen?: boolean;
   diffPanelOpen?: boolean;
-  /** A preview URL that was auto-detected by a runner (should not persist). */
-  autoPreviewUrl?: string | null;
+  previewUrl?: string | null;
 }
 
 function makeFakeTerm(opts: FakeTermOpts): OuijitTerminal {
@@ -45,14 +44,8 @@ function makeFakeTerm(opts: FakeTermOpts): OuijitTerminal {
     panels.push({ id: 'plan', kind: 'plan', planPath: opts.planPath });
     if (opts.planPanelOpen) activePanelId = 'plan';
   }
-  if (opts.autoPreviewUrl) {
-    panels.push({
-      id: 'prev',
-      kind: 'webPreview',
-      url: opts.autoPreviewUrl,
-      urlAutoDetected: true,
-      sourceRunnerPanelId: 'r',
-    });
+  if (opts.previewUrl) {
+    panels.push({ id: 'prev', kind: 'webPreview', url: opts.previewUrl });
   }
   return {
     ptyId: opts.ptyId,
@@ -121,11 +114,11 @@ describe('gatherSnapshot', () => {
     expect(snap.terminals.map((t) => t.ptyId)).toEqual(['main']);
   });
 
-  test('excludes auto-detected preview URLs from the snapshot', () => {
-    register(PROJECT, makeFakeTerm({ ptyId: 'a', label: 'Shell', autoPreviewUrl: 'http://localhost:3000' }));
+  test('persists preview panel URLs', () => {
+    register(PROJECT, makeFakeTerm({ ptyId: 'a', label: 'Shell', previewUrl: 'http://localhost:3000' }));
 
     const snap = gatherSnapshot();
-    expect(snap.terminals[0].ui.panels).toEqual([]);
+    expect(snap.terminals[0].ui.panels).toEqual([{ kind: 'webPreview', url: 'http://localhost:3000' }]);
   });
 });
 

--- a/src/__tests__/webPreviewUrlHelpers.test.ts
+++ b/src/__tests__/webPreviewUrlHelpers.test.ts
@@ -33,4 +33,3 @@ describe('normalizeUrl', () => {
     expect(normalizeUrl('  http://foo  ')).toBe('http://foo');
   });
 });
-

--- a/src/__tests__/webPreviewUrlHelpers.test.ts
+++ b/src/__tests__/webPreviewUrlHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { detectDevServerUrl, normalizeUrl } from '../components/webPreview/urlHelpers';
+import { normalizeUrl } from '../components/webPreview/urlHelpers';
 
 describe('normalizeUrl', () => {
   it('returns empty string for blank input', () => {
@@ -34,53 +34,3 @@ describe('normalizeUrl', () => {
   });
 });
 
-describe('detectDevServerUrl', () => {
-  it('finds a bare localhost URL', () => {
-    expect(detectDevServerUrl('Listening on http://localhost:3000')).toBe('http://localhost:3000');
-  });
-
-  it('finds a 127.0.0.1 URL', () => {
-    expect(detectDevServerUrl('server: http://127.0.0.1:8080')).toBe('http://127.0.0.1:8080');
-  });
-
-  it('captures an explicit path', () => {
-    expect(detectDevServerUrl('Ready at http://localhost:5173/admin')).toBe('http://localhost:5173/admin');
-  });
-
-  it('requires a port to avoid false positives on bare "localhost"', () => {
-    expect(detectDevServerUrl('Use localhost for local development.')).toBeNull();
-  });
-
-  it('returns null when no loopback URL is present', () => {
-    expect(detectDevServerUrl('Fetching https://api.github.com/repos')).toBeNull();
-  });
-
-  it('ignores 0.0.0.0 (not browsable)', () => {
-    expect(detectDevServerUrl('listening on http://0.0.0.0:3000')).toBeNull();
-  });
-
-  it('strips trailing punctuation printed by loggers', () => {
-    expect(detectDevServerUrl('Server started at http://localhost:3000.')).toBe('http://localhost:3000');
-    expect(detectDevServerUrl('Visit (http://localhost:3000)')).toBe('http://localhost:3000');
-    expect(detectDevServerUrl('See http://localhost:3000,')).toBe('http://localhost:3000');
-  });
-
-  it('strips ANSI CSI color escapes wrapping the URL', () => {
-    const ansiWrapped = 'Local:   \x1b[36mhttp://localhost:5173/\x1b[0m';
-    expect(detectDevServerUrl(ansiWrapped)).toBe('http://localhost:5173/');
-  });
-
-  it('strips ANSI OSC sequences', () => {
-    const chunk = '\x1b]0;title\x07Ready at http://localhost:3000';
-    expect(detectDevServerUrl(chunk)).toBe('http://localhost:3000');
-  });
-
-  it('returns the first URL when multiple are present', () => {
-    const chunk = 'Local: http://localhost:3000\nNetwork: http://127.0.0.1:3000';
-    expect(detectDevServerUrl(chunk)).toBe('http://localhost:3000');
-  });
-
-  it('handles https dev servers', () => {
-    expect(detectDevServerUrl('serving https://localhost:3443')).toBe('https://localhost:3443');
-  });
-});

--- a/src/components/terminal/panelTypes.ts
+++ b/src/components/terminal/panelTypes.ts
@@ -38,9 +38,6 @@ export interface WebPreviewPanel {
   id: string;
   kind: 'webPreview';
   url: string | null;
-  urlAutoDetected: boolean;
-  /** Runner panel that auto-published this URL, if any. */
-  sourceRunnerPanelId: string | null;
 }
 
 export interface PlanPanel {

--- a/src/components/terminal/sessionSnapshot.ts
+++ b/src/components/terminal/sessionSnapshot.ts
@@ -34,9 +34,7 @@ function uiFor(term: OuijitTerminal): SnapshotTerminalUi {
         });
         break;
       case 'webPreview':
-        // Only persist user-set URLs. Auto-detected ones are tied to a runner
-        // that no longer exists post-quit and would mislead the user.
-        if (p.url && !p.urlAutoDetected) panels.push({ kind: 'webPreview', url: p.url });
+        if (p.url) panels.push({ kind: 'webPreview', url: p.url });
         break;
       case 'plan':
         panels.push({ kind: 'plan', planPath: p.planPath });

--- a/src/components/terminal/terminalActions.ts
+++ b/src/components/terminal/terminalActions.ts
@@ -25,7 +25,6 @@ import { generateId } from '../../utils/ids';
 import { parseOsc133ExitCodes } from './osc133';
 import { buildEditorCommand } from './editorCommand';
 import { readSnapshot } from './sessionSnapshot';
-import { detectDevServerUrl } from '../webPreview/urlHelpers';
 import { descriptionToHookPrompt } from '../../utils/descriptionAttachments';
 import log from 'electron-log/renderer';
 
@@ -122,9 +121,7 @@ export async function applyInitialUiState(term: OuijitTerminal, ui: SnapshotTerm
           });
           break;
         case 'webPreview':
-          if (sp.url) {
-            panels.push({ id, kind: 'webPreview', url: sp.url, urlAutoDetected: false, sourceRunnerPanelId: null });
-          }
+          if (sp.url) panels.push({ id, kind: 'webPreview', url: sp.url });
           break;
         case 'plan':
           if (sp.planPath) panels.push({ id, kind: 'plan', planPath: sp.planPath });
@@ -144,13 +141,7 @@ export async function applyInitialUiState(term: OuijitTerminal, ui: SnapshotTerm
     }
     if (ui.webPreview?.url) {
       const id = generateId('panel');
-      panels.push({
-        id,
-        kind: 'webPreview',
-        url: ui.webPreview.url,
-        urlAutoDetected: false,
-        sourceRunnerPanelId: null,
-      });
+      panels.push({ id, kind: 'webPreview', url: ui.webPreview.url });
       if (ui.webPreview.panelOpen) activeId = id;
     }
     if (ui.runner) {
@@ -710,8 +701,6 @@ async function _spawnRunnerInner(instance: OuijitTerminal, panelId: string): Pro
           if (match[1]) instance.updatePanel(panelId, { command: match[1] });
         }
         updateRunnerStatusFromOsc133(data, instance, panelId);
-        const detected = detectDevServerUrl(data);
-        if (detected) instance.publishDetectedPreviewUrl(panelId, detected);
       },
       onExit: (exitCode) => {
         instance.updatePanel(panelId, { status: exitCode === 0 ? 'success' : 'error' });
@@ -957,8 +946,6 @@ export async function reconnectRunnerToParent(session: ActiveSession): Promise<b
         if (match[1]) parentTerminal.updatePanel(runnerPanelId, { command: match[1] });
       }
       updateRunnerStatusFromOsc133(data, parentTerminal, runnerPanelId);
-      const detected = detectDevServerUrl(data);
-      if (detected) parentTerminal.publishDetectedPreviewUrl(runnerPanelId, detected);
     },
     onExit: (exitCode) => {
       parentTerminal.updatePanel(runnerPanelId, { status: exitCode === 0 ? 'success' : 'error' });

--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -829,17 +829,12 @@ export class OuijitTerminal {
     return id;
   }
 
-  addWebPreviewPanel(
-    url: string | null = null,
-    opts?: { autoDetected?: boolean; sourceRunnerPanelId?: string | null; activate?: boolean },
-  ): string {
+  addWebPreviewPanel(url: string | null = null, opts?: { activate?: boolean }): string {
     const id = generateId('panel');
     const panel: WebPreviewPanel = {
       id,
       kind: 'webPreview',
       url: url || null,
-      urlAutoDetected: opts?.autoDetected ?? false,
-      sourceRunnerPanelId: opts?.sourceRunnerPanelId ?? null,
     };
     this.appendPanel(panel, opts?.activate ?? true);
     return id;
@@ -872,20 +867,14 @@ export class OuijitTerminal {
     if (idx === -1) return;
     const panel = this.panels[idx];
 
-    const removeIds = new Set<string>([id]);
-    if (panel.kind === 'runner') {
-      // Kill the child PTY and drop any auto-detected preview tabs it published.
-      this.killRunnerChild(id);
-      for (const p of this.panels) {
-        if (p.kind === 'webPreview' && p.sourceRunnerPanelId === id && p.urlAutoDetected) removeIds.add(p.id);
-      }
-    }
+    // Closing a runner tab kills the child PTY it owns.
+    if (panel.kind === 'runner') this.killRunnerChild(id);
 
-    const remaining = this.panels.filter((p) => !removeIds.has(p.id));
+    const remaining = this.panels.filter((p) => p.id !== id);
 
     // If the active panel is being removed, activate the same-index neighbor
     // (else the previous one, else collapse to the bare xterm).
-    if (this.activePanelId && removeIds.has(this.activePanelId)) {
+    if (this.activePanelId === id) {
       this.activePanelId = remaining.length === 0 ? null : remaining[Math.min(idx, remaining.length - 1)].id;
     }
 
@@ -907,24 +896,6 @@ export class OuijitTerminal {
       this.runnerChildren.delete(panelId);
     }
     this.runnerSpawning.delete(panelId);
-  }
-
-  /**
-   * A runner detected a dev-server URL. Update the preview tab it already
-   * published, or surface a new auto-detected preview tab (without stealing
-   * focus from the user's current panel). Manual URLs are left untouched.
-   */
-  publishDetectedPreviewUrl(runnerPanelId: string, url: string): void {
-    const existing = this.panels.find(
-      (p): p is WebPreviewPanel => p.kind === 'webPreview' && p.sourceRunnerPanelId === runnerPanelId,
-    );
-    if (existing) {
-      if (existing.url && !existing.urlAutoDetected) return;
-      if (existing.url === url) return;
-      this.updatePanel(existing.id, { url, urlAutoDetected: true } as Partial<WebPreviewPanel>);
-    } else {
-      this.addWebPreviewPanel(url, { autoDetected: true, sourceRunnerPanelId: runnerPanelId, activate: false });
-    }
   }
 
   // ── Hook status handling ────────────────────────────────────────────

--- a/src/components/terminal/useTerminalPanels.ts
+++ b/src/components/terminal/useTerminalPanels.ts
@@ -97,8 +97,7 @@ export function useTerminalPanels(ptyId: string | null) {
 
   const changeWebPreviewUrl = useCallback(
     (panelId: string, newUrl: string) => {
-      // A manual edit locks out future auto-detections for this panel.
-      withInstance((instance) => instance.updatePanel(panelId, { url: newUrl, urlAutoDetected: false }));
+      withInstance((instance) => instance.updatePanel(panelId, { url: newUrl }));
     },
     [withInstance],
   );

--- a/src/components/webPreview/urlHelpers.ts
+++ b/src/components/webPreview/urlHelpers.ts
@@ -13,22 +13,3 @@ export function normalizeUrl(input: string): string {
   // Bare host:port or host — assume http for dev servers.
   return `http://${trimmed}`;
 }
-
-// Strip ANSI CSI and OSC sequences so URLs split by color codes still match.
-const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07/g;
-
-// Match http[s]://localhost or loopback IP with required port. Requiring a
-// port avoids false positives on documentation URLs that mention "localhost".
-const DEV_SERVER_URL_RE = /https?:\/\/(?:localhost|127\.0\.0\.1):\d+(?:\/[^\s]*)?/;
-
-/**
- * Scan a runner-terminal output chunk for a dev server URL. Returns the first
- * match, stripped of ANSI escapes and trailing punctuation.
- */
-export function detectDevServerUrl(chunk: string): string | null {
-  const stripped = chunk.replace(ANSI_RE, '');
-  const match = DEV_SERVER_URL_RE.exec(stripped);
-  if (!match) return null;
-  // Trim trailing punctuation commonly printed by loggers (e.g. ".", ")").
-  return match[0].replace(/[.,;:!?)\]]+$/, '');
-}


### PR DESCRIPTION
Runner output is no longer scanned for dev-server URLs, and preview tabs are no longer created or updated automatically. Web previews are only opened and edited by the user.

## Removed

- `detectDevServerUrl()` in `src/components/webPreview/urlHelpers.ts`, along with its ANSI/URL regexes
- The runner `onData` hooks in `terminalActions.ts` that scanned output and published detected URLs, on both the fresh-spawn and reconnect paths
- `publishDetectedPreviewUrl()` on `OuijitTerminal`
- `urlAutoDetected` and `sourceRunnerPanelId` from `WebPreviewPanel`, and the matching options on `addWebPreviewPanel()`

## Behavior changes

- Closing a runner tab no longer sweeps away preview tabs. It kills the child PTY and removes just that tab.
- `gatherSnapshot` persists every preview URL. The carve-out that skipped auto-detected ones is gone, so previews survive relaunch.
- Editing a preview URL no longer sets a lockout flag.

`normalizeUrl` and manual preview creation (header button, `ouijit preview add` via `useCliPanelListener`) are untouched.

## Tests

- Deleted the `detectDevServerUrl` describe block (11 tests) from `webPreviewUrlHelpers.test.ts`
- Rewrote `sessionSnapshot.test.tsx`'s `'excludes auto-detected preview URLs from the snapshot'` into `'persists preview panel URLs'`, since it asserted the old behavior
