### PR TITLE
Run checks in stages before release

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,31 @@
+# Shared check suite. Called by ci.yml (pull requests, pushes to main) and by
+# the release workflow's gate job, so a PR runs exactly what the release runs
+# and the two cannot drift.
+#
+# E2E is deliberately not here. It needs an Electron rebuild plus a full Vite
+# build under xvfb, and e2e/playwright.config.ts uses retries: 0 with a 10s
+# per-test timeout, which is tight for a cold runner. The suite has also never
+# run on a GitHub runner, so its headless behaviour there is unknown.
+name: Checks
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+      - run: npm rebuild better-sqlite3 --silent
+      # Only the unit project: integration tests need a git identity the
+      # runner does not have (see #63).
+      - run: npx vitest run --project unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  # Superseded PR pushes are cancelled; main keeps a result per commit.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  checks:
+    uses: ./.github/workflows/checks.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,18 +9,9 @@ permissions:
   contents: read
 
 jobs:
+  # Same suite that ci.yml runs on every pull request.
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npm run check
-      - run: npm rebuild better-sqlite3 --silent
-      - run: npx vitest run --project unit
+    uses: ./.github/workflows/checks.yml
 
   create-draft:
     needs: test

--- a/src/hookServer.ts
+++ b/src/hookServer.ts
@@ -88,7 +88,6 @@ const actionHandlers: Record<string, ActionHandler> = {
       mainWindow.webContents.send('agent-hook-status', ptyId, status);
     }
   },
-
 };
 
 // ── Server lifecycle ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Checks only ran on tag push. `release.yml`'s `test` job gated `create-draft` and `publish`, but nothing ran on `pull_request`. A prettier violation reached main in #255 and would have failed the v1.6.0 release pipeline before a draft existed.

- **`.github/workflows/checks.yml`** (new): reusable workflow (`on: workflow_call`) holding the four steps verbatim: `npm ci`, `npm run check`, `npm rebuild better-sqlite3 --silent`, `npx vitest run --project unit`.
- **`.github/workflows/ci.yml`** (new): calls it on `pull_request` and pushes to `main`. Concurrency cancels superseded PR pushes but not main, so every main commit keeps its own result.
- **`.github/workflows/release.yml`**: the `test` job body becomes `uses: ./.github/workflows/checks.yml`. Job name is unchanged, so `create-draft`'s `needs: test` still resolves. One copy of the steps, so drift is not possible.
- **`src/hookServer.ts`**: main is currently failing `prettier --check` on a stray blank line from #255. Without this, the new CI would be red on arrival and v1.6.0 would still fail.

## E2E: left out

1. `e2e/playwright.config.ts` sets `retries: 0` with a 10s per-test timeout, tuned for a warm local machine rather than a cold runner booting Electron.
2. The suite has never run on a GitHub runner, so it would be unproven infrastructure gating every PR from day one.
3. The "terminal reconnect after reload" spec in `e2e/app.test.ts` is a known headless flake, failing identically on untouched release commits. A flaky required check trains people to ignore red.
4. Release does not run e2e either. Adding it only to PR CI would reintroduce the drift this change removes.

Making e2e stable headless and adding it to the shared workflow is separate work.
