### PR TITLE
Refresh scripts and hooks in the renderer on CLI changes

### DIFF
--- a/src/__tests__/cliTaskStartedPush.test.ts
+++ b/src/__tests__/cliTaskStartedPush.test.ts
@@ -124,6 +124,10 @@ function getTaskStartedPushes() {
   return typedPushMock.mock.calls.filter((call) => call[1] === 'cli:task-started');
 }
 
+function cliChangePayloads() {
+  return typedPushMock.mock.calls.filter((call) => call[1] === 'cli-change').map((call) => call[2]);
+}
+
 describe('cli:task-started push', () => {
   test('fires after POST /api/tasks/start when result is successful', async () => {
     createTaskWorktreeMock.mockResolvedValueOnce({
@@ -195,7 +199,7 @@ describe('cli:task-started push', () => {
     expect(getTaskStartedPushes()).toHaveLength(0);
   });
 
-  test('still emits cli-change alongside cli:task-started', async () => {
+  test('still emits cli-change alongside cli:task-started, tagged with the mutated resource', async () => {
     createTaskWorktreeMock.mockResolvedValueOnce({
       success: true,
       worktreePath: '/tmp/wt/T-1',
@@ -207,6 +211,15 @@ describe('cli:task-started push', () => {
     const channels = typedPushMock.mock.calls.map((c) => c[1]);
     expect(channels).toContain('cli-change');
     expect(channels).toContain('cli:task-started');
+    expect(cliChangePayloads()).toEqual([expect.objectContaining({ resource: 'tasks' })]);
+
+    // `resource` drives which loader the renderer re-runs, and a wrong value
+    // degrades silently (it just falls back to refreshing tasks), so pin that
+    // it tracks the route rather than being hardcoded.
+    typedPushMock.mockClear();
+    await request('PUT', `/api/scripts/dev-server?project=${PROJECT}`, token, { name: 'Dev', command: 'npm run dev' });
+
+    expect(cliChangePayloads()).toEqual([expect.objectContaining({ resource: 'scripts' })]);
   });
 
   test('forwards hookMode + hookCommand from the request body into the push', async () => {

--- a/src/__tests__/renderer/setup.ts
+++ b/src/__tests__/renderer/setup.ts
@@ -107,6 +107,12 @@ const mockApi = {
     save: vi.fn().mockResolvedValue({ success: true }),
     delete: vi.fn().mockResolvedValue({ success: true }),
   },
+  scripts: {
+    getAll: vi.fn().mockResolvedValue([]),
+    save: vi.fn().mockResolvedValue({ success: true }),
+    delete: vi.fn().mockResolvedValue({ success: true }),
+    reorder: vi.fn().mockResolvedValue({ success: true }),
+  },
   tags: {
     getAll: vi.fn().mockResolvedValue([]),
     getForTask: vi.fn().mockResolvedValue([]),

--- a/src/__tests__/renderer/useIPCListeners.test.tsx
+++ b/src/__tests__/renderer/useIPCListeners.test.tsx
@@ -87,10 +87,14 @@ function completedPayload(overrides: Partial<CliTaskCompletedPayload> = {}): Cli
   };
 }
 
+type CliChangePayload = Parameters<Parameters<typeof window.api.onCliChange>[0]>[0];
+type CliChangeCb = (payload: CliChangePayload) => void;
+
 interface ListenerStubs {
   cliTaskStartedCb: CliTaskStartedCb | null;
   cliTaskTransitionedCb: CliTaskTransitionedCb | null;
   cliTaskCompletedCb: CliTaskCompletedCb | null;
+  cliChangeCb: CliChangeCb | null;
 }
 
 /**
@@ -100,12 +104,20 @@ interface ListenerStubs {
  * fill the gaps here per-test rather than polluting the global mock.
  */
 function installListenerStubs(): ListenerStubs {
-  const stubs: ListenerStubs = { cliTaskStartedCb: null, cliTaskTransitionedCb: null, cliTaskCompletedCb: null };
+  const stubs: ListenerStubs = {
+    cliTaskStartedCb: null,
+    cliTaskTransitionedCb: null,
+    cliTaskCompletedCb: null,
+    cliChangeCb: null,
+  };
   const api = window.api as unknown as Record<string, unknown>;
   api['onUpdateAvailable'] = vi.fn(() => () => {});
   api['onShellUnsupported'] = vi.fn(() => () => {});
   api['onWhatsNew'] = vi.fn(() => () => {});
-  api['onCliChange'] = vi.fn(() => () => {});
+  api['onCliChange'] = vi.fn((cb: CliChangeCb) => {
+    stubs.cliChangeCb = cb;
+    return () => {};
+  });
   api['onCliThemeChanged'] = vi.fn(() => () => {});
   api['health'] = { onUpdate: vi.fn(() => () => {}) };
   api['onCliTaskStarted'] = vi.fn((cb: CliTaskStartedCb) => {
@@ -343,5 +355,45 @@ describe('useIPCListeners — cli:task-completed → completeTask', () => {
     expect(completeTask).toHaveBeenCalledTimes(1);
     expect(vi.mocked(completeTask).mock.calls[0][0].hookControl).toEqual({ mode: 'skip', command: undefined });
     expect(useProjectStore.getState().pendingCliCompletions[PROJECT]).toBeUndefined();
+  });
+});
+
+describe('useIPCListeners — cli-change refreshes the resource that changed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useProjectStore.getState().resetForProject();
+    useAppStore.setState({ activeProjectPath: PROJECT });
+  });
+
+  function fire(resource: string, project = PROJECT): void {
+    const stubs = installListenerStubs();
+    renderHook(() => useIPCListeners());
+    stubs.cliChangeCb!({ project, action: `PUT /api/${resource}/x`, resource, ts: 0 });
+  }
+
+  test('routes each resource to its own loader and ignores other projects', async () => {
+    // `ouijit script set` / `hook set` add run commands the terminal "+" menu
+    // reads from the store — they must refresh without a project switch.
+    fire('scripts');
+    await flush();
+    expect(window.api.scripts.getAll).toHaveBeenCalledWith(PROJECT);
+    expect(window.api.task.getAll).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    fire('hooks');
+    await flush();
+    expect(window.api.hooks.get).toHaveBeenCalledWith(PROJECT);
+    expect(window.api.task.getAll).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    fire('tasks');
+    await flush();
+    expect(window.api.task.getAll).toHaveBeenCalledWith(PROJECT);
+    expect(window.api.scripts.getAll).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    fire('scripts', '/proj/other');
+    await flush();
+    expect(window.api.scripts.getAll).not.toHaveBeenCalled();
   });
 });

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -744,6 +744,7 @@ async function handleAsync(req: IncomingMessage, res: ServerResponse, window: Br
       typedPush(window, 'cli-change', {
         project,
         action: `${method} /api/${apiPath}`,
+        resource: segments[0] ?? '',
         ts: Date.now(),
       });
 

--- a/src/components/scripts/HookList.tsx
+++ b/src/components/scripts/HookList.tsx
@@ -31,6 +31,15 @@ export function HookList({ projectPath, hooks: hookEntries, bare }: HookListProp
     loadHooks();
   }, [loadHooks]);
 
+  // The hook rows are local state (the store only tracks which types are
+  // configured), so a `ouijit hook set` while this panel is open needs its own
+  // re-read to avoid showing the old command.
+  useEffect(() => {
+    return window.api.onCliChange((payload) => {
+      if (payload.resource === 'hooks' && payload.project === projectPath) loadHooks();
+    });
+  }, [loadHooks, projectPath]);
+
   const handleDialogClose = useCallback(
     (result: { saved: boolean } | null) => {
       setEditingHook(null);

--- a/src/hooks/useIPCListeners.ts
+++ b/src/hooks/useIPCListeners.ts
@@ -159,16 +159,25 @@ export function useIPCListeners() {
       }),
     );
 
-    // CLI changes — re-fetch tasks when CLI writes to the sentinel file
+    // CLI changes — re-fetch whatever the mutated route touched. Scripts and
+    // hooks are the project's run commands: the store loads them once on
+    // project switch, so without this a `ouijit script set` / `hook set` never
+    // shows up in an already-open window (terminal "+" menu, headers, badges).
     cleanups.push(
       window.api.onCliChange((payload) => {
         const activeProject = useAppStore.getState().activeProjectPath;
-        if (activeProject && payload.project === activeProject) {
-          ipcLog.info('CLI change detected, refreshing tasks', { action: payload.action });
-          useProjectStore.getState().loadTasks(activeProject);
-          if (payload.message) {
-            useProjectStore.getState().addToast(payload.message, 'info');
-          }
+        if (!activeProject || payload.project !== activeProject) return;
+        ipcLog.info('CLI change detected, refreshing', { action: payload.action });
+        const store = useProjectStore.getState();
+        if (payload.resource === 'scripts') {
+          store.loadScripts(activeProject);
+        } else if (payload.resource === 'hooks') {
+          store.loadProjectConfig(activeProject);
+        } else {
+          store.loadTasks(activeProject);
+        }
+        if (payload.message) {
+          store.addToast(payload.message, 'info');
         }
       }),
     );

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -268,7 +268,18 @@ export interface IpcPushContract {
   'update-available': { args: [info: { version: string; url: string }] };
   'shell-unsupported': { args: [info: { shell: string }] };
   'whats-new': { args: [info: { version: string; notes: string }] };
-  'cli-change': { args: [payload: { project: string; action: string; message?: string; ts: number }] };
+  'cli-change': {
+    args: [
+      payload: {
+        project: string;
+        action: string;
+        /** First path segment of the mutated route ('tasks', 'scripts', 'hooks', …). */
+        resource: string;
+        message?: string;
+        ts: number;
+      },
+    ];
+  };
   /** A CLI theme mutation wrote global settings — re-read and re-apply. */
   'cli:theme-changed': { args: [] };
   'cli:task-started': {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -233,8 +233,9 @@ contextBridge.exposeInMainWorld('api', {
 
   onWhatsNew: (callback: (info: { version: string; notes: string }) => void) => typedListen('whats-new', callback),
 
-  onCliChange: (callback: (payload: { project: string; action: string; message?: string; ts: number }) => void) =>
-    typedListen('cli-change', callback),
+  onCliChange: (
+    callback: (payload: { project: string; action: string; resource: string; message?: string; ts: number }) => void,
+  ) => typedListen('cli-change', callback),
 
   onCliThemeChanged: (callback: () => void) => typedListen('cli:theme-changed', callback),
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -533,7 +533,7 @@ export interface ElectronAPI {
   onWhatsNew(callback: (info: { version: string; notes: string }) => void): () => void;
   /** Listen for CLI changes (sentinel file written by ouijit CLI) */
   onCliChange(
-    callback: (payload: { project: string; action: string; message?: string; ts: number }) => void,
+    callback: (payload: { project: string; action: string; resource: string; message?: string; ts: number }) => void,
   ): () => void;
   /** Listen for a CLI theme mutation — re-read and re-apply theme settings */
   onCliThemeChanged(callback: () => void): () => void;


### PR DESCRIPTION
Commands added from the CLI didn't show up in an already-open window.

`ouijit script set` / `ouijit hook set` write to the DB and push a `cli-change` IPC message, but the renderer's listener only ever called `loadTasks()`. Scripts and configured hooks load once per project switch (`ProjectViewReact.tsx`), so the terminal's "+" panel menu kept reading a stale `projectStore` until you navigated away and back.

## Changes

- `api/router.ts` — the `cli-change` push now carries `resource` (the mutated route's first path segment) alongside the action string.
- `hooks/useIPCListeners.ts` — routes the refresh by resource: `scripts` to `loadScripts`, `hooks` to `loadProjectConfig`, everything else to `loadTasks` as before.
- `components/scripts/HookList.tsx` — the hook rows keep their own local copy (the store only tracks which types are configured), so the panel re-reads on a `hooks` change.
- Contract, preload, and types updated for the new payload field.

## Tests

- `cliTaskStartedPush.test.ts` drives real HTTP through the router and asserts the payload is tagged `tasks` for a task start and `scripts` for `PUT /api/scripts/:id`, so the tag can't be hardcoded.
- `useIPCListeners.test.tsx` asserts each resource reaches its own loader and that off-project pushes are ignored. The `task.getAll` negative assertions are what make it a regression test.

