### PR TITLE
fix(tasks): drag to select card titles

### DIFF
--- a/src/__tests__/renderer/views.test.tsx
+++ b/src/__tests__/renderer/views.test.tsx
@@ -72,6 +72,22 @@ describe('KanbanCardView', () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps rename-field pointer events off the card drag activator', () => {
+    const onPointerDown = vi.fn();
+    const onMouseDown = vi.fn();
+    const { container } = render(
+      // The real card is wrapped by a div carrying dnd-kit's drag listeners.
+      <div onPointerDown={onPointerDown} onMouseDown={onMouseDown}>
+        <KanbanCardView task={baseTask} isRenamingTask />
+      </div>,
+    );
+    const textarea = container.querySelector('textarea')!;
+    fireEvent.pointerDown(textarea);
+    fireEvent.mouseDown(textarea);
+    expect(onPointerDown).not.toHaveBeenCalled();
+    expect(onMouseDown).not.toHaveBeenCalled();
+  });
+
   it('commits a non-empty new name on blur', () => {
     const onCommit = vi.fn();
     const onCancel = vi.fn();

--- a/src/components/kanban/KanbanCardView.tsx
+++ b/src/components/kanban/KanbanCardView.tsx
@@ -253,6 +253,12 @@ export const KanbanCardView = memo(function KanbanCardView({
           <textarea
             ref={nameInputRef}
             className="flex-1 font-mono text-sm font-medium text-text-primary bg-transparent border-0 border-b border-accent p-0 outline-none min-w-0 resize-none overflow-hidden [-webkit-app-region:no-drag] break-words"
+            // Keep the card's drag activator (dnd-kit listeners on the wrapper)
+            // and its shift-click selection handling off the rename field, so
+            // dragging across the text selects it instead of dragging the card.
+            onPointerDown={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
             onBlur={commitRename}
             onKeyDown={handleNameKeyDown}
             rows={1}
@@ -322,6 +328,8 @@ export const KanbanCardView = memo(function KanbanCardView({
                   <input
                     ref={terminalRenameRef}
                     className="font-mono text-[10px] leading-tight text-text-secondary bg-transparent border-0 border-b border-accent p-0 outline-none min-w-0 [-webkit-app-region:no-drag]"
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onMouseDown={(e) => e.stopPropagation()}
                     onClick={(e) => e.stopPropagation()}
                     onBlur={commitTerminalRename}
                     onKeyDown={(e) => {


### PR DESCRIPTION
## Problem

When renaming a task on the kanban board, dragging across the title text started a card drag instead of selecting the text, so copy/paste/replace was impossible.

## Fix

The card's wrapper div carries dnd-kit's drag listeners (and the card handles shift-click selection on mousedown). The inline rename `textarea` now stops pointerdown/mousedown/click propagation, the same guard the expanded description area already uses. The terminal rename input inside the card had the same problem and got the same treatment.

## Testing

- `npx vitest run src/__tests__/renderer/views.test.tsx` (18 passed), including a new case asserting the rename field's pointer events don't reach the drag activator
- `npx tsc --noEmit`, eslint clean