### PR TITLE
Mod+K switcher for terminals, projects and tasks

### DIFF
--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect, createTestRepo } from './fixtures';
 import type { Page, Locator, ElectronApplication } from '@playwright/test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -25,6 +25,18 @@ async function enterProject(appPage: Page, repoPath: string): Promise<void> {
   await sidebarItem.click();
   // First entry shows kanban board (no existing terminals)
   await expect(appPage.locator('.kanban-board')).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Helper: navigate into an already-registered project by path. `enterProject`
+ * takes the first sidebar item, which is ambiguous once more than one project
+ * is registered.
+ */
+async function enterProjectByPath(appPage: Page, repoPath: string): Promise<void> {
+  await appPage.mouse.move(2, 200);
+  const sidebarItem = appPage.locator(`[data-project-path="${repoPath}"]`);
+  await expect(sidebarItem).toBeVisible({ timeout: 10_000 });
+  await sidebarItem.click();
 }
 
 /**
@@ -467,6 +479,105 @@ test('open in editor: runs the editor hook in a task terminal with the worktree 
   await expect
     .poll(() => (fs.existsSync(markerFile) ? fs.readFileSync(markerFile, 'utf8') : null), { timeout: 15_000 })
     .toBe(worktreePath);
+});
+
+/**
+ * Everything here is out of reach of the jsdom suite: a real xterm competing
+ * for the keystroke, a real second PTY that this renderer has not hydrated,
+ * and real focus landing on a terminal after the jump.
+ */
+test('command palette: opens over a focused terminal and jumps to a session in another project', async ({
+  appPage,
+  testRepo,
+}) => {
+  // Two shells, a renderer reload and a PTY reconnect — well past the default.
+  test.setTimeout(60_000);
+
+  const otherRepo = createTestRepo('other-project');
+  try {
+    await appPage.evaluate(async (paths: string[]) => {
+      for (const p of paths) await window.api.addProject(p);
+      const projects = await window.api.refreshProjects();
+      (window as any).__appStore.getState().setProjects(projects);
+    }, [testRepo.repoPath, otherRepo.repoPath]);
+
+    // A terminal in each project.
+    await enterProjectByPath(appPage, testRepo.repoPath);
+    await expect(appPage.locator('.kanban-board')).toBeVisible({ timeout: 10_000 });
+    await dismissKanban(appPage);
+    await appPage.keyboard.press(`${modifier}+i`);
+    await expect(appPage.locator('.project-card')).toHaveCount(1, { timeout: 15_000 });
+
+    await enterProjectByPath(appPage, otherRepo.repoPath);
+    await expect(appPage.locator('.kanban-board')).toBeVisible({ timeout: 10_000 });
+    await dismissKanban(appPage);
+    await appPage.keyboard.press(`${modifier}+i`);
+    await expect(appPage.locator('.project-card')).toHaveCount(1, { timeout: 15_000 });
+
+    // Reload so the first project's PTY is still alive but no longer hydrated
+    // in this renderer. The palette has to source it from getActiveSessions and
+    // reconnect it on the way in — the path the unit suite can only mock.
+    await appPage.reload();
+    await appPage.waitForLoadState('domcontentloaded');
+    await expect(appPage.locator('.project-card--active')).toHaveCount(1, { timeout: 30_000 });
+    await appPage.waitForTimeout(3_000);
+
+    // Put the keystroke in the hardest place for it to survive: a focused xterm.
+    await appPage.locator('.terminal-xterm-container').first().click();
+    await appPage.keyboard.type('PALETTE_MARKER');
+    await appPage.waitForTimeout(500);
+
+    await appPage.keyboard.press(`${modifier}+k`);
+    const palette = appPage.locator('[data-testid="command-palette"]');
+    await expect(palette).toBeVisible({ timeout: 5_000 });
+
+    // The shell must not have received the `k` as input.
+    const shellText = await appPage.evaluate(
+      () => document.querySelector('.terminal-xterm-container .xterm-rows')?.textContent ?? '',
+    );
+    expect(shellText).toContain('PALETTE_MARKER');
+    expect(shellText, 'the `k` leaked into the terminal instead of opening the palette').not.toContain(
+      'PALETTE_MARKERk',
+    );
+
+    // Typing right after the open transition must survive it.
+    const input = appPage.getByLabel('Search terminals, projects and tasks');
+    await expect(input).toBeFocused({ timeout: 5_000 });
+    await appPage.keyboard.type('test-project');
+    await expect(input).toHaveValue('test-project');
+
+    // Terminals rank above projects, so the top row is the other project's
+    // shell, not the project itself.
+    const firstRow = appPage.locator('[data-testid="palette-row"]').first();
+    await expect(firstRow).toContainText('test-project', { timeout: 5_000 });
+    await appPage.keyboard.press('Enter');
+
+    await expect
+      .poll(() => appPage.evaluate(() => (window as any).__appStore.getState().activeProjectPath), { timeout: 20_000 })
+      .toBe(testRepo.repoPath);
+    await expect(palette).toHaveCount(0, { timeout: 5_000 });
+    // Jumping to a terminal shows terminals, not the board.
+    await expect(appPage.locator('.kanban-board')).toHaveCount(0);
+    await expect(appPage.locator('.project-card--active')).toHaveCount(1, { timeout: 20_000 });
+
+    // Focus has to land in the terminal, or the jump isn't finished.
+    await expect
+      .poll(() => appPage.evaluate(() => !!document.activeElement?.closest('.terminal-xterm-container')), {
+        timeout: 10_000,
+      })
+      .toBe(true);
+
+    // Escape closes without navigating.
+    await appPage.keyboard.press(`${modifier}+k`);
+    await expect(palette).toBeVisible({ timeout: 5_000 });
+    await appPage.keyboard.press('Escape');
+    await expect(palette).toHaveCount(0, { timeout: 5_000 });
+    expect(await appPage.evaluate(() => (window as any).__appStore.getState().activeProjectPath)).toBe(
+      testRepo.repoPath,
+    );
+  } finally {
+    otherRepo.cleanup();
+  }
 });
 
 test('whats new: modal appears and dismisses', async ({ appPage }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Component, useCallback, useEffect, useState, type ErrorInfo, type ReactNode } from 'react';
 import { useIPCListeners } from './hooks/useIPCListeners';
+import { usePaletteShortcut } from './hooks/usePaletteShortcut';
 import { useAppStore } from './stores/appStore';
 import { useProjectStore } from './stores/projectStore';
 import { useExperimentalStore } from './stores/experimentalStore';
@@ -14,6 +15,8 @@ import { InitGitRepoDialog } from './components/dialogs/InitGitRepoDialog';
 import { AddSiblingProjectsDialog } from './components/dialogs/AddSiblingProjectsDialog';
 import { WhatsNewDialog } from './components/dialogs/WhatsNewDialog';
 import { HelpDialog } from './components/dialogs/HelpDialog';
+import { CommandPalette } from './components/CommandPalette';
+import { selectProject, selectHome } from './components/navigation';
 import { installCaptureNavigator } from './capture/navigator';
 import { hydrateTerminalFont } from './components/terminal/terminalReact';
 import { hydrateNotificationSettings } from './utils/notifications';
@@ -62,6 +65,7 @@ class ViewErrorBoundary extends Component<{ children: ReactNode }, { error: Erro
 
 export function App() {
   useIPCListeners();
+  usePaletteShortcut();
 
   const activeView = useAppStore((s) => s.activeView);
   const activeProjectPath = useAppStore((s) => s.activeProjectPath);
@@ -196,37 +200,14 @@ export function App() {
     });
   }, []);
 
