### PR TITLE
Add the OS file manager to a task's Open in menu

### DIFF
--- a/src/__tests__/renderer/taskMenu.test.tsx
+++ b/src/__tests__/renderer/taskMenu.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * The "Open in" submenu shared by the kanban card and the terminal header,
+ * plus the file-manager reveal it delegates to.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openInEntry, type TaskMenuActions } from '../../components/kanban/taskMenu';
+import { fileManagerName, FILE_MANAGER_NAME, revealInFileManager } from '../../utils/fileManager';
+import { useProjectStore } from '../../stores/projectStore';
+import type { ContextMenuEntry, ContextMenuItem } from '../../components/ui/ContextMenu';
+
+function actions(): TaskMenuActions {
+  return {
+    openTerminal: vi.fn(),
+    openEditor: vi.fn(),
+    openFolder: vi.fn(),
+    setStatus: vi.fn(),
+    trash: vi.fn(),
+  };
+}
+
+function submenuOf(entry: ContextMenuEntry): ContextMenuItem[] {
+  if (!('submenu' in entry)) throw new Error('expected a submenu');
+  return entry.submenu.filter((e): e is ContextMenuItem => 'onClick' in e);
+}
+
+describe('openInEntry', () => {
+  it('offers the file manager (and sandboxes) only once the task has a worktree', () => {
+    const withWorktree = submenuOf(openInEntry(['nono'], true, actions()));
+    expect(withWorktree.map((i) => i.label)).toEqual(['Terminal', 'nono sandbox', 'Editor', FILE_MANAGER_NAME]);
+
+    const withoutWorktree = submenuOf(openInEntry(['nono'], false, actions()));
+    expect(withoutWorktree.map((i) => i.label)).toEqual(['Terminal', 'Editor']);
+  });
+
+  it('runs openFolder when the file manager entry is clicked', () => {
+    const acts = actions();
+    const entry = submenuOf(openInEntry([], true, acts)).find((i) => i.label === FILE_MANAGER_NAME);
+    entry!.onClick();
+    expect(acts.openFolder).toHaveBeenCalled();
+  });
+});
+
+describe('fileManagerName', () => {
+  it('names the platform file manager', () => {
+    expect(fileManagerName('MacIntel')).toBe('Finder');
+    expect(fileManagerName('Win32')).toBe('File Explorer');
+    expect(fileManagerName('Linux x86_64')).toBe('File Manager');
+  });
+});
+
+describe('revealInFileManager', () => {
+  beforeEach(() => {
+    vi.mocked(window.api.openInFinder).mockClear();
+    useProjectStore.setState({ toasts: [] });
+  });
+
+  it('opens the path and stays quiet on success', async () => {
+    vi.mocked(window.api.openInFinder).mockResolvedValueOnce({ success: true });
+    await revealInFileManager('/tmp/worktree');
+    expect(window.api.openInFinder).toHaveBeenCalledWith('/tmp/worktree');
+    expect(useProjectStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('toasts when the OS refuses to open the path', async () => {
+    vi.mocked(window.api.openInFinder).mockResolvedValueOnce({ success: false, error: 'no such file' });
+    await revealInFileManager('/tmp/gone');
+    const [toast] = useProjectStore.getState().toasts;
+    expect(toast.type).toBe('error');
+    expect(toast.message).toContain('/tmp/gone');
+  });
+});

--- a/src/__tests__/renderer/taskMenu.test.tsx
+++ b/src/__tests__/renderer/taskMenu.test.tsx
@@ -61,11 +61,20 @@ describe('revealInFileManager', () => {
     expect(useProjectStore.getState().toasts).toHaveLength(0);
   });
 
-  it('toasts when the OS refuses to open the path', async () => {
+  it('toasts the OS reason when it refuses to open the path', async () => {
     vi.mocked(window.api.openInFinder).mockResolvedValueOnce({ success: false, error: 'no such file' });
     await revealInFileManager('/tmp/gone');
     const [toast] = useProjectStore.getState().toasts;
     expect(toast.type).toBe('error');
     expect(toast.message).toContain('/tmp/gone');
+    expect(toast.message).toContain('no such file');
+  });
+
+  it('toasts instead of rejecting when the invoke itself fails', async () => {
+    vi.mocked(window.api.openInFinder).mockRejectedValueOnce(new Error('channel closed'));
+    await revealInFileManager('/tmp/worktree');
+    const [toast] = useProjectStore.getState().toasts;
+    expect(toast.type).toBe('error');
+    expect(toast.message).toContain('channel closed');
   });
 });

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -13,6 +13,7 @@ import { ContextMenu, type ContextMenuEntry } from '../ui/ContextMenu';
 import { HookConfigDialog } from '../dialogs/HookConfigDialog';
 import { BranchFromTaskDialog } from '../dialogs/BranchFromTaskDialog';
 import { Tooltip } from '../ui/Tooltip';
+import { revealInFileManager } from '../../utils/fileManager';
 import type { TaskChainInfo } from '../../utils/taskChain';
 import { isChainMember, isDescendantOf } from '../../utils/taskChain';
 import { KanbanCardView } from './KanbanCardView';
@@ -204,6 +205,7 @@ export const KanbanCard = memo(function KanbanCard({
           setEditorHookDialog(true);
         }
       },
+      openFolder: () => void revealInFileManager(task.worktreePath!),
       setStatus: async (status) => {
         await window.api.task.setStatus(projectPath, task.taskNumber, status);
         useProjectStore.getState().loadTasks(projectPath);

--- a/src/components/kanban/taskMenu.ts
+++ b/src/components/kanban/taskMenu.ts
@@ -1,6 +1,7 @@
 import type { ContextMenuEntry } from '../ui/ContextMenu';
 import type { SandboxProviderId, TaskStatus } from '../../types';
 import { SANDBOX_BACKEND_LABELS } from '../../types';
+import { FILE_MANAGER_NAME } from '../../utils/fileManager';
 
 /** Column display names, shared by the "Move to" menu and its toasts. */
 export const STATUS_LABELS: Record<TaskStatus, string> = {
@@ -20,6 +21,8 @@ export interface TaskMenuActions {
   /** Open a new terminal for the task; a provider opens it sandboxed. */
   openTerminal: (provider?: SandboxProviderId) => void;
   openEditor: () => void;
+  /** Reveal the task's worktree in the OS file manager. */
+  openFolder: () => void;
   setStatus: (status: TaskStatus) => void;
   /**
    * Finish the task: runs the done hook + closes its terminals, matching
@@ -30,7 +33,11 @@ export interface TaskMenuActions {
   trash: () => void;
 }
 
-/** "Open in ▸" — a host Terminal, one entry per installed sandbox backend, Editor. */
+/**
+ * "Open in ▸" — a host Terminal, one entry per installed sandbox backend,
+ * Editor, and the OS file manager. The file manager entry needs a worktree on
+ * disk to point at, so it only appears once the task has one.
+ */
 export function openInEntry(
   sandboxProviders: SandboxProviderId[],
   hasWorktree: boolean,
@@ -48,6 +55,9 @@ export function openInEntry(
     }
   }
   submenu.push({ label: 'Editor', icon: 'code', onClick: actions.openEditor });
+  if (hasWorktree) {
+    submenu.push({ label: FILE_MANAGER_NAME, icon: 'folder-open', onClick: actions.openFolder });
+  }
   return { label: 'Open in', submenu };
 }
 

--- a/src/components/terminal/TerminalHeader.tsx
+++ b/src/components/terminal/TerminalHeader.tsx
@@ -18,6 +18,7 @@ import { useTerminalPanels } from './useTerminalPanels';
 import { panelIcon, panelLabel, type TerminalPanel } from './panelTypes';
 import type { GitFileStatus, RunnerScript } from '../../types';
 import { openInEntry, moveToEntry, type TaskMenuActions } from '../kanban/taskMenu';
+import { revealInFileManager } from '../../utils/fileManager';
 import { BranchFromTaskDialog } from '../dialogs/BranchFromTaskDialog';
 
 interface TerminalHeaderProps {
@@ -116,6 +117,7 @@ export const TerminalHeader = memo(function TerminalHeader({
             setEditorHookDialog(true);
           }
         },
+        openFolder: () => void revealInFileManager(instance.worktreePath!),
         setStatus: async (status) => {
           await window.api.task.setStatus(projectPath, taskId!, status);
           useProjectStore.getState().loadTasks(projectPath);

--- a/src/ipc/contract.ts
+++ b/src/ipc/contract.ts
@@ -58,8 +58,8 @@ export type ProjectHooks = NonNullable<ProjectSettings['hooks']>;
 export interface IpcInvokeContract {
   // ── Project ──────────────────────────────────────────────────────────
   'get-projects': { args: []; return: Project[] };
-  'open-project': { args: [projectPath: string]; return: { success: boolean } };
-  'open-in-finder': { args: [projectPath: string]; return: { success: boolean } };
+  'open-project': { args: [projectPath: string]; return: { success: boolean; error?: string } };
+  'open-in-finder': { args: [projectPath: string]; return: { success: boolean; error?: string } };
   'open-file-in-editor': {
     args: [projectPath: string, workspaceRoot: string, filePath: string, line?: number];
     return: { success: boolean; error?: string };

--- a/src/ipc/handlers/project.ts
+++ b/src/ipc/handlers/project.ts
@@ -25,6 +25,21 @@ function activeProjectPaths(): Set<string> {
   return new Set(getActiveSessions().map((session) => session.projectPath));
 }
 
+/**
+ * Hands a directory to the OS file manager (Finder, Explorer, the Linux
+ * desktop's handler). shell.openPath resolves to a non-empty string when the
+ * open fails — a deleted worktree is the common case — so the renderer can
+ * surface it instead of the click doing nothing.
+ */
+async function revealPath(targetPath: string): Promise<{ success: boolean; error?: string }> {
+  const error = await shell.openPath(targetPath);
+  if (error) {
+    ipcLog.warn('open path failed', { targetPath, error });
+    return { success: false, error };
+  }
+  return { success: true };
+}
+
 /** Unregister a project, cleaning up its sandbox VM and config first. */
 async function removeProjectWithCleanup(folderPath: string): Promise<void> {
   await deleteWithCleanup(folderPath).catch(() => {});
@@ -39,15 +54,8 @@ export function registerProjectHandlers(mainWindow: BrowserWindow): void {
 
   // Both open-project and open-in-finder use shell.openPath — they share the same
   // implementation because Finder/file-manager is the correct handler for directories.
-  typedHandle('open-project', async (projectPath) => {
-    await shell.openPath(projectPath);
-    return { success: true };
-  });
-
-  typedHandle('open-in-finder', async (projectPath) => {
-    await shell.openPath(projectPath);
-    return { success: true };
-  });
+  typedHandle('open-project', (projectPath) => revealPath(projectPath));
+  typedHandle('open-in-finder', (projectPath) => revealPath(projectPath));
 
   typedHandle('open-file-in-editor', (projectPath, workspaceRoot, filePath, line) =>
     openFileInEditor(projectPath, workspaceRoot, filePath, line),

--- a/src/types.ts
+++ b/src/types.ts
@@ -464,9 +464,9 @@ export interface Project {
  */
 export interface ElectronAPI {
   getProjects(): Promise<Project[]>;
-  openProject(path: string): Promise<{ success: boolean }>;
-  /** Open project in Finder */
-  openInFinder(path: string): Promise<{ success: boolean }>;
+  openProject(path: string): Promise<{ success: boolean; error?: string }>;
+  /** Reveal a directory in the OS file manager (Finder, Explorer, ...) */
+  openInFinder(path: string): Promise<{ success: boolean; error?: string }>;
   /** Open a file at a specific line in the user's editor (auto-detects, falls back to hook) */
   openFileInEditor(
     projectPath: string,

--- a/src/utils/fileManager.ts
+++ b/src/utils/fileManager.ts
@@ -1,0 +1,27 @@
+import { useProjectStore } from '../stores/projectStore';
+
+/**
+ * What the OS calls its file manager, for menu labels.
+ * Linux desktops each ship a different one (Nautilus, Dolphin, Thunar), so the
+ * generic name is the only accurate label there.
+ */
+export function fileManagerName(platform: string = navigator.platform): string {
+  const p = platform.toLowerCase();
+  if (p.includes('mac')) return 'Finder';
+  if (p.includes('win')) return 'File Explorer';
+  return 'File Manager';
+}
+
+export const FILE_MANAGER_NAME = fileManagerName();
+
+/**
+ * Reveals a directory in the OS file manager, toasting when the OS refuses —
+ * a worktree deleted outside Ouijit would otherwise make the menu item look
+ * broken.
+ */
+export async function revealInFileManager(targetPath: string): Promise<void> {
+  const result = await window.api.openInFinder(targetPath);
+  if (!result.success) {
+    useProjectStore.getState().addToast(`Could not open ${FILE_MANAGER_NAME}: ${targetPath}`, 'error');
+  }
+}

--- a/src/utils/fileManager.ts
+++ b/src/utils/fileManager.ts
@@ -17,11 +17,18 @@ export const FILE_MANAGER_NAME = fileManagerName();
 /**
  * Reveals a directory in the OS file manager, toasting when the OS refuses —
  * a worktree deleted outside Ouijit would otherwise make the menu item look
- * broken.
+ * broken. Callers fire this without awaiting, so a rejected invoke has to be
+ * caught here or it surfaces as an unhandled rejection and a dead menu item.
  */
 export async function revealInFileManager(targetPath: string): Promise<void> {
-  const result = await window.api.openInFinder(targetPath);
-  if (!result.success) {
-    useProjectStore.getState().addToast(`Could not open ${FILE_MANAGER_NAME}: ${targetPath}`, 'error');
+  const failed = (reason?: string): void => {
+    const suffix = reason ? `: ${reason}` : '';
+    useProjectStore.getState().addToast(`Could not open ${targetPath} in ${FILE_MANAGER_NAME}${suffix}`, 'error');
+  };
+  try {
+    const result = await window.api.openInFinder(targetPath);
+    if (!result.success) failed(result.error);
+  } catch (err) {
+    failed(err instanceof Error ? err.message : String(err));
   }
 }


### PR DESCRIPTION
A task's "Open in ▸" submenu offered Terminal, sandbox backends, and Editor, but no way to get at the worktree on disk. This adds the OS file manager to it, from both the kanban card menu and the task terminal header (they share `openInEntry`, so the two stay identical).

The entry is labelled for the platform — Finder, File Explorer, or File Manager on Linux, where each desktop ships a different one — and appears once the task has a worktree to point at.

`open-in-finder` previously returned `{ success: true }` unconditionally, discarding `shell.openPath`'s error string. It now reports the failure, and the renderer toasts it, so a worktree deleted outside Ouijit explains itself instead of the click doing nothing.

## Testing

`src/__tests__/renderer/taskMenu.test.tsx` covers the submenu shape with and without a worktree, the click wiring, the platform labels, and the success / refused / rejected-invoke paths. Full unit suite: 950 passing. No e2e run.