### PR TITLE
Fix duplicate cards on reconnect and follow the submenu context menu in e2e

### DIFF
--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -37,6 +37,20 @@ async function dismissKanban(appPage: Page): Promise<void> {
 }
 
 /**
+ * Helper: pick a leaf entry out of a context-menu submenu ("Open in ▸ Terminal").
+ * The flyout is a CSS hover state on its parent row, so the parent has to be
+ * hovered before the leaf exists as a click target.
+ */
+async function chooseSubmenuItem(appPage: Page, parentLabel: string, itemLabel: string): Promise<void> {
+  const menu = appPage.locator('.context-menu--visible');
+  await expect(menu).toBeVisible({ timeout: 5_000 });
+  // Exact names throughout: the menu also lists the task's own terminals by
+  // label, and a task named "Editor task" otherwise collides with "Editor".
+  await menu.getByRole('button', { name: parentLabel, exact: true }).hover();
+  await menu.getByRole('button', { name: itemLabel, exact: true }).click();
+}
+
+/**
  * Helper: drag a kanban card to a target column using mouse events.
  * dnd-kit uses pointer events; requires mouse simulation.
  * Only reliable for adjacent-column drags (todo → in_progress).
@@ -150,11 +164,14 @@ test('project mode: terminals, kanban, context menu, and task lifecycle', async 
 
   const contextMenu = appPage.locator('.context-menu--visible');
   await expect(contextMenu).toBeVisible({ timeout: 5_000 });
-  await expect(contextMenu.locator('.context-menu-item', { hasText: 'Open in Terminal' })).toBeVisible();
-  await expect(contextMenu.locator('.context-menu-item', { hasText: 'Move to Done' })).toBeVisible();
-  await expect(contextMenu.locator('.context-menu-item--danger', { hasText: 'Move to Trash' })).toBeVisible();
+  await expect(contextMenu.getByRole('button', { name: 'Open in', exact: true })).toBeVisible();
 
-  await contextMenu.locator('.context-menu-item', { hasText: 'Open in Terminal' }).click();
+  // "Move to ▸" carries the column moves plus the danger Trash entry.
+  await contextMenu.getByRole('button', { name: 'Move to', exact: true }).hover();
+  await expect(contextMenu.getByRole('button', { name: 'Done', exact: true })).toBeVisible();
+  await expect(contextMenu.locator('.context-menu-item--danger', { hasText: 'Trash' })).toBeVisible();
+
+  await chooseSubmenuItem(appPage, 'Open in', 'Terminal');
 
   await expect(appPage.locator('.kanban-board')).not.toBeVisible({ timeout: 5_000 });
   await expect(appPage.locator('.project-card')).toHaveCount(1, { timeout: 15_000 });
@@ -172,7 +189,7 @@ test('project mode: terminals, kanban, context menu, and task lifecycle', async 
   await ipCard.click({ button: 'right' });
   await expect(appPage.locator('.context-menu--visible')).toBeVisible({ timeout: 5_000 });
 
-  await appPage.locator('.context-menu-item--danger', { hasText: 'Move to Trash' }).click();
+  await chooseSubmenuItem(appPage, 'Move to', 'Trash');
 
   // Trashing removes the card from the board immediately, no confirmation
   await expect(inProgressColumn.locator('.kanban-card')).toHaveCount(0, { timeout: 5_000 });
@@ -334,7 +351,7 @@ test('missing worktree: recovery dialog recreates worktree on open', async ({ ap
   // Open in terminal via context menu
   const kanbanCard = todoColumn.locator('.kanban-card').first();
   await kanbanCard.click({ button: 'right' });
-  await appPage.locator('.context-menu--visible .context-menu-item', { hasText: 'Open in Terminal' }).click();
+  await chooseSubmenuItem(appPage, 'Open in', 'Terminal');
   await expect(appPage.locator('.project-card')).toHaveCount(1, { timeout: 15_000 });
 
   // Get the worktree path from the task data
@@ -362,7 +379,7 @@ test('missing worktree: recovery dialog recreates worktree on open', async ({ ap
 
   // Try to open the task again — should show recovery dialog
   await ipCard.click({ button: 'right' });
-  await appPage.locator('.context-menu--visible .context-menu-item', { hasText: 'Open in Terminal' }).click();
+  await chooseSubmenuItem(appPage, 'Open in', 'Terminal');
 
   // Recovery dialog should appear
   const recoveryDialog = appPage.locator('[data-testid="dialog-overlay"][data-visible="true"] [data-testid="dialog"]');
@@ -425,7 +442,7 @@ test('open in editor: runs the editor hook in a task terminal with the worktree 
   const todoColumn = appPage.locator('.kanban-column[data-status="todo"]');
   await expect(todoColumn.locator('.kanban-card')).toHaveCount(1, { timeout: 5_000 });
   await todoColumn.locator('.kanban-card').first().click({ button: 'right' });
-  await appPage.locator('.context-menu--visible .context-menu-item', { hasText: 'Open in Terminal' }).click();
+  await chooseSubmenuItem(appPage, 'Open in', 'Terminal');
   await expect(appPage.locator('.project-card')).toHaveCount(1, { timeout: 15_000 });
 
   // Reopen the kanban and launch the editor from the in-progress card.
@@ -434,9 +451,7 @@ test('open in editor: runs the editor hook in a task terminal with the worktree 
   const ipCard = appPage.locator('.kanban-column[data-status="in_progress"] .kanban-card').first();
   await ipCard.click({ button: 'right' });
 
-  const contextMenu = appPage.locator('.context-menu--visible');
-  await expect(contextMenu).toBeVisible({ timeout: 5_000 });
-  await contextMenu.locator('.context-menu-item', { hasText: 'Open in Editor' }).click();
+  await chooseSubmenuItem(appPage, 'Open in', 'Editor');
 
   // A second terminal card opens for the editor — the visible result the old
   // detached-spawn path never produced.

--- a/src/components/terminal/terminalActions.ts
+++ b/src/components/terminal/terminalActions.ts
@@ -815,6 +815,40 @@ export function killExistingCommandInstances(
 
 // ── Reconnect all orphaned sessions for a project ────────────────────
 
+/**
+ * Reconnects currently in flight, keyed by PTY id. `terminalInstances` only
+ * gains its entry after `pty.reconnect` resolves, so a bare `has(ptyId)` check
+ * can't serialize the two callers: on a renderer reload the home view's
+ * unscoped reconnect and the project view's scoped one overlap, both pass the
+ * check for the same session, and each registers a card for it.
+ */
+const reconnectsInFlight = new Map<string, Promise<unknown>>();
+
+/**
+ * Restore `ptyId` at most once across concurrent callers. A caller that loses
+ * the race awaits the winner rather than skipping ahead, so the terminal list
+ * is final by the time it returns. ProjectViewReact reads that list to decide
+ * whether reconnection produced anything or the kanban should open instead.
+ */
+async function reconnectSessionOnce(ptyId: string, restore: () => Promise<unknown>): Promise<void> {
+  if (terminalInstances.has(ptyId)) return;
+
+  const inFlight = reconnectsInFlight.get(ptyId);
+  if (inFlight) {
+    // The winner reports its own failure; the loser only needs it to be over.
+    await inFlight.catch(() => {});
+    return;
+  }
+
+  const pending = restore();
+  reconnectsInFlight.set(ptyId, pending);
+  try {
+    await pending;
+  } finally {
+    reconnectsInFlight.delete(ptyId);
+  }
+}
+
 export async function reconnectOrphanedSessions(projectPath?: string): Promise<void> {
   let sessions: ActiveSession[];
   try {
@@ -844,38 +878,39 @@ export async function reconnectOrphanedSessions(projectPath?: string): Promise<v
   const runnerSessions = relevant.filter((s) => s.isRunner);
 
   // Reconnect main terminals first (so runner parents exist before runners
-  // reattach). The instance guard makes this idempotent across the two callers.
+  // reattach). reconnectSessionOnce makes this idempotent across the two callers.
   for (const session of mainSessions) {
-    if (terminalInstances.has(session.ptyId)) continue;
-    let worktreeBranch: string | undefined;
-    let mergeTarget: string | undefined;
-    if (session.taskId != null) {
-      const task = await window.api.task.getByNumber(session.projectPath, session.taskId);
-      worktreeBranch = task?.branch;
-      mergeTarget = task?.mergeTarget;
-    }
-
-    const [hookStatus, planPath] = await Promise.all([
-      window.api.agentHooks.getStatus(session.ptyId),
-      window.api.plan.getForPty(session.ptyId),
-    ]);
-    const initialStatus: SummaryType = hookStatus?.status === 'thinking' ? 'thinking' : 'ready';
-
-    const snapEntry = snapByPtyId.get(session.ptyId);
-    const term = await reconnectTerminal(session, {
-      worktreeBranch,
-      mergeTarget,
-      initialStatus,
-      label: snapEntry?.label ?? undefined,
-    });
-    if (term) {
-      if (snapEntry) await applyInitialUiState(term, snapEntry.ui);
-      // The plan association lives in the main process — authoritative for the
-      // path. Ensure a plan panel exists for it (without stealing focus).
-      if (planPath && !term.panels.some((p) => p.kind === 'plan' && p.planPath === planPath)) {
-        term.addPlanPanel(planPath, false);
+    await reconnectSessionOnce(session.ptyId, async () => {
+      let worktreeBranch: string | undefined;
+      let mergeTarget: string | undefined;
+      if (session.taskId != null) {
+        const task = await window.api.task.getByNumber(session.projectPath, session.taskId);
+        worktreeBranch = task?.branch;
+        mergeTarget = task?.mergeTarget;
       }
-    }
+
+      const [hookStatus, planPath] = await Promise.all([
+        window.api.agentHooks.getStatus(session.ptyId),
+        window.api.plan.getForPty(session.ptyId),
+      ]);
+      const initialStatus: SummaryType = hookStatus?.status === 'thinking' ? 'thinking' : 'ready';
+
+      const snapEntry = snapByPtyId.get(session.ptyId);
+      const term = await reconnectTerminal(session, {
+        worktreeBranch,
+        mergeTarget,
+        initialStatus,
+        label: snapEntry?.label ?? undefined,
+      });
+      if (term) {
+        if (snapEntry) await applyInitialUiState(term, snapEntry.ui);
+        // The plan association lives in the main process — authoritative for the
+        // path. Ensure a plan panel exists for it (without stealing focus).
+        if (planPath && !term.panels.some((p) => p.kind === 'plan' && p.planPath === planPath)) {
+          term.addPlanPanel(planPath, false);
+        }
+      }
+    });
   }
 
   // Restore the focused card per project. Without this, every reconnectTerminal
@@ -894,8 +929,7 @@ export async function reconnectOrphanedSessions(projectPath?: string): Promise<v
 
   // Reconnect runners to their parent terminals
   for (const session of runnerSessions) {
-    if (terminalInstances.has(session.ptyId)) continue;
-    await reconnectRunnerToParent(session);
+    await reconnectSessionOnce(session.ptyId, () => reconnectRunnerToParent(session));
   }
 }
 


### PR DESCRIPTION
Four of the nine e2e tests were failing.

## Stale tests

`project mode`, `missing worktree recovery`, and `open in editor` right-clicked a kanban card and looked for flat `Open in Terminal` / `Move to Done` / `Move to Trash` entries. The card menu nests those under `Open in ▸` and `Move to ▸` hover flyouts, so the entries no longer exist.

`chooseSubmenuItem` hovers the parent row to open the flyout, then clicks the leaf. Names are matched exactly: the menu also lists the task's own terminals by label, and the `Editor task` fixture otherwise collides with the `Editor` leaf.

## Real bug: reconnect duplicates a card

`terminal reconnect after reload` asserts that reconnection doesn't duplicate the shared session, and it was catching a genuine regression. After a reload, one PTY produced two entries in `terminalsByProject` and two cards.

On a reload the home view's unscoped `reconnectOrphanedSessions()` and the project view's scoped one overlap. `terminalInstances` only gains its entry after `pty.reconnect` resolves, so both calls passed the `has(ptyId)` guard for the same session and each registered a card for it. The guard's comment claimed it made the path idempotent across the two callers; it did not.

`reconnectSessionOnce` claims the PTY id synchronously in a module-level in-flight map, covering both the main-terminal and the runner loop. A caller that loses the race awaits the winner rather than skipping ahead, so the terminal list is final before `ProjectViewReact` reads it to decide whether reconnection produced anything or the kanban should open instead.