-  // Sidebar callbacks. Direction in the view transition reflects the relative
-  // position in the sidebar — clicking a project below the current one slides
-  // the new view up into place; above slides down. Home is treated as the
-  // top of the list.
-  //
-  // Project select pre-fetches tasks before navigating so the kanban paints
-  // correctly through the view-transition snapshot. Home select navigates
-  // immediately and refreshes in the background, since `homeRecents` is kept
-  // warm by `projectStore.loadTasks` and the app-init pre-fetch.
-  const handleProjectSelect = useCallback(async (path: string, project: Project) => {
-    const state = useAppStore.getState();
-    if (state.activeProjectPath === path) return;
-    const orderedPaths = state.projects.map((p) => p.path);
-    const oldIndex = state.activeView === 'home' ? -1 : orderedPaths.indexOf(state.activeProjectPath ?? '');
-    const newIndex = orderedPaths.indexOf(path);
-    const direction = newIndex > oldIndex ? 'down' : newIndex < oldIndex ? 'up' : undefined;
-    await useProjectStore.getState().loadTasks(path);
-    state.navigateToProject(path, project, { direction });
-    window.api.globalSettings.set('lastActiveView', JSON.stringify({ type: 'project', path }));
+  // Sidebar callbacks — the shared navigation actions, so the sidebar and the
+  // command palette can't drift apart.
+  const handleProjectSelect = useCallback((path: string, project: Project) => {
+    void selectProject(path, project);
   }, []);
 
   const handleHomeSelect = useCallback(() => {
-    const state = useAppStore.getState();
-    if (state.activeView === 'home') return;
-    // Navigate immediately; the cached homeRecents (kept warm by
-    // projectStore.loadTasks via updateProjectTaskCache, plus app-init
-    // pre-fetch) paints during the view transition. Refresh in background
-    // to reconcile with the source of truth.
-    state.navigateHome({ direction: 'up' });
-    void state.loadHomeRecents();
-    window.api.globalSettings.set('lastActiveView', JSON.stringify({ type: 'home' }));
+    selectHome();
   }, []);
 
   // Register the added folder, refresh the project list, and navigate to it.
@@ -382,6 +363,7 @@ export function App() {
         />
       )}
       {helpDialogOpen && <HelpDialog onClose={() => useAppStore.getState().setHelpDialogOpen(false)} />}
+      <CommandPalette />
     </div>
   );
 }

--- a/src/__tests__/fuzzyMatch.test.ts
+++ b/src/__tests__/fuzzyMatch.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from 'vitest';
+import { fuzzyMatch, fuzzyMatches } from '../utils/fuzzyMatch';
+
+/** Reconstruct the matched characters from the returned ranges. */
+function matched(haystack: string, ranges: [number, number][]): string {
+  return ranges.map(([start, end]) => haystack.slice(start, end)).join('');
+}
+
+function score(needle: string, haystack: string): number {
+  const result = fuzzyMatch(needle, haystack);
+  if (!result) throw new Error(`expected "${needle}" to match "${haystack}"`);
+  return result.score;
+}
+
+describe('fuzzyMatches', () => {
+  test('subsequence, case-insensitive, order-sensitive', () => {
+    expect(fuzzyMatches('', 'anything')).toBe(true);
+    expect(fuzzyMatches('ouij', 'Ouijit')).toBe(true);
+    expect(fuzzyMatches('OJT', 'ouijit')).toBe(true);
+    expect(fuzzyMatches('mdk', 'mod-k-search')).toBe(true);
+    // Right characters, wrong order.
+    expect(fuzzyMatches('kmod', 'mod-k-search')).toBe(false);
+    expect(fuzzyMatches('xyz', 'mod-k-search')).toBe(false);
+  });
+});
+
+describe('fuzzyMatch', () => {
+  test('rejects non-matches and needles longer than the haystack', () => {
+    expect(fuzzyMatch('zzz', 'mod-k-search')).toBeNull();
+    expect(fuzzyMatch('searching', 'search')).toBeNull();
+  });
+
+  test('an empty needle matches everything with no ranges', () => {
+    expect(fuzzyMatch('', 'anything')).toEqual({ score: 0, ranges: [] });
+  });
+
+  test('ranges cover exactly the matched characters, in order', () => {
+    const result = fuzzyMatch('mks', 'mod-k-search');
+    expect(result).not.toBeNull();
+    expect(matched('mod-k-search', result!.ranges)).toBe('mks');
+    // Non-overlapping and ascending.
+    const flat = result!.ranges.flat();
+    expect(flat).toEqual([...flat].sort((a, b) => a - b));
+  });
+
+  test('a consecutive run is reported as one range', () => {
+    const result = fuzzyMatch('search', 'mod-k-search');
+    expect(result!.ranges).toEqual([[6, 12]]);
+  });
+
+  test('prefers word boundaries over an earlier greedy match', () => {
+    // A left-to-right greedy matcher takes the leading "a" of "a-pretty-app";
+    // the word-boundary bonus should land the match on "app" instead.
+    const result = fuzzyMatch('app', 'a-pretty-app');
+    expect(matched('a-pretty-app', result!.ranges)).toBe('app');
+    expect(result!.ranges).toEqual([[9, 12]]);
+  });
+
+  test('ranks boundary and consecutive matches above scattered ones', () => {
+    // Same characters, better position.
+    expect(score('ouij', 'ouijit')).toBeGreaterThan(score('ouij', 'obscure-unit-inject-jump'));
+    // Consecutive beats split across words.
+    expect(score('sea', 'search')).toBeGreaterThan(score('sea', 'set-each-app'));
+    // Path separators count as boundaries.
+    expect(score('ws', '/work/src')).toBeGreaterThan(score('ws', '/wowsers'));
+  });
+
+  test('is case-insensitive for matching', () => {
+    const upper = fuzzyMatch('MKS', 'mod-k-search');
+    const lower = fuzzyMatch('mks', 'mod-k-search');
+    expect(upper!.ranges).toEqual(lower!.ranges);
+  });
+
+  test('matches camelCase boundaries', () => {
+    const result = fuzzyMatch('ct', 'commandTerminal');
+    expect(matched('commandTerminal', result!.ranges)).toBe('cT');
+    expect(result!.ranges).toEqual([
+      [0, 1],
+      [7, 8],
+    ]);
+  });
+});

