### PR TITLE
Improve the new task composer

### DIFF
--- a/src/__tests__/descriptionAttachments.test.ts
+++ b/src/__tests__/descriptionAttachments.test.ts
@@ -7,6 +7,8 @@ import {
   descriptionToHookPrompt,
   encodeAttachmentPath,
   decodeAttachmentPath,
+  getCaretOffset,
+  setCaretOffset,
 } from '../utils/descriptionAttachments';
 
 describe('parseDescription', () => {
@@ -148,5 +150,73 @@ describe('descriptionToHookPrompt with special characters', () => {
 
   test('escapes a literal backslash to keep escape sequences unambiguous', () => {
     expect(descriptionToHookPrompt('![](/tmp/a\\b.png)')).toBe('"/tmp/a\\\\b.png"');
+  });
+});
+
+/**
+ * The caret travels between the inline composer and its expanded sheet as an
+ * offset into the storage string, so both editors agree on where it sits even
+ * though their DOM differs. Chips count as their whole `![](path)` marker,
+ * matching how the value is stored.
+ */
+describe('caret offsets', () => {
+  /** Build an editor the way parseDescription would populate one. */
+  function editorFor(value: string): HTMLElement {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    for (const segment of parseDescription(value)) {
+      if (segment.type === 'text') el.appendChild(document.createTextNode(segment.value));
+      else el.appendChild(createAttachmentChip(segment.path));
+    }
+    return el;
+  }
+
+  test('round-trips a caret through two editors holding the same value', () => {
+    const value = 'fix ![](/tmp/shot.png) the header';
+    const source = editorFor(value);
+
+    // Caret just after "the " in the trailing text node.
+    const trailing = source.childNodes[2] as Text;
+    const range = document.createRange();
+    range.setStart(trailing, ' the '.length);
+    range.collapse(true);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    const offset = getCaretOffset(source);
+    // 'fix ' + the full marker + ' the '
+    expect(offset).toBe('fix ![](/tmp/shot.png) the '.length);
+
+    // The same offset lands in the same place in a freshly built editor.
+    const target = editorFor(value);
+    setCaretOffset(target, offset!);
+    expect(getCaretOffset(target)).toBe(offset);
+
+    const placed = window.getSelection()!.getRangeAt(0);
+    expect(placed.startContainer.textContent).toBe(' the header');
+    expect(placed.startOffset).toBe(' the '.length);
+  });
+
+  test('parks the caret at the end when the offset runs past the content', () => {
+    const target = editorFor('short');
+    setCaretOffset(target, 999);
+    expect(getCaretOffset(target)).toBe('short'.length);
+  });
+
+  test('reports no offset when the selection is outside the editor', () => {
+    const editor = editorFor('text');
+    const outside = document.createElement('div');
+    outside.textContent = 'elsewhere';
+    document.body.appendChild(outside);
+
+    const range = document.createRange();
+    range.setStart(outside.firstChild!, 2);
+    range.collapse(true);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    expect(getCaretOffset(editor)).toBeNull();
   });
 });

--- a/src/__tests__/renderer/kanbanAddInput.test.tsx
+++ b/src/__tests__/renderer/kanbanAddInput.test.tsx
@@ -1,217 +1,202 @@
 /**
- * Behavior tests for the kanban add form. Users can enter a short title and,
- * by tabbing into the revealed description field, a full prompt before the
- * task is created. The footer exposes Cancel and Create as clickable buttons
- * that also advertise their keyboard shortcuts (Esc / Cmd|Ctrl+Enter).
+ * Behavior tests for the new-task composer.
+ *
+ * The composer rests as a single row below the column's card list and opens
+ * into a title plus description. Two properties matter most and are covered
+ * here: a draft is never lost implicitly (Escape collapses and keeps it, only
+ * an explicit discard clears it), and the draft is one piece of state shared
+ * by the inline form and the expanded sheet.
  */
-import { describe, it, expect, vi } from 'vitest';
-import { render, fireEvent, screen } from '@testing-library/react';
-import { KanbanAddInput } from '../../components/kanban/KanbanAddInput';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import { KanbanAddInput, focusKanbanAddInput } from '../../components/kanban/KanbanAddInput';
 
-const getTitle = () => screen.getByPlaceholderText('New task...') as HTMLInputElement;
+const getRest = () => document.querySelector('.kanban-add-rest') as HTMLButtonElement | null;
+const getTitle = () => document.querySelector('.kanban-add-input') as HTMLInputElement | null;
 /** Description is a contentEditable div — query by its stable class. */
 const getDescription = () => document.querySelector('.kanban-add-description') as HTMLDivElement | null;
-const getCreateButton = () => screen.queryByRole('button', { name: /Create/ }) as HTMLButtonElement | null;
-const getCancelButton = () => screen.queryByRole('button', { name: /Cancel/ }) as HTMLButtonElement | null;
+const getSheet = () => screen.queryByTestId('composer-sheet');
+const getSheetDescription = () =>
+  getSheet()?.querySelector('.kanban-composer-sheet-editor') as HTMLDivElement | undefined;
+const getCreateButton = () => screen.queryByRole('button', { name: /^Create/ }) as HTMLButtonElement | null;
+
+/** Open the resting composer and return its title input. */
+function openComposer(): HTMLInputElement {
+  fireEvent.click(getRest()!);
+  return getTitle()!;
+}
 
 /** Set the editor's text content and fire the input event the editor listens
  *  for. Mirrors what a user typing produces, minus chip insertion. */
-function typeDescription(text: string): void {
-  const el = getDescription();
-  if (!el) throw new Error('Description editor not in DOM');
+function typeInto(el: HTMLElement, text: string): void {
   el.innerHTML = '';
   if (text) el.appendChild(document.createTextNode(text));
   fireEvent.input(el);
 }
 
+/** Swap in a partial window.api for one test, restoring it afterwards. */
+let restoreApi: (() => void) | null = null;
+function stubApi(overrides: Record<string, unknown>): void {
+  const original = window.api;
+  Object.defineProperty(window, 'api', { value: { ...original, ...overrides }, writable: true });
+  restoreApi = () => Object.defineProperty(window, 'api', { value: original, writable: true });
+}
+afterEach(() => {
+  restoreApi?.();
+  restoreApi = null;
+});
+
 describe('KanbanAddInput', () => {
-  it('hides the description field and footer buttons until the title is focused', () => {
+  it('rests as a single row and opens on click', () => {
     render(<KanbanAddInput onAdd={vi.fn()} />);
+
+    expect(getRest()).not.toBeNull();
+    expect(getTitle()).toBeNull();
     expect(getDescription()).toBeNull();
-    expect(getCreateButton()).toBeNull();
-    expect(getCancelButton()).toBeNull();
 
-    fireEvent.focus(getTitle());
+    const title = openComposer();
+    expect(title).not.toBeNull();
     expect(getDescription()).not.toBeNull();
-    expect(getCreateButton()).not.toBeNull();
-    expect(getCancelButton()).not.toBeNull();
+    expect(document.activeElement).toBe(title);
   });
 
-  it('creates a title-only task when Enter is pressed in the title field', () => {
+  it('creates from the title alone and stays open for the next task', () => {
     const onAdd = vi.fn();
     render(<KanbanAddInput onAdd={onAdd} />);
 
-    const title = getTitle();
-    fireEvent.change(title, { target: { value: 'Fix login' } });
-    fireEvent.keyDown(title, { key: 'Enter' });
-
-    expect(onAdd).toHaveBeenCalledWith('Fix login', undefined);
-  });
-
-  it('disables the Create button until the title has content', () => {
-    render(<KanbanAddInput onAdd={vi.fn()} />);
-
-    fireEvent.focus(getTitle());
-    expect(getCreateButton()!.disabled).toBe(true);
-
-    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    expect(getCreateButton()!.disabled).toBe(false);
-
-    fireEvent.change(getTitle(), { target: { value: '   ' } });
-    expect(getCreateButton()!.disabled).toBe(true);
-  });
-
-  it('creates the task when the Create button is clicked', () => {
-    const onAdd = vi.fn();
-    render(<KanbanAddInput onAdd={onAdd} />);
-
-    fireEvent.focus(getTitle());
-    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    typeDescription('Details');
-    fireEvent.click(getCreateButton()!);
-
-    expect(onAdd).toHaveBeenCalledWith('Fix login', 'Details');
-  });
-
-  it('clears and collapses the form when the Cancel button is clicked', () => {
-    render(<KanbanAddInput onAdd={vi.fn()} />);
-
-    fireEvent.focus(getTitle());
-    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    fireEvent.click(getCancelButton()!);
-
-    expect(getTitle().value).toBe('');
-    expect(getDescription()).toBeNull();
-  });
-
-  it('creates with Cmd+Enter from the description field', () => {
-    const onAdd = vi.fn();
-    render(<KanbanAddInput onAdd={onAdd} />);
-
-    fireEvent.focus(getTitle());
-    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    typeDescription('Details');
-    fireEvent.keyDown(getDescription()!, { key: 'Enter', metaKey: true });
-
-    expect(onAdd).toHaveBeenCalledWith('Fix login', 'Details');
-  });
-
-  it('creates with Ctrl+Enter from the description field', () => {
-    const onAdd = vi.fn();
-    render(<KanbanAddInput onAdd={onAdd} />);
-
-    fireEvent.focus(getTitle());
-    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    typeDescription('Details');
-    fireEvent.keyDown(getDescription()!, { key: 'Enter', ctrlKey: true });
-
-    expect(onAdd).toHaveBeenCalledWith('Fix login', 'Details');
-  });
-
-  it('does not create on a bare Enter in the description field', () => {
-    const onAdd = vi.fn();
-    render(<KanbanAddInput onAdd={onAdd} />);
-
-    fireEvent.focus(getTitle());
-    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    fireEvent.keyDown(getDescription()!, { key: 'Enter' });
-
-    expect(onAdd).not.toHaveBeenCalled();
-  });
-
-  it('does not create when the title is empty or whitespace', () => {
-    const onAdd = vi.fn();
-    render(<KanbanAddInput onAdd={onAdd} />);
-
-    const title = getTitle();
-    fireEvent.change(title, { target: { value: '   ' } });
-    fireEvent.keyDown(title, { key: 'Enter' });
-
-    expect(onAdd).not.toHaveBeenCalled();
-  });
-
-  it('clears the fields but keeps the form open for the next task after a create', () => {
-    render(<KanbanAddInput onAdd={vi.fn()} />);
-
-    const title = getTitle();
-    fireEvent.focus(title);
-    fireEvent.change(title, { target: { value: 'Fix login' } });
-    typeDescription('Details');
-    fireEvent.keyDown(title, { key: 'Enter' });
-
-    // Fields are cleared, but the form stays expanded so the next task can
-    // be entered without clicking back in.
-    expect(getTitle().value).toBe('');
-    expect(getDescription()).not.toBeNull();
-    expect(getDescription()!.textContent).toBe('');
-    expect(getCreateButton()).not.toBeNull();
-  });
-
-  it('can create a second task in a row without re-focusing the form', () => {
-    const onAdd = vi.fn();
-    render(<KanbanAddInput onAdd={onAdd} />);
-
-    const title = getTitle();
-    fireEvent.focus(title);
+    const title = openComposer();
     fireEvent.change(title, { target: { value: 'First task' } });
     fireEvent.keyDown(title, { key: 'Enter' });
 
-    fireEvent.change(title, { target: { value: 'Second task' } });
-    fireEvent.keyDown(title, { key: 'Enter' });
-
     expect(onAdd).toHaveBeenNthCalledWith(1, 'First task', undefined);
+    expect(getTitle()!.value).toBe('');
+
+    fireEvent.change(getTitle()!, { target: { value: 'Second task' } });
+    fireEvent.keyDown(getTitle()!, { key: 'Enter' });
     expect(onAdd).toHaveBeenNthCalledWith(2, 'Second task', undefined);
   });
 
-  it('clears and collapses the form on Escape from the title field', () => {
-    render(<KanbanAddInput onAdd={vi.fn()} />);
-
-    const title = getTitle();
-    fireEvent.change(title, { target: { value: 'Fix login' } });
-    fireEvent.keyDown(title, { key: 'Escape' });
-
-    expect(getTitle().value).toBe('');
-    expect(getDescription()).toBeNull();
-  });
-
-  it('clears and collapses the form on Escape from the description field', () => {
-    render(<KanbanAddInput onAdd={vi.fn()} />);
-
-    fireEvent.focus(getTitle());
-    fireEvent.change(getTitle(), { target: { value: 'Fix login' } });
-    typeDescription('Details');
-    fireEvent.keyDown(getDescription()!, { key: 'Escape' });
-
-    expect(getTitle().value).toBe('');
-    expect(getDescription()).toBeNull();
-  });
-
-  it('omits an empty description from the create call', () => {
+  it('creates with a description on Cmd+Enter, and omits a blank one', () => {
     const onAdd = vi.fn();
     render(<KanbanAddInput onAdd={onAdd} />);
 
-    const title = getTitle();
-    fireEvent.focus(title);
+    const title = openComposer();
     fireEvent.change(title, { target: { value: 'Fix login' } });
-    typeDescription('   ');
-    fireEvent.keyDown(title, { key: 'Enter' });
+    typeInto(getDescription()!, 'Session expires after 30s');
+    fireEvent.keyDown(getDescription()!, { key: 'Enter', metaKey: true });
+    expect(onAdd).toHaveBeenNthCalledWith(1, 'Fix login', 'Session expires after 30s');
 
-    expect(onAdd).toHaveBeenCalledWith('Fix login', undefined);
+    fireEvent.change(getTitle()!, { target: { value: 'Second' } });
+    typeInto(getDescription()!, '   ');
+    fireEvent.keyDown(getTitle()!, { key: 'Enter' });
+    expect(onAdd).toHaveBeenNthCalledWith(2, 'Second', undefined);
+  });
+
+  it('disables Create until the title has content', () => {
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+
+    const title = openComposer();
+    expect(getCreateButton()!.disabled).toBe(true);
+
+    fireEvent.change(title, { target: { value: 'Fix login' } });
+    expect(getCreateButton()!.disabled).toBe(false);
+
+    fireEvent.change(title, { target: { value: '   ' } });
+    expect(getCreateButton()!.disabled).toBe(true);
+  });
+
+  it('keeps the draft when Escape collapses the form, and restores it on reopen', () => {
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+
+    const title = openComposer();
+    fireEvent.change(title, { target: { value: 'Fix login' } });
+    typeInto(getDescription()!, 'Long prompt worth keeping');
+    fireEvent.keyDown(getDescription()!, { key: 'Escape' });
+
+    // Collapsed, but advertising the pending draft rather than looking empty.
+    expect(getTitle()).toBeNull();
+    expect(getRest()!.textContent).toContain('Fix login');
+
+    const reopened = openComposer();
+    expect(reopened.value).toBe('Fix login');
+    expect(getDescription()!.textContent).toBe('Long prompt worth keeping');
+  });
+
+  it('discards the draft on a second Escape, and from the Discard button', () => {
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+
+    const title = openComposer();
+    fireEvent.change(title, { target: { value: 'Fix login' } });
+    fireEvent.keyDown(title, { key: 'Escape' });
+    fireEvent.keyDown(getRest()!, { key: 'Escape' });
+
+    expect(getRest()!.textContent).toContain('New task');
+    expect(openComposer().value).toBe('');
+
+    fireEvent.change(getTitle()!, { target: { value: 'Another' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+    expect(getTitle()).toBeNull();
+    expect(getRest()!.textContent).toContain('New task');
+  });
+
+  it('shares one draft between the inline form and the expanded sheet', () => {
+    const onAdd = vi.fn();
+    render(<KanbanAddInput onAdd={onAdd} />);
+
+    const title = openComposer();
+    fireEvent.change(title, { target: { value: 'Fix login' } });
+    typeInto(getDescription()!, 'Started inline');
+    fireEvent.keyDown(getDescription()!, { key: 'e', metaKey: true });
+
+    // The sheet opens on the same draft.
+    expect(getSheet()).not.toBeNull();
+    expect(getSheetDescription()!.textContent).toBe('Started inline');
+
+    // Editing in the sheet mirrors back into the inline editor behind it.
+    typeInto(getSheetDescription()!, 'Continued in the sheet');
+    expect(getDescription()!.textContent).toBe('Continued in the sheet');
+
+    // Escape returns to the column with the draft intact, not to a cleared form.
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(getSheet()).toBeNull();
+    expect(getTitle()!.value).toBe('Fix login');
+    expect(getDescription()!.textContent).toBe('Continued in the sheet');
+  });
+
+  it('creates from the sheet and closes it', () => {
+    const onAdd = vi.fn();
+    render(<KanbanAddInput onAdd={onAdd} />);
+
+    const title = openComposer();
+    fireEvent.change(title, { target: { value: 'Fix login' } });
+    fireEvent.keyDown(title, { key: 'e', metaKey: true });
+    typeInto(getSheetDescription()!, 'Written with room to think');
+    fireEvent.keyDown(document, { key: 'Enter', metaKey: true });
+
+    expect(onAdd).toHaveBeenCalledWith('Fix login', 'Written with room to think');
+    expect(getSheet()).toBeNull();
+    expect(getTitle()!.value).toBe('');
+  });
+
+  it('opens the collapsed form when focused programmatically', () => {
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+
+    expect(getTitle()).toBeNull();
+    // Called from a document-level hotkey in the app, so it isn't a React
+    // event; act() stands in for the flush React does before the next paint.
+    act(() => focusKanbanAddInput());
+    expect(document.activeElement).toBe(getTitle());
   });
 
   it('saves an image attachment from clipboard paste with no source path', async () => {
     const onAdd = vi.fn();
     const saveAttachment = vi.fn().mockResolvedValue({ success: true, path: '/tmp/img-test.png' });
     const getPathForFile = vi.fn().mockReturnValue('');
-    const original = (window as unknown as { api?: unknown }).api;
-    (window as unknown as { api: unknown }).api = {
-      task: { saveAttachment },
-      getPathForFile,
-    };
+    stubApi({ task: { ...window.api.task, saveAttachment }, getPathForFile });
 
     render(<KanbanAddInput onAdd={onAdd} />);
-    fireEvent.focus(getTitle());
-    fireEvent.change(getTitle(), { target: { value: 'With image' } });
+    const title = openComposer();
+    fireEvent.change(title, { target: { value: 'With image' } });
 
     const editor = getDescription()!;
     const file = new File([new Uint8Array([1, 2, 3])], 'paste.png', { type: 'image/png' });
@@ -225,24 +210,17 @@ describe('KanbanAddInput', () => {
     expect(getPathForFile).toHaveBeenCalledTimes(1);
     expect(saveAttachment).toHaveBeenCalledTimes(1);
     expect(onAdd).toHaveBeenCalledWith('With image', '![](/tmp/img-test.png)');
-
-    if (original !== undefined) (window as unknown as { api: unknown }).api = original;
-    else delete (window as unknown as { api?: unknown }).api;
   });
 
   it('uses the original file path on drop, with no copy and any extension', async () => {
     const onAdd = vi.fn();
     const saveAttachment = vi.fn().mockResolvedValue({ success: false, error: 'should not be called' });
     const getPathForFile = vi.fn().mockReturnValue('/Users/me/notes/agenda.txt');
-    const original = (window as unknown as { api?: unknown }).api;
-    (window as unknown as { api: unknown }).api = {
-      task: { saveAttachment },
-      getPathForFile,
-    };
+    stubApi({ task: { ...window.api.task, saveAttachment }, getPathForFile });
 
     render(<KanbanAddInput onAdd={onAdd} />);
-    fireEvent.focus(getTitle());
-    fireEvent.change(getTitle(), { target: { value: 'With file' } });
+    const title = openComposer();
+    fireEvent.change(title, { target: { value: 'With file' } });
 
     const editor = getDescription()!;
     const file = new File([new Uint8Array([1])], 'agenda.txt', { type: 'text/plain' });
@@ -257,8 +235,5 @@ describe('KanbanAddInput', () => {
     expect(getPathForFile).toHaveBeenCalledTimes(1);
     expect(saveAttachment).not.toHaveBeenCalled();
     expect(onAdd).toHaveBeenCalledWith('With file', '![](/Users/me/notes/agenda.txt)');
-
-    if (original !== undefined) (window as unknown as { api: unknown }).api = original;
-    else delete (window as unknown as { api?: unknown }).api;
   });
 });

--- a/src/__tests__/renderer/kanbanAddInput.test.tsx
+++ b/src/__tests__/renderer/kanbanAddInput.test.tsx
@@ -16,8 +16,7 @@ const getTitle = () => document.querySelector('.kanban-add-input') as HTMLInputE
 /** Description is a contentEditable div — query by its stable class. */
 const getDescription = () => document.querySelector('.kanban-add-description') as HTMLDivElement | null;
 const getSheet = () => screen.queryByTestId('composer-sheet');
-const getSheetDescription = () =>
-  getSheet()?.querySelector('.kanban-composer-sheet-editor') as HTMLDivElement | undefined;
+const getSheetDescription = () => getSheet()?.querySelector('.composer-sheet-editor') as HTMLDivElement | undefined;
 const getCreateButton = () => screen.queryByRole('button', { name: /^Create/ }) as HTMLButtonElement | null;
 
 /** Open the resting composer and return its title input. */
@@ -32,6 +31,14 @@ function typeInto(el: HTMLElement, text: string): void {
   el.innerHTML = '';
   if (text) el.appendChild(document.createTextNode(text));
   fireEvent.input(el);
+}
+
+/** The sheet plays its exit before handing control back, like the app's other
+ *  overlays, so anything it hands off lands a transition later. */
+async function flushSheetExit(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 260));
+  });
 }
 
 /** Swap in a partial window.api for one test, restoring it afterwards. */
@@ -139,7 +146,7 @@ describe('KanbanAddInput', () => {
     expect(getRest()!.textContent).toContain('New task');
   });
 
-  it('shares one draft between the inline form and the expanded sheet', () => {
+  it('shares one draft between the inline form and the expanded sheet', async () => {
     const onAdd = vi.fn();
     render(<KanbanAddInput onAdd={onAdd} />);
 
@@ -158,12 +165,13 @@ describe('KanbanAddInput', () => {
 
     // Escape returns to the column with the draft intact, not to a cleared form.
     fireEvent.keyDown(document, { key: 'Escape' });
+    await flushSheetExit();
     expect(getSheet()).toBeNull();
     expect(getTitle()!.value).toBe('Fix login');
     expect(getDescription()!.textContent).toBe('Continued in the sheet');
   });
 
-  it('creates from the sheet and closes it', () => {
+  it('creates from the sheet and closes it', async () => {
     const onAdd = vi.fn();
     render(<KanbanAddInput onAdd={onAdd} />);
 
@@ -172,6 +180,7 @@ describe('KanbanAddInput', () => {
     fireEvent.keyDown(title, { key: 'e', metaKey: true });
     typeInto(getSheetDescription()!, 'Written with room to think');
     fireEvent.keyDown(document, { key: 'Enter', metaKey: true });
+    await flushSheetExit();
 
     expect(onAdd).toHaveBeenCalledWith('Fix login', 'Written with room to think');
     expect(getSheet()).toBeNull();

--- a/src/__tests__/renderer/kanbanAddInput.test.tsx
+++ b/src/__tests__/renderer/kanbanAddInput.test.tsx
@@ -15,6 +15,9 @@ import { useAppStore } from '../../stores/appStore';
 import { useProjectStore } from '../../stores/projectStore';
 import { openTaskComposer } from '../../utils/openTaskComposer';
 
+/** The platform modifier the app binds to, mirrored so these run on any host. */
+const MOD = navigator.platform.toLowerCase().includes('mac') ? { metaKey: true } : { ctrlKey: true };
+
 const getRest = () => document.querySelector('.kanban-add-rest') as HTMLButtonElement | null;
 const getTitle = () => document.querySelector('.kanban-add-input') as HTMLInputElement | null;
 /** Description is a contentEditable div — query by its stable class. */
@@ -60,7 +63,7 @@ afterEach(() => {
 // The draft outlives the component by design, so it also outlives a test.
 beforeEach(() => {
   useComposerStore.setState({ draft: { name: '', description: '' }, sheetOpen: false, sheetCaret: null });
-  useAppStore.setState({ composerSheetOpen: false });
+  useAppStore.setState({ composerSheetCount: 0 });
   useProjectStore.setState({ activePanel: 'terminals', kanbanVisible: true });
 });
 
@@ -101,7 +104,7 @@ describe('KanbanAddInput', () => {
     const title = openComposer();
     fireEvent.change(title, { target: { value: 'Fix login' } });
     typeInto(getDescription()!, 'Session expires after 30s');
-    fireEvent.keyDown(getDescription()!, { key: 'Enter', metaKey: true });
+    fireEvent.keyDown(getDescription()!, { key: 'Enter', ...MOD });
     expect(onAdd).toHaveBeenNthCalledWith(1, 'Fix login', 'Session expires after 30s');
 
     fireEvent.change(getTitle()!, { target: { value: 'Second' } });
@@ -164,7 +167,7 @@ describe('KanbanAddInput', () => {
     const title = openComposer();
     fireEvent.change(title, { target: { value: 'Fix login' } });
     typeInto(getDescription()!, 'Started inline');
-    fireEvent.keyDown(getDescription()!, { key: 'e', metaKey: true });
+    fireEvent.keyDown(getDescription()!, { key: 'e', ...MOD });
 
     // The sheet opens on the same draft.
     expect(getSheet()).not.toBeNull();
@@ -188,9 +191,9 @@ describe('KanbanAddInput', () => {
 
     const title = openComposer();
     fireEvent.change(title, { target: { value: 'Fix login' } });
-    fireEvent.keyDown(title, { key: 'e', metaKey: true });
+    fireEvent.keyDown(title, { key: 'e', ...MOD });
     typeInto(getSheetDescription()!, 'Written with room to think');
-    fireEvent.keyDown(document, { key: 'Enter', metaKey: true });
+    fireEvent.keyDown(document, { key: 'Enter', ...MOD });
     await flushSheetExit();
 
     expect(onAdd).toHaveBeenCalledWith('Fix login', 'Written with room to think');
@@ -254,7 +257,7 @@ describe('KanbanAddInput', () => {
     fireEvent.paste(editor, { clipboardData: dataTransfer });
     await new Promise((r) => setTimeout(r, 0));
 
-    fireEvent.keyDown(editor, { key: 'Enter', metaKey: true });
+    fireEvent.keyDown(editor, { key: 'Enter', ...MOD });
     expect(getPathForFile).toHaveBeenCalledTimes(1);
     expect(saveAttachment).toHaveBeenCalledTimes(1);
     expect(onAdd).toHaveBeenCalledWith('With image', '![](/tmp/img-test.png)');
@@ -279,7 +282,7 @@ describe('KanbanAddInput', () => {
     fireEvent.drop(editor, { dataTransfer, clientX: 0, clientY: 0 });
     await new Promise((r) => setTimeout(r, 0));
 
-    fireEvent.keyDown(editor, { key: 'Enter', metaKey: true });
+    fireEvent.keyDown(editor, { key: 'Enter', ...MOD });
     expect(getPathForFile).toHaveBeenCalledTimes(1);
     expect(saveAttachment).not.toHaveBeenCalled();
     expect(onAdd).toHaveBeenCalledWith('With file', '![](/Users/me/notes/agenda.txt)');

--- a/src/__tests__/renderer/kanbanAddInput.test.tsx
+++ b/src/__tests__/renderer/kanbanAddInput.test.tsx
@@ -140,18 +140,18 @@ describe('KanbanAddInput', () => {
     expect(getDescription()!.textContent).toBe('Long prompt worth keeping');
   });
 
-  it('discards the draft on a second Escape, and from the Discard button', () => {
+  it('discards the draft only from the Discard button', () => {
     render(<KanbanAddInput onAdd={vi.fn()} />);
 
     const title = openComposer();
     fireEvent.change(title, { target: { value: 'Fix login' } });
+
+    // Collapsing is not discarding, however many times you press Escape.
     fireEvent.keyDown(title, { key: 'Escape' });
-    fireEvent.keyDown(getRest()!, { key: 'Escape' });
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(getRest()!.textContent).toContain('Fix login');
 
-    expect(getRest()!.textContent).toContain('New task');
-    expect(openComposer().value).toBe('');
-
-    fireEvent.change(getTitle()!, { target: { value: 'Another' } });
+    fireEvent.click(getRest()!);
     fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
     expect(getTitle()).toBeNull();
     expect(getRest()!.textContent).toContain('New task');

--- a/src/__tests__/renderer/kanbanAddInput.test.tsx
+++ b/src/__tests__/renderer/kanbanAddInput.test.tsx
@@ -7,9 +7,13 @@
  * an explicit discard clears it), and the draft is one piece of state shared
  * by the inline form and the expanded sheet.
  */
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, fireEvent, screen, act } from '@testing-library/react';
 import { KanbanAddInput, focusKanbanAddInput } from '../../components/kanban/KanbanAddInput';
+import { useComposerStore } from '../../stores/composerStore';
+import { useAppStore } from '../../stores/appStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { openTaskComposer } from '../../utils/openTaskComposer';
 
 const getRest = () => document.querySelector('.kanban-add-rest') as HTMLButtonElement | null;
 const getTitle = () => document.querySelector('.kanban-add-input') as HTMLInputElement | null;
@@ -51,6 +55,13 @@ function stubApi(overrides: Record<string, unknown>): void {
 afterEach(() => {
   restoreApi?.();
   restoreApi = null;
+});
+
+// The draft outlives the component by design, so it also outlives a test.
+beforeEach(() => {
+  useComposerStore.setState({ draft: { name: '', description: '' }, sheetOpen: false, sheetCaret: null });
+  useAppStore.setState({ composerSheetOpen: false });
+  useProjectStore.setState({ activePanel: 'terminals', kanbanVisible: true });
 });
 
 describe('KanbanAddInput', () => {
@@ -185,6 +196,34 @@ describe('KanbanAddInput', () => {
     expect(onAdd).toHaveBeenCalledWith('Fix login', 'Written with room to think');
     expect(getSheet()).toBeNull();
     expect(getTitle()!.value).toBe('');
+  });
+
+  it('routes the new-task shortcut to the column on the board, and to the sheet elsewhere', () => {
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+
+    // On the board the composer is already on screen, so focus it.
+    act(() => openTaskComposer());
+    expect(document.activeElement).toBe(getTitle());
+    expect(getSheet()).toBeNull();
+
+    // Off the board there is nothing to focus, so the sheet comes to you
+    // rather than the view switching underneath.
+    useProjectStore.setState({ kanbanVisible: false });
+    act(() => openTaskComposer());
+    expect(useComposerStore.getState().sheetOpen).toBe(true);
+    expect(useProjectStore.getState().kanbanVisible).toBe(false);
+  });
+
+  it('carries a draft written off the board back to the column composer', () => {
+    useProjectStore.setState({ kanbanVisible: false });
+    act(() => openTaskComposer());
+    useComposerStore.getState().setName('Started from a terminal');
+    useComposerStore.getState().closeSheet();
+
+    // Arriving at the board later, the draft is waiting in the resting row.
+    useProjectStore.setState({ kanbanVisible: true });
+    render(<KanbanAddInput onAdd={vi.fn()} />);
+    expect(getRest()!.textContent).toContain('Started from a terminal');
   });
 
   it('opens the collapsed form when focused programmatically', () => {

--- a/src/__tests__/renderer/taskComposerSurfaces.test.tsx
+++ b/src/__tests__/renderer/taskComposerSurfaces.test.tsx
@@ -18,6 +18,9 @@ import { useAppStore } from '../../stores/appStore';
 import { useProjectStore } from '../../stores/projectStore';
 import type { TaskWithWorkspace } from '../../types';
 
+/** The platform modifier the app binds to, mirrored so these run on any host. */
+const MOD = navigator.platform.toLowerCase().includes('mac') ? { metaKey: true } : { ctrlKey: true };
+
 const getSheet = () => screen.queryByTestId('composer-sheet');
 const getSheetEditor = () => getSheet()?.querySelector('.composer-sheet-editor') as HTMLDivElement | undefined;
 const getSheetName = () => getSheet()?.querySelector('textarea') as HTMLTextAreaElement | undefined;
@@ -38,7 +41,7 @@ async function flushSheetExit(): Promise<void> {
 
 beforeEach(() => {
   useComposerStore.setState({ draft: { name: '', description: '' }, sheetOpen: false, sheetCaret: null });
-  useAppStore.setState({ composerSheetOpen: false });
+  useAppStore.setState({ composerSheetCount: 0 });
   // Off the board, which is when the standalone sheet is the one that renders.
   useProjectStore.setState({ activePanel: 'terminals', kanbanVisible: false });
 });
@@ -81,12 +84,29 @@ describe('StandaloneComposerSheet', () => {
 
     fireEvent.change(getSheetName()!, { target: { value: 'Fix login' } });
     typeInto(getSheetEditor()!, 'Session expires after 30s');
-    fireEvent.keyDown(document, { key: 'Enter', metaKey: true });
+    fireEvent.keyDown(document, { key: 'Enter', ...MOD });
     await flushSheetExit();
 
     expect(create).toHaveBeenCalledWith('/p', 'Fix login', 'Session expires after 30s');
     expect(useComposerStore.getState().draft).toEqual({ name: '', description: '' });
     expect(getSheet()).toBeNull();
+    create.mockRestore();
+  });
+
+  it('creates once when the submit shortcut repeats', async () => {
+    const create = vi.spyOn(window.api.task, 'create').mockResolvedValue({ success: true } as never);
+    act(() => useComposerStore.getState().openSheet());
+    render(<StandaloneComposerSheet projectPath="/p" />);
+    fireEvent.change(getSheetName()!, { target: { value: 'Fix login' } });
+
+    // The submit is deferred behind the exit transition, so without a latch a
+    // held key queues one timer per repeat and each creates the task again.
+    fireEvent.keyDown(document, { key: 'Enter', ...MOD });
+    fireEvent.keyDown(document, { key: 'Enter', ...MOD });
+    fireEvent.keyDown(document, { key: 'Enter', ...MOD, repeat: true });
+    await flushSheetExit();
+
+    expect(create).toHaveBeenCalledTimes(1);
     create.mockRestore();
   });
 
@@ -129,7 +149,7 @@ describe("the card's description sheet", () => {
     const editor = openCardEditor();
     expect(editor.textContent).toBe('Started on the card');
 
-    fireEvent.keyDown(editor, { key: 'e', metaKey: true });
+    fireEvent.keyDown(editor, { key: 'e', ...MOD });
     expect(getSheetEditor()!.textContent).toBe('Started on the card');
 
     // Editing in the sheet mirrors back into the card underneath, which is what
@@ -137,20 +157,34 @@ describe("the card's description sheet", () => {
     typeInto(getSheetEditor()!, 'Rewritten with room to think');
     expect(container.querySelector('.kanban-description-editor')!.textContent).toBe('Rewritten with room to think');
 
-    fireEvent.keyDown(document, { key: 'Enter', metaKey: true });
+    fireEvent.keyDown(document, { key: 'Enter', ...MOD });
     await flushSheetExit();
     expect(onUpdateDescription).toHaveBeenCalledWith(7, 'Rewritten with room to think');
     expect(getSheet()).toBeNull();
   });
 
+  it('does not commit the description when the sheet takes focus', () => {
+    const onUpdateDescription = vi.fn();
+    render(<KanbanCardView task={task} onUpdateDescription={onUpdateDescription} />);
+
+    const editor = openCardEditor();
+    fireEvent.keyDown(editor, { key: 'e', ...MOD });
+
+    // Opening the sheet moves focus to its editor, which blurs this one. A
+    // blur commit there would write the description out and drop the card's
+    // editor back to read-only underneath the sheet.
+    fireEvent.blur(editor);
+    expect(onUpdateDescription).not.toHaveBeenCalled();
+  });
+
   it('tells the board to leave Escape alone while the sheet is up', async () => {
     render(<KanbanCardView task={task} onUpdateDescription={vi.fn()} />);
 
-    fireEvent.keyDown(openCardEditor(), { key: 'e', metaKey: true });
-    expect(useAppStore.getState().composerSheetOpen).toBe(true);
+    fireEvent.keyDown(openCardEditor(), { key: 'e', ...MOD });
+    expect(useAppStore.getState().composerSheetCount).toBe(1);
 
     fireEvent.keyDown(document, { key: 'Escape' });
     await flushSheetExit();
-    expect(useAppStore.getState().composerSheetOpen).toBe(false);
+    expect(useAppStore.getState().composerSheetCount).toBe(0);
   });
 });

--- a/src/__tests__/renderer/taskComposerSurfaces.test.tsx
+++ b/src/__tests__/renderer/taskComposerSurfaces.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * The composer's other two surfaces, and the placement the whole design rests
+ * on.
+ *
+ * `kanbanAddInput.test.tsx` covers the column composer. This covers what it
+ * hands off to: the standalone sheet that ⌘N opens away from the board, the
+ * card's sheet for editing an existing description, and the structural fact
+ * that the composer sits outside the column's scroll container — which is the
+ * fix that made any of this worth doing.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import { KanbanColumnView } from '../../components/kanban/KanbanColumnView';
+import { KanbanCardView } from '../../components/kanban/KanbanCardView';
+import { StandaloneComposerSheet } from '../../components/kanban/StandaloneComposerSheet';
+import { useComposerStore } from '../../stores/composerStore';
+import { useAppStore } from '../../stores/appStore';
+import { useProjectStore } from '../../stores/projectStore';
+import type { TaskWithWorkspace } from '../../types';
+
+const getSheet = () => screen.queryByTestId('composer-sheet');
+const getSheetEditor = () => getSheet()?.querySelector('.composer-sheet-editor') as HTMLDivElement | undefined;
+const getSheetName = () => getSheet()?.querySelector('textarea') as HTMLTextAreaElement | undefined;
+
+/** Set a contentEditable's text and fire the input event the editor listens for. */
+function typeInto(el: HTMLElement, text: string): void {
+  el.innerHTML = '';
+  if (text) el.appendChild(document.createTextNode(text));
+  fireEvent.input(el);
+}
+
+/** The sheet plays its exit before handing control back. */
+async function flushSheetExit(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 260));
+  });
+}
+
+beforeEach(() => {
+  useComposerStore.setState({ draft: { name: '', description: '' }, sheetOpen: false, sheetCaret: null });
+  useAppStore.setState({ composerSheetOpen: false });
+  // Off the board, which is when the standalone sheet is the one that renders.
+  useProjectStore.setState({ activePanel: 'terminals', kanbanVisible: false });
+});
+
+describe('column placement', () => {
+  it('keeps the footer out of the scrolling card list', () => {
+    const { container } = render(
+      <KanbanColumnView status="todo" label="Todo" count={0} footer={<div data-testid="composer" />}>
+        <div data-testid="card" />
+      </KanbanColumnView>,
+    );
+
+    const body = container.querySelector('.kanban-column-body')!;
+    expect(body.contains(screen.getByTestId('card'))).toBe(true);
+    // The whole point: column length can't push the composer out of view.
+    expect(body.contains(screen.getByTestId('composer'))).toBe(false);
+  });
+});
+
+describe('StandaloneComposerSheet', () => {
+  it('stays closed until the sheet is opened away from the board', () => {
+    const { rerender } = render(<StandaloneComposerSheet projectPath="/p" />);
+    expect(getSheet()).toBeNull();
+
+    act(() => useComposerStore.getState().openSheet());
+    rerender(<StandaloneComposerSheet projectPath="/p" />);
+    expect(getSheet()).not.toBeNull();
+
+    // On the board the column composer owns the sheet, so this one stands down
+    // and the two can never both render it.
+    act(() => useProjectStore.setState({ kanbanVisible: true }));
+    rerender(<StandaloneComposerSheet projectPath="/p" />);
+    expect(getSheet()).toBeNull();
+  });
+
+  it('creates the task through the API and clears the draft', async () => {
+    const create = vi.spyOn(window.api.task, 'create').mockResolvedValue({ success: true } as never);
+    act(() => useComposerStore.getState().openSheet());
+    render(<StandaloneComposerSheet projectPath="/p" />);
+
+    fireEvent.change(getSheetName()!, { target: { value: 'Fix login' } });
+    typeInto(getSheetEditor()!, 'Session expires after 30s');
+    fireEvent.keyDown(document, { key: 'Enter', metaKey: true });
+    await flushSheetExit();
+
+    expect(create).toHaveBeenCalledWith('/p', 'Fix login', 'Session expires after 30s');
+    expect(useComposerStore.getState().draft).toEqual({ name: '', description: '' });
+    expect(getSheet()).toBeNull();
+    create.mockRestore();
+  });
+
+  it('keeps the draft when collapsed, and drops it only on discard', async () => {
+    act(() => useComposerStore.getState().openSheet());
+    render(<StandaloneComposerSheet projectPath="/p" />);
+
+    fireEvent.change(getSheetName()!, { target: { value: 'Half written' } });
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await flushSheetExit();
+    expect(useComposerStore.getState().draft.name).toBe('Half written');
+
+    act(() => useComposerStore.getState().openSheet());
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+    expect(useComposerStore.getState().draft.name).toBe('');
+  });
+});
+
+describe("the card's description sheet", () => {
+  const task = {
+    taskNumber: 7,
+    name: 'fix(pty): scrollback lost on reconnect',
+    status: 'todo',
+    prompt: 'Started on the card',
+  } as TaskWithWorkspace;
+
+  /** Expand the card, then click the description to start editing it. */
+  function openCardEditor(): HTMLElement {
+    const caret = document.querySelector('.kanban-card button')! as HTMLButtonElement;
+    fireEvent.click(caret);
+    const editor = document.querySelector('.kanban-description-editor') as HTMLElement;
+    fireEvent.click(editor);
+    return document.querySelector('.kanban-description-editor') as HTMLElement;
+  }
+
+  it('carries the card description into the sheet and saves what was written there', async () => {
+    const onUpdateDescription = vi.fn();
+    const { container } = render(<KanbanCardView task={task} onUpdateDescription={onUpdateDescription} />);
+
+    const editor = openCardEditor();
+    expect(editor.textContent).toBe('Started on the card');
+
+    fireEvent.keyDown(editor, { key: 'e', metaKey: true });
+    expect(getSheetEditor()!.textContent).toBe('Started on the card');
+
+    // Editing in the sheet mirrors back into the card underneath, which is what
+    // makes saving read the right value from one place.
+    typeInto(getSheetEditor()!, 'Rewritten with room to think');
+    expect(container.querySelector('.kanban-description-editor')!.textContent).toBe('Rewritten with room to think');
+
+    fireEvent.keyDown(document, { key: 'Enter', metaKey: true });
+    await flushSheetExit();
+    expect(onUpdateDescription).toHaveBeenCalledWith(7, 'Rewritten with room to think');
+    expect(getSheet()).toBeNull();
+  });
+
+  it('tells the board to leave Escape alone while the sheet is up', async () => {
+    render(<KanbanCardView task={task} onUpdateDescription={vi.fn()} />);
+
+    fireEvent.keyDown(openCardEditor(), { key: 'e', metaKey: true });
+    expect(useAppStore.getState().composerSheetOpen).toBe(true);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await flushSheetExit();
+    expect(useAppStore.getState().composerSheetOpen).toBe(false);
+  });
+});

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -28,6 +28,7 @@ import { frecencyBoost, loadFrecency, persistFrecency, recordUse, type FrecencyM
 import { buildPaletteItems, KIND_LABEL, type PaletteItem, type PaletteKind } from './palette/paletteItems';
 import { PaletteRow } from './palette/PaletteRow';
 import { Icon } from './terminal/Icon';
+import { KeyHint } from './ui/KeyHint';
 import type { ActiveSession } from '../types';
 
 /** Per-group cap while browsing, so one crowded group can't bury the others. */
@@ -405,24 +406,13 @@ function PaletteBody({ visible }: { visible: boolean }) {
         )}
 
         <div className="shrink-0 flex items-center gap-4 px-3 py-2 border-t border-ink/[0.06] text-[11px] text-ink/40">
-          <Hint keys="↑↓" label="Navigate" />
-          {action && <Hint keys="↵" label={action} />}
+          <KeyHint keys="↑↓" label="Navigate" />
+          {action && <KeyHint keys="↵" label={action} />}
           <span className="flex-1" />
-          <Hint keys="esc" label="Close" />
+          <KeyHint keys="esc" label="Close" />
         </div>
       </div>
     </div>,
     document.body,
-  );
-}
-
-function Hint({ keys, label }: { keys: string; label: string }) {
-  return (
-    <span className="flex items-center gap-1.5 min-w-0">
-      <kbd className="font-mono text-[10px] leading-none px-1.5 py-1 rounded bg-ink/[0.06] text-text-tertiary">
-        {keys}
-      </kbd>
-      <span className="truncate">{label}</span>
-    </span>
   );
 }

--- a/src/components/ProjectViewReact.tsx
+++ b/src/components/ProjectViewReact.tsx
@@ -8,11 +8,9 @@ import { TerminalCardStack } from './terminal/TerminalCardStack';
 import { TerminalCanvas, syncCanvasWithTerminals } from './canvas/TerminalCanvas';
 import { KanbanBoard } from './kanban/KanbanBoard';
 import { ProjectSettingsPanel } from './scripts/ProjectSettingsPanel';
-import { TaskComposerSheet } from './kanban/TaskComposerSheet';
+import { StandaloneComposerSheet } from './kanban/StandaloneComposerSheet';
 import { RunHookDialog } from './dialogs/RunHookDialog';
-import { useComposerStore, isBoardMounted } from '../stores/composerStore';
 import { openTaskComposer } from '../utils/openTaskComposer';
-import { resolveAttachmentPath } from '../utils/taskAttachments';
 import {
   addProjectTerminal,
   closeProjectTerminal,
@@ -339,61 +337,6 @@ export function ProjectView() {
       <GlobalRunHookDialog />
       <StandaloneComposerSheet projectPath={projectPath} />
     </div>
-  );
-}
-
-/**
- * The composer sheet as its own surface, for ⌘N away from the board. When the
- * board is up its column composer owns the sheet instead, so exactly one of
- * the two renders it and both read the same draft.
- */
-function StandaloneComposerSheet({ projectPath }: { projectPath: string }) {
-  const kanbanVisible = useProjectStore((s) => s.kanbanVisible);
-  const activePanel = useProjectStore((s) => s.activePanel);
-  const sheetOpen = useComposerStore((s) => s.sheetOpen);
-  const name = useComposerStore((s) => s.draft.name);
-  const description = useComposerStore((s) => s.draft.description);
-
-  const boardMounted = isBoardMounted(activePanel, kanbanVisible);
-
-  // The board's Escape handler stands down while a composer sheet is up.
-  useEffect(() => {
-    const owned = sheetOpen && !boardMounted;
-    useAppStore.getState().setComposerSheetOpen(owned);
-    return () => useAppStore.getState().setComposerSheetOpen(false);
-  }, [sheetOpen, boardMounted]);
-
-  const create = useCallback(async () => {
-    const trimmedName = name.trim();
-    if (!trimmedName) return;
-    const trimmedDescription = description.trim();
-    const composer = useComposerStore.getState();
-    composer.clearDraft();
-    composer.closeSheet();
-    await window.api.task.create(projectPath, trimmedName, trimmedDescription || undefined);
-    void useProjectStore.getState().loadTasks(projectPath);
-  }, [name, description, projectPath]);
-
-  if (!sheetOpen || boardMounted) return null;
-
-  return (
-    <TaskComposerSheet
-      mode="create"
-      name={name}
-      description={description}
-      onNameChange={useComposerStore.getState().setName}
-      onDescriptionChange={useComposerStore.getState().setDescription}
-      onAttachFile={resolveAttachmentPath}
-      onSubmit={create}
-      // Nothing to hand a caret back to out here; the draft is kept either way
-      // and the column composer picks it up when you next open the board.
-      onCollapse={() => useComposerStore.getState().closeSheet()}
-      onDiscard={() => {
-        const composer = useComposerStore.getState();
-        composer.clearDraft();
-        composer.closeSheet();
-      }}
-    />
   );
 }
 

--- a/src/components/ProjectViewReact.tsx
+++ b/src/components/ProjectViewReact.tsx
@@ -8,8 +8,11 @@ import { TerminalCardStack } from './terminal/TerminalCardStack';
 import { TerminalCanvas, syncCanvasWithTerminals } from './canvas/TerminalCanvas';
 import { KanbanBoard } from './kanban/KanbanBoard';
 import { ProjectSettingsPanel } from './scripts/ProjectSettingsPanel';
-import { focusKanbanAddInput } from './kanban/KanbanAddInput';
+import { TaskComposerSheet } from './kanban/TaskComposerSheet';
 import { RunHookDialog } from './dialogs/RunHookDialog';
+import { useComposerStore, isBoardMounted } from '../stores/composerStore';
+import { openTaskComposer } from '../utils/openTaskComposer';
+import { resolveAttachmentPath } from '../utils/taskAttachments';
 import {
   addProjectTerminal,
   closeProjectTerminal,
@@ -90,14 +93,12 @@ export function ProjectView() {
         return;
       }
 
-      // Cmd+N — show kanban board and focus new task input
+      // Cmd+N — focus the column composer on the board, open the sheet from
+      // anywhere else rather than yanking the view over to the board
       if (key === 'n') {
         e.preventDefault();
         e.stopPropagation();
-        const store = useProjectStore.getState();
-        store.setActivePanel('terminals');
-        store.setKanbanVisible(true);
-        requestAnimationFrame(() => focusKanbanAddInput());
+        openTaskComposer();
         return;
       }
 
@@ -336,7 +337,63 @@ export function ProjectView() {
         </>
       )}
       <GlobalRunHookDialog />
+      <StandaloneComposerSheet projectPath={projectPath} />
     </div>
+  );
+}
+
+/**
+ * The composer sheet as its own surface, for ⌘N away from the board. When the
+ * board is up its column composer owns the sheet instead, so exactly one of
+ * the two renders it and both read the same draft.
+ */
+function StandaloneComposerSheet({ projectPath }: { projectPath: string }) {
+  const kanbanVisible = useProjectStore((s) => s.kanbanVisible);
+  const activePanel = useProjectStore((s) => s.activePanel);
+  const sheetOpen = useComposerStore((s) => s.sheetOpen);
+  const name = useComposerStore((s) => s.draft.name);
+  const description = useComposerStore((s) => s.draft.description);
+
+  const boardMounted = isBoardMounted(activePanel, kanbanVisible);
+
+  // The board's Escape handler stands down while a composer sheet is up.
+  useEffect(() => {
+    const owned = sheetOpen && !boardMounted;
+    useAppStore.getState().setComposerSheetOpen(owned);
+    return () => useAppStore.getState().setComposerSheetOpen(false);
+  }, [sheetOpen, boardMounted]);
+
+  const create = useCallback(async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    const trimmedDescription = description.trim();
+    const composer = useComposerStore.getState();
+    composer.clearDraft();
+    composer.closeSheet();
+    await window.api.task.create(projectPath, trimmedName, trimmedDescription || undefined);
+    void useProjectStore.getState().loadTasks(projectPath);
+  }, [name, description, projectPath]);
+
+  if (!sheetOpen || boardMounted) return null;
+
+  return (
+    <TaskComposerSheet
+      mode="create"
+      name={name}
+      description={description}
+      onNameChange={useComposerStore.getState().setName}
+      onDescriptionChange={useComposerStore.getState().setDescription}
+      onAttachFile={resolveAttachmentPath}
+      onSubmit={create}
+      // Nothing to hand a caret back to out here; the draft is kept either way
+      // and the column composer picks it up when you next open the board.
+      onCollapse={() => useComposerStore.getState().closeSheet()}
+      onDiscard={() => {
+        const composer = useComposerStore.getState();
+        composer.clearDraft();
+        composer.closeSheet();
+      }}
+    />
   );
 }
 

--- a/src/components/TitleBarReact.tsx
+++ b/src/components/TitleBarReact.tsx
@@ -8,7 +8,7 @@ import { useTerminalStore, collectActiveTags } from '../stores/terminalStore';
 import { Icon } from './terminal/Icon';
 import { TagFilterControl } from './terminal/TagFilterControl';
 import { addProjectTerminal } from './terminal/terminalActions';
-import { focusKanbanAddInput } from './kanban/KanbanAddInput';
+import { openTaskComposer } from '../utils/openTaskComposer';
 import { Tooltip } from './ui/Tooltip';
 import { TooltipButton } from './ui/TooltipButton';
 
@@ -80,12 +80,7 @@ export function TitleBar({ mode }: TitleBarProps) {
     }
   }, [activeProjectPath]);
 
-  const handleNewTask = useCallback(() => {
-    const store = useProjectStore.getState();
-    store.setActivePanel('terminals');
-    store.setKanbanVisible(true);
-    requestAnimationFrame(() => focusKanbanAddInput());
-  }, []);
+  const handleNewTask = useCallback(() => openTaskComposer(), []);
 
   const isProjectOrHome = mode === 'project' || mode === 'home';
   const needsTrafficLightPad = isMac && !fullscreen;

--- a/src/components/kanban/DescriptionChipEditor.tsx
+++ b/src/components/kanban/DescriptionChipEditor.tsx
@@ -1,15 +1,35 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from 'react';
 import {
   createAttachmentChip,
+  getCaretOffset,
   isAttachmentChip,
   parseDescription,
   serializeDescriptionDOM,
+  setCaretOffset,
 } from '../../utils/descriptionAttachments';
+
+/**
+ * How the content sits inside a height-capped editor. Drives the "there is
+ * more text up/down" fades and the promoted expand affordance, so the parent
+ * doesn't have to read scroll geometry off a ref it doesn't own.
+ */
+export interface DescriptionEditorMetrics {
+  /** Content is taller than the box, so the editor is scrolling internally. */
+  overflowing: boolean;
+  atTop: boolean;
+  atBottom: boolean;
+}
 
 export interface DescriptionChipEditorHandle {
   getValue: () => string;
   setValue: (value: string) => void;
   focus: () => void;
+  /** Caret position as an offset into the storage string, or null if unfocused. */
+  getCaret: () => number | null;
+  /** Focus the editor and place the caret at a storage-string offset. */
+  focusAtCaret: (offset: number) => void;
+  /** Re-measure and re-emit metrics, e.g. after the cap height changes. */
+  refreshMetrics: () => void;
 }
 
 export interface DescriptionChipEditorProps {
@@ -30,6 +50,12 @@ export interface DescriptionChipEditorProps {
   /** Defaults to true. */
   editable?: boolean;
   autoFocus?: boolean;
+  /**
+   * Fires whenever the content's fit inside the box changes — on edit, on
+   * scroll, and on demand via `refreshMetrics`. Only useful when the editor
+   * is height-capped; an uncapped editor never overflows.
+   */
+  onMetrics?: (metrics: DescriptionEditorMetrics) => void;
   onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
   onFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
@@ -54,6 +80,7 @@ export const DescriptionChipEditor = forwardRef<DescriptionChipEditorHandle, Des
       style,
       editable = true,
       autoFocus = false,
+      onMetrics,
       onKeyDown,
       onBlur,
       onFocus,
@@ -62,6 +89,20 @@ export const DescriptionChipEditor = forwardRef<DescriptionChipEditorHandle, Des
     ref,
   ) {
     const editorRef = useRef<HTMLDivElement>(null);
+
+    /** Read the current fit and hand it to the parent. Cheap enough to call
+     *  on every keystroke: three layout reads, no writes. */
+    const emitMetrics = useCallback(() => {
+      const el = editorRef.current;
+      if (!el || !onMetrics) return;
+      const slack = el.scrollHeight - el.clientHeight;
+      onMetrics({
+        // A pixel of slack is rounding, not overflow.
+        overflowing: slack > 1,
+        atTop: el.scrollTop <= 1,
+        atBottom: el.scrollTop >= slack - 1,
+      });
+    }, [onMetrics]);
 
     const populate = useCallback((value: string) => {
       const el = editorRef.current;
@@ -79,6 +120,7 @@ export const DescriptionChipEditor = forwardRef<DescriptionChipEditorHandle, Des
     useEffect(() => {
       populate(initialValue);
       if (autoFocus) editorRef.current?.focus();
+      emitMetrics();
       // Intentionally only on mount: subsequent prop changes don't repopulate.
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -89,16 +131,32 @@ export const DescriptionChipEditor = forwardRef<DescriptionChipEditorHandle, Des
       const serialized = serializeDescriptionDOM(el);
       el.dataset.empty = serialized.length === 0 ? 'true' : 'false';
       onChange?.(serialized);
-    }, [onChange]);
+      emitMetrics();
+    }, [onChange, emitMetrics]);
 
     useImperativeHandle(
       ref,
       () => ({
         getValue: () => (editorRef.current ? serializeDescriptionDOM(editorRef.current) : ''),
-        setValue: (value: string) => populate(value),
+        setValue: (value: string) => {
+          populate(value);
+          emitMetrics();
+        },
         focus: () => editorRef.current?.focus(),
+        getCaret: () => (editorRef.current ? getCaretOffset(editorRef.current) : null),
+        focusAtCaret: (offset: number) => {
+          const el = editorRef.current;
+          if (!el) return;
+          el.focus();
+          setCaretOffset(el, offset);
+          // Bring the caret's line into view when it landed inside the
+          // scrolled-off part of a capped editor.
+          el.scrollTop = Math.min(el.scrollTop, el.scrollHeight);
+          emitMetrics();
+        },
+        refreshMetrics: emitMetrics,
       }),
-      [populate],
+      [populate, emitMetrics],
     );
 
     const insertChipAtRange = useCallback(
@@ -245,6 +303,7 @@ export const DescriptionChipEditor = forwardRef<DescriptionChipEditorHandle, Des
         data-placeholder={placeholder ?? ''}
         data-empty={initialValue.length === 0 ? 'true' : 'false'}
         onInput={emitChange}
+        onScroll={emitMetrics}
         onPaste={handlePaste}
         onDragOver={handleDragOver}
         onDrop={handleDrop}

--- a/src/components/kanban/DescriptionChipEditor.tsx
+++ b/src/components/kanban/DescriptionChipEditor.tsx
@@ -63,12 +63,30 @@ export interface DescriptionChipEditorProps {
 }
 
 /**
+ * Bring the caret's line into view after the caret is placed. Only does
+ * anything when the editor is height-capped and the caret landed in the part
+ * that's scrolled off.
+ */
+function scrollCaretIntoView(el: HTMLElement): void {
+  const selection = el.ownerDocument.defaultView?.getSelection();
+  if (!selection || selection.rangeCount === 0) return;
+  const caret = selection.getRangeAt(0).getBoundingClientRect();
+  const box = el.getBoundingClientRect();
+  // jsdom and an unlaid-out editor both report zeroes; nothing to do either way.
+  if (caret.height === 0 && caret.top === 0) return;
+  const margin = 8;
+  if (caret.top < box.top + margin) el.scrollTop -= box.top + margin - caret.top;
+  else if (caret.bottom > box.bottom - margin) el.scrollTop += caret.bottom - box.bottom + margin;
+}
+
+/**
  * Uncontrolled contentEditable that renders task descriptions with inline
  * image attachment chips. The DOM is the source of truth between explicit
  * resets via the imperative handle; `onChange` mirrors every edit so a parent
  * holding the value in state stays in sync. Re-render is safe because no
  * children are passed to the editable div — React never touches its content.
  */
+
 export const DescriptionChipEditor = forwardRef<DescriptionChipEditorHandle, DescriptionChipEditorProps>(
   function DescriptionChipEditor(
     {
@@ -147,11 +165,14 @@ export const DescriptionChipEditor = forwardRef<DescriptionChipEditorHandle, Des
         focusAtCaret: (offset: number) => {
           const el = editorRef.current;
           if (!el) return;
+          // setCaretOffset measures against the flat structure `populate`
+          // produces. Typing in a contentEditable adds block wrappers whose
+          // newlines it can't see, so repopulate from the current value first
+          // and the precondition holds by construction.
+          populate(serializeDescriptionDOM(el));
           el.focus();
           setCaretOffset(el, offset);
-          // Bring the caret's line into view when it landed inside the
-          // scrolled-off part of a capped editor.
-          el.scrollTop = Math.min(el.scrollTop, el.scrollHeight);
+          scrollCaretIntoView(el);
           emitMetrics();
         },
         refreshMetrics: emitMetrics,

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -1,9 +1,34 @@
-import { useState, useRef, useCallback } from 'react';
-import { DescriptionChipEditor, type DescriptionChipEditorHandle } from './DescriptionChipEditor';
+import { useState, useRef, useCallback, useEffect } from 'react';
+import {
+  DescriptionChipEditor,
+  type DescriptionChipEditorHandle,
+  type DescriptionEditorMetrics,
+} from './DescriptionChipEditor';
+import { TaskComposerSheet } from './TaskComposerSheet';
 import { Icon } from '../terminal/Icon';
 import { useProjectStore } from '../../stores/projectStore';
+import { useAppStore } from '../../stores/appStore';
 
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
+/** Modifier name for tooltips and the resting row's shortcut hint. */
+const MOD_LABEL = isMac ? '⌘' : 'Ctrl ';
+
+/**
+ * The description grows with its content up to this share of the column body,
+ * then scrolls internally. Enough room for a real paragraph, few enough cards
+ * hidden that you keep your place in the column.
+ */
+const DESCRIPTION_CAP_RATIO = 0.4;
+
+/** Bounds for a height set by dragging the composer's top edge. */
+const MIN_DRAG_HEIGHT = 72;
+/** Leave at least this much column body visible above a dragged composer. */
+const DRAG_HEADROOM = 48;
+
+/** Global setting holding the dragged height, so it survives restarts. */
+const HEIGHT_SETTING_KEY = 'ui:composerDescriptionHeight';
+
+const EMPTY_METRICS: DescriptionEditorMetrics = { overflowing: false, atTop: true, atBottom: true };
 
 function SubmitHint({ withModifier }: { withModifier: boolean }) {
   return (
@@ -14,14 +39,19 @@ function SubmitHint({ withModifier }: { withModifier: boolean }) {
   );
 }
 
-function CancelHint() {
-  return <span className="kanban-add-button-hint kanban-add-button-hint-text">Esc</span>;
-}
-
 interface KanbanAddInputProps {
   onAdd: (name: string, description?: string) => void;
 }
 
+/**
+ * The new-task composer, pinned below the Todo column's card list.
+ *
+ * Three things make it work at any column length and any draft length:
+ * it lives outside the column's scroll container, its description grows only
+ * to a share of the column before scrolling internally, and at that point it
+ * offers an expanded sheet holding the same draft. A draft is never discarded
+ * implicitly — Escape collapses and keeps it.
+ */
 export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -29,18 +59,71 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
   // Which input owns focus right now — drives the submit hint, since plain
   // Enter creates from the title field but the description needs ⌘/Ctrl+↵.
   const [focusedField, setFocusedField] = useState<'title' | 'description'>('title');
+  const [metrics, setMetrics] = useState<DescriptionEditorMetrics>(EMPTY_METRICS);
+  const [sheetCaret, setSheetCaret] = useState<number | null>(null);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [pinnedHeight, setPinnedHeight] = useState<number | null>(null);
+
   const inputRef = useRef<HTMLInputElement>(null);
   const editorRef = useRef<DescriptionChipEditorHandle>(null);
+  const formRef = useRef<HTMLDivElement>(null);
+  /** Set when the form is opened from the collapsed row, consumed on mount. */
+  const focusOnOpenRef = useRef(false);
 
-  const reset = useCallback(() => {
+  const hasDraft = name.trim().length > 0 || description.trim().length > 0;
+  const canSubmit = name.trim().length > 0;
+
+  // Restore the dragged height once; a missing or malformed value just means
+  // the cap is in charge, which is the default anyway.
+  useEffect(() => {
+    let cancelled = false;
+    void window.api.globalSettings.get(HEIGHT_SETTING_KEY).then((stored) => {
+      const parsed = stored ? Number.parseInt(stored, 10) : NaN;
+      if (!cancelled && Number.isFinite(parsed) && parsed >= MIN_DRAG_HEIGHT) setPinnedHeight(parsed);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // The cap moved (drag, restore, or reset), so the fades and the promoted
+  // expand affordance need re-measuring against the new box.
+  useEffect(() => {
+    editorRef.current?.refreshMetrics();
+  }, [pinnedHeight, active]);
+
+  // Let the board know the sheet owns Escape and ⌘N while it's up.
+  useEffect(() => {
+    useAppStore.getState().setComposerSheetOpen(sheetOpen);
+    return () => useAppStore.getState().setComposerSheetOpen(false);
+  }, [sheetOpen]);
+
+  const openForm = useCallback(() => {
+    focusOnOpenRef.current = true;
+    setActive(true);
+  }, []);
+
+  useEffect(() => {
+    if (!active || !focusOnOpenRef.current) return;
+    focusOnOpenRef.current = false;
+    inputRef.current?.focus();
+  }, [active]);
+
+  /** Close the form without touching the draft. */
+  const collapse = useCallback(() => {
+    setActive(false);
+    setFocusedField('title');
+  }, []);
+
+  /** Throw the draft away and close. The only path that loses text. */
+  const discard = useCallback(() => {
     setName('');
     setDescription('');
     editorRef.current?.setValue('');
     setActive(false);
     setFocusedField('title');
+    setSheetOpen(false);
   }, []);
-
-  const canSubmit = name.trim().length > 0;
 
   const submit = useCallback(() => {
     const trimmedName = name.trim();
@@ -52,35 +135,74 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     setName('');
     setDescription('');
     editorRef.current?.setValue('');
-    inputRef.current?.focus();
+    setSheetOpen(false);
+    setActive(true);
+    requestAnimationFrame(() => inputRef.current?.focus());
   }, [name, description, onAdd]);
+
+  const expand = useCallback(() => {
+    setSheetCaret(editorRef.current?.getCaret() ?? null);
+    setSheetOpen(true);
+  }, []);
+
+  /** Return from the sheet, putting the caret back where it was left. */
+  const collapseSheet = useCallback((caret: number | null) => {
+    setSheetOpen(false);
+    setActive(true);
+    requestAnimationFrame(() => {
+      if (caret != null) editorRef.current?.focusAtCaret(caret);
+      else inputRef.current?.focus();
+    });
+  }, []);
+
+  /** Cmd or Ctrl, accepting either so the bindings work on any keyboard. */
+  const isModifier = (e: React.KeyboardEvent): boolean => e.metaKey || e.ctrlKey;
 
   const handleNameKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') {
+      if (isModifier(e) && e.key.toLowerCase() === 'e') {
+        e.preventDefault();
+        expand();
+      } else if (e.key === 'Enter') {
         e.preventDefault();
         submit();
       } else if (e.key === 'Escape') {
-        reset();
-        inputRef.current?.blur();
+        e.preventDefault();
+        collapse();
       }
       // Tab falls through to native focus handling, moving into the description field.
     },
-    [submit, reset],
+    [submit, collapse, expand],
   );
 
   const handleDescriptionKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       // Cmd/Ctrl+Enter submits; plain Enter falls through to contentEditable's
-      // native line-break handling. Escape resets the form.
-      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      // native line-break handling.
+      if (isModifier(e) && e.key.toLowerCase() === 'e') {
+        e.preventDefault();
+        expand();
+      } else if (e.key === 'Enter' && isModifier(e)) {
         e.preventDefault();
         submit();
       } else if (e.key === 'Escape') {
-        reset();
+        e.preventDefault();
+        collapse();
       }
     },
-    [submit, reset],
+    [submit, collapse, expand],
+  );
+
+  const handleRestKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // A second Escape, on the collapsed row, is what actually discards.
+      if (e.key === 'Escape' && hasDraft) {
+        e.preventDefault();
+        e.stopPropagation();
+        discard();
+      }
+    },
+    [hasDraft, discard],
   );
 
   const handleDescriptionFocus = useCallback(() => setFocusedField('description'), []);
@@ -90,13 +212,15 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
   }, []);
 
   // Collapse only when focus leaves the whole form and nothing was entered.
+  // With something in it the form stays open — the draft outlives a stray click.
   const handleBlur = useCallback(
     (e: React.FocusEvent) => {
       const nextFocus = e.relatedTarget as Node | null;
       if (nextFocus && e.currentTarget.contains(nextFocus)) return;
-      if (!name.trim() && !description.trim()) setActive(false);
+      if (sheetOpen) return;
+      if (!hasDraft) setActive(false);
     },
-    [name, description],
+    [hasDraft, sheetOpen],
   );
 
   const handleAttachFile = useCallback(async (file: File): Promise<string | null> => {
@@ -120,38 +244,148 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     return null;
   }, []);
 
+  // ── Drag the top edge to pin a height ──────────────────────────────
+  const dragRef = useRef<{ startY: number; startHeight: number; max: number } | null>(null);
+
+  const handleGripPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const editor = document.querySelector<HTMLElement>('.kanban-add-description');
+    const form = formRef.current;
+    if (!editor || !form) return;
+    // The column publishes its body height as a custom property; the cap and
+    // the drag ceiling are both shares of it.
+    const bodyHeight = Number.parseFloat(getComputedStyle(form).getPropertyValue('--kanban-body-h')) || 0;
+    dragRef.current = {
+      startY: e.clientY,
+      startHeight: editor.getBoundingClientRect().height,
+      max: Math.max(MIN_DRAG_HEIGHT, bodyHeight - DRAG_HEADROOM),
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+    e.preventDefault();
+  }, []);
+
+  const handleGripPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    // Dragging up (a smaller clientY) makes the composer taller.
+    const next = drag.startHeight + (drag.startY - e.clientY);
+    setPinnedHeight(Math.round(Math.min(drag.max, Math.max(MIN_DRAG_HEIGHT, next))));
+  }, []);
+
+  const handleGripPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!dragRef.current) return;
+      dragRef.current = null;
+      e.currentTarget.releasePointerCapture(e.pointerId);
+      if (pinnedHeight != null) void window.api.globalSettings.set(HEIGHT_SETTING_KEY, String(pinnedHeight));
+    },
+    [pinnedHeight],
+  );
+
+  const resetHeight = useCallback(() => {
+    setPinnedHeight(null);
+    void window.api.globalSettings.set(HEIGHT_SETTING_KEY, '');
+    editorRef.current?.focus();
+  }, []);
+
+  /** Which edges are hiding text, so the mask fades only those. */
+  const clip = !metrics.overflowing ? 'none' : metrics.atTop ? 'bottom' : metrics.atBottom ? 'top' : 'both';
+
+  const capStyle: React.CSSProperties =
+    pinnedHeight != null
+      ? { height: pinnedHeight, maxHeight: pinnedHeight }
+      : { maxHeight: `calc(var(--kanban-body-h, 20rem) * ${DESCRIPTION_CAP_RATIO})` };
+
   return (
-    <div className="kanban-add-form" onBlur={handleBlur}>
-      <input
-        ref={inputRef}
-        type="text"
-        className="kanban-add-input w-full font-mono text-sm font-medium text-text-primary bg-transparent px-3 py-3.5 outline-none transition-all duration-150 ease-out border-none focus:bg-ink/[0.04]"
-        style={{ borderBottom: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
-        placeholder="New task..."
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        onKeyDown={handleNameKeyDown}
-        onFocus={handleNameFocus}
-      />
+    <div ref={formRef} className="kanban-add-form" onBlur={handleBlur}>
+      {!active && (
+        <button
+          type="button"
+          className="kanban-add-rest"
+          onClick={openForm}
+          onKeyDown={handleRestKeyDown}
+          aria-label={hasDraft ? 'Resume draft task' : 'New task'}
+        >
+          {hasDraft ? (
+            <>
+              <span className="kanban-add-draft-dot" />
+              <span className="kanban-add-draft-label">{name.trim() || 'Untitled draft'}</span>
+              <span className="kanban-add-button-hint kanban-add-button-hint-text">Esc to discard</span>
+            </>
+          ) : (
+            <>
+              <span className="kanban-add-rest-plus">+</span>
+              <span>New task</span>
+              <span className="kanban-add-button-hint kanban-add-button-hint-text">{MOD_LABEL}N</span>
+            </>
+          )}
+        </button>
+      )}
+
       {active && (
         <>
-          <DescriptionChipEditor
-            ref={editorRef}
-            initialValue=""
-            onChange={setDescription}
-            onAttachFile={handleAttachFile}
-            placeholder="Description (optional)"
-            onKeyDown={handleDescriptionKeyDown}
-            onFocus={handleDescriptionFocus}
-            className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none focus:bg-ink/[0.04]"
-            style={{ minHeight: '4.5rem', whiteSpace: 'pre-wrap', wordWrap: 'break-word', lineHeight: 1.5 }}
-          />
-          {/* DOM order is [Create, Cancel] so Tab from the description lands
-              on Create first; flex-row-reverse keeps Cancel on the visual left. */}
           <div
-            className="flex flex-row-reverse items-center justify-start gap-2 px-2 py-1.5"
+            className="kanban-add-grip"
+            title={pinnedHeight != null ? 'Drag to set the height, double-click to reset' : 'Drag to set the height'}
+            onPointerDown={handleGripPointerDown}
+            onPointerMove={handleGripPointerMove}
+            onPointerUp={handleGripPointerUp}
+            onPointerCancel={handleGripPointerUp}
+            // Reset belongs to the control that set the height, rather than a
+            // link in the footer that's only ever relevant after a drag.
+            onDoubleClick={resetHeight}
+          />
+          <input
+            ref={inputRef}
+            type="text"
+            className="kanban-add-input w-full font-mono text-sm font-medium text-text-primary bg-transparent px-3 py-3.5 outline-none transition-all duration-150 ease-out border-none focus:bg-ink/[0.04]"
             style={{ borderBottom: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
-          >
+            placeholder="New task..."
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={handleNameKeyDown}
+            onFocus={handleNameFocus}
+          />
+          <div className={`kanban-add-description-wrap${metrics.overflowing ? ' is-capped' : ''}`} data-clip={clip}>
+            <DescriptionChipEditor
+              ref={editorRef}
+              // The editor mounts with the form, so a draft kept through a
+              // collapse comes back with it. Uncontrolled from then on.
+              initialValue={description}
+              onChange={setDescription}
+              onAttachFile={handleAttachFile}
+              onMetrics={setMetrics}
+              placeholder="Description (optional)"
+              onKeyDown={handleDescriptionKeyDown}
+              onFocus={handleDescriptionFocus}
+              className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none focus:bg-ink/[0.04]"
+              style={{
+                minHeight: '4.5rem',
+                whiteSpace: 'pre-wrap',
+                wordWrap: 'break-word',
+                lineHeight: 1.5,
+                overflowY: 'auto',
+                ...capStyle,
+              }}
+            />
+            <button
+              type="button"
+              className="kanban-add-expand"
+              // The tooltip carries the shortcut and, once the box is
+              // clipping, says what expanding buys you.
+              title={`${metrics.overflowing ? 'Expand to the full sheet' : 'Expand'}  ${MOD_LABEL}E`}
+              aria-label="Expand the description"
+              // Keep focus in the editor so the caret is still readable when
+              // the sheet asks for it.
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={expand}
+            >
+              <Icon name="arrows-out" className="w-3.5 h-3.5" />
+            </button>
+          </div>
+          {/* DOM order is [Create, Discard] so Tab from the description lands
+              on Create first; flex-row-reverse keeps Discard on the visual left.
+              No bottom rule: this row is the column's bottom edge now. */}
+          <div className="flex flex-row-reverse items-center justify-start gap-2 px-2 py-1.5">
             <button
               type="button"
               onClick={submit}
@@ -163,21 +397,49 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
             </button>
             <button
               type="button"
-              onClick={reset}
+              onClick={discard}
               className="kanban-add-button text-text-tertiary hover:text-text-primary hover:bg-ink/[0.04]"
             >
-              Cancel
-              <CancelHint />
+              Discard
             </button>
           </div>
         </>
+      )}
+
+      {sheetOpen && (
+        <TaskComposerSheet
+          mode="create"
+          name={name}
+          description={description}
+          initialCaret={sheetCaret}
+          onNameChange={setName}
+          onDescriptionChange={(value) => {
+            setDescription(value);
+            // Mirror into the inline editor behind the scrim so collapsing
+            // reads as a return to the same draft, not a jump to a stale one.
+            editorRef.current?.setValue(value);
+          }}
+          onAttachFile={handleAttachFile}
+          onSubmit={submit}
+          onCollapse={collapseSheet}
+          onDiscard={discard}
+        />
       )}
     </div>
   );
 }
 
-/** Focus the kanban add input programmatically */
+/** Focus the kanban add input programmatically, opening the form if collapsed */
 export function focusKanbanAddInput(): void {
-  const input = document.querySelector('.kanban-add-input') as HTMLInputElement;
-  input?.focus();
+  // The expanded sheet holds the same draft and already has focus; pulling it
+  // back to the input behind the scrim would strand the caret.
+  if (useAppStore.getState().composerSheetOpen) return;
+
+  const input = document.querySelector<HTMLInputElement>('.kanban-add-input');
+  if (input) {
+    input.focus();
+    return;
+  }
+  // Collapsed: the click handler opens the form, which focuses the title.
+  document.querySelector<HTMLButtonElement>('.kanban-add-rest')?.click();
 }

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -6,8 +6,10 @@ import {
 } from './DescriptionChipEditor';
 import { TaskComposerSheet } from './TaskComposerSheet';
 import { Icon } from '../terminal/Icon';
-import { useProjectStore } from '../../stores/projectStore';
+import { Tooltip } from '../ui/Tooltip';
 import { useAppStore } from '../../stores/appStore';
+import { useComposerStore } from '../../stores/composerStore';
+import { resolveAttachmentPath } from '../../utils/taskAttachments';
 
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
 /** Modifier name for tooltips and the resting row's shortcut hint. */
@@ -53,15 +55,20 @@ interface KanbanAddInputProps {
  * implicitly — Escape collapses and keeps it.
  */
 export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
+  // The draft is shared with the standalone sheet, which opens on ⌘N when the
+  // board isn't on screen, so it has to outlive this component.
+  const name = useComposerStore((s) => s.draft.name);
+  const description = useComposerStore((s) => s.draft.description);
+  const sheetOpen = useComposerStore((s) => s.sheetOpen);
+  const sheetCaret = useComposerStore((s) => s.sheetCaret);
+  const setName = useComposerStore((s) => s.setName);
+  const setDescription = useComposerStore((s) => s.setDescription);
+
   const [active, setActive] = useState(false);
   // Which input owns focus right now — drives the submit hint, since plain
   // Enter creates from the title field but the description needs ⌘/Ctrl+↵.
   const [focusedField, setFocusedField] = useState<'title' | 'description'>('title');
   const [metrics, setMetrics] = useState<DescriptionEditorMetrics>(EMPTY_METRICS);
-  const [sheetCaret, setSheetCaret] = useState<number | null>(null);
-  const [sheetOpen, setSheetOpen] = useState(false);
   const [pinnedHeight, setPinnedHeight] = useState<number | null>(null);
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -117,12 +124,12 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
 
   /** Throw the draft away and close. The only path that loses text. */
   const discard = useCallback(() => {
-    setName('');
-    setDescription('');
+    const composer = useComposerStore.getState();
+    composer.clearDraft();
+    composer.closeSheet();
     editorRef.current?.setValue('');
     setActive(false);
     setFocusedField('title');
-    setSheetOpen(false);
   }, []);
 
   const submit = useCallback(() => {
@@ -132,22 +139,21 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     onAdd(trimmedName, trimmedDescription || undefined);
     // Clear the fields but keep the form open and focused so the next task
     // can be typed immediately without clicking back in.
-    setName('');
-    setDescription('');
+    const composer = useComposerStore.getState();
+    composer.clearDraft();
+    composer.closeSheet();
     editorRef.current?.setValue('');
-    setSheetOpen(false);
     setActive(true);
     requestAnimationFrame(() => inputRef.current?.focus());
   }, [name, description, onAdd]);
 
   const expand = useCallback(() => {
-    setSheetCaret(editorRef.current?.getCaret() ?? null);
-    setSheetOpen(true);
+    useComposerStore.getState().openSheet(editorRef.current?.getCaret() ?? null);
   }, []);
 
   /** Return from the sheet, putting the caret back where it was left. */
   const collapseSheet = useCallback((caret: number | null) => {
-    setSheetOpen(false);
+    useComposerStore.getState().closeSheet();
     setActive(true);
     requestAnimationFrame(() => {
       if (caret != null) editorRef.current?.focusAtCaret(caret);
@@ -222,27 +228,6 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     },
     [hasDraft, sheetOpen],
   );
-
-  const handleAttachFile = useCallback(async (file: File): Promise<string | null> => {
-    // Prefer the file's existing on-disk path — drag-drop from Finder and
-    // most clipboard file pastes already have one. Skipping the copy keeps
-    // the user's file under their control and works for any extension.
-    const existingPath = window.api.getPathForFile(file);
-    if (existingPath) return existingPath;
-
-    // No source path — bytes only (typically a clipboard-pasted screenshot).
-    // Save those to userData so CLI agents have a stable path to read.
-    if (!file.type.startsWith('image/')) {
-      useProjectStore.getState().addToast('Only image clipboard content can be attached', 'error');
-      return null;
-    }
-    const ext = file.type.split('/')[1] || 'png';
-    const data = new Uint8Array(await file.arrayBuffer());
-    const result = await window.api.task.saveAttachment(data, ext);
-    if (result.success && result.path) return result.path;
-    useProjectStore.getState().addToast(result.error || 'Failed to attach image', 'error');
-    return null;
-  }, []);
 
   // ── Drag the top edge to pin a height ──────────────────────────────
   const dragRef = useRef<{ startY: number; startHeight: number; max: number } | null>(null);
@@ -352,7 +337,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
               // collapse comes back with it. Uncontrolled from then on.
               initialValue={description}
               onChange={setDescription}
-              onAttachFile={handleAttachFile}
+              onAttachFile={resolveAttachmentPath}
               onMetrics={setMetrics}
               placeholder="Description (optional)"
               onKeyDown={handleDescriptionKeyDown}
@@ -367,20 +352,30 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
                 ...capStyle,
               }}
             />
-            <button
-              type="button"
-              className="kanban-add-expand"
-              // The tooltip carries the shortcut and, once the box is
-              // clipping, says what expanding buys you.
-              title={`${metrics.overflowing ? 'Expand to the full sheet' : 'Expand'}  ${MOD_LABEL}E`}
-              aria-label="Expand the description"
-              // Keep focus in the editor so the caret is still readable when
-              // the sheet asks for it.
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={expand}
+            {/* The tooltip carries the shortcut and, once the box is
+                clipping, says what expanding buys you. */}
+            <Tooltip
+              placement="left"
+              text={
+                <span className="flex items-center gap-2">
+                  {metrics.overflowing ? 'Expand to the full sheet' : 'Expand'}
+                  <span className="kanban-add-button-hint kanban-add-button-hint-text">{MOD_LABEL}E</span>
+                </span>
+              }
+              referenceClassName="kanban-add-expand-anchor"
             >
-              <Icon name="arrows-out" className="w-3.5 h-3.5" />
-            </button>
+              <button
+                type="button"
+                className="kanban-add-expand"
+                aria-label="Expand the description"
+                // Keep focus in the editor so the caret is still readable when
+                // the sheet asks for it.
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={expand}
+              >
+                <Icon name="arrows-out" className="w-3.5 h-3.5" />
+              </button>
+            </Tooltip>
           </div>
           {/* DOM order is [Create, Discard] so Tab from the description lands
               on Create first; flex-row-reverse keeps Discard on the visual left.
@@ -419,7 +414,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
             // reads as a return to the same draft, not a jump to a stale one.
             editorRef.current?.setValue(value);
           }}
-          onAttachFile={handleAttachFile}
+          onAttachFile={resolveAttachmentPath}
           onSubmit={submit}
           onCollapse={collapseSheet}
           onDiscard={discard}

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -322,7 +322,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
           <input
             ref={inputRef}
             type="text"
-            className="kanban-add-input w-full font-mono text-sm font-medium text-text-primary bg-transparent px-3 py-3.5 outline-none transition-all duration-150 ease-out border-none focus:bg-ink/[0.04]"
+            className="kanban-add-input w-full text-[15px] text-text-primary bg-transparent px-3 py-3 outline-none transition-all duration-150 ease-out border-none focus:bg-ink/[0.04]"
             style={{ borderBottom: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
             placeholder="New task..."
             value={name}
@@ -342,12 +342,11 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
               placeholder="Description (optional)"
               onKeyDown={handleDescriptionKeyDown}
               onFocus={handleDescriptionFocus}
-              className="kanban-add-description w-full font-mono text-xs text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none focus:bg-ink/[0.04]"
+              className="kanban-add-description w-full text-sm leading-relaxed text-text-secondary bg-transparent px-3 py-2.5 outline-none transition-all duration-150 ease-out border-none focus:bg-ink/[0.04]"
               style={{
                 minHeight: '4.5rem',
                 whiteSpace: 'pre-wrap',
                 wordWrap: 'break-word',
-                lineHeight: 1.5,
                 overflowY: 'auto',
                 ...capStyle,
               }}

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -199,18 +199,6 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     [submit, collapse, expand],
   );
 
-  const handleRestKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      // A second Escape, on the collapsed row, is what actually discards.
-      if (e.key === 'Escape' && hasDraft) {
-        e.preventDefault();
-        e.stopPropagation();
-        discard();
-      }
-    },
-    [hasDraft, discard],
-  );
-
   const handleDescriptionFocus = useCallback(() => setFocusedField('description'), []);
   const handleNameFocus = useCallback(() => {
     setActive(true);
@@ -287,14 +275,12 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
           type="button"
           className="kanban-add-rest"
           onClick={openForm}
-          onKeyDown={handleRestKeyDown}
           aria-label={hasDraft ? 'Resume draft task' : 'New task'}
         >
           {hasDraft ? (
             <>
               <Icon name="file-dashed" className="kanban-add-draft-icon" />
               <span className="kanban-add-draft-label">{name.trim() || 'Untitled draft'}</span>
-              <span className="kanban-add-button-hint kanban-add-button-hint-text">Esc to discard</span>
             </>
           ) : (
             <>

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -292,7 +292,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
         >
           {hasDraft ? (
             <>
-              <span className="kanban-add-draft-dot" />
+              <Icon name="file-dashed" className="kanban-add-draft-icon" />
               <span className="kanban-add-draft-label">{name.trim() || 'Untitled draft'}</span>
               <span className="kanban-add-button-hint kanban-add-button-hint-text">Esc to discard</span>
             </>

--- a/src/components/kanban/KanbanAddInput.tsx
+++ b/src/components/kanban/KanbanAddInput.tsx
@@ -10,10 +10,9 @@ import { Tooltip } from '../ui/Tooltip';
 import { useAppStore } from '../../stores/appStore';
 import { useComposerStore } from '../../stores/composerStore';
 import { resolveAttachmentPath } from '../../utils/taskAttachments';
+import { isModKey, MOD_LABEL } from '../../utils/modKey';
 
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
-/** Modifier name for tooltips and the resting row's shortcut hint. */
-const MOD_LABEL = isMac ? '⌘' : 'Ctrl ';
 
 /**
  * The description grows with its content up to this share of the column body,
@@ -24,8 +23,9 @@ const DESCRIPTION_CAP_RATIO = 0.4;
 
 /** Bounds for a height set by dragging the composer's top edge. */
 const MIN_DRAG_HEIGHT = 72;
-/** Leave at least this much column body visible above a dragged composer. */
-const DRAG_HEADROOM = 48;
+/** Cards that must stay visible above a dragged composer. Matches the card
+ *  list's own min-height, which is what stops it absorbing the difference. */
+const MIN_CARD_LIST_HEIGHT = 80;
 
 /** Global setting holding the dragged height, so it survives restarts. */
 const HEIGHT_SETTING_KEY = 'ui:composerDescriptionHeight';
@@ -99,10 +99,12 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     editorRef.current?.refreshMetrics();
   }, [pinnedHeight, active]);
 
-  // Let the board know the sheet owns Escape and ⌘N while it's up.
+  // Let the board know the sheet owns Escape and ⌘N while it's up. Registered
+  // only while open, so a component that never opens one can't clear the count.
   useEffect(() => {
-    useAppStore.getState().setComposerSheetOpen(sheetOpen);
-    return () => useAppStore.getState().setComposerSheetOpen(false);
+    if (!sheetOpen) return;
+    useAppStore.getState().openComposerSheet();
+    return () => useAppStore.getState().closeComposerSheet();
   }, [sheetOpen]);
 
   const openForm = useCallback(() => {
@@ -161,12 +163,9 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     });
   }, []);
 
-  /** Cmd or Ctrl, accepting either so the bindings work on any keyboard. */
-  const isModifier = (e: React.KeyboardEvent): boolean => e.metaKey || e.ctrlKey;
-
   const handleNameKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (isModifier(e) && e.key.toLowerCase() === 'e') {
+      if (isModKey(e) && e.key.toLowerCase() === 'e') {
         e.preventDefault();
         expand();
       } else if (e.key === 'Enter') {
@@ -185,10 +184,10 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     (e: React.KeyboardEvent) => {
       // Cmd/Ctrl+Enter submits; plain Enter falls through to contentEditable's
       // native line-break handling.
-      if (isModifier(e) && e.key.toLowerCase() === 'e') {
+      if (isModKey(e) && e.key.toLowerCase() === 'e') {
         e.preventDefault();
         expand();
-      } else if (e.key === 'Enter' && isModifier(e)) {
+      } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         submit();
       } else if (e.key === 'Escape') {
@@ -224,13 +223,17 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
     const editor = document.querySelector<HTMLElement>('.kanban-add-description');
     const form = formRef.current;
     if (!editor || !form) return;
-    // The column publishes its body height as a custom property; the cap and
-    // the drag ceiling are both shares of it.
+    // The column publishes the room below its header as a custom property. That
+    // span holds the card list *and* this composer, so the ceiling has to
+    // subtract the composer's own chrome and the list's min-height — otherwise
+    // the form grows past the column and the action row is clipped away.
     const bodyHeight = Number.parseFloat(getComputedStyle(form).getPropertyValue('--kanban-body-h')) || 0;
+    const editorHeight = editor.getBoundingClientRect().height;
+    const chrome = form.getBoundingClientRect().height - editorHeight;
     dragRef.current = {
       startY: e.clientY,
-      startHeight: editor.getBoundingClientRect().height,
-      max: Math.max(MIN_DRAG_HEIGHT, bodyHeight - DRAG_HEADROOM),
+      startHeight: editorHeight,
+      max: Math.max(MIN_DRAG_HEIGHT, bodyHeight - chrome - MIN_CARD_LIST_HEIGHT),
     };
     e.currentTarget.setPointerCapture(e.pointerId);
     e.preventDefault();
@@ -413,7 +416,7 @@ export function KanbanAddInput({ onAdd }: KanbanAddInputProps) {
 export function focusKanbanAddInput(): void {
   // The expanded sheet holds the same draft and already has focus; pulling it
   // back to the input behind the scrim would strand the caret.
-  if (useAppStore.getState().composerSheetOpen) return;
+  if (useAppStore.getState().composerSheetCount > 0) return;
 
   const input = document.querySelector<HTMLInputElement>('.kanban-add-input');
   if (input) {

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -767,9 +767,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
             }}
           >
             <div className="flex items-start gap-2">
-              <span className="flex-1 font-mono text-sm font-medium text-text-primary min-w-0 break-words">
-                {activeTask.name}
-              </span>
+              <span className="flex-1 text-[15px] text-text-primary min-w-0 break-words">{activeTask.name}</span>
             </div>
             {selectedTaskCount > 1 && (
               <span

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -176,7 +176,7 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
 
   // Hotkeys
   const runHookActive = useProjectStore((s) => s.runHookQueue.length > 0);
-  const composerSheetOpen = useAppStore((s) => s.composerSheetOpen);
+  const composerSheetOpen = useAppStore((s) => s.composerSheetCount > 0);
   const hasOpenDialog = !!(runHookActive || hookDialog || missingWorktreeDialog || composerSheetOpen);
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -176,7 +176,8 @@ export function KanbanBoard({ projectPath, onHide }: KanbanBoardProps) {
 
   // Hotkeys
   const runHookActive = useProjectStore((s) => s.runHookQueue.length > 0);
-  const hasOpenDialog = !!(runHookActive || hookDialog || missingWorktreeDialog);
+  const composerSheetOpen = useAppStore((s) => s.composerSheetOpen);
+  const hasOpenDialog = !!(runHookActive || hookDialog || missingWorktreeDialog || composerSheetOpen);
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -14,6 +14,7 @@ import { HookConfigDialog } from '../dialogs/HookConfigDialog';
 import { BranchFromTaskDialog } from '../dialogs/BranchFromTaskDialog';
 import { Tooltip } from '../ui/Tooltip';
 import { revealInFileManager } from '../../utils/fileManager';
+import { resolveAttachmentPath } from '../../utils/taskAttachments';
 import type { TaskChainInfo } from '../../utils/taskChain';
 import { isChainMember, isDescendantOf } from '../../utils/taskChain';
 import { KanbanCardView } from './KanbanCardView';
@@ -265,27 +266,6 @@ export const KanbanCard = memo(function KanbanCard({
     handleStartRenameTask,
   ]);
 
-  const handleAttachFile = useCallback(async (file: File): Promise<string | null> => {
-    // Prefer the file's existing on-disk path — drag-drop from Finder and
-    // most clipboard file pastes already have one. Skipping the copy keeps
-    // the user's file under their control and works for any extension.
-    const existingPath = window.api.getPathForFile(file);
-    if (existingPath) return existingPath;
-
-    // No source path — bytes only (typically a clipboard-pasted screenshot).
-    // Save those to userData so CLI agents have a stable path to read.
-    if (!file.type.startsWith('image/')) {
-      useProjectStore.getState().addToast('Only image clipboard content can be attached', 'error');
-      return null;
-    }
-    const ext = file.type.split('/')[1] || 'png';
-    const data = new Uint8Array(await file.arrayBuffer());
-    const result = await window.api.task.saveAttachment(data, ext);
-    if (result.success && result.path) return result.path;
-    useProjectStore.getState().addToast(result.error || 'Failed to attach image', 'error');
-    return null;
-  }, []);
-
   return (
     <>
       <KanbanCardView
@@ -307,7 +287,7 @@ export const KanbanCard = memo(function KanbanCard({
         onPlainClick={handlePlainClick}
         onContextMenu={(e) => setContextMenu({ x: e.clientX, y: e.clientY })}
         onUpdateDescription={onUpdateDescription}
-        onAttachFile={handleAttachFile}
+        onAttachFile={resolveAttachmentPath}
         onSwitchToTerminal={onSwitchToTerminal}
         onTerminalContextMenu={(ptyId, e) => setTerminalContextMenu({ x: e.clientX, y: e.clientY, ptyId })}
         isRenamingTask={isRenamingTask}

--- a/src/components/kanban/KanbanCardView.tsx
+++ b/src/components/kanban/KanbanCardView.tsx
@@ -11,6 +11,7 @@ import {
 import { TaskComposerSheet } from './TaskComposerSheet';
 import { Tooltip } from '../ui/Tooltip';
 import { useAppStore } from '../../stores/appStore';
+import { isModKey, MOD_LABEL } from '../../utils/modKey';
 
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
 
@@ -177,10 +178,13 @@ export const KanbanCardView = memo(function KanbanCardView({
     });
   }, []);
 
-  // The board leaves Escape to the sheet while it's open.
+  // The board leaves Escape to the sheet while it's open. Only registered
+  // while open: every card mounts this, and a card remounting from a
+  // background task reload must not clear a sheet someone else has up.
   useEffect(() => {
-    useAppStore.getState().setComposerSheetOpen(sheetOpen);
-    return () => useAppStore.getState().setComposerSheetOpen(false);
+    if (!sheetOpen) return;
+    useAppStore.getState().openComposerSheet();
+    return () => useAppStore.getState().closeComposerSheet();
   }, [sheetOpen]);
 
   /**
@@ -221,7 +225,7 @@ export const KanbanCardView = memo(function KanbanCardView({
   /** Enter (without shift) commits the description; ⌘E opens the sheet. */
   const handleEditorKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'e') {
+      if (isModKey(e) && e.key.toLowerCase() === 'e') {
         e.preventDefault();
         expandDescription();
       } else if (e.key === 'Enter' && !e.shiftKey) {
@@ -411,7 +415,10 @@ export const KanbanCardView = memo(function KanbanCardView({
               placeholder="Add description…"
               editable={editingDesc}
               onKeyDown={handleEditorKeyDown}
-              onBlur={editingDesc ? commitDescription : undefined}
+              // Not while the sheet is up: opening it moves focus to its own
+              // editor, and a blur commit there would write the description
+              // out and drop this editor back to read-only underneath it.
+              onBlur={editingDesc && !sheetOpen ? commitDescription : undefined}
               onClick={() => {
                 if (!editingDesc) setEditingDesc(true);
               }}
@@ -436,7 +443,7 @@ export const KanbanCardView = memo(function KanbanCardView({
                 text={
                   <span className="flex items-center gap-2">
                     Expand
-                    <span className="kanban-add-button-hint kanban-add-button-hint-text">{isMac ? '⌘' : 'Ctrl '}E</span>
+                    <span className="kanban-add-button-hint kanban-add-button-hint-text">{MOD_LABEL}E</span>
                   </span>
                 }
                 referenceClassName="kanban-add-expand-anchor"

--- a/src/components/kanban/KanbanCardView.tsx
+++ b/src/components/kanban/KanbanCardView.tsx
@@ -9,6 +9,7 @@ import {
   type DescriptionEditorMetrics,
 } from './DescriptionChipEditor';
 import { TaskComposerSheet } from './TaskComposerSheet';
+import { Tooltip } from '../ui/Tooltip';
 import { useAppStore } from '../../stores/appStore';
 
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
@@ -430,17 +431,27 @@ export const KanbanCardView = memo(function KanbanCardView({
               }
             />
             {editingDesc && (
-              <button
-                type="button"
-                className="kanban-add-expand"
-                title={`Expand  ${isMac ? '⌘E' : 'Ctrl E'}`}
-                aria-label="Expand the description"
-                // Hold focus in the editor so its caret is still readable.
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={expandDescription}
+              <Tooltip
+                placement="left"
+                text={
+                  <span className="flex items-center gap-2">
+                    Expand
+                    <span className="kanban-add-button-hint kanban-add-button-hint-text">{isMac ? '⌘' : 'Ctrl '}E</span>
+                  </span>
+                }
+                referenceClassName="kanban-add-expand-anchor"
               >
-                <Icon name="arrows-out" className="w-3.5 h-3.5" />
-              </button>
+                <button
+                  type="button"
+                  className="kanban-add-expand"
+                  aria-label="Expand the description"
+                  // Hold focus in the editor so its caret is still readable.
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={expandDescription}
+                >
+                  <Icon name="arrows-out" className="w-3.5 h-3.5" />
+                </button>
+              </Tooltip>
             )}
           </div>
           {task.branch && (

--- a/src/components/kanban/KanbanCardView.tsx
+++ b/src/components/kanban/KanbanCardView.tsx
@@ -456,6 +456,7 @@ export const KanbanCardView = memo(function KanbanCardView({
       {sheetOpen && (
         <TaskComposerSheet
           mode="edit"
+          name={task.name}
           description={sheetDraft}
           initialCaret={sheetCaret}
           onDescriptionChange={(value) => {

--- a/src/components/kanban/KanbanCardView.tsx
+++ b/src/components/kanban/KanbanCardView.tsx
@@ -3,9 +3,20 @@ import type { TaskWithWorkspace } from '../../types';
 import type { TerminalDisplayState } from '../../stores/terminalStore';
 import { Icon } from '../terminal/Icon';
 import { StatusDot, sandboxSuffix } from '../terminal/StatusDot';
-import { DescriptionChipEditor, type DescriptionChipEditorHandle } from './DescriptionChipEditor';
+import {
+  DescriptionChipEditor,
+  type DescriptionChipEditorHandle,
+  type DescriptionEditorMetrics,
+} from './DescriptionChipEditor';
+import { TaskComposerSheet } from './TaskComposerSheet';
+import { useAppStore } from '../../stores/appStore';
 
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
+
+/** Matches the new-task composer's cap: a share of the column's card list. */
+const DESCRIPTION_CAP_RATIO = 0.4;
+
+const EMPTY_METRICS: DescriptionEditorMetrics = { overflowing: false, atTop: true, atBottom: true };
 
 export interface KanbanCardViewProps {
   task: TaskWithWorkspace;
@@ -87,6 +98,10 @@ export const KanbanCardView = memo(function KanbanCardView({
 }: KanbanCardViewProps) {
   const [expanded, setExpanded] = useState(false);
   const [editingDesc, setEditingDesc] = useState(false);
+  const [metrics, setMetrics] = useState<DescriptionEditorMetrics>(EMPTY_METRICS);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [sheetDraft, setSheetDraft] = useState('');
+  const [sheetCaret, setSheetCaret] = useState<number | null>(null);
   const nameInputRef = useRef<HTMLTextAreaElement>(null);
   const descEditorRef = useRef<DescriptionChipEditorHandle>(null);
   const terminalRenameRef = useRef<HTMLInputElement>(null);
@@ -140,6 +155,34 @@ export const KanbanCardView = memo(function KanbanCardView({
   }, [task.taskNumber, onUpdateDescription]);
 
   /**
+   * Hand the in-progress description to the expanded sheet. The card's editor
+   * stays mounted underneath and is mirrored on every keystroke, so collapsing
+   * returns to the same text with the caret where it was left.
+   */
+  const expandDescription = useCallback(() => {
+    setSheetDraft(descEditorRef.current?.getValue() ?? '');
+    setSheetCaret(descEditorRef.current?.getCaret() ?? null);
+    setSheetOpen(true);
+  }, []);
+
+  /** Which edges are hiding text, so the mask fades only those. */
+  const clip = !metrics.overflowing ? 'none' : metrics.atTop ? 'bottom' : metrics.atBottom ? 'top' : 'both';
+
+  const collapseSheet = useCallback((caret: number | null) => {
+    setSheetOpen(false);
+    requestAnimationFrame(() => {
+      if (caret != null) descEditorRef.current?.focusAtCaret(caret);
+      else descEditorRef.current?.focus();
+    });
+  }, []);
+
+  // The board leaves Escape to the sheet while it's open.
+  useEffect(() => {
+    useAppStore.getState().setComposerSheetOpen(sheetOpen);
+    return () => useAppStore.getState().setComposerSheetOpen(false);
+  }, [sheetOpen]);
+
+  /**
    * Sync the editor with `task.prompt` when an external change arrives — but
    * skip the case where the change is just our own commit round-tripping back
    * (otherwise we'd repopulate the DOM and stomp the caret). While editing,
@@ -174,15 +217,18 @@ export const KanbanCardView = memo(function KanbanCardView({
     [editingDesc, onUpdateDescription, task.taskNumber],
   );
 
-  /** Enter (without shift) commits the description. */
+  /** Enter (without shift) commits the description; ⌘E opens the sheet. */
   const handleEditorKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'e') {
+        e.preventDefault();
+        expandDescription();
+      } else if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         commitDescription();
       }
     },
-    [commitDescription],
+    [commitDescription, expandDescription],
   );
 
   const commitTerminalRename = useCallback(() => {
@@ -349,12 +395,18 @@ export const KanbanCardView = memo(function KanbanCardView({
           // start a card drag.
           onPointerDown={(e) => e.stopPropagation()}
         >
-          <div className="flex flex-col gap-1 text-sm">
+          <div
+            className={`kanban-add-description-wrap flex flex-col gap-1 text-sm${
+              editingDesc && metrics.overflowing ? ' is-capped' : ''
+            }`}
+            data-clip={editingDesc ? clip : 'none'}
+          >
             <DescriptionChipEditor
               ref={descEditorRef}
               initialValue={task.prompt ?? ''}
               onChange={handleEditorChange}
               onAttachFile={onAttachFile}
+              onMetrics={editingDesc ? setMetrics : undefined}
               placeholder="Add description…"
               editable={editingDesc}
               onKeyDown={handleEditorKeyDown}
@@ -363,8 +415,33 @@ export const KanbanCardView = memo(function KanbanCardView({
                 if (!editingDesc) setEditingDesc(true);
               }}
               className={`text-text-secondary cursor-text break-words${editingDesc ? ' outline-none' : ' line-clamp-3'}`}
-              style={editingDesc ? { whiteSpace: 'pre-wrap', wordWrap: 'break-word', lineHeight: 1.5 } : undefined}
+              style={
+                editingDesc
+                  ? {
+                      whiteSpace: 'pre-wrap',
+                      wordWrap: 'break-word',
+                      lineHeight: 1.5,
+                      // The same cap the composer uses, so a long description
+                      // can't grow past its share of the column.
+                      maxHeight: `calc(var(--kanban-body-h, 20rem) * ${DESCRIPTION_CAP_RATIO})`,
+                      overflowY: 'auto',
+                    }
+                  : undefined
+              }
             />
+            {editingDesc && (
+              <button
+                type="button"
+                className="kanban-add-expand"
+                title={`Expand  ${isMac ? '⌘E' : 'Ctrl E'}`}
+                aria-label="Expand the description"
+                // Hold focus in the editor so its caret is still readable.
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={expandDescription}
+              >
+                <Icon name="arrows-out" className="w-3.5 h-3.5" />
+              </button>
+            )}
           </div>
           {task.branch && (
             <div className="flex items-center gap-1 font-mono text-[13px] text-ink/50 min-w-0 overflow-hidden [&>svg]:w-3 [&>svg]:h-3 [&>svg]:shrink-0">
@@ -374,6 +451,26 @@ export const KanbanCardView = memo(function KanbanCardView({
           )}
           {formattedDate && <div className="flex flex-col gap-1 text-sm">Created {formattedDate}</div>}
         </div>
+      )}
+
+      {sheetOpen && (
+        <TaskComposerSheet
+          mode="edit"
+          description={sheetDraft}
+          initialCaret={sheetCaret}
+          onDescriptionChange={(value) => {
+            setSheetDraft(value);
+            // Mirror into the card's editor so collapsing returns to the same
+            // text, and so a commit reads the value from one place.
+            descEditorRef.current?.setValue(value);
+          }}
+          onAttachFile={onAttachFile ?? (async () => null)}
+          onSubmit={() => {
+            setSheetOpen(false);
+            commitDescription();
+          }}
+          onCollapse={collapseSheet}
+        />
       )}
     </div>
   );

--- a/src/components/kanban/KanbanCardView.tsx
+++ b/src/components/kanban/KanbanCardView.tsx
@@ -299,14 +299,14 @@ export const KanbanCardView = memo(function KanbanCardView({
         {isRenamingTask ? (
           <textarea
             ref={nameInputRef}
-            className="flex-1 font-mono text-sm font-medium text-text-primary bg-transparent border-0 border-b border-accent p-0 outline-none min-w-0 resize-none overflow-hidden [-webkit-app-region:no-drag] break-words"
+            className="flex-1 text-[15px] text-text-primary bg-transparent border-0 border-b border-accent p-0 outline-none min-w-0 resize-none overflow-hidden [-webkit-app-region:no-drag] break-words"
             onBlur={commitRename}
             onKeyDown={handleNameKeyDown}
             rows={1}
           />
         ) : (
           <span
-            className={`kanban-card-name flex-1 font-mono text-sm font-medium min-w-0 break-words ${isDone ? 'line-through text-text-secondary' : 'text-text-primary'}`}
+            className={`kanban-card-name flex-1 text-[15px] min-w-0 break-words ${isDone ? 'line-through text-text-secondary' : 'text-text-primary'}`}
             onDoubleClick={onStartRenameTask}
           >
             {task.name}
@@ -415,7 +415,7 @@ export const KanbanCardView = memo(function KanbanCardView({
               onClick={() => {
                 if (!editingDesc) setEditingDesc(true);
               }}
-              className={`text-text-secondary cursor-text break-words${editingDesc ? ' outline-none' : ' line-clamp-3'}`}
+              className={`text-sm leading-relaxed text-text-secondary cursor-text break-words${editingDesc ? ' outline-none' : ' line-clamp-3'}`}
               style={
                 editingDesc
                   ? {

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -81,6 +81,7 @@ export function KanbanColumn({
       onBodyClick={(e) => {
         if (e.target === e.currentTarget) useProjectStore.getState().clearSelection();
       }}
+      footer={onAddTask ? <KanbanAddInput onAdd={onAddTask} /> : undefined}
     >
       <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
         {tasks.map((task) => (
@@ -106,7 +107,6 @@ export function KanbanColumn({
           No tasks yet. Type a name below to add one.
         </div>
       )}
-      {onAddTask && <KanbanAddInput onAdd={onAddTask} />}
     </KanbanColumnView>
   );
 }

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -170,9 +170,7 @@ function SortableCard({
           style={{ borderBottom: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
         >
           <div className="flex items-start gap-2">
-            <span className="flex-1 font-mono text-sm font-medium text-text-primary min-w-0 break-words">
-              {task.name}
-            </span>
+            <span className="flex-1 text-[15px] text-text-primary min-w-0 break-words">{task.name}</span>
           </div>
         </div>
       </div>

--- a/src/components/kanban/KanbanColumnView.tsx
+++ b/src/components/kanban/KanbanColumnView.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent, ReactNode, Ref } from 'react';
+import { useEffect, useRef, type MouseEvent, type ReactNode, type Ref } from 'react';
 import type { HookType } from '../../types';
 import { Icon } from '../terminal/Icon';
 
@@ -16,6 +16,11 @@ export interface KanbanColumnViewProps {
    *  modifier-key affordances mid-drag (e.g. "shift to skip hook"). */
   caption?: string;
   children?: ReactNode;
+  /**
+   * Pinned below the scrolling card list. The new-task composer lives here so
+   * column length never pushes it out of view.
+   */
+  footer?: ReactNode;
 }
 
 /**
@@ -36,9 +41,37 @@ export function KanbanColumnView({
   onBodyClick,
   caption,
   children,
+  footer,
 }: KanbanColumnViewProps) {
+  const columnRef = useRef<HTMLDivElement>(null);
+  const headerRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * Publish the room a column has for its card list as `--kanban-body-h`, so
+   * the composer can cap its description at a share of it without measuring
+   * anything itself.
+   *
+   * Deliberately derived from the *column* rather than the card list: the
+   * composer sits in the same flex column, so a cap measured off the live body
+   * height would shrink as the composer grew, chasing its own tail. Column
+   * height minus the header is fixed by the board, so the cap holds still.
+   */
+  useEffect(() => {
+    const column = columnRef.current;
+    const header = headerRef.current;
+    if (!column || !header || typeof ResizeObserver === 'undefined') return;
+
+    const publish = () =>
+      column.style.setProperty('--kanban-body-h', `${Math.max(0, column.clientHeight - header.offsetHeight)}px`);
+    publish();
+    const observer = new ResizeObserver(publish);
+    observer.observe(column);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <div
+      ref={columnRef}
       className="kanban-column flex flex-col transition-all duration-150 ease-out shrink-0 last:border-r-0"
       style={{
         minWidth: 240,
@@ -47,7 +80,7 @@ export function KanbanColumnView({
       }}
       data-status={status}
     >
-      <div className="flex items-center gap-2 px-3 py-2.5 shrink-0 h-[46px]">
+      <div ref={headerRef} className="flex items-center gap-2 px-3 py-2.5 shrink-0 h-[46px]">
         <span className="text-[13px] font-medium text-text-secondary tracking-wide flex-1">
           {label}
           {caption ? (
@@ -80,6 +113,7 @@ export function KanbanColumnView({
       >
         {children}
       </div>
+      {footer && <div className="kanban-column-footer shrink-0">{footer}</div>}
     </div>
   );
 }

--- a/src/components/kanban/StandaloneComposerSheet.tsx
+++ b/src/components/kanban/StandaloneComposerSheet.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useEffect } from 'react';
+import { TaskComposerSheet } from './TaskComposerSheet';
+import { useAppStore } from '../../stores/appStore';
+import { useComposerStore, isBoardMounted } from '../../stores/composerStore';
+import { useProjectStore } from '../../stores/projectStore';
+import { resolveAttachmentPath } from '../../utils/taskAttachments';
+
+/**
+ * The composer sheet as its own surface, for ⌘N away from the board.
+ *
+ * When the board is up, its column composer owns the sheet instead, so exactly
+ * one of the two renders it and both read the same draft. Creating from here
+ * goes straight to the API, since there is no board to hand the task to.
+ */
+export function StandaloneComposerSheet({ projectPath }: { projectPath: string }) {
+  const kanbanVisible = useProjectStore((s) => s.kanbanVisible);
+  const activePanel = useProjectStore((s) => s.activePanel);
+  const sheetOpen = useComposerStore((s) => s.sheetOpen);
+  const name = useComposerStore((s) => s.draft.name);
+  const description = useComposerStore((s) => s.draft.description);
+
+  const boardMounted = isBoardMounted(activePanel, kanbanVisible);
+  const owned = sheetOpen && !boardMounted;
+
+  // The board's Escape handler stands down while a composer sheet is up.
+  useEffect(() => {
+    useAppStore.getState().setComposerSheetOpen(owned);
+    return () => useAppStore.getState().setComposerSheetOpen(false);
+  }, [owned]);
+
+  const create = useCallback(async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    const trimmedDescription = description.trim();
+    const composer = useComposerStore.getState();
+    composer.clearDraft();
+    composer.closeSheet();
+    await window.api.task.create(projectPath, trimmedName, trimmedDescription || undefined);
+    void useProjectStore.getState().loadTasks(projectPath);
+  }, [name, description, projectPath]);
+
+  const discard = useCallback(() => {
+    const composer = useComposerStore.getState();
+    composer.clearDraft();
+    composer.closeSheet();
+  }, []);
+
+  if (!owned) return null;
+
+  return (
+    <TaskComposerSheet
+      mode="create"
+      name={name}
+      description={description}
+      onNameChange={useComposerStore.getState().setName}
+      onDescriptionChange={useComposerStore.getState().setDescription}
+      onAttachFile={resolveAttachmentPath}
+      onSubmit={create}
+      // Nothing to hand a caret back to out here; the draft is kept either way
+      // and the column composer picks it up when you next open the board.
+      onCollapse={() => useComposerStore.getState().closeSheet()}
+      onDiscard={discard}
+    />
+  );
+}

--- a/src/components/kanban/StandaloneComposerSheet.tsx
+++ b/src/components/kanban/StandaloneComposerSheet.tsx
@@ -24,19 +24,27 @@ export function StandaloneComposerSheet({ projectPath }: { projectPath: string }
 
   // The board's Escape handler stands down while a composer sheet is up.
   useEffect(() => {
-    useAppStore.getState().setComposerSheetOpen(owned);
-    return () => useAppStore.getState().setComposerSheetOpen(false);
+    if (!owned) return;
+    useAppStore.getState().openComposerSheet();
+    return () => useAppStore.getState().closeComposerSheet();
   }, [owned]);
 
   const create = useCallback(async () => {
     const trimmedName = name.trim();
     if (!trimmedName) return;
     const trimmedDescription = description.trim();
-    const composer = useComposerStore.getState();
-    composer.clearDraft();
-    composer.closeSheet();
-    await window.api.task.create(projectPath, trimmedName, trimmedDescription || undefined);
-    void useProjectStore.getState().loadTasks(projectPath);
+    // Close first so the sheet doesn't sit there through the round trip, but
+    // hold the draft until the task actually exists — losing a written prompt
+    // to a failed IPC call is the one outcome worth guarding against.
+    useComposerStore.getState().closeSheet();
+    try {
+      const result = await window.api.task.create(projectPath, trimmedName, trimmedDescription || undefined);
+      if (!result?.success) throw new Error(result?.error ?? 'Failed to create task');
+      useComposerStore.getState().clearDraft();
+      void useProjectStore.getState().loadTasks(projectPath);
+    } catch (error) {
+      useProjectStore.getState().addToast(error instanceof Error ? error.message : 'Failed to create task', 'error');
+    }
   }, [name, description, projectPath]);
 
   const discard = useCallback(() => {

--- a/src/components/kanban/TaskComposerSheet.tsx
+++ b/src/components/kanban/TaskComposerSheet.tsx
@@ -1,14 +1,19 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { DescriptionChipEditor, type DescriptionChipEditorHandle } from './DescriptionChipEditor';
 import { Icon } from '../terminal/Icon';
+import { KeyHint } from '../ui/KeyHint';
 
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
+const MOD = isMac ? '⌘' : 'Ctrl ';
+
+/** Matches the palette's enter/exit so the two overlays feel like siblings. */
+const TRANSITION_MS = 200;
 
 interface TaskComposerSheetProps {
   /** Storage-format description the sheet opens with. */
   description: string;
-  /** Task name. Omitted in `edit` mode, where the name is renamed on the card. */
+  /** Task name. Editable in `create` mode, shown as context in `edit`. */
   name?: string;
   /** Caret offset to restore, carried over from the inline editor. */
   initialCaret?: number | null;
@@ -26,11 +31,15 @@ interface TaskComposerSheetProps {
 }
 
 /**
- * The composer's expanded view: the same draft as the inline form, given a
- * centered sheet and a reading measure. Both editors are views onto one piece
- * of state held by the parent, so switching between them is a change of
- * surface rather than a handoff — including the caret, which travels as an
- * offset into the storage string.
+ * The composer's expanded view: the same draft as the inline form, given room
+ * to write in. Built on the same floating panel as the command palette —
+ * top-anchored so it grows downward under a fixed header, glass-beveled, on
+ * the terminal surface — because this is a writing surface the user chose to
+ * open, not a dialog interrupting them.
+ *
+ * Both editors are views onto one piece of state held by the parent, so moving
+ * between them is a change of surface rather than a handoff, including the
+ * caret, which travels as an offset into the storage string.
  */
 export function TaskComposerSheet({
   description,
@@ -44,21 +53,39 @@ export function TaskComposerSheet({
   onCollapse,
   onDiscard,
 }: TaskComposerSheetProps) {
+  const [visible, setVisible] = useState(false);
   const editorRef = useRef<DescriptionChipEditorHandle>(null);
   const nameRef = useRef<HTMLInputElement>(null);
-  const mouseDownTargetRef = useRef<EventTarget | null>(null);
 
-  const canSubmit = mode === 'edit' || (name ?? '').trim().length > 0;
+  const isCreate = mode === 'create';
+  const canSubmit = !isCreate || (name ?? '').trim().length > 0;
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  /** Play the exit before handing control back, like the app's other overlays. */
+  const dismiss = useCallback((run: () => void) => {
+    setVisible(false);
+    setTimeout(run, TRANSITION_MS);
+  }, []);
 
   const collapse = useCallback(() => {
-    onCollapse(editorRef.current?.getCaret() ?? null);
-  }, [onCollapse]);
+    const caret = editorRef.current?.getCaret() ?? null;
+    dismiss(() => onCollapse(caret));
+  }, [dismiss, onCollapse]);
+
+  const submit = useCallback(() => {
+    if (!canSubmit) return;
+    dismiss(onSubmit);
+  }, [canSubmit, dismiss, onSubmit]);
 
   // Land where the inline editor left off. An empty name in create mode means
   // this is a fresh draft, so start there instead of in the description.
   useEffect(() => {
     const frame = requestAnimationFrame(() => {
-      if (mode === 'create' && !(name ?? '').trim()) {
+      if (isCreate && !(name ?? '').trim()) {
         nameRef.current?.focus();
         return;
       }
@@ -75,126 +102,101 @@ export function TaskComposerSheet({
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        e.stopPropagation();
-        collapse();
-      } else if (mod && e.key.toLowerCase() === 'e') {
+      if (e.key === 'Escape' || (mod && e.key.toLowerCase() === 'e')) {
         e.preventDefault();
         e.stopPropagation();
         collapse();
       } else if (mod && e.key === 'Enter') {
         e.preventDefault();
         e.stopPropagation();
-        if (canSubmit) onSubmit();
+        submit();
       }
     };
     document.addEventListener('keydown', handler, true);
     return () => document.removeEventListener('keydown', handler, true);
-  }, [collapse, onSubmit, canSubmit]);
+  }, [collapse, submit]);
 
   return createPortal(
     <div
       data-testid="composer-sheet-overlay"
-      className="fixed inset-0 z-[10001] flex items-center justify-center p-10"
+      data-visible={visible}
+      className={`fixed inset-0 z-[10003] flex justify-center px-6 pt-[12vh] pb-10 transition-opacity duration-200 ease-out ${
+        visible ? 'opacity-100' : 'opacity-0'
+      }`}
       style={{ background: 'rgba(0, 0, 0, 0.4)', backdropFilter: 'blur(4px)', WebkitBackdropFilter: 'blur(4px)' }}
       onMouseDown={(e) => {
-        mouseDownTargetRef.current = e.target;
-      }}
-      onClick={(e) => {
-        // Only a click that both started and ended on the scrim dismisses, so
-        // a text selection dragged out of the editor doesn't close the sheet.
-        if (e.target === e.currentTarget && mouseDownTargetRef.current === e.currentTarget) collapse();
+        if (e.target === e.currentTarget) collapse();
       }}
     >
       <div
         data-testid="composer-sheet"
-        className="kanban-composer-sheet flex flex-col w-full overflow-hidden bg-surface border border-border rounded-xl"
-        style={{ maxWidth: 660, maxHeight: '100%', boxShadow: 'var(--shadow-menu)' }}
+        className={`glass-bevel w-full max-w-[40rem] max-h-full flex flex-col rounded-[14px] border border-bezel-panel overflow-hidden ${
+          visible ? 'opacity-100 scale-100 translate-y-0' : 'opacity-0 scale-95 -translate-y-2'
+        }`}
+        style={{
+          background: 'var(--color-terminal-bg)',
+          boxShadow: 'var(--shadow-panel)',
+          transition: 'opacity 200ms ease-out, transform 200ms ease-out',
+        }}
       >
-        <div
-          className="flex items-center gap-2 px-3 py-2 shrink-0"
-          style={{ borderBottom: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
-        >
-          <span className="kanban-composer-chip">{mode === 'create' ? 'Todo' : 'Description'}</span>
-          <span className="text-xs text-text-secondary">{mode === 'create' ? 'New task' : 'Editing'}</span>
-          <span className="flex-1" />
-          <button
-            type="button"
-            onClick={collapse}
-            className="kanban-add-button text-text-secondary hover:text-text-primary hover:bg-ink/[0.04]"
-          >
-            <Icon name="arrows-in" className="w-3.5 h-3.5" />
-            Collapse
-            <span className="kanban-add-button-hint kanban-add-button-hint-text">{isMac ? '⌘E' : 'Ctrl E'}</span>
-          </button>
+        {/* Name row, styled as the card name it becomes. */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-ink/[0.06] shrink-0">
+          <span className="shrink-0 text-text-tertiary [&>svg]:w-4 [&>svg]:h-4">
+            <Icon name={isCreate ? 'file-plus' : 'pencil-simple'} />
+          </span>
+          {isCreate ? (
+            <input
+              ref={nameRef}
+              type="text"
+              value={name ?? ''}
+              onChange={(e) => onNameChange?.(e.target.value)}
+              onKeyDown={(e) => {
+                // Enter moves on rather than submitting: at this size the
+                // description is almost certainly the point.
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  editorRef.current?.focus();
+                }
+              }}
+              placeholder="Task name"
+              spellCheck={false}
+              aria-label="Task name"
+              className="flex-1 min-w-0 bg-transparent border-none outline-none font-mono text-sm font-medium text-text-primary placeholder:text-text-tertiary"
+            />
+          ) : (
+            <span className="flex-1 min-w-0 truncate font-mono text-sm font-medium text-text-primary">{name}</span>
+          )}
+          <span className="shrink-0 text-[11px] text-ink/40">{isCreate ? 'Todo' : 'Description'}</span>
         </div>
 
-        {mode === 'create' && (
-          <input
-            ref={nameRef}
-            type="text"
-            className="w-full font-mono text-base font-medium text-text-primary bg-transparent px-5 py-4 outline-none border-none focus:bg-ink/[0.04] transition-all duration-150 ease-out"
-            style={{ borderBottom: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
-            placeholder="Task name"
-            value={name ?? ''}
-            onChange={(e) => onNameChange?.(e.target.value)}
-            onKeyDown={(e) => {
-              // Enter moves on rather than submitting: in a sheet this size,
-              // the description is almost certainly the point.
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                editorRef.current?.focus();
-              }
-            }}
-          />
-        )}
-
+        {/* The writing surface. Padding is generous on purpose: it sets the
+            measure and, being inside the editable box, stays clickable. */}
         <DescriptionChipEditor
           ref={editorRef}
           initialValue={description}
           onChange={onDescriptionChange}
           onAttachFile={onAttachFile}
-          placeholder="Description, or the prompt the agent should start from…"
-          className="kanban-composer-sheet-editor flex-1 w-full self-center font-mono text-[13px] text-text-primary bg-transparent outline-none border-none"
-          style={{
-            // A measure, so a long prompt reads as prose instead of a wall of
-            // 90-character lines.
-            maxWidth: '66ch',
-            minHeight: 260,
-            padding: '18px 0 24px',
-            whiteSpace: 'pre-wrap',
-            wordWrap: 'break-word',
-            lineHeight: 1.65,
-            overflowY: 'auto',
-          }}
+          placeholder={isCreate ? 'Describe the task, or write the prompt to start from…' : 'Add a description…'}
+          className="composer-sheet-editor settings-scrollable w-full overflow-y-auto px-8 pt-5 pb-6 font-mono text-[13px] text-text-primary bg-transparent outline-none border-none"
+          style={{ minHeight: '13rem', maxHeight: '46vh', whiteSpace: 'pre-wrap', wordWrap: 'break-word' }}
         />
 
-        <div
-          className="flex items-center gap-2 px-2.5 py-2 shrink-0"
-          style={{ borderTop: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
-        >
-          <span className="font-mono text-[10.5px] text-text-tertiary px-1.5">
-            Drop an image anywhere in the description
-          </span>
+        <div className="shrink-0 flex items-center gap-4 px-3 py-2 border-t border-ink/[0.06] text-[11px] text-ink/40">
+          <KeyHint keys="esc" label={isCreate ? 'Draft stays in the column' : 'Back to the card'} />
           <span className="flex-1" />
           {onDiscard && (
-            <button
-              type="button"
-              onClick={onDiscard}
-              className="kanban-add-button text-text-tertiary hover:text-text-primary hover:bg-ink/[0.04]"
-            >
+            <button type="button" onClick={onDiscard} className="composer-sheet-action">
               Discard
             </button>
           )}
           <button
             type="button"
-            onClick={onSubmit}
+            onClick={submit}
             disabled={!canSubmit}
-            className="kanban-add-button kanban-add-button-filled"
+            className="composer-sheet-action composer-sheet-action-primary"
           >
-            {mode === 'create' ? 'Create task' : 'Save'}
-            <span className="kanban-add-button-hint kanban-add-button-hint-text">{isMac ? '⌘↵' : 'Ctrl ↵'}</span>
+            {isCreate ? 'Create task' : 'Save'}
+            <kbd>{MOD}↵</kbd>
           </button>
         </div>
       </div>

--- a/src/components/kanban/TaskComposerSheet.tsx
+++ b/src/components/kanban/TaskComposerSheet.tsx
@@ -3,9 +3,7 @@ import { createPortal } from 'react-dom';
 import { DescriptionChipEditor, type DescriptionChipEditorHandle } from './DescriptionChipEditor';
 import { Icon } from '../terminal/Icon';
 import { KeyHint } from '../ui/KeyHint';
-
-const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
-const MOD = isMac ? '⌘' : 'Ctrl ';
+import { isModKey, MOD_LABEL } from '../../utils/modKey';
 
 /** Matches the app's other overlays, so the surfaces enter and leave alike. */
 const TRANSITION_MS = 200;
@@ -68,8 +66,15 @@ export function TaskComposerSheet({
     return () => cancelAnimationFrame(frame);
   }, []);
 
-  /** Play the exit before handing control back, like the app's other overlays. */
+  /**
+   * Play the exit before handing control back, like the app's other overlays.
+   * Latched, because the callback is deferred: without it, holding ⌘↵ queues a
+   * timer per repeat and each one creates the same task again.
+   */
+  const dismissedRef = useRef(false);
   const dismiss = useCallback((run: () => void) => {
+    if (dismissedRef.current) return;
+    dismissedRef.current = true;
     setVisible(false);
     setTimeout(run, TRANSITION_MS);
   }, []);
@@ -113,7 +118,11 @@ export function TaskComposerSheet({
   // handler, which would clear the card selection underneath.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      const mod = e.metaKey || e.ctrlKey;
+      if (e.repeat) return;
+      const mod = isModKey(e);
+      // ⌘E only on the platform it belongs to: Ctrl+E is move-to-end-of-line
+      // in a macOS text field, and shadowing it here would cost more than the
+      // shortcut is worth.
       if (e.key === 'Escape' || (mod && e.key.toLowerCase() === 'e')) {
         e.preventDefault();
         e.stopPropagation();
@@ -220,7 +229,7 @@ export function TaskComposerSheet({
           )}
           <button type="button" onClick={submit} disabled={!canSubmit} className="btn-primary">
             {isCreate ? 'Create task' : 'Save'}
-            <span className="opacity-60 font-mono text-[11px]">{MOD}↵</span>
+            <span className="opacity-60 font-mono text-[11px]">{MOD_LABEL}↵</span>
           </button>
         </div>
       </div>

--- a/src/components/kanban/TaskComposerSheet.tsx
+++ b/src/components/kanban/TaskComposerSheet.tsx
@@ -7,7 +7,7 @@ import { KeyHint } from '../ui/KeyHint';
 const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
 const MOD = isMac ? '⌘' : 'Ctrl ';
 
-/** Matches the palette's enter/exit so the two overlays feel like siblings. */
+/** Matches the app's other overlays, so the surfaces enter and leave alike. */
 const TRANSITION_MS = 200;
 
 interface TaskComposerSheetProps {
@@ -31,11 +31,13 @@ interface TaskComposerSheetProps {
 }
 
 /**
- * The composer's expanded view: the same draft as the inline form, given room
- * to write in. Built on the same floating panel as the command palette —
- * top-anchored so it grows downward under a fixed header, glass-beveled, on
- * the terminal surface — because this is a writing surface the user chose to
- * open, not a dialog interrupting them.
+ * The composer's expanded view, built as a document rather than a form.
+ *
+ * The panel is the app's floating surface — glass bevel, 14px squircle, panel
+ * shadow — and inside it the draft is laid out the way the plan panel lays out
+ * a markdown file: a thin chrome strip naming what you're looking at, then a
+ * page with real margins holding a heading and its prose, scrolling as one
+ * body. Actions are the app's flat pills.
  *
  * Both editors are views onto one piece of state held by the parent, so moving
  * between them is a change of surface rather than a handoff, including the
@@ -55,7 +57,8 @@ export function TaskComposerSheet({
 }: TaskComposerSheetProps) {
   const [visible, setVisible] = useState(false);
   const editorRef = useRef<DescriptionChipEditorHandle>(null);
-  const nameRef = useRef<HTMLInputElement>(null);
+  const nameRef = useRef<HTMLTextAreaElement>(null);
+  const pageRef = useRef<HTMLDivElement>(null);
 
   const isCreate = mode === 'create';
   const canSubmit = !isCreate || (name ?? '').trim().length > 0;
@@ -81,9 +84,18 @@ export function TaskComposerSheet({
     dismiss(onSubmit);
   }, [canSubmit, dismiss, onSubmit]);
 
+  /** Grow the title with its content — it wraps like a heading, not a field. */
+  const sizeName = useCallback(() => {
+    const el = nameRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, []);
+
   // Land where the inline editor left off. An empty name in create mode means
   // this is a fresh draft, so start there instead of in the description.
   useEffect(() => {
+    sizeName();
     const frame = requestAnimationFrame(() => {
       if (isCreate && !(name ?? '').trim()) {
         nameRef.current?.focus();
@@ -120,9 +132,7 @@ export function TaskComposerSheet({
     <div
       data-testid="composer-sheet-overlay"
       data-visible={visible}
-      // items-start, so the panel is sized by its content. Stretching it to
-      // the viewport would strand the footer mid-panel with dead space below.
-      className={`fixed inset-0 z-[10003] flex items-start justify-center px-6 pt-[12vh] pb-10 transition-opacity duration-200 ease-out ${
+      className={`fixed inset-0 z-[10003] flex items-start justify-center px-6 pt-[9vh] pb-10 transition-opacity duration-200 ease-out ${
         visible ? 'opacity-100' : 'opacity-0'
       }`}
       style={{ background: 'rgba(0, 0, 0, 0.4)', backdropFilter: 'blur(4px)', WebkitBackdropFilter: 'blur(4px)' }}
@@ -132,7 +142,7 @@ export function TaskComposerSheet({
     >
       <div
         data-testid="composer-sheet"
-        className={`glass-bevel w-full max-w-[40rem] max-h-full flex flex-col rounded-[14px] border border-bezel-panel overflow-hidden ${
+        className={`glass-bevel w-full max-w-[44rem] max-h-full flex flex-col rounded-[14px] border border-bezel-panel overflow-hidden ${
           visible ? 'opacity-100 scale-100 translate-y-0' : 'opacity-0 scale-95 -translate-y-2'
         }`}
         style={{
@@ -141,20 +151,40 @@ export function TaskComposerSheet({
           transition: 'opacity 200ms ease-out, transform 200ms ease-out',
         }}
       >
-        {/* Name row, styled as the card name it becomes. */}
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-ink/[0.06] shrink-0">
-          <span className="shrink-0 text-text-tertiary [&>svg]:w-4 [&>svg]:h-4">
-            <Icon name={isCreate ? 'file-plus' : 'pencil-simple'} />
-          </span>
+        {/* Chrome strip, the way the plan panel names the file it's showing. */}
+        <div className="flex items-center gap-2 px-3 py-1.5 shrink-0">
+          <Icon name={isCreate ? 'file-plus' : 'file-text'} className="w-3.5 h-3.5 text-ink/50 shrink-0" />
+          <span className="text-[13px] text-ink/50 truncate flex-1">{isCreate ? 'New task' : 'Description'}</span>
+          <span className="text-[13px] text-ink/35 shrink-0">{isCreate ? 'Todo' : name}</span>
+        </div>
+
+        {/* The page: heading and prose in one scrolling body, with margins. */}
+        <div
+          ref={pageRef}
+          // px-20 on a 44rem page leaves the text about three quarters of the
+          // width, which is a page's proportions and holds the measure near
+          // 78 characters.
+          className="composer-sheet-page settings-scrollable flex-1 min-h-0 overflow-y-auto px-20 pt-8 pb-10"
+          onMouseDown={(e) => {
+            // Clicking the page margins puts the caret at the end, so there's
+            // no dead area inside the document.
+            if (e.target !== pageRef.current) return;
+            e.preventDefault();
+            editorRef.current?.focusAtCaret(Number.MAX_SAFE_INTEGER);
+          }}
+        >
           {isCreate ? (
-            <input
+            <textarea
               ref={nameRef}
-              type="text"
+              rows={1}
               value={name ?? ''}
-              onChange={(e) => onNameChange?.(e.target.value)}
+              onChange={(e) => {
+                onNameChange?.(e.target.value);
+                sizeName();
+              }}
               onKeyDown={(e) => {
-                // Enter moves on rather than submitting: at this size the
-                // description is almost certainly the point.
+                // Enter moves into the body rather than submitting: on a page
+                // this size, the description is the point.
                 if (e.key === 'Enter') {
                   e.preventDefault();
                   editorRef.current?.focus();
@@ -163,44 +193,34 @@ export function TaskComposerSheet({
               placeholder="Task name"
               spellCheck={false}
               aria-label="Task name"
-              className="flex-1 min-w-0 bg-transparent border-none outline-none text-[15px] text-text-primary placeholder:text-text-tertiary"
+              className="w-full resize-none overflow-hidden bg-transparent border-none outline-none text-lg font-semibold text-text-primary placeholder:text-text-tertiary placeholder:font-normal"
             />
           ) : (
-            <span className="flex-1 min-w-0 truncate text-[15px] text-text-primary">{name}</span>
+            <h1 className="text-lg font-semibold text-text-primary">{name}</h1>
           )}
-          <span className="shrink-0 text-[11px] text-ink/40">{isCreate ? 'Todo' : 'Description'}</span>
-        </div>
 
-        {/* The writing surface. Padding is generous on purpose: it sets the
-            measure and, being inside the editable box, stays clickable. */}
-        <DescriptionChipEditor
-          ref={editorRef}
-          initialValue={description}
-          onChange={onDescriptionChange}
-          onAttachFile={onAttachFile}
-          placeholder={isCreate ? 'Describe the task, or write the prompt to start from…' : 'Add a description…'}
-          className="composer-sheet-editor settings-scrollable w-full overflow-y-auto px-8 pt-5 pb-6 text-sm leading-relaxed text-text-primary bg-transparent outline-none border-none"
-          // Floor is a few lines, not a canvas: an empty sheet should look
-          // ready rather than vacant, and it grows from there as you write.
-          style={{ minHeight: '8.5rem', maxHeight: '46vh', whiteSpace: 'pre-wrap', wordWrap: 'break-word' }}
-        />
+          <DescriptionChipEditor
+            ref={editorRef}
+            initialValue={description}
+            onChange={onDescriptionChange}
+            onAttachFile={onAttachFile}
+            placeholder={isCreate ? 'Describe the task, or write the prompt to start from…' : 'Add a description…'}
+            className="composer-sheet-editor mt-3 w-full text-sm leading-relaxed text-ink/80 bg-transparent outline-none border-none"
+            style={{ minHeight: '18rem', whiteSpace: 'pre-wrap', wordWrap: 'break-word' }}
+          />
+        </div>
 
         <div className="shrink-0 flex items-center gap-4 px-3 py-2 border-t border-ink/[0.06] text-[11px] text-ink/40">
           <KeyHint keys="esc" label={isCreate ? 'Draft stays in the column' : 'Back to the card'} />
           <span className="flex-1" />
           {onDiscard && (
-            <button type="button" onClick={onDiscard} className="composer-sheet-action">
+            <button type="button" onClick={onDiscard} className="btn-secondary">
               Discard
             </button>
           )}
-          <button
-            type="button"
-            onClick={submit}
-            disabled={!canSubmit}
-            className="composer-sheet-action composer-sheet-action-primary"
-          >
+          <button type="button" onClick={submit} disabled={!canSubmit} className="btn-primary">
             {isCreate ? 'Create task' : 'Save'}
-            <kbd>{MOD}↵</kbd>
+            <span className="opacity-60 font-mono text-[11px]">{MOD}↵</span>
           </button>
         </div>
       </div>

--- a/src/components/kanban/TaskComposerSheet.tsx
+++ b/src/components/kanban/TaskComposerSheet.tsx
@@ -163,10 +163,10 @@ export function TaskComposerSheet({
               placeholder="Task name"
               spellCheck={false}
               aria-label="Task name"
-              className="flex-1 min-w-0 bg-transparent border-none outline-none font-mono text-sm font-medium text-text-primary placeholder:text-text-tertiary"
+              className="flex-1 min-w-0 bg-transparent border-none outline-none text-[15px] text-text-primary placeholder:text-text-tertiary"
             />
           ) : (
-            <span className="flex-1 min-w-0 truncate font-mono text-sm font-medium text-text-primary">{name}</span>
+            <span className="flex-1 min-w-0 truncate text-[15px] text-text-primary">{name}</span>
           )}
           <span className="shrink-0 text-[11px] text-ink/40">{isCreate ? 'Todo' : 'Description'}</span>
         </div>
@@ -179,7 +179,7 @@ export function TaskComposerSheet({
           onChange={onDescriptionChange}
           onAttachFile={onAttachFile}
           placeholder={isCreate ? 'Describe the task, or write the prompt to start from…' : 'Add a description…'}
-          className="composer-sheet-editor settings-scrollable w-full overflow-y-auto px-8 pt-5 pb-6 font-mono text-[13px] text-text-primary bg-transparent outline-none border-none"
+          className="composer-sheet-editor settings-scrollable w-full overflow-y-auto px-8 pt-5 pb-6 text-sm leading-relaxed text-text-primary bg-transparent outline-none border-none"
           // Floor is a few lines, not a canvas: an empty sheet should look
           // ready rather than vacant, and it grows from there as you write.
           style={{ minHeight: '8.5rem', maxHeight: '46vh', whiteSpace: 'pre-wrap', wordWrap: 'break-word' }}

--- a/src/components/kanban/TaskComposerSheet.tsx
+++ b/src/components/kanban/TaskComposerSheet.tsx
@@ -120,7 +120,9 @@ export function TaskComposerSheet({
     <div
       data-testid="composer-sheet-overlay"
       data-visible={visible}
-      className={`fixed inset-0 z-[10003] flex justify-center px-6 pt-[12vh] pb-10 transition-opacity duration-200 ease-out ${
+      // items-start, so the panel is sized by its content. Stretching it to
+      // the viewport would strand the footer mid-panel with dead space below.
+      className={`fixed inset-0 z-[10003] flex items-start justify-center px-6 pt-[12vh] pb-10 transition-opacity duration-200 ease-out ${
         visible ? 'opacity-100' : 'opacity-0'
       }`}
       style={{ background: 'rgba(0, 0, 0, 0.4)', backdropFilter: 'blur(4px)', WebkitBackdropFilter: 'blur(4px)' }}
@@ -178,7 +180,9 @@ export function TaskComposerSheet({
           onAttachFile={onAttachFile}
           placeholder={isCreate ? 'Describe the task, or write the prompt to start from…' : 'Add a description…'}
           className="composer-sheet-editor settings-scrollable w-full overflow-y-auto px-8 pt-5 pb-6 font-mono text-[13px] text-text-primary bg-transparent outline-none border-none"
-          style={{ minHeight: '13rem', maxHeight: '46vh', whiteSpace: 'pre-wrap', wordWrap: 'break-word' }}
+          // Floor is a few lines, not a canvas: an empty sheet should look
+          // ready rather than vacant, and it grows from there as you write.
+          style={{ minHeight: '8.5rem', maxHeight: '46vh', whiteSpace: 'pre-wrap', wordWrap: 'break-word' }}
         />
 
         <div className="shrink-0 flex items-center gap-4 px-3 py-2 border-t border-ink/[0.06] text-[11px] text-ink/40">

--- a/src/components/kanban/TaskComposerSheet.tsx
+++ b/src/components/kanban/TaskComposerSheet.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { DescriptionChipEditor, type DescriptionChipEditorHandle } from './DescriptionChipEditor';
+import { Icon } from '../terminal/Icon';
+
+const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
+
+interface TaskComposerSheetProps {
+  /** Storage-format description the sheet opens with. */
+  description: string;
+  /** Task name. Omitted in `edit` mode, where the name is renamed on the card. */
+  name?: string;
+  /** Caret offset to restore, carried over from the inline editor. */
+  initialCaret?: number | null;
+  mode: 'create' | 'edit';
+  onNameChange?: (name: string) => void;
+  /** Fires on every keystroke so the inline editor behind the scrim stays in step. */
+  onDescriptionChange: (description: string) => void;
+  onAttachFile: (file: File) => Promise<string | null>;
+  /** Create the task, or save the edited description. */
+  onSubmit: () => void;
+  /** Close and hand the caret back to the inline editor. Null when unknown. */
+  onCollapse: (caret: number | null) => void;
+  /** Throw the draft away. Omitted in `edit` mode. */
+  onDiscard?: () => void;
+}
+
+/**
+ * The composer's expanded view: the same draft as the inline form, given a
+ * centered sheet and a reading measure. Both editors are views onto one piece
+ * of state held by the parent, so switching between them is a change of
+ * surface rather than a handoff — including the caret, which travels as an
+ * offset into the storage string.
+ */
+export function TaskComposerSheet({
+  description,
+  name,
+  initialCaret,
+  mode,
+  onNameChange,
+  onDescriptionChange,
+  onAttachFile,
+  onSubmit,
+  onCollapse,
+  onDiscard,
+}: TaskComposerSheetProps) {
+  const editorRef = useRef<DescriptionChipEditorHandle>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const mouseDownTargetRef = useRef<EventTarget | null>(null);
+
+  const canSubmit = mode === 'edit' || (name ?? '').trim().length > 0;
+
+  const collapse = useCallback(() => {
+    onCollapse(editorRef.current?.getCaret() ?? null);
+  }, [onCollapse]);
+
+  // Land where the inline editor left off. An empty name in create mode means
+  // this is a fresh draft, so start there instead of in the description.
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      if (mode === 'create' && !(name ?? '').trim()) {
+        nameRef.current?.focus();
+        return;
+      }
+      if (initialCaret != null) editorRef.current?.focusAtCaret(initialCaret);
+      else editorRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+    // Only on open: later prop changes are the user's own typing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Capture-phase so Escape closes the sheet instead of reaching the board's
+  // handler, which would clear the card selection underneath.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        collapse();
+      } else if (mod && e.key.toLowerCase() === 'e') {
+        e.preventDefault();
+        e.stopPropagation();
+        collapse();
+      } else if (mod && e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        if (canSubmit) onSubmit();
+      }
+    };
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
+  }, [collapse, onSubmit, canSubmit]);
+
+  return createPortal(
+    <div
+      data-testid="composer-sheet-overlay"
+      className="fixed inset-0 z-[10001] flex items-center justify-center p-10"
+      style={{ background: 'rgba(0, 0, 0, 0.4)', backdropFilter: 'blur(4px)', WebkitBackdropFilter: 'blur(4px)' }}
+      onMouseDown={(e) => {
+        mouseDownTargetRef.current = e.target;
+      }}
+      onClick={(e) => {
+        // Only a click that both started and ended on the scrim dismisses, so
+        // a text selection dragged out of the editor doesn't close the sheet.
+        if (e.target === e.currentTarget && mouseDownTargetRef.current === e.currentTarget) collapse();
+      }}
+    >
+      <div
+        data-testid="composer-sheet"
+        className="kanban-composer-sheet flex flex-col w-full overflow-hidden bg-surface border border-border rounded-xl"
+        style={{ maxWidth: 660, maxHeight: '100%', boxShadow: 'var(--shadow-menu)' }}
+      >
+        <div
+          className="flex items-center gap-2 px-3 py-2 shrink-0"
+          style={{ borderBottom: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
+        >
+          <span className="kanban-composer-chip">{mode === 'create' ? 'Todo' : 'Description'}</span>
+          <span className="text-xs text-text-secondary">{mode === 'create' ? 'New task' : 'Editing'}</span>
+          <span className="flex-1" />
+          <button
+            type="button"
+            onClick={collapse}
+            className="kanban-add-button text-text-secondary hover:text-text-primary hover:bg-ink/[0.04]"
+          >
+            <Icon name="arrows-in" className="w-3.5 h-3.5" />
+            Collapse
+            <span className="kanban-add-button-hint kanban-add-button-hint-text">{isMac ? '⌘E' : 'Ctrl E'}</span>
+          </button>
+        </div>
+
+        {mode === 'create' && (
+          <input
+            ref={nameRef}
+            type="text"
+            className="w-full font-mono text-base font-medium text-text-primary bg-transparent px-5 py-4 outline-none border-none focus:bg-ink/[0.04] transition-all duration-150 ease-out"
+            style={{ borderBottom: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
+            placeholder="Task name"
+            value={name ?? ''}
+            onChange={(e) => onNameChange?.(e.target.value)}
+            onKeyDown={(e) => {
+              // Enter moves on rather than submitting: in a sheet this size,
+              // the description is almost certainly the point.
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                editorRef.current?.focus();
+              }
+            }}
+          />
+        )}
+
+        <DescriptionChipEditor
+          ref={editorRef}
+          initialValue={description}
+          onChange={onDescriptionChange}
+          onAttachFile={onAttachFile}
+          placeholder="Description, or the prompt the agent should start from…"
+          className="kanban-composer-sheet-editor flex-1 w-full self-center font-mono text-[13px] text-text-primary bg-transparent outline-none border-none"
+          style={{
+            // A measure, so a long prompt reads as prose instead of a wall of
+            // 90-character lines.
+            maxWidth: '66ch',
+            minHeight: 260,
+            padding: '18px 0 24px',
+            whiteSpace: 'pre-wrap',
+            wordWrap: 'break-word',
+            lineHeight: 1.65,
+            overflowY: 'auto',
+          }}
+        />
+
+        <div
+          className="flex items-center gap-2 px-2.5 py-2 shrink-0"
+          style={{ borderTop: '1px solid color-mix(in srgb, var(--color-ink) 6%, transparent)' }}
+        >
+          <span className="font-mono text-[10.5px] text-text-tertiary px-1.5">
+            Drop an image anywhere in the description
+          </span>
+          <span className="flex-1" />
+          {onDiscard && (
+            <button
+              type="button"
+              onClick={onDiscard}
+              className="kanban-add-button text-text-tertiary hover:text-text-primary hover:bg-ink/[0.04]"
+            >
+              Discard
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={!canSubmit}
+            className="kanban-add-button kanban-add-button-filled"
+          >
+            {mode === 'create' ? 'Create task' : 'Save'}
+            <span className="kanban-add-button-hint kanban-add-button-hint-text">{isMac ? '⌘↵' : 'Ctrl ↵'}</span>
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/ui/KeyHint.tsx
+++ b/src/components/ui/KeyHint.tsx
@@ -1,0 +1,15 @@
+/**
+ * One entry in the keyboard legend along the bottom of the app's overlay
+ * surfaces — the command palette and the task composer sheet. Sized to sit
+ * quietly under the content it describes.
+ */
+export function KeyHint({ keys, label }: { keys: string; label: string }) {
+  return (
+    <span className="flex items-center gap-1.5 min-w-0">
+      <kbd className="font-mono text-[10px] leading-none px-1.5 py-1 rounded bg-ink/[0.06] text-text-tertiary">
+        {keys}
+      </kbd>
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -825,6 +825,181 @@ textarea,
   line-height: 1;
 }
 
+.kanban-add-button-filled {
+  background: var(--color-accent);
+  color: var(--color-accent-ink);
+  padding: 7px 14px;
+}
+
+.kanban-add-button-filled:hover {
+  background: var(--color-accent-hover);
+}
+
+.kanban-add-button-filled:disabled:hover {
+  background: var(--color-accent);
+}
+
+/* ── New-task composer ────────────────────────────────────────────── */
+
+/* Pinned below the card list rather than scrolling with it, so it reads as
+   part of the column's frame. */
+.kanban-column-footer .kanban-add-form {
+  background: color-mix(in srgb, var(--color-ink) 2%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--color-ink) 8%, transparent);
+  box-shadow: 0 -8px 16px -10px rgba(0, 0, 0, 0.45);
+}
+
+/* Resting state: one row, same place at any column length. */
+.kanban-add-rest {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--color-text-tertiary);
+  font-family: 'Iosevka Term Extended', ui-monospace, monospace;
+  font-size: 13px;
+  padding: 13px 12px;
+  text-align: left;
+  cursor: text;
+  transition:
+    background-color 120ms ease-out,
+    color 120ms ease-out;
+}
+
+.kanban-add-rest:hover {
+  background: color-mix(in srgb, var(--color-ink) 4%, transparent);
+  color: var(--color-text-secondary);
+}
+
+.kanban-add-rest-plus {
+  opacity: 0.7;
+}
+
+.kanban-add-rest .kanban-add-button-hint {
+  margin-left: auto;
+  opacity: 0.5;
+}
+
+/* A draft survives collapsing; the row says so instead of looking empty. */
+.kanban-add-draft-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  flex-shrink: 0;
+}
+
+.kanban-add-draft-label {
+  color: var(--color-text-secondary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Drag strip along the composer's top edge. */
+.kanban-add-grip {
+  height: 9px;
+  display: grid;
+  place-items: center;
+  cursor: ns-resize;
+  touch-action: none;
+}
+
+.kanban-add-grip::before {
+  content: '';
+  width: 26px;
+  height: 2px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--color-ink) 12%, transparent);
+  transition: background-color 120ms ease-out;
+}
+
+.kanban-add-grip:hover::before {
+  background: var(--color-text-secondary);
+}
+
+.kanban-add-description-wrap {
+  position: relative;
+}
+
+/* Edge fades stand in for a scrollbar: they say "more text this way" without
+   taking width from a 240px column. Masking the text rather than painting a
+   gradient over it means the fade works on any background, including the
+   focus tint and whatever the column sits on. The mask applies to the border
+   box, so it stays at the visual edges while the content scrolls under it. */
+.kanban-add-description-wrap[data-clip='top'] .kanban-description-editor {
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 20px);
+  mask-image: linear-gradient(to bottom, transparent 0, #000 20px);
+}
+
+.kanban-add-description-wrap[data-clip='bottom'] .kanban-description-editor {
+  -webkit-mask-image: linear-gradient(to top, transparent 0, #000 20px);
+  mask-image: linear-gradient(to top, transparent 0, #000 20px);
+}
+
+.kanban-add-description-wrap[data-clip='both'] .kanban-description-editor {
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 20px, #000 calc(100% - 20px), transparent 100%);
+  mask-image: linear-gradient(to bottom, transparent 0, #000 20px, #000 calc(100% - 20px), transparent 100%);
+}
+
+.kanban-add-expand {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--color-text-tertiary);
+  opacity: 0;
+  transition:
+    opacity 140ms ease-out,
+    background-color 120ms ease-out,
+    color 140ms ease-out;
+}
+
+.kanban-add-description-wrap:hover .kanban-add-expand,
+.kanban-add-description-wrap:focus-within .kanban-add-expand {
+  opacity: 1;
+}
+
+.kanban-add-expand:hover {
+  background: color-mix(in srgb, var(--color-ink) 8%, transparent);
+  color: var(--color-text-primary);
+}
+
+/* At the cap the affordance stops being a hover-only secret: this is the
+   moment the inline box has run out of room. */
+.kanban-add-description-wrap.is-capped .kanban-add-expand {
+  opacity: 1;
+  color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+}
+
+/* ── Expanded composer sheet ──────────────────────────────────────── */
+
+.kanban-composer-chip {
+  font-family: 'Iosevka Term Extended', ui-monospace, monospace;
+  font-size: 10.5px;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--color-ink) 6%, transparent);
+  color: var(--color-text-secondary);
+}
+
+/* The editor is narrowed to a measure, so its focus tint would read as a
+   floating stripe. Let the sheet carry the surface instead. */
+.kanban-composer-sheet-editor:focus {
+  background: transparent;
+}
+
 /* ── Task description attachment chip ─────────────────────────────── */
 
 .kanban-description-editor {

--- a/src/index.css
+++ b/src/index.css
@@ -986,67 +986,11 @@ textarea,
   color: var(--color-text-tertiary);
 }
 
-/* Footer actions. Quieter than a filled pill — this bar is a legend the
-   primary action sits in, not a dialog's button row. */
-.composer-sheet-action {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 5px 8px 5px 10px;
-  border: none;
-  border-radius: 7px;
-  background: transparent;
-  color: var(--color-text-secondary);
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 1;
-  transition:
-    color 100ms ease-out,
-    background-color 100ms ease-out;
-}
-
-.composer-sheet-action:hover {
-  background: color-mix(in srgb, var(--color-ink) 6%, transparent);
-  color: var(--color-text-primary);
-}
-
-.composer-sheet-action-primary {
-  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
-  color: var(--color-accent);
-}
-
-.composer-sheet-action-primary:hover {
-  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
-  color: var(--color-accent);
-}
-
-/* Disabled drops the accent entirely rather than fading it. A washed-out
-   tint on a dark panel reads as a rendering fault; a neutral, legible
-   control reads as "not yet". */
-.composer-sheet-action:disabled,
-.composer-sheet-action:disabled:hover {
-  background: color-mix(in srgb, var(--color-ink) 5%, transparent);
-  color: var(--color-text-tertiary);
-}
-
-.composer-sheet-action kbd {
-  font-family: 'Iosevka Term Extended', ui-monospace, monospace;
-  font-size: 10px;
-  line-height: 1;
-  padding: 3px 5px;
-  border-radius: 4px;
-  background: color-mix(in srgb, var(--color-ink) 8%, transparent);
-  color: inherit;
-}
-
-.composer-sheet-action-primary kbd {
-  background: color-mix(in srgb, var(--color-accent) 26%, transparent);
-}
-
-/* After the primary rule, so a disabled button's shortcut chip loses the
-   accent with the rest of it instead of sitting there lit up. */
-.composer-sheet-action:disabled kbd {
-  background: color-mix(in srgb, var(--color-ink) 8%, transparent);
+/* The page's caret sits at the text edge, so the body needs room below the
+   last line to click into — a document's bottom margin, not padding that
+   ends where the text does. */
+.composer-sheet-page {
+  cursor: text;
 }
 
 /* ── Task description attachment chip ─────────────────────────────── */

--- a/src/index.css
+++ b/src/index.css
@@ -971,14 +971,16 @@ textarea,
 /* ── Expanded composer sheet ──────────────────────────────────────── */
 
 /* Prose settings for the sheet's editor: looser leading than the 240px
-   inline box, and a placeholder that sits on the first line rather than
-   being italicised at this size. */
+   inline box. The placeholder drops the italic the inline editor uses —
+   at this size a full italic line reads as content, not as a prompt.
+   Both classes, to outrank the base rule further down the file. */
 .composer-sheet-editor {
   line-height: 1.7;
 }
 
-.composer-sheet-editor[data-empty='true']::before {
+.kanban-description-editor.composer-sheet-editor[data-empty='true']::before {
   font-style: normal;
+  color: var(--color-text-tertiary);
 }
 
 /* Footer actions. Quieter than a filled pill — this bar is a legend the
@@ -1015,13 +1017,13 @@ textarea,
   color: var(--color-accent);
 }
 
-.composer-sheet-action:disabled {
-  opacity: 0.4;
-}
-
+/* Disabled drops the accent entirely rather than fading it. A washed-out
+   tint on a dark panel reads as a rendering fault; a neutral, legible
+   control reads as "not yet". */
+.composer-sheet-action:disabled,
 .composer-sheet-action:disabled:hover {
-  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
-  color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-ink) 5%, transparent);
+  color: var(--color-text-tertiary);
 }
 
 .composer-sheet-action kbd {
@@ -1031,10 +1033,17 @@ textarea,
   padding: 3px 5px;
   border-radius: 4px;
   background: color-mix(in srgb, var(--color-ink) 8%, transparent);
+  color: inherit;
 }
 
 .composer-sheet-action-primary kbd {
-  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 26%, transparent);
+}
+
+/* After the primary rule, so a disabled button's shortcut chip loses the
+   accent with the rest of it instead of sitting there lit up. */
+.composer-sheet-action:disabled kbd {
+  background: color-mix(in srgb, var(--color-ink) 8%, transparent);
 }
 
 /* ── Task description attachment chip ─────────────────────────────── */

--- a/src/index.css
+++ b/src/index.css
@@ -931,10 +931,16 @@ textarea,
   mask-image: linear-gradient(to bottom, transparent 0, #000 20px, #000 calc(100% - 20px), transparent 100%);
 }
 
-.kanban-add-expand {
+/* The tooltip wraps its reference in a div, so the anchor carries the
+   positioning and the button just fills it. */
+.kanban-add-expand-anchor {
   position: absolute;
   top: 5px;
   right: 5px;
+  display: block;
+}
+
+.kanban-add-expand {
   width: 24px;
   height: 24px;
   display: grid;

--- a/src/index.css
+++ b/src/index.css
@@ -844,7 +844,6 @@ textarea,
   border: none;
   background: transparent;
   color: var(--color-text-tertiary);
-  font-family: 'Iosevka Term Extended', ui-monospace, monospace;
   font-size: 13px;
   padding: 13px 12px;
   text-align: left;
@@ -976,14 +975,9 @@ textarea,
 
 /* ── Expanded composer sheet ──────────────────────────────────────── */
 
-/* Prose settings for the sheet's editor: looser leading than the 240px
-   inline box. The placeholder drops the italic the inline editor uses —
-   at this size a full italic line reads as content, not as a prompt.
-   Both classes, to outrank the base rule further down the file. */
-.composer-sheet-editor {
-  line-height: 1.7;
-}
-
+/* The placeholder drops the italic the inline editor uses — at this size a
+   full italic line reads as content, not as a prompt. Both classes, to
+   outrank the base rule further down the file. */
 .kanban-description-editor.composer-sheet-editor[data-empty='true']::before {
   font-style: normal;
   color: var(--color-text-tertiary);

--- a/src/index.css
+++ b/src/index.css
@@ -865,15 +865,18 @@ textarea,
 .kanban-add-rest .kanban-add-button-hint {
   margin-left: auto;
   opacity: 0.5;
+  /* Never wrap or get squeezed: the draft title beside it truncates instead. */
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
-/* A draft survives collapsing; the row says so instead of looking empty. */
-.kanban-add-draft-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--color-accent);
+/* A draft survives collapsing; the row says so instead of looking empty.
+   The dashed page reads as "unfinished" on its own, which a dot never did. */
+.kanban-add-draft-icon {
+  width: 15px;
+  height: 15px;
   flex-shrink: 0;
+  color: var(--color-accent);
 }
 
 .kanban-add-draft-label {

--- a/src/index.css
+++ b/src/index.css
@@ -825,20 +825,6 @@ textarea,
   line-height: 1;
 }
 
-.kanban-add-button-filled {
-  background: var(--color-accent);
-  color: var(--color-accent-ink);
-  padding: 7px 14px;
-}
-
-.kanban-add-button-filled:hover {
-  background: var(--color-accent-hover);
-}
-
-.kanban-add-button-filled:disabled:hover {
-  background: var(--color-accent);
-}
-
 /* ── New-task composer ────────────────────────────────────────────── */
 
 /* Pinned below the card list rather than scrolling with it, so it reads as
@@ -984,20 +970,71 @@ textarea,
 
 /* ── Expanded composer sheet ──────────────────────────────────────── */
 
-.kanban-composer-chip {
-  font-family: 'Iosevka Term Extended', ui-monospace, monospace;
-  font-size: 10.5px;
-  line-height: 1;
-  padding: 4px 8px;
-  border-radius: 4px;
-  background: color-mix(in srgb, var(--color-ink) 6%, transparent);
-  color: var(--color-text-secondary);
+/* Prose settings for the sheet's editor: looser leading than the 240px
+   inline box, and a placeholder that sits on the first line rather than
+   being italicised at this size. */
+.composer-sheet-editor {
+  line-height: 1.7;
 }
 
-/* The editor is narrowed to a measure, so its focus tint would read as a
-   floating stripe. Let the sheet carry the surface instead. */
-.kanban-composer-sheet-editor:focus {
+.composer-sheet-editor[data-empty='true']::before {
+  font-style: normal;
+}
+
+/* Footer actions. Quieter than a filled pill — this bar is a legend the
+   primary action sits in, not a dialog's button row. */
+.composer-sheet-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px 5px 10px;
+  border: none;
+  border-radius: 7px;
   background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  transition:
+    color 100ms ease-out,
+    background-color 100ms ease-out;
+}
+
+.composer-sheet-action:hover {
+  background: color-mix(in srgb, var(--color-ink) 6%, transparent);
+  color: var(--color-text-primary);
+}
+
+.composer-sheet-action-primary {
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+  color: var(--color-accent);
+}
+
+.composer-sheet-action-primary:hover {
+  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
+  color: var(--color-accent);
+}
+
+.composer-sheet-action:disabled {
+  opacity: 0.4;
+}
+
+.composer-sheet-action:disabled:hover {
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+  color: var(--color-accent);
+}
+
+.composer-sheet-action kbd {
+  font-family: 'Iosevka Term Extended', ui-monospace, monospace;
+  font-size: 10px;
+  line-height: 1;
+  padding: 3px 5px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--color-ink) 8%, transparent);
+}
+
+.composer-sheet-action-primary kbd {
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
 
 /* ── Task description attachment chip ─────────────────────────────── */

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -22,11 +22,16 @@ interface AppStoreState {
   whatsNew: { version: string; notes: string } | null;
   helpDialogOpen: boolean;
   /**
-   * The new-task composer's expanded sheet is open. The board reads this to
-   * leave Escape alone while the sheet owns it, the same way it does for the
-   * hook and worktree dialogs.
+   * How many composer sheets are open. The board reads this to leave Escape
+   * alone while a sheet owns it, the same way it does for the hook and
+   * worktree dialogs.
+   *
+   * A count rather than a flag because several components can open one — the
+   * column composer, the standalone sheet, and any card — and they mount and
+   * unmount independently. With a boolean, a background `loadTasks` that
+   * remounts a card would clear the flag out from under an open sheet.
    */
-  composerSheetOpen: boolean;
+  composerSheetCount: number;
   /**
    * Session-only onboarding panel state. Lives in the app store (not in the
    * OnboardingPanel component) so it survives kanban-toggle remounts — without
@@ -52,7 +57,9 @@ interface AppStoreActions {
   setSandboxStarting: (starting: boolean) => void;
   setWhatsNew: (info: { version: string; notes: string } | null) => void;
   setHelpDialogOpen: (open: boolean) => void;
-  setComposerSheetOpen: (open: boolean) => void;
+  /** Register an open composer sheet; returns nothing, pair with the close. */
+  openComposerSheet: () => void;
+  closeComposerSheet: () => void;
   setOnboardingSoftDismissed: (value: boolean) => void;
   setOnboardingStuckLatched: (value: boolean) => void;
   setHealth: (status: HealthStatus | null) => void;
@@ -93,7 +100,7 @@ export const useAppStore = create<AppStore>()((set, get) => ({
   sandboxStarting: false,
   whatsNew: null,
   helpDialogOpen: false,
-  composerSheetOpen: false,
+  composerSheetCount: 0,
   onboardingSoftDismissed: false,
   onboardingStuckLatched: false,
   health: null,
@@ -114,7 +121,9 @@ export const useAppStore = create<AppStore>()((set, get) => ({
 
   setHelpDialogOpen: (open) => set({ helpDialogOpen: open }),
 
-  setComposerSheetOpen: (open) => set({ composerSheetOpen: open }),
+  openComposerSheet: () => set((s) => ({ composerSheetCount: s.composerSheetCount + 1 })),
+
+  closeComposerSheet: () => set((s) => ({ composerSheetCount: Math.max(0, s.composerSheetCount - 1) })),
 
   setOnboardingSoftDismissed: (value) => set({ onboardingSoftDismissed: value }),
 

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -22,6 +22,12 @@ interface AppStoreState {
   whatsNew: { version: string; notes: string } | null;
   helpDialogOpen: boolean;
   /**
+   * The new-task composer's expanded sheet is open. The board reads this to
+   * leave Escape alone while the sheet owns it, the same way it does for the
+   * hook and worktree dialogs.
+   */
+  composerSheetOpen: boolean;
+  /**
    * Session-only onboarding panel state. Lives in the app store (not in the
    * OnboardingPanel component) so it survives kanban-toggle remounts — without
    * this, hitting "Hide for now" or being in the stuck state would reset every
@@ -46,6 +52,7 @@ interface AppStoreActions {
   setSandboxStarting: (starting: boolean) => void;
   setWhatsNew: (info: { version: string; notes: string } | null) => void;
   setHelpDialogOpen: (open: boolean) => void;
+  setComposerSheetOpen: (open: boolean) => void;
   setOnboardingSoftDismissed: (value: boolean) => void;
   setOnboardingStuckLatched: (value: boolean) => void;
   setHealth: (status: HealthStatus | null) => void;
@@ -86,6 +93,7 @@ export const useAppStore = create<AppStore>()((set, get) => ({
   sandboxStarting: false,
   whatsNew: null,
   helpDialogOpen: false,
+  composerSheetOpen: false,
   onboardingSoftDismissed: false,
   onboardingStuckLatched: false,
   health: null,
@@ -105,6 +113,8 @@ export const useAppStore = create<AppStore>()((set, get) => ({
   setWhatsNew: (info) => set({ whatsNew: info }),
 
   setHelpDialogOpen: (open) => set({ helpDialogOpen: open }),
+
+  setComposerSheetOpen: (open) => set({ composerSheetOpen: open }),
 
   setOnboardingSoftDismissed: (value) => set({ onboardingSoftDismissed: value }),
 

--- a/src/stores/composerStore.ts
+++ b/src/stores/composerStore.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand';
+
+/**
+ * The new-task draft, and whether its expanded sheet is up.
+ *
+ * The draft lives here rather than inside the column composer because it
+ * outlives that component: ⌘N away from the board opens the sheet on its own,
+ * and whatever you leave unfinished is waiting in the column's resting row
+ * when you come back to it. One draft, whichever surface you reached it from.
+ */
+interface ComposerStore {
+  draft: { name: string; description: string };
+  /** The expanded sheet is open. Rendered by the board when it's mounted, by
+   *  the project view when it isn't. */
+  sheetOpen: boolean;
+  /** Caret offset the sheet opens at, handed over by the inline editor. */
+  sheetCaret: number | null;
+
+  setName: (name: string) => void;
+  setDescription: (description: string) => void;
+  clearDraft: () => void;
+  openSheet: (caret?: number | null) => void;
+  closeSheet: () => void;
+}
+
+export const useComposerStore = create<ComposerStore>()((set) => ({
+  draft: { name: '', description: '' },
+  sheetOpen: false,
+  sheetCaret: null,
+
+  setName: (name) => set((s) => ({ draft: { ...s.draft, name } })),
+
+  setDescription: (description) => set((s) => ({ draft: { ...s.draft, description } })),
+
+  clearDraft: () => set({ draft: { name: '', description: '' } }),
+
+  openSheet: (caret = null) => set({ sheetOpen: true, sheetCaret: caret }),
+
+  closeSheet: () => set({ sheetOpen: false, sheetCaret: null }),
+}));
+
+/** True when the board is on screen, so the column composer exists to focus. */
+export function isBoardMounted(activePanel: string, kanbanVisible: boolean): boolean {
+  return activePanel !== 'settings' && kanbanVisible;
+}

--- a/src/utils/descriptionAttachments.ts
+++ b/src/utils/descriptionAttachments.ts
@@ -72,16 +72,52 @@ export function parseDescription(text: string): DescriptionSegment[] {
  * text content, with `<br>` and block boundaries becoming newlines.
  */
 export function serializeDescriptionDOM(root: Node): string {
+  return walkDescriptionDOM(root).text.trim();
+}
+
+/** A DOM Range start position, used to stop the walk at the caret. */
+interface CaretStop {
+  node: Node;
+  offset: number;
+}
+
+/**
+ * The shared walk behind serialization and caret measurement. Without a stop
+ * it produces the full (untrimmed) storage string; with one it stops at that
+ * position, so `text.length` is the caret's offset into the same string.
+ */
+function walkDescriptionDOM(root: Node, stop?: CaretStop): { text: string; stopped: boolean } {
   let out = '';
+  let stopped = false;
 
   const appendBlockBoundary = (): void => {
     // Avoid duplicate newlines from nested blocks.
     if (out.length > 0 && !out.endsWith('\n')) out += '\n';
   };
 
+  /** Walk an element's children, honouring a stop that points between them. */
+  const walkChildren = (parent: Node): void => {
+    const children = Array.from(parent.childNodes);
+    for (let i = 0; i < children.length; i++) {
+      if (stop && stop.node === parent && stop.offset === i) {
+        stopped = true;
+        return;
+      }
+      walk(children[i]);
+      if (stopped) return;
+    }
+    if (stop && stop.node === parent && stop.offset >= children.length) stopped = true;
+  };
+
   const walk = (node: Node): void => {
     if (node.nodeType === Node.TEXT_NODE) {
-      out += node.textContent ?? '';
+      const text = node.textContent ?? '';
+      if (stop && stop.node === node) {
+        out += text.slice(0, stop.offset);
+        stopped = true;
+      } else {
+        out += text;
+      }
       return;
     }
     if (node.nodeType !== Node.ELEMENT_NODE) return;
@@ -100,13 +136,82 @@ export function serializeDescriptionDOM(root: Node): string {
     const isBlock = el.tagName === 'DIV' || el.tagName === 'P';
     if (isBlock) appendBlockBoundary();
 
-    for (const child of Array.from(el.childNodes)) walk(child);
+    walkChildren(el);
+    if (stopped) return;
 
     if (isBlock) appendBlockBoundary();
   };
 
-  for (const child of Array.from(root.childNodes)) walk(child);
-  return out.trim();
+  walkChildren(root);
+  return { text: out, stopped };
+}
+
+/** Serialized length of one chip, i.e. the `![](path)` marker it stands for. */
+function chipMarkerLength(chip: HTMLElement): number {
+  return `![](${encodeAttachmentPath(chip.getAttribute(ATTACHMENT_PATH_ATTR) ?? '')})`.length;
+}
+
+/**
+ * Where the caret sits, expressed as an offset into the *storage* string
+ * rather than into the DOM. That makes it portable between two editors
+ * showing the same value, which is what moving a draft between the inline
+ * composer and the expanded sheet needs. A chip counts as the full length of
+ * its `![](path)` marker, matching how the value is stored.
+ *
+ * Returns null when the selection isn't inside `root`.
+ */
+export function getCaretOffset(root: HTMLElement): number | null {
+  const selection = root.ownerDocument.defaultView?.getSelection();
+  if (!selection || selection.rangeCount === 0) return null;
+  const range = selection.getRangeAt(0);
+  if (!root.contains(range.startContainer)) return null;
+
+  const prefix = walkDescriptionDOM(root, { node: range.startContainer, offset: range.startOffset });
+  if (!prefix.stopped) return null;
+
+  // serializeDescriptionDOM trims, so drop the leading whitespace the caret
+  // offset would otherwise be measured past.
+  const full = walkDescriptionDOM(root).text;
+  const trimmedFromStart = full.length - full.trimStart().length;
+  return Math.max(0, prefix.text.length - trimmedFromStart);
+}
+
+/**
+ * Place the caret `offset` characters into the storage string. Intended for
+ * an editor that was just repopulated from that value, where the children are
+ * the flat list of text nodes and chips that `parseDescription` produces.
+ */
+export function setCaretOffset(root: HTMLElement, offset: number): void {
+  const doc = root.ownerDocument;
+  const selection = doc.defaultView?.getSelection();
+  if (!selection) return;
+
+  const range = doc.createRange();
+  let remaining = Math.max(0, offset);
+  let placed = false;
+
+  for (const node of Array.from(root.childNodes)) {
+    const length = isAttachmentChip(node) ? chipMarkerLength(node) : (node.textContent ?? '').length;
+    if (remaining <= length) {
+      if (node.nodeType === Node.TEXT_NODE) range.setStart(node, remaining);
+      else if (remaining === 0) range.setStartBefore(node);
+      else range.setStartAfter(node);
+      placed = true;
+      break;
+    }
+    remaining -= length;
+  }
+
+  if (placed) {
+    range.collapse(true);
+  } else {
+    // Past the end (or an empty editor): park at the end of the content.
+    range.selectNodeContents(root);
+    range.collapse(false);
+  }
+
+  selection.removeAllRanges();
+  selection.addRange(range);
 }
 
 /**

--- a/src/utils/modKey.ts
+++ b/src/utils/modKey.ts
@@ -1,0 +1,16 @@
+const isMac = typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac');
+
+/**
+ * The platform's command modifier: Cmd on macOS, Ctrl elsewhere.
+ *
+ * Deliberately not `metaKey || ctrlKey`. Accepting either binds Ctrl+letter on
+ * macOS too, which shadows the system emacs bindings that work in every text
+ * field — Ctrl+E for end-of-line, Ctrl+A for start, Ctrl+K to kill the line.
+ * The board's own hotkeys already resolve the modifier this way.
+ */
+export function isModKey(e: { metaKey: boolean; ctrlKey: boolean }): boolean {
+  return isMac ? e.metaKey : e.ctrlKey;
+}
+
+/** Label for the same modifier, for tooltips and key hints. */
+export const MOD_LABEL = isMac ? '⌘' : 'Ctrl ';

--- a/src/utils/openTaskComposer.ts
+++ b/src/utils/openTaskComposer.ts
@@ -1,0 +1,23 @@
+import { focusKanbanAddInput } from '../components/kanban/KanbanAddInput';
+import { useComposerStore, isBoardMounted } from '../stores/composerStore';
+import { useProjectStore } from '../stores/projectStore';
+
+/**
+ * The single entry point for "new task", behind ⌘N and the title bar button.
+ *
+ * On the board, the composer is already on screen, so this just focuses it —
+ * the new task lands where you can see it. Anywhere else, the expanded sheet
+ * opens over whatever you were doing instead of switching the view out from
+ * under you. Both write the same draft, so leaving one and arriving at the
+ * other picks up where you left off.
+ */
+export function openTaskComposer(): void {
+  const { activePanel, kanbanVisible } = useProjectStore.getState();
+
+  if (isBoardMounted(activePanel, kanbanVisible)) {
+    focusKanbanAddInput();
+    return;
+  }
+
+  useComposerStore.getState().openSheet();
+}

--- a/src/utils/taskAttachments.ts
+++ b/src/utils/taskAttachments.ts
@@ -1,0 +1,32 @@
+import { useProjectStore } from '../stores/projectStore';
+
+/**
+ * Resolve a pasted or dropped file to the absolute path that goes into a task
+ * description as a chip. Returns null when the file can't be attached, having
+ * already surfaced the reason as a toast.
+ *
+ * Shared by every surface that edits a description — the column composer, its
+ * expanded sheet, and the card — so all three treat a dropped file the same
+ * way.
+ */
+export async function resolveAttachmentPath(file: File): Promise<string | null> {
+  // Prefer the file's existing on-disk path — drag-drop from Finder and most
+  // clipboard file pastes already have one. Skipping the copy keeps the user's
+  // file under their control and works for any extension.
+  const existingPath = window.api.getPathForFile(file);
+  if (existingPath) return existingPath;
+
+  // No source path — bytes only (typically a clipboard-pasted screenshot).
+  // Save those to userData so CLI agents have a stable path to read.
+  if (!file.type.startsWith('image/')) {
+    useProjectStore.getState().addToast('Only image clipboard content can be attached', 'error');
+    return null;
+  }
+  const ext = file.type.split('/')[1] || 'png';
+  const data = new Uint8Array(await file.arrayBuffer());
+  const result = await window.api.task.saveAttachment(data, ext);
+  if (result.success && result.path) return result.path;
+
+  useProjectStore.getState().addToast(result.error || 'Failed to attach image', 'error');
+  return null;
+}


### PR DESCRIPTION
The composer had two problems. It was the last child of the Todo column's scrolling body, so it dropped below the fold as soon as the column filled. And its description was a fixed 4.5rem box in a 240px column, which got worse the more you wrote.

## What changed

**It's pinned.** The composer moves into a new column footer, outside the scroll container. Same place at 2 tasks or 200, for the cost of one 42px row.

**The description stops growing before it eats the column.** It grows with its content up to 40% of the column, then scrolls internally with masked edges. The cap is measured from column height minus header rather than the live card list — the composer shares that flex column, so a cap measured off the body would have shrunk as the composer grew, chasing its own tail.

**There's a way out when that isn't enough.** At the cap the expand control turns accent, and `⌘E` opens the same draft as a document: heading and prose in one scrolling page with real margins, laid out the way the plan panel lays out a markdown file. The caret travels between the two surfaces as an offset into the storage string, and the inline editor mirrors the sheet, so collapsing is a return rather than a jump.

**Escape stopped discarding.** It collapses and keeps the draft, which the resting row shows with a draft icon and the pending title. Only the Discard button clears.

**`⌘N` routes.** On the board it focuses the column composer, so the task lands where you can see it. Anywhere else it opens the sheet over what you were doing instead of switching the view out from under you. Both write one draft, so starting a task from a terminal and arriving at the board later picks up where you left off.

**Task names are prose.** The GitHub work sets 15px sans for a PR title and mono for its branch ref, and the palette already followed suit. Task names were mono everywhere, setting a person's sentence in the same face as a branch name. They're sans now; branch names, terminal labels, `T-` numbers and attachment paths stay mono.

Also: the composer's top edge drags to a height that overrides the cap and persists, double-click resets it; the card's description editor reuses the same cap and sheet; and the attachment handler that was duplicated across three call sites is now one helper.

## Testing

19 tests across the composer, its two other surfaces, and the caret helpers. The three surface tests were mutation-checked — breaking the sheet-to-card mirror and moving the footer back inside the card list each fail them.

Not covered, deliberately: the cap metrics and the drag-to-resize grip both depend on real layout, which jsdom reports as zero. Testing them would assert a fake rather than the behaviour, so those are the parts worth a human eye.