--- a/src/__tests__/renderer/commandPalette.test.tsx
+++ b/src/__tests__/renderer/commandPalette.test.tsx
@@ -1,0 +1,265 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('electron-log/renderer', () => ({
+  default: { scope: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
+}));
+
+// The palette reaches terminals through `navigation`, which pulls in the real
+// terminal machinery (xterm). Both sides are stubbed: `terminalActions` so
+// spawning/reconnecting is observable, `terminalReact` so no xterm is
+// constructed in jsdom.
+vi.mock('../../components/terminal/terminalActions', () => ({
+  addProjectTerminal: vi.fn().mockResolvedValue(true),
+  reconnectOrphanedSessions: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../components/terminal/terminalReact', () => ({
+  terminalInstances: new Map(),
+}));
+
+import { CommandPalette } from '../../components/CommandPalette';
+import { usePaletteShortcut } from '../../hooks/usePaletteShortcut';
+import { addProjectTerminal, reconnectOrphanedSessions } from '../../components/terminal/terminalActions';
+import { useAppStore } from '../../stores/appStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { useTerminalStore, DEFAULT_DISPLAY_STATE, type TerminalDisplayState } from '../../stores/terminalStore';
+import { useUIStore } from '../../stores/uiStore';
+import type { ActiveSession, Project, TaskWithWorkspace } from '../../types';
+
+const projectA: Project = { path: '/work/alpha', name: 'Alpha' };
+const projectB: Project = { path: '/work/bravo', name: 'Bravo' };
+
+function display(over: Partial<TerminalDisplayState> & { ptyId: string; projectPath: string }): TerminalDisplayState {
+  return { ...DEFAULT_DISPLAY_STATE, ...over } as TerminalDisplayState;
+}
+
+function task(over: Partial<TaskWithWorkspace> & { taskNumber: number }): TaskWithWorkspace {
+  return {
+    name: `Task ${over.taskNumber}`,
+    status: 'in_progress',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    ...over,
+  } as TaskWithWorkspace;
+}
+
+/**
+ * One live session per surface the palette has to reconcile:
+ *   alpha-1  hydrated in the store, in the active project
+ *   bravo-1  live but never hydrated by this renderer
+ *   bravo-r  a runner — a panel on a card, not a switchable terminal
+ *   alpha-7  hydrated, backs task 7 (so task 7 must not also list as a task)
+ */
+const SESSIONS: ActiveSession[] = [
+  { ptyId: 'alpha-1', projectPath: projectA.path, command: '', label: 'Alpha shell' },
+  { ptyId: 'alpha-7', projectPath: projectA.path, command: '', label: 'Seven', taskId: 7 },
+  { ptyId: 'bravo-1', projectPath: projectB.path, command: '', label: 'Bravo agent' },
+  { ptyId: 'bravo-r', projectPath: projectB.path, command: 'npm run dev', label: 'dev', isRunner: true },
+];
+
+const TASKS: Record<string, TaskWithWorkspace[]> = {
+  [projectA.path]: [
+    task({ taskNumber: 7, name: 'Seven', worktreePath: '/wt/seven', branch: 'seven' }),
+    task({ taskNumber: 9, name: 'Nine', worktreePath: '/wt/nine', branch: 'nine' }),
+    // No worktree: the palette must not offer to start it.
+    task({ taskNumber: 11, name: 'Eleven' }),
+  ],
+  [projectB.path]: [],
+};
+
+function seed(): void {
+  useAppStore.setState({
+    projects: [projectA, projectB],
+    activeView: 'project',
+    activeProjectPath: projectA.path,
+    activeProjectData: projectA,
+    taskCacheByProject: { ...TASKS },
+  });
+  useTerminalStore.setState({
+    terminalsByProject: { [projectA.path]: ['alpha-1', 'alpha-7'] },
+    displayStates: {
+      'alpha-1': display({ ptyId: 'alpha-1', projectPath: projectA.path, label: 'Alpha shell' }),
+      'alpha-7': display({ ptyId: 'alpha-7', projectPath: projectA.path, label: 'Seven', taskId: 7 }),
+    },
+    activeIndices: { [projectA.path]: 0 },
+  });
+  useProjectStore.setState({ tagFilter: null, terminalLayout: 'stack', kanbanVisible: true });
+  useUIStore.setState({ paletteOpen: true, homeActivePtyId: null, homeTagFilter: null });
+}
+
+function rowLabels(): string[] {
+  return screen.queryAllByTestId('palette-row').map((row) => row.textContent ?? '');
+}
+
+/** Wait for the async `getActiveSessions` fetch to land in the list. */
+async function openPalette() {
+  render(<CommandPalette />);
+  await waitFor(() => expect(rowLabels().some((l) => l.includes('Bravo agent'))).toBe(true));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.api.pty.getActiveSessions = vi.fn().mockResolvedValue(SESSIONS);
+  // Opening the palette kicks off a background task-cache refresh, so the IPC
+  // has to agree with the seeded cache or it would wipe it.
+  window.api.task.getAll = vi.fn(async (path: string) => TASKS[path] ?? []);
+  window.api.globalSettings.set = vi.fn().mockResolvedValue({ success: true });
+  vi.mocked(addProjectTerminal).mockResolvedValue(true);
+  vi.mocked(reconnectOrphanedSessions).mockResolvedValue(undefined);
+  seed();
+});
+
+function Harness() {
+  usePaletteShortcut();
+  return <CommandPalette />;
+}
+
+describe('mod+K shortcut', () => {
+  test('toggles the palette open and closed', () => {
+    useUIStore.setState({ paletteOpen: false });
+    render(<Harness />);
+    expect(screen.queryByTestId('command-palette')).toBeNull();
+
+    // jsdom reports a non-mac platform, so the modifier is ctrl.
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+    expect(useUIStore.getState().paletteOpen).toBe(true);
+
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+    expect(useUIStore.getState().paletteOpen).toBe(false);
+
+    // Unmodified `k` is just a keystroke.
+    fireEvent.keyDown(document, { key: 'k' });
+    expect(useUIStore.getState().paletteOpen).toBe(false);
+  });
+});
+
+describe('command palette results', () => {
+  test('lists switchable terminals, projects and worktree-backed tasks, without duplicates', async () => {
+    await openPalette();
+    const labels = rowLabels();
+
+    // Terminals: store-hydrated and not-yet-hydrated sessions, deduped by ptyId.
+    expect(labels.filter((l) => l.includes('Alpha shell'))).toHaveLength(1);
+    expect(labels.some((l) => l.includes('Bravo agent'))).toBe(true);
+
+    // Runners are panels on a parent card, never their own row.
+    expect(labels.some((l) => l.includes('npm run dev'))).toBe(false);
+
+    // Task 7 already has a live terminal, so it lists once — as that terminal.
+    expect(labels.filter((l) => l.includes('T-7'))).toHaveLength(1);
+    // Task 9 has a worktree and no terminal, so it lists as a task.
+    expect(labels.some((l) => l.includes('Nine'))).toBe(true);
+    // Task 11 has no worktree — opening it would have to create one.
+    expect(labels.some((l) => l.includes('Eleven'))).toBe(false);
+
+    // Projects are listed too.
+    expect(labels.some((l) => l.includes('Bravo') && l.includes('/work/bravo'))).toBe(true);
+
+    // Sections keep their order: terminals, then projects, then tasks.
+    expect(screen.getAllByText(/^(Terminals|Projects|Tasks)$/).map((n) => n.textContent)).toEqual([
+      'Terminals',
+      'Projects',
+      'Tasks',
+    ]);
+  });
+
+  test('filters fuzzily and Escape closes', async () => {
+    await openPalette();
+    const input = screen.getByLabelText('Search terminals, projects and tasks');
+
+    fireEvent.change(input, { target: { value: 'brv' } });
+    await waitFor(() => expect(rowLabels().some((l) => l.includes('Bravo agent'))).toBe(true));
+    expect(rowLabels().some((l) => l.includes('Alpha shell'))).toBe(false);
+
+    fireEvent.change(input, { target: { value: 'zzzz' } });
+    expect(screen.getByText('No matches')).toBeTruthy();
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(useUIStore.getState().paletteOpen).toBe(false);
+  });
+});
+
+describe('command palette navigation', () => {
+  test('opens a terminal from a project this renderer never hydrated', async () => {
+    // Reconnecting is what registers the session in the store.
+    vi.mocked(reconnectOrphanedSessions).mockImplementation(async (projectPath?: string) => {
+      if (projectPath !== projectB.path) return;
+      useTerminalStore.getState().addTerminal(projectB.path, 'bravo-1', { label: 'Bravo agent' });
+    });
+
+    await openPalette();
+    const input = screen.getByLabelText('Search terminals, projects and tasks');
+    fireEvent.change(input, { target: { value: 'Bravo agent' } });
+    await waitFor(() => expect(rowLabels()[0]).toContain('Bravo agent'));
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(reconnectOrphanedSessions).toHaveBeenCalledWith(projectB.path));
+    await waitFor(() => expect(useAppStore.getState().activeProjectPath).toBe(projectB.path));
+
+    const terminals = useTerminalStore.getState().terminalsByProject[projectB.path] ?? [];
+    expect(useTerminalStore.getState().activeIndices[projectB.path]).toBe(terminals.indexOf('bravo-1'));
+    // Jumping to a terminal shows the terminals, not the board.
+    expect(useProjectStore.getState().kanbanVisible).toBe(false);
+    expect(useProjectStore.getState().activePanel).toBe('terminals');
+  });
+
+  test('clears a tag filter that would hide the terminal being opened', async () => {
+    // The card stack resets the active index back to the visible head, so
+    // without this the jump would silently bounce.
+    useProjectStore.setState({ tagFilter: 'review' });
+    useTerminalStore.setState({
+      terminalsByProject: { [projectA.path]: ['alpha-1', 'alpha-7'] },
+      displayStates: {
+        'alpha-1': display({ ptyId: 'alpha-1', projectPath: projectA.path, label: 'Alpha shell' }),
+        'alpha-7': display({
+          ptyId: 'alpha-7',
+          projectPath: projectA.path,
+          label: 'Seven',
+          taskId: 7,
+          tags: ['review'],
+        }),
+      },
+      activeIndices: { [projectA.path]: 1 },
+    });
+
+    await openPalette();
+    const input = screen.getByLabelText('Search terminals, projects and tasks');
+    fireEvent.change(input, { target: { value: 'Alpha shell' } });
+    await waitFor(() => expect(rowLabels()[0]).toContain('Alpha shell'));
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(useProjectStore.getState().tagFilter).toBeNull());
+    expect(useTerminalStore.getState().activeIndices[projectA.path]).toBe(0);
+  });
+
+  test('opens a task worktree as a plain shell — no hook, no worktree creation', async () => {
+    await openPalette();
+    const input = screen.getByLabelText('Search terminals, projects and tasks');
+    fireEvent.change(input, { target: { value: 'Nine' } });
+    await waitFor(() => expect(rowLabels()[0]).toContain('Nine'));
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(addProjectTerminal).toHaveBeenCalled());
+    expect(addProjectTerminal).toHaveBeenCalledWith(projectA.path, undefined, {
+      existingWorktree: { path: '/wt/nine', branch: 'nine', createdAt: '2026-07-01T00:00:00.000Z' },
+      taskId: 9,
+      skipAutoHook: true,
+    });
+    // A switcher never starts a task.
+    expect(window.api.task.start).not.toHaveBeenCalled();
+  });
+
+  test('selecting a project loads its tasks, navigates, and persists the view', async () => {
+    await openPalette();
+    const input = screen.getByLabelText('Search terminals, projects and tasks');
+    fireEvent.change(input, { target: { value: '/work/bravo' } });
+    await waitFor(() => expect(rowLabels()[0]).toContain('Bravo'));
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(useAppStore.getState().activeProjectPath).toBe(projectB.path));
+    expect(window.api.task.getAll).toHaveBeenCalledWith(projectB.path);
+    expect(window.api.globalSettings.set).toHaveBeenCalledWith(
+      'lastActiveView',
+      JSON.stringify({ type: 'project', path: projectB.path }),
+    );
+  });
+});

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,497 @@
+/**
+ * Mod+K switcher.
+ *
+ * Searches the three things you navigate between — live terminals, projects and
+ * worktree-backed tasks — and jumps to one. Everything it can reach already
+ * exists in a store or behind one IPC call, so opening it costs a
+ * `getActiveSessions` round trip and a background task-cache refresh.
+ *
+ * It is a switcher, not a launcher: nothing here creates a worktree, changes a
+ * task's status or runs a hook.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useAppStore } from '../stores/appStore';
+import { useTerminalStore } from '../stores/terminalStore';
+import { useUIStore } from '../stores/uiStore';
+import { fuzzyMatch, type MatchRange } from '../utils/fuzzyMatch';
+import { projectIconColor, getInitials } from '../utils/projectIcon';
+import { formatRelativeTime } from '../utils/formatDate';
+import { Icon } from './terminal/Icon';
+import { StatusDot } from './terminal/StatusDot';
+import { selectProject, focusTerminal, openTaskWorktree } from './navigation';
+import type { ActiveSession, Project, SandboxProviderId, TaskWithWorkspace } from '../types';
+
+/** A match on the primary text outranks the same match on supporting text. */
+const PRIMARY_BONUS = 1;
+/** Per-section cap, so one crowded section can't bury the others. */
+const SECTION_LIMIT = 12;
+/** Fade-out duration; matches the dialog transitions. */
+const EXIT_MS = 200;
+
+const STATUS_LABEL: Record<string, string> = {
+  todo: 'to do',
+  in_progress: 'in progress',
+  in_review: 'to review',
+  done: 'done',
+};
+
+type SectionKey = 'terminals' | 'projects' | 'tasks';
+
+const SECTION_ORDER: SectionKey[] = ['terminals', 'projects', 'tasks'];
+const SECTION_TITLE: Record<SectionKey, string> = {
+  terminals: 'Terminals',
+  projects: 'Projects',
+  tasks: 'Tasks',
+};
+
+interface PaletteItem {
+  id: string;
+  section: SectionKey;
+  /** Matched and highlighted. */
+  primary: string;
+  /** Matched, shown dimmed, not highlighted. */
+  secondary: string;
+  /** Owning project, when there is one — drives the row thumbnail. */
+  project?: Project;
+  taskNumber?: number;
+  tags?: string[];
+  trailing?: string;
+  dimmed?: boolean;
+  /** Terminal rows carry the same status/sandbox dot their card header shows. */
+  status?: { summaryType: string; sandboxProvider?: SandboxProviderId };
+  run: () => void;
+}
+
+interface ScoredItem extends PaletteItem {
+  score: number;
+  ranges: MatchRange[];
+}
+
+function scoreItem(query: string, item: PaletteItem): ScoredItem | null {
+  if (query.length === 0) return { ...item, score: 0, ranges: [] };
+  const primary = fuzzyMatch(query, item.primary);
+  const secondary = item.secondary ? fuzzyMatch(query, item.secondary) : null;
+  if (!primary && !secondary) return null;
+  const score = Math.max(primary ? primary.score + PRIMARY_BONUS : -Infinity, secondary ? secondary.score : -Infinity);
+  return { ...item, score, ranges: primary?.ranges ?? [] };
+}
+
+/** Split text into matched / unmatched runs for highlighting. */
+function highlight(text: string, ranges: MatchRange[]): React.ReactNode {
+  if (ranges.length === 0) return text;
+  const parts: React.ReactNode[] = [];
+  let cursor = 0;
+  ranges.forEach(([start, end], i) => {
+    if (start > cursor) parts.push(text.slice(cursor, start));
+    parts.push(
+      <span key={i} className="text-accent">
+        {text.slice(start, end)}
+      </span>,
+    );
+    cursor = end;
+  });
+  if (cursor < text.length) parts.push(text.slice(cursor));
+  return parts;
+}
+
+/**
+ * Mount/unmount gate for the enter and exit transitions, mirroring how the
+ * app's dialogs animate: paint once in the hidden state, flip visible on the
+ * next frame, and hold the DOM for the length of the fade on the way out.
+ * `openCount` keys the body so a reopen inside that window starts clean rather
+ * than resurrecting the previous query.
+ */
+export function CommandPalette() {
+  const open = useUIStore((s) => s.paletteOpen);
+  const [mounted, setMounted] = useState(open);
+  const [visible, setVisible] = useState(false);
+  // Bumped only on a closed→open transition, so the body remounts fresh on
+  // reopen but never mid-session. Seeded from the initial `open` so the first
+  // paint doesn't count as a transition — a bump there would remount the body
+  // a frame after mount and wipe anything already typed.
+  const [session, setSession] = useState(0);
+  const wasOpen = useRef(open);
+
+  useEffect(() => {
+    const reopened = open && !wasOpen.current;
+    wasOpen.current = open;
+    if (open) {
+      if (reopened) setSession((s) => s + 1);
+      setMounted(true);
+      const frame = requestAnimationFrame(() => setVisible(true));
+      return () => cancelAnimationFrame(frame);
+    }
+    setVisible(false);
+    const timer = setTimeout(() => setMounted(false), EXIT_MS);
+    return () => clearTimeout(timer);
+  }, [open]);
+
+  if (!mounted) return null;
+  return <PaletteBody key={session} visible={visible} />;
+}
+
+function PaletteBody({ visible }: { visible: boolean }) {
+  const projects = useAppStore((s) => s.projects);
+  const activeProjectPath = useAppStore((s) => s.activeProjectPath);
+  const taskCacheByProject = useAppStore((s) => s.taskCacheByProject);
+  const terminalsByProject = useTerminalStore((s) => s.terminalsByProject);
+  const displayStates = useTerminalStore((s) => s.displayStates);
+
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState(0);
+  const [sessions, setSessions] = useState<ActiveSession[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const selectedRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => useUIStore.getState().setPaletteOpen(false), []);
+
+  // Live sessions are the authoritative terminal list — the store only holds
+  // projects this renderer has hydrated. The task cache refresh reconciles in
+  // the background; the palette paints from whatever is already cached.
+  useEffect(() => {
+    let cancelled = false;
+    window.api.pty
+      .getActiveSessions()
+      .then((live) => {
+        if (!cancelled) setSessions(live);
+      })
+      .catch(() => {
+        /* store-backed terminals still list */
+      });
+    void useAppStore.getState().loadHomeRecents();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  const projectByPath = useMemo(() => new Map(projects.map((p) => [p.path, p])), [projects]);
+
+  const items = useMemo<PaletteItem[]>(() => {
+    const result: PaletteItem[] = [];
+
+    // ── Terminals ──
+    // Store first (rich display state), then any live session this renderer
+    // hasn't hydrated. Runners are panels on a parent card, not switchable
+    // terminals; loading slots have no session behind them yet.
+    const seenPtyIds = new Set<string>();
+    const terminalItems: { item: PaletteItem; rank: number }[] = [];
+
+    for (const [projectPath, ptyIds] of Object.entries(terminalsByProject)) {
+      for (const ptyId of ptyIds) {
+        const display = displayStates[ptyId];
+        if (!display || display.isLoading) continue;
+        seenPtyIds.add(ptyId);
+        const project = projectByPath.get(projectPath);
+        terminalItems.push({
+          rank: projectPath === activeProjectPath ? 0 : 1,
+          item: {
+            id: `terminal:${ptyId}`,
+            section: 'terminals',
+            primary: display.label || 'Terminal',
+            secondary: project?.name ?? projectPath,
+            project,
+            taskNumber: display.taskId ?? undefined,
+            tags: display.tags,
+            trailing: display.exited ? 'exited' : undefined,
+            dimmed: display.exited,
+            status: { summaryType: display.summaryType, sandboxProvider: display.sandboxProvider },
+            run: () => void focusTerminal(ptyId, projectPath),
+          },
+        });
+      }
+    }
+
+    for (const session of sessions) {
+      if (session.isRunner || seenPtyIds.has(session.ptyId)) continue;
+      seenPtyIds.add(session.ptyId);
+      const project = projectByPath.get(session.projectPath);
+      terminalItems.push({
+        rank: session.projectPath === activeProjectPath ? 0 : 2,
+        item: {
+          id: `terminal:${session.ptyId}`,
+          section: 'terminals',
+          primary: session.label || 'Terminal',
+          secondary: project?.name ?? session.projectPath,
+          project,
+          taskNumber: session.taskId ?? undefined,
+          // Not hydrated yet, so there's no live summary — the card will show
+          // the real one once it reconnects.
+          status: { summaryType: 'ready', sandboxProvider: session.sandboxProvider },
+          run: () => void focusTerminal(session.ptyId, session.projectPath),
+        },
+      });
+    }
+
+    terminalItems.sort((a, b) => a.rank - b.rank);
+    result.push(...terminalItems.map((t) => t.item));
+
+    // ── Projects ──
+    for (const project of projects) {
+      result.push({
+        id: `project:${project.path}`,
+        section: 'projects',
+        primary: project.name,
+        secondary: project.path,
+        project,
+        run: () => void selectProject(project.path, project),
+      });
+    }
+
+    // ── Tasks ──
+    // Only tasks with a worktree already on disk: opening one is then a plain
+    // shell in an existing directory, never a task start. A task whose terminal
+    // is already live is reachable from the Terminals section instead.
+    const liveTaskKeys = new Set<string>();
+    for (const display of Object.values(displayStates)) {
+      if (display.taskId != null) liveTaskKeys.add(`${display.projectPath}#${display.taskId}`);
+    }
+    for (const session of sessions) {
+      if (session.taskId != null) liveTaskKeys.add(`${session.projectPath}#${session.taskId}`);
+    }
+
+    const taskItems: { item: PaletteItem; createdAt: string }[] = [];
+    for (const [projectPath, tasks] of Object.entries(taskCacheByProject)) {
+      const project = projectByPath.get(projectPath);
+      if (!project) continue;
+      for (const task of tasks) {
+        if (!task.worktreePath || !task.branch) continue;
+        if (liveTaskKeys.has(`${projectPath}#${task.taskNumber}`)) continue;
+        taskItems.push({ createdAt: task.createdAt, item: taskItem(project, task) });
+      }
+    }
+    taskItems.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    result.push(...taskItems.map((t) => t.item));
+
+    return result;
+  }, [projects, projectByPath, activeProjectPath, terminalsByProject, displayStates, sessions, taskCacheByProject]);
+
+  const sections = useMemo(() => {
+    const scored = items.map((item) => scoreItem(query, item)).filter((i): i is ScoredItem => i !== null);
+    return SECTION_ORDER.map((key) => {
+      const rows = scored.filter((i) => i.section === key);
+      // With no query the arrays are already in their default order; a query
+      // re-ranks within each section but never reorders the sections.
+      if (query.length > 0) rows.sort((a, b) => b.score - a.score);
+      return { key, rows: rows.slice(0, SECTION_LIMIT) };
+    }).filter((s) => s.rows.length > 0);
+  }, [items, query]);
+
+  const flat = useMemo(() => sections.flatMap((s) => s.rows), [sections]);
+
+  // Keep the cursor in range as results change under it.
+  useEffect(() => {
+    setSelected((current) => (current >= flat.length ? 0 : current));
+  }, [flat.length]);
+
+  useEffect(() => {
+    // Optional call: jsdom doesn't implement scrollIntoView.
+    selectedRef.current?.scrollIntoView?.({ block: 'nearest' });
+  }, [selected]);
+
+  // Close before running: `navigateToProject` wraps `startViewTransition`,
+  // which snapshots the whole document — an overlay still mounted would be
+  // captured in the outgoing frame and crossfade away.
+  const activate = useCallback(
+    (item: PaletteItem | undefined) => {
+      if (!item) return;
+      close();
+      requestAnimationFrame(() => item.run());
+    },
+    [close],
+  );
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        close();
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelected((current) => (flat.length === 0 ? 0 : (current + 1) % flat.length));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelected((current) => (flat.length === 0 ? 0 : (current - 1 + flat.length) % flat.length));
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        activate(flat[selected]);
+      }
+    },
+    [flat, selected, activate, close],
+  );
+
+  let rowIndex = -1;
+
+  return createPortal(
+    <div
+      data-testid="command-palette"
+      data-visible={visible}
+      className={`fixed inset-0 z-[10003] flex justify-center px-6 pt-[14vh] pb-10 transition-opacity duration-200 ease-out ${
+        visible ? 'opacity-100' : 'opacity-0'
+      }`}
+      style={{ background: 'rgba(0, 0, 0, 0.4)', backdropFilter: 'blur(4px)', WebkitBackdropFilter: 'blur(4px)' }}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+    >
+      <div
+        className={`glass-bevel w-full max-w-[40rem] max-h-full flex flex-col rounded-[14px] border border-bezel-panel overflow-hidden ${
+          visible ? 'opacity-100 scale-100 translate-y-0' : 'opacity-0 scale-95 -translate-y-2'
+        }`}
+        style={{
+          background: 'var(--color-terminal-bg)',
+          boxShadow: 'var(--shadow-panel)',
+          transition: 'opacity 200ms ease-out, transform 200ms ease-out',
+        }}
+        onKeyDown={onKeyDown}
+      >
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-ink/[0.06] shrink-0">
+          <span className="shrink-0 text-text-tertiary [&>svg]:w-4 [&>svg]:h-4">
+            <Icon name="magnifying-glass" />
+          </span>
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setSelected(0);
+            }}
+            placeholder="Jump to a terminal, project or task"
+            spellCheck={false}
+            aria-label="Search terminals, projects and tasks"
+            className="flex-1 min-w-0 bg-transparent border-none outline-none text-sm text-text-primary placeholder:text-text-tertiary [-webkit-app-region:no-drag]"
+          />
+        </div>
+
+        {flat.length === 0 ? (
+          <div className="px-4 py-8 text-center text-xs text-text-tertiary">No matches</div>
+        ) : (
+          <div role="listbox" aria-label="Results" className="flex-1 min-h-0 overflow-y-auto settings-scrollable py-1">
+            {sections.map((section) => (
+              <div key={section.key} role="group" aria-label={SECTION_TITLE[section.key]}>
+                <div
+                  className="sticky top-0 z-10 px-4 py-1.5 text-[11px] text-text-tertiary"
+                  style={{ background: 'var(--color-terminal-bg)' }}
+                >
+                  {SECTION_TITLE[section.key]}
+                </div>
+                {section.rows.map((row) => {
+                  rowIndex++;
+                  const isSelected = rowIndex === selected;
+                  const index = rowIndex;
+                  return (
+                    <PaletteRow
+                      key={row.id}
+                      row={row}
+                      selected={isSelected}
+                      rowRef={isSelected ? selectedRef : undefined}
+                      onHover={() => setSelected(index)}
+                      onClick={() => activate(row)}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function taskItem(project: Project, task: TaskWithWorkspace): PaletteItem {
+  return {
+    id: `task:${project.path}#${task.taskNumber}`,
+    section: 'tasks',
+    primary: task.name || 'Untitled',
+    secondary: project.name,
+    project,
+    taskNumber: task.taskNumber,
+    trailing: `${STATUS_LABEL[task.status] ?? task.status} · ${formatRelativeTime(new Date(task.createdAt))}`,
+    run: () =>
+      void openTaskWorktree({
+        project,
+        taskNumber: task.taskNumber,
+        worktreePath: task.worktreePath as string,
+        branch: task.branch as string,
+        createdAt: task.createdAt,
+      }),
+  };
+}
+
+interface PaletteRowProps {
+  row: ScoredItem;
+  selected: boolean;
+  rowRef?: React.RefObject<HTMLDivElement | null>;
+  onHover: () => void;
+  onClick: () => void;
+}
+
+function PaletteRow({ row, selected, rowRef, onHover, onClick }: PaletteRowProps) {
+  return (
+    <div
+      ref={rowRef}
+      role="option"
+      aria-selected={selected}
+      data-testid="palette-row"
+      onMouseMove={onHover}
+      onClick={onClick}
+      className={`flex items-center gap-3 px-4 py-2 cursor-default transition-colors duration-100 ease-out [-webkit-app-region:no-drag] ${
+        selected ? 'bg-accent/15' : ''
+      }`}
+    >
+      {row.project ? (
+        <div className="project-tile w-7 h-7 shrink-0 overflow-hidden">
+          <div
+            className="w-full h-full flex items-center justify-center text-xs font-bold text-white"
+            style={{ backgroundColor: projectIconColor(row.project), textShadow: '0 1px 2px rgba(0, 0, 0, 0.2)' }}
+          >
+            {getInitials(row.project.name)}
+          </div>
+        </div>
+      ) : (
+        <span className="w-7 h-7 shrink-0 flex items-center justify-center text-text-tertiary [&>svg]:w-4 [&>svg]:h-4">
+          <Icon name="terminal" />
+        </span>
+      )}
+
+      <div className="flex flex-col min-w-0 flex-1 gap-0.5">
+        <div className="flex items-center gap-2 min-w-0">
+          {row.status && (
+            <StatusDot summaryType={row.status.summaryType} sandboxProvider={row.status.sandboxProvider} />
+          )}
+          {row.taskNumber != null && (
+            <span className="font-mono text-[11px] text-text-tertiary tabular-nums shrink-0">T-{row.taskNumber}</span>
+          )}
+          <span className={`text-sm truncate ${row.dimmed ? 'text-text-tertiary' : 'text-text-primary'}`}>
+            {highlight(row.primary, row.ranges)}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5 text-[11px] text-text-tertiary min-w-0">
+          <span className="truncate">{row.secondary}</span>
+          {row.tags && row.tags.length > 0 && (
+            <>
+              <span aria-hidden>·</span>
+              <span className="truncate">{row.tags.join(', ')}</span>
+            </>
+          )}
+        </div>
+      </div>
+
+      {row.trailing && <span className="shrink-0 text-[11px] text-text-tertiary">{row.trailing}</span>}
+    </div>
+  );
+}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -10,7 +10,7 @@
  * task's status or runs a hook.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useAppStore } from '../stores/appStore';
 import { useTerminalStore } from '../stores/terminalStore';
@@ -166,9 +166,26 @@ function PaletteBody({ visible }: { visible: boolean }) {
     };
   }, []);
 
-  useEffect(() => {
-    requestAnimationFrame(() => inputRef.current?.focus());
+  // Focus before paint, not on the next frame. A deferred focus leaves a window
+  // where the palette is on screen but the keystrokes still belong to whatever
+  // had focus before — typically an xterm, which would eat the first characters
+  // typed and the Escape that was meant to dismiss this.
+  useLayoutEffect(() => {
+    inputRef.current?.focus();
   }, []);
+
+  // Escape at the document level, in capture, the way the dialogs handle it —
+  // dismissal must not depend on focus being somewhere in particular.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      e.stopPropagation();
+      close();
+    };
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
+  }, [close]);
 
   const projectByPath = useMemo(() => new Map(projects.map((p) => [p.path, p])), [projects]);
 
@@ -308,12 +325,6 @@ function PaletteBody({ visible }: { visible: boolean }) {
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        e.stopPropagation();
-        close();
-        return;
-      }
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         setSelected((current) => (flat.length === 0 ? 0 : (current + 1) % flat.length));
@@ -329,7 +340,7 @@ function PaletteBody({ visible }: { visible: boolean }) {
         activate(flat[selected]);
       }
     },
-    [flat, selected, activate, close],
+    [flat, selected, activate],
   );
 
   let rowIndex = -1;

--- a/src/components/HomeViewReact.tsx
+++ b/src/components/HomeViewReact.tsx
@@ -51,7 +51,11 @@ export function HomeView() {
     return ids;
   }, [terminalsByProject, displayStates, homeTagFilter]);
 
-  const [activePtyId, setActivePtyId] = useState<string | null>(null);
+  // Front card of the stack. Held in the UI store rather than local state so
+  // the command palette can promote a home-owned session from anywhere; the
+  // depth/recency ordering below still lives here.
+  const activePtyId = useUIStore((s) => s.homeActivePtyId);
+  const setActivePtyId = useUIStore((s) => s.setHomeActivePtyId);
   const reconnectedRef = useRef(false);
 
   // Stack order: bigger tick = closer to the front. A terminal gets a tick
@@ -184,7 +188,7 @@ export function HomeView() {
       const next = stackItems.find((i): i is Extract<StackItem, { type: 'terminal' }> => i.type === 'terminal');
       setActivePtyId(next ? next.ptyId : allPtyIds[allPtyIds.length - 1]);
     }
-  }, [allPtyIds, activePtyId, stackItems]);
+  }, [allPtyIds, activePtyId, stackItems, setActivePtyId]);
 
   const maxDepth = stackItems.length > 0 ? stackItems[stackItems.length - 1].depth : 0;
 
@@ -257,7 +261,7 @@ export function HomeView() {
     };
     document.addEventListener('keydown', handler, true);
     return () => document.removeEventListener('keydown', handler, true);
-  }, [activePtyId, stackItems]);
+  }, [activePtyId, stackItems, setActivePtyId]);
 
   // Build depth map: ptyId → depth (active = 0, others from stackItems)
   const depthMap = useMemo(() => {

--- a/src/components/navigation.ts
+++ b/src/components/navigation.ts
@@ -1,0 +1,161 @@
+/**
+ * Shared navigation actions.
+ *
+ * The sidebar, the app-init restore and the command palette all need the same
+ * "go to this project / home / terminal" behavior, and the sequences are
+ * order-sensitive (tasks are pre-fetched before navigating so the kanban paints
+ * correctly through the view-transition snapshot; the terminal card stack
+ * reverts an active index that a tag filter hides). Keeping one copy here means
+ * the palette can't drift from what clicking the sidebar does.
+ */
+
+import type { Project } from '../types';
+import { useAppStore } from '../stores/appStore';
+import { useProjectStore } from '../stores/projectStore';
+import { useTerminalStore, terminalMatchesTag } from '../stores/terminalStore';
+import { useCanvasStore } from '../stores/canvasStore';
+import { useUIStore } from '../stores/uiStore';
+import { addProjectTerminal, reconnectOrphanedSessions } from './terminal/terminalActions';
+import { terminalInstances } from './terminal/terminalReact';
+
+/**
+ * Navigate to a project. Direction of the view transition reflects the
+ * relative position in the sidebar — a project below the current one slides the
+ * new view up into place, above slides down. Home is the top of the list.
+ *
+ * Tasks are loaded before navigating so the first paint of the project view
+ * (kanban included) shows real content rather than an empty board.
+ */
+export async function selectProject(path: string, project: Project): Promise<void> {
+  const state = useAppStore.getState();
+  if (state.activeProjectPath === path) return;
+  const orderedPaths = state.projects.map((p) => p.path);
+  const oldIndex = state.activeView === 'home' ? -1 : orderedPaths.indexOf(state.activeProjectPath ?? '');
+  const newIndex = orderedPaths.indexOf(path);
+  const direction = newIndex > oldIndex ? 'down' : newIndex < oldIndex ? 'up' : undefined;
+  await useProjectStore.getState().loadTasks(path);
+  state.navigateToProject(path, project, { direction });
+  window.api.globalSettings.set('lastActiveView', JSON.stringify({ type: 'project', path }));
+}
+
+/**
+ * Navigate home. Navigates immediately — the cached `homeRecents` paints during
+ * the view transition — and reconciles with a background refresh.
+ */
+export function selectHome(): void {
+  const state = useAppStore.getState();
+  if (state.activeView === 'home') return;
+  state.navigateHome({ direction: 'up' });
+  void state.loadHomeRecents();
+  window.api.globalSettings.set('lastActiveView', JSON.stringify({ type: 'home' }));
+}
+
+/** Fit and focus a terminal's xterm once React has had a frame to mount it. */
+function focusXterm(ptyId: string): void {
+  requestAnimationFrame(() => {
+    const instance = terminalInstances.get(ptyId);
+    if (!instance) return;
+    instance.fit();
+    instance.xterm.focus();
+  });
+}
+
+/**
+ * Bring a terminal to the front, wherever it lives.
+ *
+ * A session that this renderer hasn't hydrated yet (its project was never
+ * visited this launch) is reconnected first — `reconnectOrphanedSessions` is
+ * idempotent, so this is safe for already-registered projects too.
+ *
+ * `projectPath` is only needed for that not-yet-hydrated case; for a terminal
+ * already in the store it's read from the display state.
+ */
+export async function focusTerminal(ptyId: string, projectPath?: string): Promise<void> {
+  let display = useTerminalStore.getState().displayStates[ptyId];
+  if (!display) {
+    if (!projectPath) return;
+    await reconnectOrphanedSessions(projectPath);
+    display = useTerminalStore.getState().displayStates[ptyId];
+    if (!display) return;
+  }
+
+  const ownerPath = display.projectPath;
+  const project = useAppStore.getState().projects.find((p) => p.path === ownerPath);
+
+  // No registered project owns it: a shell spawned from home, or a project
+  // that has since been removed. The home stack renders those.
+  if (!project) {
+    const ui = useUIStore.getState();
+    if (ui.homeTagFilter && !terminalMatchesTag(display, ui.homeTagFilter)) {
+      ui.setHomeTagFilter(null);
+    }
+    ui.setHomeActivePtyId(ptyId);
+    selectHome();
+    focusXterm(ptyId);
+    return;
+  }
+
+  // A tag filter that hides the target would make this a no-op: the card stack
+  // resets the active index back to the head of the visible list.
+  const projectStore = useProjectStore.getState();
+  if (projectStore.tagFilter && !terminalMatchesTag(display, projectStore.tagFilter)) {
+    projectStore.setTagFilter(null);
+  }
+
+  await selectProject(ownerPath, project);
+
+  const store = useProjectStore.getState();
+  store.setActivePanel('terminals');
+  store.setKanbanVisible(false);
+
+  if (store.terminalLayout === 'canvas') {
+    const canvas = useCanvasStore.getState().canvasByProject[ownerPath];
+    if (canvas) {
+      const nodes = canvas.nodes.map((node) => ({ ...node, selected: node.id === ptyId }));
+      useCanvasStore.getState().loadCanvas(ownerPath, { ...canvas, nodes });
+    }
+  } else {
+    const terminals = useTerminalStore.getState().terminalsByProject[ownerPath] ?? [];
+    const index = terminals.indexOf(ptyId);
+    if (index >= 0) useTerminalStore.getState().setActiveIndex(ownerPath, index);
+  }
+
+  focusXterm(ptyId);
+}
+
+export interface TaskWorktreeTarget {
+  project: Project;
+  taskNumber: number;
+  worktreePath: string;
+  branch: string;
+  createdAt: string;
+}
+
+/**
+ * Open a plain shell in an existing task worktree.
+ *
+ * `skipAutoHook` keeps this a pure navigation action: without it,
+ * `addProjectTerminal` substitutes the project's continue hook as the start
+ * command and relaunches the agent (what the home recents panel wants, not what
+ * a switcher should do).
+ *
+ * Spawns before navigating, matching the recents panel — the project view force-
+ * shows the kanban when it mounts with no terminals registered for the project.
+ */
+export async function openTaskWorktree(target: TaskWorktreeTarget): Promise<void> {
+  const added = await addProjectTerminal(target.project.path, undefined, {
+    existingWorktree: {
+      path: target.worktreePath,
+      branch: target.branch,
+      createdAt: target.createdAt,
+    },
+    taskId: target.taskNumber,
+    skipAutoHook: true,
+  });
+  if (!added) return;
+
+  await selectProject(target.project.path, target.project);
+  const store = useProjectStore.getState();
+  store.setActivePanel('terminals');
+  store.setKanbanVisible(false);
+}

--- a/src/components/terminal/terminalReact.ts
+++ b/src/components/terminal/terminalReact.ts
@@ -122,7 +122,7 @@ function setupTerminalAppHotkeys(terminal: XTerminal, writeToPty: (data: string)
       }
 
       // App hotkeys that should pass through to hotkeys-js
-      const appHotkeys = ['n', 't', 'b', 'i', 'p', 'd', 's', 'w', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+      const appHotkeys = ['n', 't', 'b', 'i', 'p', 'd', 's', 'w', 'k', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
       if (appHotkeys.includes(key)) {
         return false;
       }

--- a/src/hooks/usePaletteShortcut.ts
+++ b/src/hooks/usePaletteShortcut.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useUIStore } from '../stores/uiStore';
+
+/**
+ * Mod+K toggles the command palette.
+ *
+ * Registered once at the app level so it works from every view, in capture
+ * phase so a focused xterm can't swallow it (`terminalReact` also lists `k` in
+ * its app-hotkey passthrough, for the case where the event reaches xterm first).
+ */
+export function usePaletteShortcut(): void {
+  useEffect(() => {
+    const isMac = navigator.platform.toLowerCase().includes('mac');
+    const handler = (e: KeyboardEvent) => {
+      if (e.repeat) return;
+      const mod = isMac ? e.metaKey : e.ctrlKey;
+      if (!mod || e.altKey || e.shiftKey) return;
+      if (e.key.toLowerCase() !== 'k') return;
+      e.preventDefault();
+      e.stopPropagation();
+      useUIStore.getState().togglePalette();
+    };
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
+  }, []);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -383,6 +383,16 @@ textarea,
   mask-position: center;
 }
 
+/* Project icon tile — a true squircle rather than a rounded rectangle.
+   `corner-shape` gives continuous curvature: flat along the edges, rounding
+   only into the corner, which is why the radius here is larger than the
+   `rounded-md` a circular-arc corner would use at this size. Browsers without
+   `corner-shape` (Chromium < 139) fall back to a plain rounded rect. */
+.project-tile {
+  border-radius: 12px;
+  corner-shape: squircle;
+}
+
 /* ===================================
    Glass bevel — outer-edge bezel effect
    =================================== */

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -16,7 +16,6 @@ interface AppStoreState {
   fullscreen: boolean;
   platform: 'darwin' | 'other';
   projects: Project[];
-  sidebarSearch: string;
   sandboxAvailable: boolean;
   sandboxVmStatus: string;
   sandboxStarting: boolean;
@@ -43,7 +42,6 @@ interface AppStoreState {
 interface AppStoreActions {
   setProjects: (projects: Project[]) => void;
   setFullscreen: (fullscreen: boolean) => void;
-  setSidebarSearch: (search: string) => void;
   setSandboxStatus: (available: boolean, vmStatus: string) => void;
   setSandboxStarting: (starting: boolean) => void;
   setWhatsNew: (info: { version: string; notes: string } | null) => void;
@@ -83,7 +81,6 @@ export const useAppStore = create<AppStore>()((set, get) => ({
   fullscreen: false,
   platform: navigator.platform.toLowerCase().includes('mac') ? 'darwin' : 'other',
   projects: [],
-  sidebarSearch: '',
   sandboxAvailable: false,
   sandboxVmStatus: '',
   sandboxStarting: false,
@@ -100,8 +97,6 @@ export const useAppStore = create<AppStore>()((set, get) => ({
   setProjects: (projects) => set({ projects }),
 
   setFullscreen: (fullscreen) => set({ fullscreen }),
-
-  setSidebarSearch: (search) => set({ sidebarSearch: search }),
 
   setSandboxStatus: (available, vmStatus) => set({ sandboxAvailable: available, sandboxVmStatus: vmStatus }),
 

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -13,6 +13,14 @@ interface UIStoreState {
   homeGroupMode: HomeGroupMode;
   /** When set, the home terminal stack shows only sessions whose task has this tag (across all projects). */
   homeTagFilter: string | null;
+  /**
+   * Front card of the home terminal stack. Lives here rather than in HomeView
+   * so the command palette can bring a home-owned session to the front from
+   * anywhere; HomeView still owns the stack's depth/recency ordering.
+   */
+  homeActivePtyId: string | null;
+  /** Command palette (mod+K) visibility. Session-only. */
+  paletteOpen: boolean;
 }
 
 interface UIStoreActions {
@@ -24,6 +32,9 @@ interface UIStoreActions {
   closeAllDropdowns: () => void;
   setHomeGroupMode: (mode: HomeGroupMode) => void;
   setHomeTagFilter: (tag: string | null) => void;
+  setHomeActivePtyId: (ptyId: string | null) => void;
+  setPaletteOpen: (open: boolean) => void;
+  togglePalette: () => void;
 }
 
 type UIStore = UIStoreState & UIStoreActions;
@@ -34,6 +45,8 @@ export const useUIStore = create<UIStore>()((set, get) => ({
   gitDropdownVisible: false,
   homeGroupMode: 'project',
   homeTagFilter: null,
+  homeActivePtyId: null,
+  paletteOpen: false,
 
   setSidebarVisible: (visible) => set({ sidebarVisible: visible }),
 
@@ -57,4 +70,10 @@ export const useUIStore = create<UIStore>()((set, get) => ({
   setHomeGroupMode: (mode) => set({ homeGroupMode: mode }),
 
   setHomeTagFilter: (tag) => set({ homeTagFilter: tag }),
+
+  setHomeActivePtyId: (ptyId) => set({ homeActivePtyId: ptyId }),
+
+  setPaletteOpen: (open) => set({ paletteOpen: open }),
+
+  togglePalette: () => set((s) => ({ paletteOpen: !s.paletteOpen })),
 }));

--- a/src/utils/fuzzyMatch.ts
+++ b/src/utils/fuzzyMatch.ts
@@ -1,0 +1,161 @@
+/**
+ * Subsequence fuzzy matcher used by the command palette.
+ *
+ * Scores with the fzy algorithm: a small dynamic program over
+ * (needle char × haystack char) that prefers matches at word boundaries, runs
+ * of consecutive characters, and short leading gaps. Greedy left-to-right
+ * matching gets these wrong in exactly the cases a palette hits most — "app"
+ * against "my-app" should land on the word, not on the leading "a".
+ *
+ * Haystacks here are labels, task names and paths, so the O(needle × haystack)
+ * matrix stays tiny. Inputs past MAX_HAYSTACK are rejected rather than scored.
+ *
+ * Matrix naming follows fzy:
+ *   D[i][j] — best score for needle[0..i] where needle[i] matches haystack[j]
+ *   M[i][j] — best score achievable for needle[0..i] within haystack[0..j]
+ */
+
+const SCORE_MIN = -Infinity;
+
+const GAP_LEADING = -0.005;
+const GAP_TRAILING = -0.005;
+const GAP_INNER = -0.01;
+
+const MATCH_CONSECUTIVE = 1.0;
+const MATCH_SLASH = 0.9;
+const MATCH_WORD = 0.8;
+const MATCH_CAPITAL = 0.7;
+const MATCH_DOT = 0.6;
+
+const MAX_NEEDLE = 32;
+const MAX_HAYSTACK = 1024;
+
+/** Inclusive-start, exclusive-end index pair into the haystack. */
+export type MatchRange = [start: number, end: number];
+
+export interface FuzzyMatch {
+  /** Higher is better. Only comparable between matches on the same needle. */
+  score: number;
+  /** Matched character runs, in order, for highlighting. */
+  ranges: MatchRange[];
+}
+
+function isLower(ch: string): boolean {
+  return ch >= 'a' && ch <= 'z';
+}
+
+function isUpper(ch: string): boolean {
+  return ch >= 'A' && ch <= 'Z';
+}
+
+/**
+ * Per-position bonus for the haystack: how significant a match at index i is,
+ * judged by the character before it. Index 0 counts as following a separator.
+ */
+function computeBonuses(haystack: string): number[] {
+  const bonuses = new Array<number>(haystack.length);
+  let prev = '/';
+  for (let i = 0; i < haystack.length; i++) {
+    const ch = haystack[i];
+    if (prev === '/') bonuses[i] = MATCH_SLASH;
+    else if (prev === '-' || prev === '_' || prev === ' ') bonuses[i] = MATCH_WORD;
+    else if (prev === '.') bonuses[i] = MATCH_DOT;
+    else if (isLower(prev) && isUpper(ch)) bonuses[i] = MATCH_CAPITAL;
+    else bonuses[i] = 0;
+    prev = ch;
+  }
+  return bonuses;
+}
+
+/** Whether every needle char appears in haystack, in order (case-insensitive). */
+export function fuzzyMatches(needle: string, haystack: string): boolean {
+  if (needle.length === 0) return true;
+  const n = needle.toLowerCase();
+  const h = haystack.toLowerCase();
+  let j = 0;
+  for (let i = 0; i < h.length; i++) {
+    if (h[i] === n[j] && ++j === n.length) return true;
+  }
+  return false;
+}
+
+/**
+ * Score `needle` against `haystack`, returning null when it doesn't match.
+ * An empty needle matches everything with score 0 and no ranges.
+ */
+export function fuzzyMatch(needle: string, haystack: string): FuzzyMatch | null {
+  if (needle.length === 0) return { score: 0, ranges: [] };
+  if (needle.length > MAX_NEEDLE || haystack.length === 0 || haystack.length > MAX_HAYSTACK) return null;
+  if (needle.length > haystack.length) return null;
+  if (!fuzzyMatches(needle, haystack)) return null;
+
+  const n = needle.toLowerCase();
+  const h = haystack.toLowerCase();
+  const m = n.length;
+  const len = h.length;
+  const bonuses = computeBonuses(haystack);
+
+  const D: number[][] = [];
+  const M: number[][] = [];
+
+  for (let i = 0; i < m; i++) {
+    const dRow = new Array<number>(len).fill(SCORE_MIN);
+    const mRow = new Array<number>(len).fill(SCORE_MIN);
+    const prevD = i > 0 ? D[i - 1] : null;
+    const prevM = i > 0 ? M[i - 1] : null;
+    // Only the last needle char may leave a cheap trailing gap; earlier ones
+    // still have the rest of the needle to place.
+    const gap = i === m - 1 ? GAP_TRAILING : GAP_INNER;
+    let best = SCORE_MIN;
+
+    for (let j = 0; j < len; j++) {
+      let score = SCORE_MIN;
+      if (n[i] === h[j]) {
+        if (i === 0) {
+          score = j * GAP_LEADING + bonuses[j];
+        } else if (j > 0 && prevD && prevM) {
+          // Start fresh after a gap, or extend a run. A consecutive match
+          // scores the run bonus instead of the position bonus, not both.
+          score = Math.max(prevM[j - 1] + bonuses[j], prevD[j - 1] + MATCH_CONSECUTIVE);
+        }
+      }
+      dRow[j] = score;
+      // SCORE_MIN is -Infinity, so a gap off an impossible cell stays impossible.
+      best = Math.max(score, best + gap);
+      mRow[j] = best;
+    }
+
+    D.push(dRow);
+    M.push(mRow);
+  }
+
+  const score = M[m - 1][len - 1];
+  if (score === SCORE_MIN) return null;
+
+  // Traceback: walk needle chars back to front, taking the latest haystack
+  // position where the running best was actually achieved by a match.
+  // `matchRequired` carries a consecutive run backwards so its members aren't
+  // re-attributed to an earlier, lower-scoring position.
+  const positions = new Array<number>(m).fill(-1);
+  let matchRequired = false;
+  let j = len - 1;
+  for (let i = m - 1; i >= 0; i--) {
+    for (; j >= 0; j--) {
+      if (D[i][j] !== SCORE_MIN && (matchRequired || D[i][j] === M[i][j])) {
+        matchRequired = i > 0 && j > 0 && M[i][j] === D[i - 1][j - 1] + MATCH_CONSECUTIVE;
+        positions[i] = j--;
+        break;
+      }
+    }
+  }
+
+  const ranges: MatchRange[] = [];
+  for (const pos of positions) {
+    if (pos < 0) continue;
+    const last = ranges[ranges.length - 1];
+    if (last && last[1] === pos) last[1] = pos + 1;
+    else ranges.push([pos, pos + 1]);
+  }
+
+  return { score, ranges };
+}


### PR DESCRIPTION
Fast switching previously meant hovering the sidebar for projects, or landing on Home and clicking through the card stack for terminals. Mod+K opens a palette over both views that searches terminals, projects and tasks, and jumps to one.

## Behavior

**Terminals** are the union of the terminal store and `pty.getActiveSessions`, so sessions in projects this renderer never hydrated are reachable too — selecting one reconnects that project first. Runners are excluded; they're panels on a parent card, not switchable terminals.

**Tasks** are limited to those with a worktree already on disk and no live terminal (a task with a live terminal is reachable as that terminal). They open as a plain shell via `skipAutoHook`, so the palette stays a switcher: it never creates a worktree, changes a status, or runs a hook.

**Ranking** uses the fzy algorithm rather than greedy subsequence matching, which lands `app` on the word in `my-app` instead of the leading `a`, and returns ranges for match highlighting.

## Supporting changes

- The sidebar's navigation moves into `components/navigation.ts` so it and the palette share one path. `focusTerminal` clears an active tag filter when it would hide the target — otherwise `TerminalCardStack` resets the active index back to the visible head and the jump silently bounces.
- The home stack's active card lifts into `uiStore` so a home-owned session can be promoted from outside `HomeView`. The stack's depth and recency ordering stays in the component.
- `k` added to the xterm app-hotkey passthrough.
- Unused `sidebarSearch` state dropped from `appStore`.

## Notes

- Project tiles use CSS `corner-shape: squircle` (Chromium 139+, which Electron 39 ships). Browsers without it fall back to a plain rounded rect. This is the first use of the property in the app; the sidebar and recents thumbs are still plain rounded rects.
- No new UI chrome — the shortcut is undiscoverable by design for now.
